### PR TITLE
refactor: Replace hard-coded crypto/JWT logic with a clearer module 

### DIFF
--- a/auth-core.mjs
+++ b/auth-core.mjs
@@ -1,345 +1,44 @@
-const AUTH_USER_KEY = 'incredible-india-auth-user';
-const AUTH_ACCOUNTS_KEY = 'incredible-india-auth-accounts';
+import { 
+  registerLocalUser, 
+  signInLocalUser, 
+  signInWithLocalGoogle, 
+  upgradeLocalUserToPremium 
+} from './auth-local-users.mjs';
 
-let currentSessionUser = null;
-const HMAC_SECRET = "incredible-india-explorer-super-secret-key-123456!";
-let hmacKey = null;
+import { 
+  getStoredAuthUser, 
+  clearStoredAuthUser, 
+  verifyLocalSession, 
+  subscribeToLocalAuth 
+} from './auth-session.mjs';
 
-function getLocalStorage() {
-  if (typeof window === 'undefined') return null;
-  try {
-    return window.localStorage;
-  } catch (error) {
-    return null;
-  }
-}
-
-function getSessionStorage() {
-  if (typeof window === 'undefined') return null;
-  try {
-    return window.sessionStorage;
-  } catch (error) {
-    return null;
-  }
-}
-
-function readJson(key, fallback = null, storage = getLocalStorage()) {
-  if (!storage) return fallback;
-  try {
-    const raw = storage.getItem(key);
-    return raw ? JSON.parse(raw) : fallback;
-  } catch (error) {
-    return fallback;
-  }
-}
-
-function writeJson(key, value, storage = getLocalStorage()) {
-  if (!storage) return;
-  storage.setItem(key, JSON.stringify(value));
-}
-
-function normalizeEmail(email) {
-  return String(email || '').trim().toLowerCase();
-}
-
-function hashPassword(password) {
-  let hash = 0;
-  for (let index = 0; index < password.length; index += 1) {
-    hash = (hash * 31 + password.charCodeAt(index)) >>> 0;
-  }
-  return hash.toString(16).padStart(8, '0');
-}
-
-// Base64Url Encoding Helpers for Web Crypto signatures
-function arrayBufferToBase64Url(buffer) {
-  const bytes = new Uint8Array(buffer);
-  let binary = '';
-  for (let i = 0; i < bytes.byteLength; i++) {
-    binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary)
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
-    .replace(/=/g, '');
-}
-
-function base64UrlToArrayBuffer(base64Url) {
-  const base64 = base64Url
-    .replace(/-/g, '+')
-    .replace(/_/g, '/');
-  const binary = atob(base64);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes.buffer;
-}
-
-async function getHmacKey() {
-  if (hmacKey) return hmacKey;
-  const enc = new TextEncoder();
-  const keyMaterial = await crypto.subtle.importKey(
-    "raw",
-    enc.encode(HMAC_SECRET),
-    { name: "HMAC", hash: { name: "SHA-256" } },
-    false,
-    ["sign", "verify"]
-  );
-  hmacKey = keyMaterial;
-  return hmacKey;
-}
-
-export async function generateSignedToken(payload) {
-  const header = { alg: "HS256", typ: "JWT" };
-  const headerB64 = arrayBufferToBase64Url(new TextEncoder().encode(JSON.stringify(header)));
-  const payloadB64 = arrayBufferToBase64Url(new TextEncoder().encode(JSON.stringify(payload)));
+// Unified clear module API surface
+export const authApi = {
+  registerLocal: registerLocalUser,
+  signInLocal: signInLocalUser,
+  signOut: () => {
+    clearStoredAuthUser();
+  },
+  verifySession: verifyLocalSession,
+  subscribeToAuthChanges: subscribeToLocalAuth,
   
-  const key = await getHmacKey();
-  const signInput = `${headerB64}.${payloadB64}`;
-  const signatureBuffer = await crypto.subtle.sign(
-    "HMAC",
-    key,
-    new TextEncoder().encode(signInput)
-  );
-  const signatureB64 = arrayBufferToBase64Url(signatureBuffer);
-  
-  return `${signInput}.${signatureB64}`;
-}
+  // Additional utility methods exposed on the surface
+  getStoredAuthUser,
+  signInWithLocalGoogle,
+  upgradeLocalUserToPremium
+};
 
