### PR TITLE
fix(ui): add poster fallback image for background hero video (fixes #192)

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
 
         <!-- Hero Section -->
         <section id="home" class="hero-section scroll-section">
-            <video autoplay muted loop class="hero-video">
+            <video autoplay muted loop class="hero-video" poster="assets/hero_banner.png">
                 <source
                     src="https://assets.mixkit.co/videos/preview/mixkit-landscape-of-mountains-and-a-lake-at-sunset-31514-large.mp4"
                     type="video/mp4">


### PR DESCRIPTION
## Description
This pull request resolves **Issue #192** where slow networks or offline state left the landing page hero section blank and dark because the background `<video>` element lacked a fallback banner image.

## Key Changes
- Added `poster="assets/hero_banner.png"` to the homepage hero background `<video>` tag.
- If the video is loading or fails to load entirely (due to lack of connection), the browser will display the beautiful pre-cached hero banner image asset, maintaining visual consistency and premium aesthetics.

## How to Test
1. Load the site locally.
2. In Chrome DevTools, go to the Network tab and choose **Slow 3G** or **Offline**.
3. Reload the page and verify that the page immediately displays the fallback hero image in the background instead of a black void.