### PR TITLE
fix(audio): prevent speech synthesis and soundscape leaks

### DIFF
--- a/app.js
+++ b/app.js
@@ -1434,6 +1434,10 @@ function playSoundscape(festName, drumElement) {
     initAudioSynth();
     stopSoundscape();
 
+    if (window.appLifecycle) {
+        window.appLifecycle.registerCleanup(() => stopSoundscape());
+    }
+
     soundscapeActive = true;
     currentFestivalPlaying = festName;
 
@@ -1743,6 +1747,10 @@ function playStateSoundscape(stateName) {
     initAudioSynth();
     stopSoundscape();
 
+    if (window.appLifecycle) {
+        window.appLifecycle.registerCleanup(() => stopSoundscape());
+    }
+
     soundscapeActive = true;
     currentFestivalPlaying = "State";
 
@@ -1829,6 +1837,11 @@ function initBharatGuide() {
         chatWindow.classList.toggle('open');
         if (chatWindow.classList.contains('open')) {
             chatInput.focus();
+        } else {
+            if (isSynthesizing) {
+                window.speechSynthesis.cancel();
+                isSynthesizing = false;
+            }
         }
     });
 
@@ -5494,6 +5507,11 @@ function initBharatGuide() {
         chatWindow.classList.toggle('open');
         if (chatWindow.classList.contains('open')) {
             chatInput.focus();
+        } else {
+            if (isSynthesizing) {
+                window.speechSynthesis.cancel();
+                isSynthesizing = false;
+            }
         }
     });
 
@@ -6007,7 +6025,6 @@ if ('serviceWorker' in navigator) {
                   showPWAToast(event.data.message, 'success');
                 }
             });
-
+        }
     });
 }
-

--- a/router.js
+++ b/router.js
@@ -505,6 +505,13 @@ class Router {
                 this.logger.error('Failed to cleanup soundscape', e);
             }
         }
+        if (window.speechSynthesis && typeof window.speechSynthesis.cancel === 'function') {
+            try {
+                window.speechSynthesis.cancel();
+            } catch (e) {
+                this.logger.error('Failed to cancel speech synthesis', e);
+            }
+        }
 
         document.dispatchEvent(new CustomEvent('app:before-route', { detail: { path } }));
 


### PR DESCRIPTION
### Target Files
`app.js` and `router.js`

### Root Cause Analysis
1. Active Web Audio oscillators (such as generic state ambient drones or festival soundscapes) are never cleaned up on page transitions because they were not integrated into the SPA router's lifecycle hooks.
2. The chatbot's Speech Synthesis speech continues speaking in the background when closing the chatbot via the FAB toggle button, because speech cancellation was only bound to the "Close Chat" cross button (`btnCloseChat`), not the FAB toggle.
3. The chatbot speech is not cancelled during page transitions, allowing the chatbot voice to leak into other pages when the user navigates away.

### Proposed Changes
1. **Soundscape Navigation Cleanup**: Registered a cleanup callback using `window.appLifecycle.registerCleanup` inside `playSoundscape` and `playStateSoundscape` in `app.js` to trigger `stopSoundscape()` upon route transitions.
2. **FAB Toggle Speech Cancellation**: Added speech synthesis cancellation inside the FAB toggle click listener in both definitions of `initBharatGuide` in `app.js` to ensure the bot stops speaking when the window is closed.
3. **Route Navigation Speech Cancellation**: Added a safety `window.speechSynthesis.cancel()` call inside the router's `handleRoute` function in `router.js` to clean up any active speech when navigating away.
4. **Syntax Fix**: Corrected a missing closing curly brace in `app.js`'s service worker loading script to restore syntax integrity.

### Verification
- Ran syntax validation checks via `node --check app.js router.js` confirming correct JavaScript syntax.