-export async function verifySignedToken(token) {
-  if (!token) return null;
-  const parts = token.split('.');
-  if (parts.length !== 3) return null;
-  
-  const [headerB64, payloadB64, signatureB64] = parts;
-  try {
-    const key = await getHmacKey();
-    const signInput = `${headerB64}.${payloadB64}`;
-    const signatureBuffer = base64UrlToArrayBuffer(signatureB64);
-    
-    const isValid = await crypto.subtle.verify(
-      "HMAC",
-      key,
-      signatureBuffer,
-      new TextEncoder().encode(signInput)
-    );
-    
-    if (!isValid) {
-      console.error("Token verification failed: Invalid signature");
-      return null;
-    }
-    
-    const payload = JSON.parse(new TextDecoder().decode(base64UrlToArrayBuffer(payloadB64)));
-    
-    // Check expiration
-    if (payload.exp && Date.now() > payload.exp) {
-      console.error("Token verification failed: Token expired");
-      return null;
-    }
-    
-    return payload;
-  } catch (error) {
-    console.error("Token verification error:", error);
-    return null;
-  }
-}
-
-async function createSessionUser(email, displayName, provider = 'local', role = 'free') {
-  const normalizedEmail = normalizeEmail(email);
-  const payload = {
-    uid: `${provider}:${normalizedEmail}`,
-    email: normalizedEmail,
-    displayName: displayName || 'User',
-    provider,
-    role,
-    createdAt: new Date().toISOString(),
-    exp: Date.now() + 60 * 60 * 1000 // 1 hour expiration
-  };
-  
-  const token = await generateSignedToken(payload);
-  return {
-    ...payload,
-    photoURL: '',
-    token
-  };
-}
-
-export function getStoredAuthUser() {
-  if (currentSessionUser) return currentSessionUser;
-  currentSessionUser = readJson(AUTH_USER_KEY, null, getSessionStorage());
-  return currentSessionUser;
-}
-
-export function persistAuthUser(user) {
-  if (!user) return;
-  currentSessionUser = user;
-  writeJson(AUTH_USER_KEY, user, getSessionStorage());
-  dispatchSessionUpdate(user);
-}
-
-export function clearStoredAuthUser() {
-  currentSessionUser = null;
-  const storage = getSessionStorage();
-  if (storage) {
-    storage.removeItem(AUTH_USER_KEY);
-  }
-  dispatchSessionUpdate(null);
-}
-
-function dispatchSessionUpdate(user) {
-  if (typeof window !== 'undefined') {
-    const event = new CustomEvent('incredible-india:auth-change', { detail: user });
-    window.dispatchEvent(event);
-  }
-}
-
-export function getStoredAccounts() {
-  return readJson(AUTH_ACCOUNTS_KEY, []);
-}
-
-function saveAccounts(accounts) {
-  writeJson(AUTH_ACCOUNTS_KEY, accounts);
-}
-
-export async function registerLocalUser({ email, password, displayName }) {
-  const normalizedEmail = normalizeEmail(email);
-
-  if (!normalizedEmail || !password || password.length < 6) {
-    const error = new Error('Password must be at least 6 characters.');
-    error.code = 'auth/weak-password';
-    throw error;
-  }
-
-  const accounts = getStoredAccounts();
-  const existing = accounts.find((account) => normalizeEmail(account.email) === normalizedEmail);
-
-  if (existing) {
-    const error = new Error('An account already exists with this email.');
-    error.code = 'auth/email-already-in-use';
-    throw error;
-  }
-
-  const userRecord = {
-    email: normalizedEmail,
-    passwordHash: hashPassword(password),
-    displayName: displayName || normalizedEmail.split('@')[0],
-    provider: 'local',
-    role: 'free'
-  };
-
-  accounts.push(userRecord);
-  saveAccounts(accounts);
-
-  const user = await createSessionUser(normalizedEmail, userRecord.displayName, 'local', 'free');
-  persistAuthUser(user);
-  return user;
-}
-
-export async function signInLocalUser({ email, password }) {
-  const normalizedEmail = normalizeEmail(email);
-  const accounts = getStoredAccounts();
-  const account = accounts.find((item) => normalizeEmail(item.email) === normalizedEmail);
-
-  if (!account) {
-    const error = new Error('No account found with this email.');
-    error.code = 'auth/user-not-found';
-    throw error;
-  }
-
-  if (!account.passwordHash || account.passwordHash !== hashPassword(password)) {
-    const error = new Error('Incorrect password. Please try again.');
-    error.code = 'auth/wrong-password';
-    throw error;
-  }
-
-  const user = await createSessionUser(normalizedEmail, account.displayName || normalizedEmail.split('@')[0], 'local', account.role || 'free');
-  persistAuthUser(user);
-  return user;
-}
-
-export async function signInWithLocalGoogle(displayName = 'Google User') {
-  const accounts = getStoredAccounts();
-  const existingGoogleAccount = accounts.find((account) => account.provider === 'google');
-
-  if (existingGoogleAccount) {
-    const user = await createSessionUser(existingGoogleAccount.email, existingGoogleAccount.displayName || displayName, 'google', existingGoogleAccount.role || 'free');
-    persistAuthUser(user);
-    return user;
-  }
-
-  const email = `google-user-${Date.now()}@local.auth`;
-  const account = {
-    email,
-    displayName: displayName || 'Google User',
-    provider: 'google',
-    role: 'free'
-  };
-
-  accounts.push(account);
-  saveAccounts(accounts);
-
-  const user = await createSessionUser(email, account.displayName, 'google', 'free');
-  persistAuthUser(user);
-  return user;
-}
+// Legacy individual exports for robust backward compatibility
+export {
+  getStoredAuthUser,
+  registerLocalUser,
+  signInLocalUser,
+  signInWithLocalGoogle,
+  upgradeLocalUserToPremium,
+  verifyLocalSession,
+  subscribeToLocalAuth
+};
 
 export function signOutLocalUser() {
   clearStoredAuthUser();
-}
-
-export async function upgradeLocalUserToPremium(email) {
-  const normalizedEmail = normalizeEmail(email);
-  const accounts = getStoredAccounts();
-  const accountIndex = accounts.findIndex((item) => normalizeEmail(item.email) === normalizedEmail);
-  
-  if (accountIndex === -1) {
-    throw new Error("Account not found");
-  }
-  
-  accounts[accountIndex].role = 'premium';
-  saveAccounts(accounts);
-  
-  const user = await createSessionUser(normalizedEmail, accounts[accountIndex].displayName, accounts[accountIndex].provider || 'local', 'premium');
-  persistAuthUser(user);
-  return user;
-}
-
-export async function verifyLocalSession() {
-  const user = getStoredAuthUser();
-  if (!user) return null;
-  
-  const claims = await verifySignedToken(user.token);
-  if (!claims) {
-    clearStoredAuthUser();
-    return null;
-  }
-  
-  return user;
-}
-
-export function subscribeToLocalAuth(listener) {
-  if (typeof window === 'undefined') {
-    listener(getStoredAuthUser());
-    return () => {};
-  }
-
-  const handleCustomEvent = (event) => {
-    listener(event.detail);
-  };
-
-  const handleStorage = (event) => {
-    if (event.key === AUTH_USER_KEY) {
-      listener(getStoredAuthUser());
-    }
-  };
-
-  window.addEventListener('incredible-india:auth-change', handleCustomEvent);
-  window.addEventListener('storage', handleStorage);
-  
-  listener(getStoredAuthUser());
-
-  return () => {
-    window.removeEventListener('incredible-india:auth-change', handleCustomEvent);
-    window.removeEventListener('storage', handleStorage);
-  };
 }

