### PR TITLE
Fix: Reposition Scroll Down indicator to prevent overlap with Hero CTA buttons (#267)

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -385,6 +385,7 @@ button {
     width: 100%;
     height: 100vh;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
     padding: 0 24px;
@@ -460,6 +461,7 @@ button {
     display: flex;
     gap: 20px;
     justify-content: center;
+    margin-top: 10px;
 }
 
 .hero-scroll-indicator {
@@ -1917,7 +1919,7 @@ button {
   }
 
   .hero-scroll-indicator {
-    bottom: 14px;
+    margin-top: 16px;
   }
 }
 
@@ -9656,13 +9658,10 @@ button {
     display: flex;
     gap: 20px;
     justify-content: center;
+    margin-top: 10px;
 }
 
 .hero-scroll-indicator {
-    position: absolute;
-    bottom: 30px;
-    left: 50%;
-    transform: translateX(-50%);
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -9673,6 +9672,7 @@ button {
     letter-spacing: 1px;
     text-transform: uppercase;
     z-index: 2;
+    margin-top: 40px;
 }
 
 .mouse-icon {
@@ -10899,6 +10899,7 @@ button {
     .hero-buttons {
         flex-direction: column;
         gap: 12px;
+        margin-top: 16px;
     }
 
     .section-header h2 {


### PR DESCRIPTION
## Description
Fixes #267

The "Scroll Down" indicator in the hero section was absolutely positioned 
(`position: absolute; bottom: 30px;`), which caused it to overlap with the 
"Explore Map" and "Take a Quiz" buttons on smaller and shorter viewports, 
breaking the visual hierarchy.

## Changes
- Changed `.hero-section` to a column-based flex layout (`flex-direction: column`)
- Removed absolute positioning from `.hero-scroll-indicator` and let it flow 
  naturally below the CTA buttons using `margin-top` instead
- Added spacing (`margin-top`) to `.hero-buttons` for better visual separation
- Adjusted responsive rules for mobile (`max-width: 768px`) and short-height 
  screens (`max-height: 750px`) to keep spacing consistent
- Applied the same fix in both places the hero CSS block appears in `styles.css`, 
  since it is duplicated in the file

## Testing
- Verified in browser dev tools across desktop, tablet, and mobile widths
- Verified on short-height viewports (e.g. landscape mobile) that the indicator 
  no longer overlaps the buttons
- Confirmed the indicator still hides correctly on very short screens 
  (`max-height: 600px` rule, unchanged)

I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PRs.
Hi @Eshajha19 , could you please review this merged PR for a potential bonus label based on the metrics below? Thanks! 
<img width="662" height="301" alt="labels" src="https://github.com/user-attachments/assets/4b86c2c8-0e82-49bd-968b-26c8374cf900" />

