### PR TITLE
Randomize quiz option order in the Food & State Quiz

### DIFF
--- a/app.js
+++ b/app.js
@@ -775,6 +775,11 @@ function initQuiz() {
         feedback.classList.add('hidden');
 
         const q = quizQuestions[currentQuestionIndex];
+        const shuffledOptions = [...q.options];
+        for (let i = shuffledOptions.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [shuffledOptions[i], shuffledOptions[j]] = [shuffledOptions[j], shuffledOptions[i]];
+        }
 
         // Set texts and fills
         currentQNum.innerText = currentQuestionIndex + 1;
@@ -783,7 +788,7 @@ function initQuiz() {
 
         // Load Options buttons
         optionsGrid.innerHTML = '';
-        q.options.forEach(opt => {
+        shuffledOptions.forEach(opt => {
             const btn = document.createElement('button');
             btn.className = 'option-btn';
             btn.innerText = opt;


### PR DESCRIPTION
## Description

This PR improves the **Food & State Quiz** by randomizing the order of answer options before they are displayed.

Previously, the correct answer always appeared as the first option, making the quiz predictable. This change shuffles the options while preserving the existing answer validation logic, resulting in a more engaging and fair quiz experience.

Fixes #58

## Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