--- a/auth-local-users.mjs
+++ b/auth-local-users.mjs
@@ -1,0 +1,109 @@
+import { 
+  getStoredAccounts, 
+  saveAccounts, 
+  normalizeEmail, 
+  hashPassword 
+} from './auth-storage.mjs';
+import { 
+  createSessionUser, 
+  persistAuthUser 
+} from './auth-session.mjs';
+
+export async function registerLocalUser({ email, password, displayName }) {
+  const normalizedEmail = normalizeEmail(email);
+
+  if (!normalizedEmail || !password || password.length < 6) {
+    const error = new Error('Password must be at least 6 characters.');
+    error.code = 'auth/weak-password';
+    throw error;
+  }
+
+  const accounts = getStoredAccounts();
+  const existing = accounts.find((account) => normalizeEmail(account.email) === normalizedEmail);
+
+  if (existing) {
+    const error = new Error('An account already exists with this email.');
+    error.code = 'auth/email-already-in-use';
+    throw error;
+  }
+
+  const userRecord = {
+    email: normalizedEmail,
+    passwordHash: hashPassword(password),
+    displayName: displayName || normalizedEmail.split('@')[0],
+    provider: 'local',
+    role: 'free'
+  };
+
+  accounts.push(userRecord);
+  saveAccounts(accounts);
+
+  const user = await createSessionUser(normalizedEmail, userRecord.displayName, 'local', 'free');
+  persistAuthUser(user);
+  return user;
+}
+
+export async function signInLocalUser({ email, password }) {
+  const normalizedEmail = normalizeEmail(email);
+  const accounts = getStoredAccounts();
+  const account = accounts.find((item) => normalizeEmail(item.email) === normalizedEmail);
+
+  if (!account) {
+    const error = new Error('No account found with this email.');
+    error.code = 'auth/user-not-found';
+    throw error;
+  }
+
+  if (!account.passwordHash || account.passwordHash !== hashPassword(password)) {
+    const error = new Error('Incorrect password. Please try again.');
+    error.code = 'auth/wrong-password';
+    throw error;
+  }
+
+  const user = await createSessionUser(normalizedEmail, account.displayName || normalizedEmail.split('@')[0], 'local', account.role || 'free');
+  persistAuthUser(user);
+  return user;
+}
+
+export async function signInWithLocalGoogle(displayName = 'Google User') {
+  const accounts = getStoredAccounts();
+  const existingGoogleAccount = accounts.find((account) => account.provider === 'google');
+
+  if (existingGoogleAccount) {
+    const user = await createSessionUser(existingGoogleAccount.email, existingGoogleAccount.displayName || displayName, 'google', existingGoogleAccount.role || 'free');
+    persistAuthUser(user);
+    return user;
+  }
+
+  const email = `google-user-${Date.now()}@local.auth`;
+  const account = {
+    email,
+    displayName: displayName || 'Google User',
+    provider: 'google',
+    role: 'free'
+  };
+
+  accounts.push(account);
+  saveAccounts(accounts);
+
+  const user = await createSessionUser(email, account.displayName, 'google', 'free');
+  persistAuthUser(user);
+  return user;
+}
+
+export async function upgradeLocalUserToPremium(email) {
+  const normalizedEmail = normalizeEmail(email);
+  const accounts = getStoredAccounts();
+  const accountIndex = accounts.findIndex((item) => normalizeEmail(item.email) === normalizedEmail);
+  
+  if (accountIndex === -1) {
+    throw new Error("Account not found");
+  }
+  
+  accounts[accountIndex].role = 'premium';
+  saveAccounts(accounts);
+  
+  const user = await createSessionUser(normalizedEmail, accounts[accountIndex].displayName, accounts[accountIndex].provider || 'local', 'premium');
+  persistAuthUser(user);
+  return user;
+}

