### PR TITLE
fix(router): resolve relative navbar and footer links in subdirectories

### DIFF
--- a/router.js
+++ b/router.js
@@ -417,10 +417,10 @@ class Router {
 
         // Record initial script and style states
         document.querySelectorAll('script[src]').forEach(s => {
-            this.loadedScripts.add(s.getAttribute('src'));
+            this.loadedScripts.add(s.src);
         });
         document.querySelectorAll('link[rel="stylesheet"]').forEach(l => {
-            this.loadedStyles.add(l.getAttribute('href'));
+            this.loadedStyles.add(l.href);
         });
 
         // Set global access hooks
@@ -541,13 +541,16 @@ class Router {
                 this.appRoot.innerHTML = newMain.innerHTML;
 
                 // Sync new styles in document head
-                await this.processHead(doc);
+                await this.processHead(doc, path);
+
+                // Sync header and footer relative URLs and active classes
+                this.syncHeaderFooter(doc, this.currentPath, path);
 
                 // Set tracking route for scripts
                 this.currentPath = path;
 
                 // Process and evaluate new scripts
-                this.processBodyScripts(doc);
+                this.processBodyScripts(doc, path);
 
                 if (push) {
                     window.history.pushState(null, '', path);
@@ -592,29 +595,104 @@ class Router {
         }
     }
 
-    processHead(doc) {
+    syncHeaderFooter(doc, currentPagePath, newPagePath) {
+        const currentNavbar = document.getElementById('navbar') || document.querySelector('header');
+        const newNavbar = doc.getElementById('navbar') || doc.querySelector('header');
+        const currentFooter = document.querySelector('footer');
+        const newFooter = doc.querySelector('footer');
+
+        const currentPageUrl = new URL(currentPagePath, window.location.origin).href;
+        const newPageUrl = new URL(newPagePath, window.location.origin).href;
+
+        const updateLinks = (currentContainer, newContainer) => {
+            if (!currentContainer || !newContainer) return;
+            const currentLinks = Array.from(currentContainer.querySelectorAll('a'));
+            const newLinks = Array.from(newContainer.querySelectorAll('a'));
+
+            newLinks.forEach(newLink => {
+                const newHrefAttr = newLink.getAttribute('href');
+                if (!newHrefAttr) return;
+
+                // Resolve new absolute URL
+                let newAbsUrl;
+                try {
+                    newAbsUrl = new URL(newHrefAttr, newPageUrl).href;
+                } catch (e) {
+                    return; // Invalid URL
+                }
+
+                // Find matching link in current links
+                let matchedLink = null;
+                
+                // 1. Try matching by ID if present
+                const newId = newLink.id;
+                if (newId) {
+                    matchedLink = currentLinks.find(l => l.id === newId);
+                }
+
+                // 2. Try matching by resolved absolute URL target
+                if (!matchedLink) {
+                    matchedLink = currentLinks.find(l => {
+                        const curHrefAttr = l.getAttribute('href');
+                        if (!curHrefAttr) return false;
+                        try {
+                            return new URL(curHrefAttr, currentPageUrl).href === newAbsUrl;
+                        } catch (e) {
+                            return false;
+                        }
+                    });
+                }
+
+                // 3. Fallback: Try matching by exact text content
+                if (!matchedLink) {
+                    const newText = newLink.textContent.trim();
+                    if (newText) {
+                        matchedLink = currentLinks.find(l => l.textContent.trim() === newText);
+                    }
+                }
+
+                // If found, update attributes
+                if (matchedLink) {
+                    matchedLink.setAttribute('href', newHrefAttr);
+                    if (newLink.className) {
+                        matchedLink.className = newLink.className;
+                    } else {
+                        matchedLink.removeAttribute('class');
+                    }
+                }
+            });
+        };
+
+        updateLinks(currentNavbar, newNavbar);
+        updateLinks(currentFooter, newFooter);
+    }
+
+    processHead(doc, path) {
         const promises = [];
         doc.querySelectorAll('link[rel="stylesheet"]').forEach(link => {
             const href = link.getAttribute('href');
-            if (href && !this.loadedStyles.has(href)) {
-                const newLink = document.createElement('link');
-                newLink.rel = 'stylesheet';
-                newLink.href = href;
+            if (href) {
+                const absoluteHref = new URL(href, new URL(path, window.location.origin)).href;
+                if (!this.loadedStyles.has(absoluteHref)) {
+                    const newLink = document.createElement('link');
+                    newLink.rel = 'stylesheet';
+                    newLink.href = href;
 
-                const p = new Promise(resolve => {
-                    newLink.onload = () => resolve();
-                    newLink.onerror = () => resolve();
-                });
-                promises.push(p);
+                    const p = new Promise(resolve => {
+                        newLink.onload = () => resolve();
+                        newLink.onerror = () => resolve();
+                    });
+                    promises.push(p);
 
-                document.head.appendChild(newLink);
-                this.loadedStyles.add(href);
+                    document.head.appendChild(newLink);
+                    this.loadedStyles.add(absoluteHref);
+                }
             }
         });
         return Promise.all(promises);
     }
 
-    processBodyScripts(doc) {
+    processBodyScripts(doc, path) {
         const scripts = [...doc.querySelectorAll('script')];
 
         scripts.forEach(oldScript => {
@@ -622,7 +700,8 @@ class Router {
 
             if (src) {
                 // External script execution
-                if (!this.loadedScripts.has(src)) {
+                const absoluteSrc = new URL(src, new URL(path, window.location.origin)).href;
+                if (!this.loadedScripts.has(absoluteSrc)) {
                     const newScript = document.createElement('script');
                     newScript.src = src;
                     Array.from(oldScript.attributes).forEach(attr => {
@@ -631,7 +710,7 @@ class Router {
                         }
                     });
                     document.body.appendChild(newScript);
-                    this.loadedScripts.add(src);
+                    this.loadedScripts.add(absoluteSrc);
                 }
             } else {
                 // Inline script sandbox wrapper processing


### PR DESCRIPTION
### Target Files
`router.js`

### Root Cause Analysis
The SPA routing engine (`router.js`) replaces content inside the `<main id="app-root">` element during page transitions. However, `<header>` and `<footer>` elements are left unchanged in the DOM. Since they contain relative links (e.g. `cuisine.html` or `../cuisine.html`), the browser resolves these paths relative to the current address bar URL instead of the document they originated from. If navigating to a subdirectory (like `/freedom-timeline/index.html` or `/states/rj.html`), any click on these navbar/footer links resolves to a non-existent subdirectory path (e.g. `/freedom-timeline/cuisine.html`), triggering a 404 error and breaking SPA navigation.

### Proposed Changes
1. **Dynamic Attribute Synchronization (`syncHeaderFooter`)**: Mutates `href` and `class` attributes of links in DOM header and footer to match the correct relative URLs of the target page parsed from the fetched HTML response.
2. **Event Listener Preservation**: Mutates attributes directly on existing DOM nodes instead of replacing `<header>` and `<footer>` elements, preserving all registered event listeners (such as theme toggle, mobile toggle, and search trigger).
3. **Absolute URL Deduplication**: Resolves relative pathnames of styles and scripts to fully qualified absolute URLs before deduplicating in `loadedScripts` and `loadedStyles` sets. This prevents duplicate loading/execution of script assets.

### Verification
- Standalone path resolution test suite executed successfully via Node, asserting all directory transitions correctly calculate relative paths:
  - `/index.html` -> `/freedom-timeline/index.html` (resolves to `../cuisine.html`)
  - `/freedom-timeline/index.html` -> `/cuisine.html` (resolves to `cuisine.html`)
  - `/states/rj.html` -> `/freedom-timeline/index.html` (resolves to `../cuisine.html`)
  - `/index.html` -> `/states/rj.html` (resolves to `../handloom/index.html`)
