### PR TITLE
Add Scroll-to-Top button to remaining pages (#266)

### DIFF
--- a/arts-crafts.html
+++ b/arts-crafts.html
@@ -625,10 +625,13 @@
         </div>
         <div class="footer-credits" style="align-self: center;">
             <p>&copy; 2026 Incredible India Explorer. Created with Vanilla HTML, CSS & JavaScript.</p>
-        </div>
+</div>
     </footer>
-    <script src="app.js" defer></script>
-    <script type="module" src="firebase-config.js"></script>
+
+    <!-- Scroll To Top Button -->
+    <button class="btn-scroll-top" id="btn-scroll-top" aria-label="Scroll to Top">&#8593;</button>
+
+    <script src="app.js" defer></script>    <script type="module" src="firebase-config.js"></script>
     <script type="module" src="auth.js"></script>
     <script src="router.js" defer></script>
 </body>

--- a/data-india.html
+++ b/data-india.html
@@ -195,12 +195,14 @@
     <footer class="footer footer-pd">
         <div class="footer-credits footer-credits-align">
             <p>&copy; 2026 Incredible India Explorer. Created with Vanilla HTML, CSS & JavaScript.</p>
-        </div>
+</div>
     </footer>
-    
+
+    <!-- Scroll To Top Button -->
+    <button class="btn-scroll-top" id="btn-scroll-top" aria-label="Scroll to Top">&#8593;</button>
+
     <script>
-        document.addEventListener("DOMContentLoaded", () => {
-            // GDP Chart Implementation
+        document.addEventListener("DOMContentLoaded", () => {            // GDP Chart Implementation
             const canvasGdp = document.getElementById('gdpChart');
             if (canvasGdp) {
                 const ctxGdp = canvasGdp.getContext('2d');

--- a/forts/index.html
+++ b/forts/index.html
@@ -147,10 +147,12 @@
                 </div>
             </div>
         </div>
-    </div>
+</div>
 
-    <script src="../app.js" defer></script>
-    <script src="script.js" defer></script>
+    <!-- Scroll To Top Button -->
+    <button class="btn-scroll-top" id="btn-scroll-top" aria-label="Scroll to Top">&#8593;</button>
+
+    <script src="../app.js" defer></script>    <script src="script.js" defer></script>
     <script src="../router.js" defer></script>
     <script type="module" src="../auth.js"></script>
 </body>

--- a/freedom-story.html
+++ b/freedom-story.html
@@ -113,12 +113,14 @@
     </div>
     <div class="footer-credits footer-credits-center">
         <p>&copy; 2026 Incredible India Explorer. Created with Vanilla HTML, CSS & JavaScript.</p>
-    </div>
+</div>
 </footer>
 
+<!-- Scroll To Top Button -->
+<button class="btn-scroll-top" id="btn-scroll-top" aria-label="Scroll to Top">&#8593;</button>
+
 <!-- Theme toggle logic from app.js -->
-<script src="app.js" defer></script>
-<script src="story-engine.js" defer></script>
+<script src="app.js" defer></script><script src="story-engine.js" defer></script>
 <script src="router.js" defer></script>
     <script src="freedom-story-journey.js" defer></script>
 </body>

--- a/languages.html
+++ b/languages.html
@@ -329,11 +329,13 @@
         </div>
         <div class="footer-credits align-center">
             <p>&copy; 2026 Incredible India Explorer. Created with Vanilla HTML, CSS & JavaScript.</p>
-        </div>
+</div>
     </footer>
-    
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
+
+    <!-- Scroll To Top Button -->
+    <button class="btn-scroll-top" id="btn-scroll-top" aria-label="Scroll to Top">&#8593;</button>
+
+    <script>        document.addEventListener('DOMContentLoaded', () => {
             const languages = [
                 { name: 'Hindi', script: 'नमस्ते', region: 'North & Central India', code: 'hi-IN' },
                 { name: 'Bengali', script: 'নমস্কার', region: 'West Bengal, Tripura', code: 'bn-IN' },

--- a/learn.html
+++ b/learn.html
@@ -215,8 +215,11 @@
 <p>© 2026 Incredible India Explorer. Created with Vanilla HTML, CSS &amp; JavaScript.</p>
 </div>
 </footer>
-<script src="app.js" defer></script>
-<script src="firebase-config.js" type="module"></script>
+
+<!-- Scroll To Top Button -->
+<button class="btn-scroll-top" id="btn-scroll-top" aria-label="Scroll to Top">&#8593;</button>
+
+<script src="app.js" defer></script><script src="firebase-config.js" type="module"></script>
 <script src="auth.js" type="module"></script>
 <script src="router.js" defer></script>
     <script src="learn-journey.js" defer></script>

--- a/personalities.html
+++ b/personalities.html
@@ -472,8 +472,11 @@
 <p>© 2026 Incredible India Explorer. Created with Vanilla HTML, CSS &amp; JavaScript.</p>
 </div>
 </footer>
-<script src="app.js" defer></script>
-<script src="firebase-config.js" type="module"></script>
+
+<!-- Scroll To Top Button -->
+<button class="btn-scroll-top" id="btn-scroll-top" aria-label="Scroll to Top">&#8593;</button>
+
+<script src="app.js" defer></script><script src="firebase-config.js" type="module"></script>
 <script src="auth.js" type="module"></script>
 <script src="router.js" defer></script>
     <script src="personalities-journey.js" defer></script>

--- a/premium.html
+++ b/premium.html
@@ -329,12 +329,14 @@
             <div class="footer-credits">
                 <p>&copy; 2026 Incredible India Explorer.</p>
             </div>
-        </div>
+</div>
     </footer>
 
+    <!-- Scroll To Top Button -->
+    <button class="btn-scroll-top" id="btn-scroll-top" aria-label="Scroll to Top">&#8593;</button>
+
     <script>
-        (() => {
-            // Timeline Logic
+        (() => {            // Timeline Logic
             const eraData = {
             1: { 
                 title: "Ancient India (3300 BCE - 500 CE)", 

--- a/route-planner.html
+++ b/route-planner.html
@@ -176,11 +176,13 @@
   </div>
   <div class="footer-credits" style="align-self: center;">
     <p>© 2026 Incredible India Explorer. Created with Vanilla HTML, CSS &amp; JavaScript.</p>
-  </div>
+</div>
 </footer>
 
-<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
-<script src="app.js" defer></script>
+<!-- Scroll To Top Button -->
+<button class="btn-scroll-top" id="btn-scroll-top" aria-label="Scroll to Top">&#8593;</button>
+
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script><script src="app.js" defer></script>
 <script src="route-planner.js"></script>
 <script src="route-planner-ui.js" defer></script>
     <script type="module" src="auth.js"></script>

--- a/smart-cities.html
+++ b/smart-cities.html
@@ -271,8 +271,11 @@
 <p>© 2026 Incredible India Explorer. Created with Vanilla HTML, CSS &amp; JavaScript.</p>
 </div>
 </footer>
-<script src="app.js" defer></script>
-<script src="firebase-config.js" type="module"></script>
+
+<!-- Scroll To Top Button -->
+<button class="btn-scroll-top" id="btn-scroll-top" aria-label="Scroll to Top">&#8593;</button>
+
+<script src="app.js" defer></script><script src="firebase-config.js" type="module"></script>
 <script src="auth.js" type="module"></script>
 <script src="router.js" defer></script>
     <script src="smart-cities-journey.js" defer></script>

--- a/spiritual.html
+++ b/spiritual.html
@@ -308,10 +308,13 @@
         </div>
         <div class="footer-credits" style="align-self: center;">
             <p>&copy; 2026 Incredible India Explorer. Created with Vanilla HTML, CSS & JavaScript.</p>
-        </div>
+</div>
     </footer>
-    <script src="app.js" defer></script>
-    <script type="module" src="firebase-config.js"></script>
+
+    <!-- Scroll To Top Button -->
+    <button class="btn-scroll-top" id="btn-scroll-top" aria-label="Scroll to Top">&#8593;</button>
+
+    <script src="app.js" defer></script>    <script type="module" src="firebase-config.js"></script>
     <script type="module" src="auth.js"></script>
     <script src="router.js" defer></script>
 </body>

--- a/unesco.html
+++ b/unesco.html
@@ -136,11 +136,13 @@
     </div>
 
     <footer class="unesco-footer">
-        <p>Part of <a href="index.html">Incredible India Explorer</a> · Celebrating India's world heritage.</p>
+<p>Part of <a href="index.html">Incredible India Explorer</a> · Celebrating India's world heritage.</p>
     </footer>
 
-    <script src="app.js" defer></script>
-    <script src="journey.js" defer></script>
+    <!-- Scroll To Top Button -->
+    <button class="btn-scroll-top" id="btn-scroll-top" aria-label="Scroll to Top">&#8593;</button>
+
+    <script src="app.js" defer></script>    <script src="journey.js" defer></script>
     <script src="unesco.js" defer></script>
     <script src="router.js" defer></script>
     <script type="module" src="auth.js"></script>


### PR DESCRIPTION
This PR resolves #266.

While auditing the codebase, I found that the Scroll-to-Top button's functionality (smooth scroll, visibility threshold, hover/transition effects, and accessibility via aria-label) was already implemented in app.js and styles.css and already working correctly on several pages.

However, 12 pages were missing the actual button element in their HTML, so the feature simply wasn't visible there. This PR adds the existing button markup to those pages:

- arts-crafts.html
- personalities.html
- spiritual.html
- languages.html
- unesco.html
- smart-cities.html
- data-india.html
- premium.html
- learn.html
- freedom-story.html
- route-planner.html
- forts/index.html

No JS or CSS changes were needed since the shared logic in app.js/styles.css already covers threshold-based visibility, smooth scrolling, and hover states.

Out of scope for this PR: a few standalone widget-style pages (itinery-generator.html, offline-sync-dashboard.html, geological-wonders, innovation-timeline, ancient-mathematics-explorer) don't use the shared app.js navigation system and would need a different implementation approach — happy to open a follow-up issue for those if useful.


https://github.com/user-attachments/assets/2642fea5-96e0-4854-b265-217250f03536



I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PRs.
Hi @Eshajha19 , could you please review this merged PR for a potential bonus label based on the metrics below? Thanks!
<img width="662" height="301" alt="labels" src="https://github.com/user-attachments/assets/cde0f43b-8cb0-4821-80d8-f4f0e261d936" />