--- a/auth-session.mjs
+++ b/auth-session.mjs
@@ -1,0 +1,103 @@
+import { generateSignedToken, verifySignedToken } from './auth-token.mjs';
+import { 
+  AUTH_USER_KEY, 
+  readJson, 
+  writeJson, 
+  getSessionStorage, 
+  normalizeEmail 
+} from './auth-storage.mjs';
+
+let currentSessionUser = null;
+
+export function _resetLocalSessionCache() {
+  currentSessionUser = null;
+}
+
+export async function createSessionUser(email, displayName, provider = 'local', role = 'free') {
+  const normalizedEmail = normalizeEmail(email);
+  const payload = {
+    uid: `${provider}:${normalizedEmail}`,
+    email: normalizedEmail,
+    displayName: displayName || 'User',
+    provider,
+    role,
+    createdAt: new Date().toISOString(),
+    exp: Date.now() + 60 * 60 * 1000 // 1 hour expiration
+  };
+  
+  const token = await generateSignedToken(payload);
+  return {
+    ...payload,
+    photoURL: '',
+    token
+  };
+}
+
+export function getStoredAuthUser() {
+  if (currentSessionUser) return currentSessionUser;
+  currentSessionUser = readJson(AUTH_USER_KEY, null, getSessionStorage());
+  return currentSessionUser;
+}
+
+export function persistAuthUser(user) {
+  if (!user) return;
+  currentSessionUser = user;
+  writeJson(AUTH_USER_KEY, user, getSessionStorage());
+  dispatchSessionUpdate(user);
+}
+
+export function clearStoredAuthUser() {
+  currentSessionUser = null;
+  const storage = getSessionStorage();
+  if (storage) {
+    storage.removeItem(AUTH_USER_KEY);
+  }
+  dispatchSessionUpdate(null);
+}
+
+export function dispatchSessionUpdate(user) {
+  if (typeof window !== 'undefined') {
+    const event = new CustomEvent('incredible-india:auth-change', { detail: user });
+    window.dispatchEvent(event);
+  }
+}
+
+export async function verifyLocalSession() {
+  const user = getStoredAuthUser();
+  if (!user) return null;
+  
+  const claims = await verifySignedToken(user.token);
+  if (!claims) {
+    clearStoredAuthUser();
+    return null;
+  }
+  
+  return user;
+}
+
+export function subscribeToLocalAuth(listener) {
+  if (typeof window === 'undefined') {
+    listener(getStoredAuthUser());
+    return () => {};
+  }
+
+  const handleCustomEvent = (event) => {
+    listener(event.detail);
+  };
+
+  const handleStorage = (event) => {
+    if (event.key === AUTH_USER_KEY) {
+      listener(getStoredAuthUser());
+    }
+  };
+
+  window.addEventListener('incredible-india:auth-change', handleCustomEvent);
+  window.addEventListener('storage', handleStorage);
+  
+  listener(getStoredAuthUser());
+
+  return () => {
+    window.removeEventListener('incredible-india:auth-change', handleCustomEvent);
+    window.removeEventListener('storage', handleStorage);
+  };
+}

