### PR TITLE
fix dropdown menu overlapping

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -3468,12 +3468,12 @@ button {
     position: absolute;
     top: 100%;
     left: 0;
-    background-color: var(--glass-bg);
+    background-color: var(--bg-dark-modal);
     min-width: 220px;
-    box-shadow: 0 8px 32px var(--shadow-color);
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
-    border: 1px solid var(--glass-border);
+    border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 8px;
     z-index: 1000;
     padding: 0.5rem 0;


### PR DESCRIPTION
## Summary of Change
This PR fixes a visual layout bug on desktop viewports where the dropdown navigation menus (such as "Explore More" and "Learn & Data") were rendering with a transparent background. This caused the menu links to mesh awkwardly with the grid cards and page text beneath them, making the links unreadable. 

The fix updates the `.dropdown-menu` class in `styles.css` by replacing undefined CSS glass variables (`--glass-bg`, `--shadow-color`, `--glass-border`) with explicit fallback values (`var(--bg-dark-modal)`, a solid drop shadow, and a subtle border opacity) that cleanly match the dark theme and lift the dropdown above background content.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings