### PR TITLE
fix: Broken/incorrect element reference in music play button rendering

### DIFF
--- a/app.js
+++ b/app.js
@@ -2623,9 +2623,10 @@ function initMusicPage() {
     });
 
     artistGrid.addEventListener('click', event => {
-        const playButton = event.target.closest('[data-music-play]');
+        const playButton = event.target.closest('button[data-music-play]');
         if (playButton) {
             event.stopPropagation();
+            event.preventDefault();
             const card = playButton.closest('[data-artist-id]');
             const artistId = card?.getAttribute('data-artist-id');
             if (!artistId) return;
@@ -2634,7 +2635,7 @@ function initMusicPage() {
             return;
         }
 
-        const detailsButton = event.target.closest('[data-music-details]');
+        const detailsButton = event.target.closest('button[data-music-details]');
         const card = event.target.closest('[data-artist-id]');
 
         if (detailsButton && card) {

--- a/js-modules/music.js
+++ b/js-modules/music.js
@@ -303,9 +303,10 @@ function initMusicPage() {
     });
 
     artistGrid.addEventListener('click', event => {
-        const playButton = event.target.closest('[data-music-play]');
+        const playButton = event.target.closest('button[data-music-play]');
         if (playButton) {
             event.stopPropagation();
+            event.preventDefault();
             const card = playButton.closest('[data-artist-id]');
             const artistId = card?.getAttribute('data-artist-id');
             if (!artistId) return;
@@ -314,7 +315,7 @@ function initMusicPage() {
             return;
         }
 
-        const detailsButton = event.target.closest('[data-music-details]');
+        const detailsButton = event.target.closest('button[data-music-details]');
         const card = event.target.closest('[data-artist-id]');
 
         if (detailsButton && card) {


### PR DESCRIPTION
Changes applied to both app.js and music.js
:
closest('[data-music-play]') → closest('button[data-music-play]') — The selector now requires the matched element to be a <button>, preventing false negatives when event.target is a child <span> or text node that bubbles up and could potentially match a non-button ancestor with the same attribute.

closest('[data-music-details]') → closest('button[data-music-details]') — Same robustness improvement for the details button, ensuring the delegated handler only matches the actual button element.

Added event.preventDefault() in the play button branch — Prevents any default button behavior from interfering with the custom toggle logic, which is especially important during rapid re-renders.


closes #215

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Music page controls to ensure play and details actions respond only to the intended buttons.
  * Prevented unintended default actions when selecting a music play button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->