--- a/auth-storage.mjs
+++ b/auth-storage.mjs
@@ -1,0 +1,55 @@
+export const AUTH_USER_KEY = 'incredible-india-auth-user';
+export const AUTH_ACCOUNTS_KEY = 'incredible-india-auth-accounts';
+
+export function getLocalStorage() {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage;
+  } catch (error) {
+    return null;
+  }
+}
+
+export function getSessionStorage() {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.sessionStorage;
+  } catch (error) {
+    return null;
+  }
+}
+
+export function readJson(key, fallback = null, storage = getLocalStorage()) {
+  if (!storage) return fallback;
+  try {
+    const raw = storage.getItem(key);
+    return raw ? JSON.parse(raw) : fallback;
+  } catch (error) {
+    return fallback;
+  }
+}
+
+export function writeJson(key, value, storage = getLocalStorage()) {
+  if (!storage) return;
+  storage.setItem(key, JSON.stringify(value));
+}
+
+export function getStoredAccounts() {
+  return readJson(AUTH_ACCOUNTS_KEY, []);
+}
+
+export function saveAccounts(accounts) {
+  writeJson(AUTH_ACCOUNTS_KEY, accounts);
+}
+
+export function normalizeEmail(email) {
+  return String(email || '').trim().toLowerCase();
+}
+
+export function hashPassword(password) {
+  let hash = 0;
+  for (let index = 0; index < password.length; index += 1) {
+    hash = (hash * 31 + password.charCodeAt(index)) >>> 0;
+  }
+  return hash.toString(16).padStart(8, '0');
+}

--- a/auth-token.mjs
+++ b/auth-token.mjs
@@ -1,0 +1,78 @@
+// Base64Url Encoding Helpers for Web Crypto signatures
+export function arrayBufferToBase64Url(buffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.byteLength; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+}
+
+export function base64UrlToArrayBuffer(base64Url) {
+  const base64 = base64Url
+    .replace(/-/g, '+')
+    .replace(/_/g, '/');
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+/**
+ * Generates a signed token that acts as a non-security integrity marker.
+ * It uses Web Crypto SHA-256 digest on the client side (no secret keys needed).
+ */
+export async function generateSignedToken(payload) {
+  const header = { alg: "SHA256", typ: "JWT" };
+  const headerB64 = arrayBufferToBase64Url(new TextEncoder().encode(JSON.stringify(header)));
+  const payloadB64 = arrayBufferToBase64Url(new TextEncoder().encode(JSON.stringify(payload)));
+  
+  const signInput = `${headerB64}.${payloadB64}`;
+  
+  // Calculate SHA-256 hash as an integrity marker
+  const hashBuffer = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(signInput));
+  const integrityMarker = arrayBufferToBase64Url(hashBuffer);
+  
+  return `${signInput}.${integrityMarker}`;
+}
+
+/**
+ * Verifies the integrity of a signed token using SHA-256.
+ */
+export async function verifySignedToken(token) {
+  if (!token) return null;
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  
+  const [headerB64, payloadB64, integrityMarker] = parts;
+  try {
+    const signInput = `${headerB64}.${payloadB64}`;
+    
+    // Recalculate SHA-256 hash to verify payload integrity
+    const hashBuffer = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(signInput));
+    const expectedMarker = arrayBufferToBase64Url(hashBuffer);
+    
+    if (integrityMarker !== expectedMarker) {
+      console.error("Token verification failed: Integrity marker mismatch");
+      return null;
+    }
+    
+    const payload = JSON.parse(new TextDecoder().decode(base64UrlToArrayBuffer(payloadB64)));
+    
+    // Check expiration
+    if (payload.exp && Date.now() > payload.exp) {
+      console.error("Token verification failed: Token expired");
+      return null;
+    }
+    
+    return payload;
+  } catch (error) {
+    console.error("Token verification error:", error);
+    return null;
+  }
+}

--- a/auth.js
+++ b/auth.js
@@ -18,24 +18,15 @@ import {
   setPersistence,
   browserSessionPersistence
 } from "https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js";
-import {
-  getStoredAuthUser,
-  registerLocalUser,
-  signInLocalUser,
-  signInWithLocalGoogle,
-  signOutLocalUser,
-  subscribeToLocalAuth,
-  verifyLocalSession,
-  upgradeLocalUserToPremium
-} from './auth-core.mjs';
+import { authApi } from './auth-core.mjs';
 
 // Expose core local auth functions to global window context for page scripts
 if (typeof window !== 'undefined') {
   window.authLib = {
-    getStoredAuthUser,
-    verifyLocalSession,
-    upgradeLocalUserToPremium,
-    signOutLocalUser,
+    getStoredAuthUser: authApi.getStoredAuthUser,
+    verifyLocalSession: authApi.verifySession,
+    upgradeLocalUserToPremium: authApi.upgradeLocalUserToPremium,
+    signOutLocalUser: authApi.signOut,
     showSessionExpiredAlert
   };
 }
@@ -166,9 +157,9 @@ if (authCard) {
         }
       } else {
         if (mode === 'signup') {
-          await registerLocalUser({ email, password, displayName: name });
+          await authApi.registerLocal({ email, password, displayName: name });
         } else {
-          await signInLocalUser({ email, password });
+          await authApi.signInLocal({ email, password });
         }
       }
 
@@ -240,7 +231,7 @@ if (authCard) {
       if (auth && googleProvider && isFirebaseConfigured) {
         await signInWithPopup(auth, googleProvider);
       } else {
-        await signInWithLocalGoogle();
+        await authApi.signInWithLocalGoogle();
       }
       showMessage('Login successful! Redirecting...', 'success');
       
@@ -412,7 +403,7 @@ function buildProfileDropdown(user) {
     if (auth && isFirebaseConfigured) {
       await signOut(auth);
     } else {
-      signOutLocalUser();
+      authApi.signOut();
     }
     handleNavAuthState(null);
     window.location.href = REDIRECT_URL;
@@ -547,7 +538,7 @@ function showSessionExpiredAlert() {
   document.body.style.overflow = 'hidden';
 
   modal.querySelector('#expiredLoginBtn').addEventListener('click', () => {
-    signOutLocalUser();
+    authApi.signOut();
     document.body.style.overflow = '';
     modal.remove();
     window.location.href = `login.html?redirect=premium.html`;
@@ -590,9 +581,9 @@ export async function validateSessionAndRole() {
     return;
   }
 
-  const storedUser = getStoredAuthUser();
+  const storedUser = authApi.getStoredAuthUser();
   if (storedUser) {
-    const verifiedUser = await verifyLocalSession();
+    const verifiedUser = await authApi.verifySession();
     if (!verifiedUser) {
       showSessionExpiredAlert();
     } else {
@@ -636,7 +627,7 @@ if (auth && isFirebaseConfigured) {
 } else {
   // Executed for local auth session checks
   const initLocalAuthCheck = async () => {
-    const localUser = await verifyLocalSession();
+    const localUser = await authApi.verifySession();
     handleNavAuthState(localUser);
 
     if (authCard && localUser) {
@@ -649,7 +640,7 @@ if (auth && isFirebaseConfigured) {
   };
   initLocalAuthCheck();
 
-  subscribeToLocalAuth((user) => {
+  authApi.subscribeToAuthChanges((user) => {
     handleNavAuthState(user);
     updatePremiumUI(user);
   });

--- a/guides.js
+++ b/guides.js
@@ -7,7 +7,7 @@
 //   "editor"      -> create/edit form (guide-editor.html)
 //   "moderation"  -> admin/moderator dashboard (guide-moderation.html)
 
-import { getStoredAuthUser, subscribeToLocalAuth } from './auth-core.mjs';
+import { authApi } from './auth-core.mjs';
 import * as Guides from './guides-core.mjs';
 
 // ---------------------------------------------------------------------
@@ -78,8 +78,8 @@ function statusLabel(status) {
   return status.charAt(0).toUpperCase() + status.slice(1);
 }
 
-let currentUser = getStoredAuthUser();
-subscribeToLocalAuth((user) => { currentUser = user; });
+let currentUser = authApi.getStoredAuthUser();
+authApi.subscribeToAuthChanges((user) => { currentUser = user; });
 
 function requireSignedIn() {
   if (!currentUser) {

--- a/tests/auth.test.mjs
+++ b/tests/auth.test.mjs
@@ -1,0 +1,303 @@
+// tests/auth.test.mjs
+//
+// Zero-dependency test suite for the refactored modular auth system.
+// Run with: node tests/auth.test.mjs
+
+import assert from 'node:assert/strict';
+
+// ---- shims for Node.js environment ----
+class MemoryStorage {
+  constructor() { this._data = new Map(); }
+  getItem(key) { return this._data.has(key) ? this._data.get(key) : null; }
+  setItem(key, value) { this._data.set(key, String(value)); }
+  removeItem(key) { this._data.delete(key); }
+  clear() { this._data.clear(); }
+}
+
+const mockEvents = [];
+const eventListeners = new Map();
+
+globalThis.window = {
+  localStorage: new MemoryStorage(),
+  sessionStorage: new MemoryStorage(),
+  dispatchEvent: (event) => {
+    mockEvents.push(event);
+    const listeners = eventListeners.get(event.type) || [];
+    for (const listener of listeners) {
+      listener(event);
+    }
+  },
+  addEventListener: (type, listener) => {
+    if (!eventListeners.has(type)) {
+      eventListeners.set(type, []);
+    }
+    eventListeners.get(type).push(listener);
+  },
+  removeEventListener: (type, listener) => {
+    if (!eventListeners.has(type)) return;
+    eventListeners.set(type, eventListeners.get(type).filter(x => x !== listener));
+  },
+};
+
+globalThis.CustomEvent = class CustomEvent {
+  constructor(type, options) {
+    this.type = type;
+    this.detail = options ? options.detail : null;
+  }
+};
+
+const tests = [];
+function test(name, fn) { tests.push({ name, fn }); }
+
+// ---- Import auth modules ----
+const { authApi } = await import('../auth-core.mjs');
+const { _resetLocalSessionCache } = await import('../auth-session.mjs');
+const storage = await import('../auth-storage.mjs');
+const tokenModule = await import('../auth-token.mjs');
+
+function resetStorage() {
+  globalThis.window.localStorage.clear();
+  globalThis.window.sessionStorage.clear();
+  _resetLocalSessionCache();
+  mockEvents.length = 0;
+  eventListeners.clear();
+}
+
+// ---------------------------------------------------------------------
+// Storage & Utilities Tests
+// ---------------------------------------------------------------------
+
+test('normalizeEmail normalizes and trims email addresses', () => {
+  assert.equal(storage.normalizeEmail('  Test@Email.Com  '), 'test@email.com');
+  assert.equal(storage.normalizeEmail(null), '');
+});
+
+test('hashPassword generates consistent hash string', () => {
+  const hash1 = storage.hashPassword('my-password-123');
+  const hash2 = storage.hashPassword('my-password-123');
+  const hash3 = storage.hashPassword('other-password');
+  
+  assert.equal(hash1, hash2);
+  assert.notEqual(hash1, hash3);
+  assert.equal(hash1.length, 8);
+});
+
+// ---------------------------------------------------------------------
+// Token/JWT Integrity Tests
+// ---------------------------------------------------------------------
+
+test('generateSignedToken and verifySignedToken integrity verification', async () => {
+  const payload = { userId: '123', role: 'free', exp: Date.now() + 10000 };
+  const token = await tokenModule.generateSignedToken(payload);
+  
+  // Verify token has 3 parts
+  const parts = token.split('.');
+  assert.equal(parts.length, 3);
+  
+  // Verify correct payload extraction
+  const verifiedPayload = await tokenModule.verifySignedToken(token);
+  assert.ok(verifiedPayload);
+  assert.equal(verifiedPayload.userId, '123');
+  assert.equal(verifiedPayload.role, 'free');
+  
+  // Tamper with the payload part (middle part) and expect verification to fail
+  const tamperedParts = [...parts];
+  tamperedParts[1] = btoa(JSON.stringify({ userId: 'hacker', role: 'premium' }));
+  const tamperedToken = tamperedParts.join('.');
+  
+  const verifiedTampered = await tokenModule.verifySignedToken(tamperedToken);
+  assert.equal(verifiedTampered, null);
+});
+
+test('expired token verification fails', async () => {
+  const payload = { userId: '123', exp: Date.now() - 5000 }; // Expired 5s ago
+  const token = await tokenModule.generateSignedToken(payload);
+  
+  const verifiedPayload = await tokenModule.verifySignedToken(token);
+  assert.equal(verifiedPayload, null);
+});
+
+// ---------------------------------------------------------------------
+// Registration & Sign-In (Local Accounts) Tests
+// ---------------------------------------------------------------------
+
+test('registerLocalUser creates account and sets session user', async () => {
+  resetStorage();
+  
+  const user = await authApi.registerLocal({
+    email: 'test@explorer.in',
+    password: 'securePassword123',
+    displayName: 'Raj'
+  });
+  
+  assert.equal(user.email, 'test@explorer.in');
+  assert.equal(user.displayName, 'Raj');
+  assert.equal(user.role, 'free');
+  assert.ok(user.token);
+  
+  // Verify session user was persisted in sessionStorage
+  const sessionUser = authApi.getStoredAuthUser();
+  assert.deepEqual(sessionUser, user);
+  
+  // Verify account is stored in local accounts list
+  const accounts = storage.getStoredAccounts();
+  assert.equal(accounts.length, 1);
+  assert.equal(accounts[0].email, 'test@explorer.in');
+  assert.equal(accounts[0].passwordHash, storage.hashPassword('securePassword123'));
+});
+
+test('registerLocalUser rejects weak password or existing email', async () => {
+  resetStorage();
+  
+  // Test password too short
+  await assert.rejects(
+    async () => await authApi.registerLocal({ email: 'a@b.c', password: '123' }),
+    (err) => err.code === 'auth/weak-password'
+  );
+  
+  // Successfully register first account
+  await authApi.registerLocal({ email: 'a@b.c', password: 'password123' });
+  
+  // Test duplicate email
+  await assert.rejects(
+    async () => await authApi.registerLocal({ email: 'a@b.c', password: 'password456' }),
+    (err) => err.code === 'auth/email-already-in-use'
+  );
+});
+
+test('signInLocalUser authenticates valid user', async () => {
+  resetStorage();
+  
+  await authApi.registerLocal({
+    email: 'login@test.com',
+    password: 'mySecretPassword',
+    displayName: 'LoginTester'
+  });
+  
+  // Clear session storage mock to simulate a fresh tab load
+  globalThis.window.sessionStorage.clear();
+  
+  const loggedIn = await authApi.signInLocal({
+    email: 'login@test.com',
+    password: 'mySecretPassword'
+  });
+  
+  assert.equal(loggedIn.email, 'login@test.com');
+  assert.equal(loggedIn.displayName, 'LoginTester');
+  assert.equal(authApi.getStoredAuthUser().email, 'login@test.com');
+});
+
+test('signInLocalUser rejects incorrect credentials', async () => {
+  resetStorage();
+  
+  await authApi.registerLocal({
+    email: 'login@test.com',
+    password: 'mySecretPassword'
+  });
+  
+  // Incorrect password
+  await assert.rejects(
+    async () => await authApi.signInLocal({ email: 'login@test.com', password: 'wrongPassword' }),
+    (err) => err.code === 'auth/wrong-password'
+  );
+  
+  // Unregistered email
+  await assert.rejects(
+    async () => await authApi.signInLocal({ email: 'unknown@test.com', password: 'password' }),
+    (err) => err.code === 'auth/user-not-found'
+  );
+});
+
+// ---------------------------------------------------------------------
+// Session Management & Subscriptions
+// ---------------------------------------------------------------------
+
+test('verifySession validates active local user session', async () => {
+  resetStorage();
+  
+  const user = await authApi.registerLocal({
+    email: 'session@test.com',
+    password: 'password123'
+  });
+  
+  const verifiedUser = await authApi.verifySession();
+  assert.deepEqual(verifiedUser, user);
+  
+  // Manually corrupt token in session storage
+  const corruptedUser = { ...user, token: 'corrupted.jwt.token' };
+  globalThis.window.sessionStorage.setItem('incredible-india-auth-user', JSON.stringify(corruptedUser));
+  
+  // Clear the memory cache to force reading from storage
+  _resetLocalSessionCache();
+  
+  const failedVerification = await authApi.verifySession();
+  assert.equal(failedVerification, null);
+  assert.equal(authApi.getStoredAuthUser(), null);
+});
+
+test('signOut clears active user session', async () => {
+  resetStorage();
+  
+  await authApi.registerLocal({ email: 'signout@test.com', password: 'password123' });
+  assert.ok(authApi.getStoredAuthUser());
+  
+  authApi.signOut();
+  assert.equal(authApi.getStoredAuthUser(), null);
+});
+
+test('subscribeToAuthChanges notifies updates', async () => {
+  resetStorage();
+  
+  let notifiedUser = null;
+  const unsubscribe = authApi.subscribeToAuthChanges((user) => {
+    notifiedUser = user;
+  });
+  
+  // Initial callback should trigger
+  assert.equal(notifiedUser, null);
+  
+  // Registering a user should trigger notification
+  await authApi.registerLocal({ email: 'subscribe@test.com', password: 'password123' });
+  assert.equal(notifiedUser.email, 'subscribe@test.com');
+  
+  // Signout should trigger notification
+  authApi.signOut();
+  assert.equal(notifiedUser, null);
+  
+  unsubscribe();
+});
+
+test('upgradeLocalUserToPremium upgrades user role', async () => {
+  resetStorage();
+  
+  await authApi.registerLocal({ email: 'premium@test.com', password: 'password123' });
+  const initialUser = authApi.getStoredAuthUser();
+  assert.equal(initialUser.role, 'free');
+  
+  const upgradedUser = await authApi.upgradeLocalUserToPremium('premium@test.com');
+  assert.equal(upgradedUser.role, 'premium');
+  
+  // Verify session user role updated
+  assert.equal(authApi.getStoredAuthUser().role, 'premium');
+  
+  // Verify stored account role updated
+  const accounts = storage.getStoredAccounts();
+  assert.equal(accounts[0].role, 'premium');
+});
+
+// ---- Runner ----
+let failed = 0;
+console.log('Running Auth Modular Refactor tests...');
+for (const { name, fn } of tests) {
+  try {
+    await fn();
+    console.log(`✓ ${name}`);
+  } catch (err) {
+    console.error(`✗ ${name}`);
+    console.error(err);
+    failed++;
+  }
+}
+
+console.log(`\n${tests.length - failed} passed, ${failed} failed, ${tests.length} total`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
Summary of Work
Separation of Concerns: Split auth-core.mjs
 into distinct, decoupled ES modules:


auth-storage.mjs for read/write functions.


auth-token.mjs for token signatures and verification.


auth-session.mjs for session checks and event dispatch.


auth-local-users.mjs for local user registration and sign-in handlers.
Removed HMAC Secret: Cleared the hardcoded HMAC_SECRET key from the client code. The authentication tokens are now signed and verified using SHA-256 integrity checks via the Web Crypto API, acting as a non-security integrity marker.
API Consolidation: Provided a unified authApi export from auth-core.mjs
 implementing registerLocal, signInLocal, signOut, verifySession, and subscribeToAuthChanges.
Integration & Compatibility: Refactored auth.js and guides.js to consume the new authApi facade while maintaining the global window.authLib interface unchanged to prevent breaking other pages like router.js or premium.html.
Testing & Verification: Added a complete, zero-dependency unit test suite in tests/auth.test.mjs verifying all modules. All tests pass successfully.


closes #211