### PR TITLE
Fix: theme toggle stops working after navigating between pages

### DIFF
--- a/pages-common.js
+++ b/pages-common.js
@@ -119,8 +119,8 @@ function initSiteChrome() {
     }
 
     // Theme toggle (dark/light) - persisted via localStorage, same key as main site
-    if (themeBtn) {
-        const setThemeIcon = (isLightTheme) => {
+if (themeBtn && !themeBtn.dataset.listenerBound) {
+        themeBtn.dataset.listenerBound = "true";        const setThemeIcon = (isLightTheme) => {
             themeBtn.innerHTML = isLightTheme ? '🌙' : '☀️';
             themeBtn.setAttribute('title', isLightTheme ? 'Toggle Dark Mode' : 'Toggle Light Mode');
         };


### PR DESCRIPTION
Fixes #265

## Problem
The theme toggle button would stop responding to clicks after navigating
between a few pages in the app. Clicking it sometimes did nothing at all,
or the light/dark state wouldn't match the icon shown.

## Root Cause
This site uses a client-side router (`router.js`) that swaps page content
in and out, but the navbar (and the `theme-toggle` button inside it) stays
on the page the whole time — it's never removed or recreated.

Two files independently set up the click behavior for that same button
every time the page content changes:

- `app.js` already has a safety check (`themeBtn.dataset.listenerBound`)
  so it only attaches its click listener once, ever.
- `pages-common.js` had **no such check**, so every single page navigation
  attached *another* click listener to the same button, on top of all the
  previous ones.

After a few navigations, the button had many stacked click listeners. A
single click would fire all of them, toggling the theme back and forth
multiple times per click — which cancels itself out on an even number of
listeners, making the button appear broken.

`river.html` made this worse, since it loads both `app.js` and
`pages-common.js` directly on the same page.

I confirmed this with a small reproduction script simulating the router
firing its `app:route-changed` event 3 times, then clicking the button —
the theme failed to change at all until the fix was applied.

## Fix
Added the same idempotency guard `app.js` already uses to
`pages-common.js`, so the click listener is only ever attached once per
button, regardless of how many times routes change or how many scripts
try to initialize it:

## Testing
- [x] Clicked the toggle repeatedly on the homepage — switches every click
- [x] Navigated across 4+ pages via in-app links, then clicked the toggle
      — still switches on the first click
- [x] Refreshed after switching to light mode — theme persists correctly
- [x] Verified `river.html` (loads both `app.js` and `pages-common.js`)
      no longer double-toggles
- [x] Reproduced the bug in isolation with a jsdom script before the fix,
      confirmed it's resolved after

## Files changed
- `pages-common.js` (2 lines)

I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PRs.
Hi @Eshajha19  could you please review this merged PR for a potential bonus label based on the metrics below? Thanks! 
<img width="662" height="301" alt="labels" src="https://github.com/user-attachments/assets/4cb19079-737e-4634-8885-2bd2bc567d74" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate theme toggle initialization, ensuring theme controls behave consistently when site navigation is initialized more than once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->