### PR TITLE
Enrich Culture section with state-wise regional dance data (#271)

### DIFF
--- a/culture.html
+++ b/culture.html
@@ -114,6 +114,7 @@
             <div class="modal-header">
                 <span class="modal-badge green-bg" id="culture-modal-badge">Dance</span>
                 <h3 id="culture-modal-title">Bharatanatyam</h3>
+                <p class="culture-modal-state" id="culture-modal-state">Tamil Nadu</p>
             </div>
             <div class="modal-body">
                 <div class="culture-modal-img-wrapper" style="margin-bottom: 25px; border-radius: 12px; overflow: hidden; height: 300px;">

--- a/data.js
+++ b/data.js
@@ -641,14 +641,100 @@ const cultureData = [
   {
     "title": "Bhangra",
     "category": "dance",
+    "state": "Punjab",
     "description": "A highly energetic, celebratory folk dance from Punjab. Danced to the fast, driving rhythm of the double-headed Dhol drum, it was originally performed during the spring harvest festival Baisakhi.",
     "image": "assets/bhangra.png"
   },
   {
     "title": "Tabla",
     "category": "music",
+    "state": "Uttar Pradesh",
     "description": "The primary percussion instrument of North Indian music. It consists of a pair of small drums played with hands and fingers, capable of a vast range of acoustic tones and lightning-fast tempos.",
     "image": "assets/tabla.png"
+  },
+  {
+    "title": "Kathak",
+    "category": "dance",
+    "state": "Uttar Pradesh",
+    "description": "A classical dance form known for its fast spins, intricate footwork, and expressive storytelling, shaped by both temple traditions and the royal courts of North India.",
+    "image": "assets/dances/kathak.jpg"
+  },
+  {
+    "title": "Garba",
+    "category": "dance",
+    "state": "Gujarat",
+    "description": "A joyful circular folk dance performed during Navratri in honor of Goddess Durga, danced around a central lamp or idol to the beat of traditional songs.",
+    "image": "assets/dances/garba.png"
+  },
+  {
+    "title": "Ghoomar",
+    "category": "dance",
+    "state": "Rajasthan",
+    "description": "A graceful folk dance performed by women in flowing, twirling ghagra skirts, traditionally danced to welcome a new bride into the family.",
+    "image": "assets/dances/ghoomar.png"
+  },
+  {
+    "title": "Kalbelia",
+    "category": "dance",
+    "state": "Rajasthan",
+    "description": "A striking folk dance of the Kalbelia snake-charmer community, performed in flowing black skirts with movements that mimic a serpent. It is recognized by UNESCO as Intangible Cultural Heritage.",
+    "image": "assets/dances/kalbelia.png"
+  },
+  {
+    "title": "Kuchipudi",
+    "category": "dance",
+    "state": "Andhra Pradesh",
+    "description": "A classical dance-drama combining fast rhythmic footwork, expressive acting, and song, traditionally performed as a devotional narrative in temple courtyards.",
+    "image": "assets/dances/kuchipudi.png"
+  },
+  {
+    "title": "Lavani",
+    "category": "dance",
+    "state": "Maharashtra",
+    "description": "A powerful and energetic folk dance performed to the beat of the dholki drum, known for its strong rhythm and bold, expressive movements.",
+    "image": "assets/dances/lavani.png"
+  },
+  {
+    "title": "Manipuri",
+    "category": "dance",
+    "state": "Manipur",
+    "description": "A classical dance style marked by gentle, flowing movements and minimal facial expression, traditionally depicting the Raas Leela of Radha and Krishna.",
+    "image": "assets/dances/manipuri.png"
+  },
+  {
+    "title": "Mohiniyattam",
+    "category": "dance",
+    "state": "Kerala",
+    "description": "A graceful classical dance whose name means 'dance of the enchantress'. It features soft, swaying body movements and gentle hand gestures.",
+    "image": "assets/dances/mohiniyattam.png"
+  },
+  {
+    "title": "Odissi",
+    "category": "dance",
+    "state": "Odisha",
+    "description": "One of India's oldest classical dance forms, recognized by its signature tribhangi (three-bend) posture and sculpture-like poses inspired by temple carvings.",
+    "image": "assets/dances/odissi.png"
+  },
+  {
+    "title": "Pandavani",
+    "category": "dance",
+    "state": "Chhattisgarh",
+    "description": "A dramatic folk performance style where a single narrator sings and acts out episodes from the Mahabharata, often accompanying themselves on a small stringed instrument.",
+    "image": "assets/dances/pandavani.png"
+  },
+  {
+    "title": "Sattriya",
+    "category": "dance",
+    "state": "Assam",
+    "description": "A classical dance form introduced by the Vaishnavite saint Srimanta Sankardeva, traditionally performed within monasteries known as sattras.",
+    "image": "assets/dances/sattriya.png"
+  },
+  {
+    "title": "Chhau",
+    "category": "dance",
+    "state": "Odisha, West Bengal & Jharkhand",
+    "description": "A vigorous mask dance blending martial arts, acrobatics, and folk tradition, performed to depict stories from Hindu epics like the Mahabharata.",
+    "image": "assets/dances/chhau.png"
   }
 ];
 

--- a/js-modules/culture.js
+++ b/js-modules/culture.js
@@ -6,6 +6,7 @@ function initCulturePage() {
     const mBadge = document.getElementById('culture-modal-badge');
     const mTitle = document.getElementById('culture-modal-title');
     const mImg = document.getElementById('culture-modal-img');
+    const mDesc = document.getElementById('culture-modal-description');
 const mState = document.getElementById('culture-modal-state');
     let currentCategory = 'all';
 

--- a/js-modules/culture.js
+++ b/js-modules/culture.js
@@ -6,8 +6,7 @@ function initCulturePage() {
     const mBadge = document.getElementById('culture-modal-badge');
     const mTitle = document.getElementById('culture-modal-title');
     const mImg = document.getElementById('culture-modal-img');
-    const mDesc = document.getElementById('culture-modal-description');
-
+const mState = document.getElementById('culture-modal-state');
     let currentCategory = 'all';
 
     render();
@@ -58,6 +57,7 @@ function initCulturePage() {
                 <img src="${item.image}" alt="${item.title}" loading="lazy">
                 <div class="cuisine-card-body">
                     <span class="cuisine-origin">${item.category}</span>
+                    <span class="culture-card-state">📍 ${item.state || 'All India'}</span>
                     <h3>${item.title}</h3>
                     <p>${item.description.substring(0, 120)}...</p>
                 </div>
@@ -67,6 +67,7 @@ function initCulturePage() {
                 mBadge.innerText = item.category;
                 mBadge.className = `modal-badge ${item.category === 'dance' ? 'green-bg' : item.category === 'music' ? 'gold-bg' : 'saffron-bg'}`;
                 mTitle.innerText = item.title;
+                mState.innerText = `📍 ${item.state || 'All India'}`;
                 mImg.src = item.image;
                 mImg.alt = item.title;
                 mDesc.innerText = item.description;

--- a/styles.css
+++ b/styles.css
@@ -6264,6 +6264,21 @@ button {
     transform: scale(1.06);
 }
 
+.culture-card-state {
+    display: inline-block;
+    margin-left: 8px;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+.culture-modal-state {
+    color: var(--primary-gold);
+    font-size: 0.95rem;
+    margin-top: 6px;
+    font-weight: 500;
+}
+
 /* ==========================================================================
    RESPONSIVE DESIGN ADDITIONS
    ========================================================================== */


### PR DESCRIPTION
This PR partially addresses #271 by adding state-wise regional context to the Culture section.

Changes:
- Added a `state` field to every entry in `cultureData` (data.js) so each art form is tied to its region of origin.
- Added 12 new classical/folk dance entries (Kathak, Garba, Ghoomar, Kalbelia, Kuchipudi, Lavani, Manipuri, Mohiniyattam, Odissi, Pandavani, Sattriya, Chhau) using existing unused images in assets/dances/, expanding coverage across states like Rajasthan, Gujarat, Kerala, Odisha, Assam, Manipur, Maharashtra, Andhra Pradesh, Chhattisgarh, UP, West Bengal, and Jharkhand.
- Updated culture.js to display the state on each culture card and inside the details modal.
- Updated culture.html to add the modal element for showing state.
- Added minor CSS for the new state tag styling.

This gives users a clearer sense of India's regional cultural diversity when browsing the Culture page, as requested in the issue. Traditional attire/art-form expansion can be tackled in a follow-up PR since more image assets are needed for those categories.

Closes/Contributes to #271

I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PRs.
Hi @Eshajha19 , could you please review this merged PR for a potential bonus label based on the metrics below? Thanks!
<img width="662" height="301" alt="labels" src="https://github.com/user-attachments/assets/2eb5e552-62c4-4385-95fe-46e27a2306f6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Culture cards and detail modals now display the associated Indian state for each cultural item.
  * Items without a specific state show “All India” by default.
  * Added improved styling to make state information clear and visually distinct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->