### PR TITLE
Fix: Unbounded localStorage caching in route-planner.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -775,9 +775,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -792,9 +789,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -809,9 +803,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -826,9 +817,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -843,9 +831,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -860,9 +845,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -877,9 +859,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -894,9 +873,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -911,9 +887,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -928,9 +901,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -945,9 +915,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -962,9 +929,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -979,9 +943,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/route-planner.js
+++ b/route-planner.js
@@ -127,17 +127,126 @@ const TRANSPORT_MODES = {
 // ---------------------------------------------------------------------------
 const CACHE_PREFIX = "iie_route_cache_v1:";
 const CACHE_TTL_MS = 1000 * 60 * 60 * 24 * 7; // 7 days
+const MAX_CACHE_ENTRIES = 20;
 
 function buildCacheKey(stopIds, mode) {
   return `${CACHE_PREFIX}${mode}:${stopIds.join(">")}`;
 }
 
+function isQuotaExceededError(err) {
+  return (
+    err &&
+    (err.name === "QuotaExceededError" ||
+      err.name === "NS_ERROR_DOM_QUOTA_REACHED" ||
+      err.code === 22 ||
+      err.code === 1014 ||
+      (err.message && (err.message.includes("quota") || err.message.includes("limit"))))
+  );
+}
+
+function purgeAllRouteCaches() {
+  if (typeof localStorage === "undefined") return;
+  const keysToRemove = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && key.startsWith(CACHE_PREFIX)) {
+      keysToRemove.push(key);
+    }
+  }
+  keysToRemove.forEach((key) => {
+    try {
+      localStorage.removeItem(key);
+    } catch (e) {}
+  });
+}
+
+function sweepExpiredCache() {
+  if (typeof localStorage === "undefined") return;
+  const keysToRemove = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && key.startsWith(CACHE_PREFIX)) {
+      try {
+        const raw = localStorage.getItem(key);
+        if (raw) {
+          const entry = JSON.parse(raw);
+          if (Date.now() - entry.savedAt > CACHE_TTL_MS) {
+            keysToRemove.push(key);
+          }
+        }
+      } catch (err) {
+        keysToRemove.push(key);
+      }
+    }
+  }
+  keysToRemove.forEach((key) => {
+    try {
+      localStorage.removeItem(key);
+    } catch (e) {}
+  });
+}
+
+function enforceLimitAndSave(newKey, newEntry) {
+  if (typeof localStorage === "undefined") return;
+
+  const entries = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    if (key && key.startsWith(CACHE_PREFIX) && key !== newKey) {
+      try {
+        const raw = localStorage.getItem(key);
+        if (raw) {
+          const parsed = JSON.parse(raw);
+          entries.push({
+            key,
+            lastAccessedAt: parsed.lastAccessedAt || parsed.savedAt || 0
+          });
+        }
+      } catch (err) {
+        localStorage.removeItem(key);
+      }
+    }
+  }
+
+  entries.sort((a, b) => a.lastAccessedAt - b.lastAccessedAt);
+
+  while (entries.length >= MAX_CACHE_ENTRIES) {
+    const oldest = entries.shift();
+    if (oldest) {
+      localStorage.removeItem(oldest.key);
+    }
+  }
+
+  try {
+    localStorage.setItem(newKey, JSON.stringify(newEntry));
+  } catch (err) {
+    if (isQuotaExceededError(err)) {
+      purgeAllRouteCaches();
+      try {
+        localStorage.setItem(newKey, JSON.stringify(newEntry));
+      } catch (retryErr) {
+        // Ignore
+      }
+    }
+  }
+}
+
 function readCache(stopIds, mode) {
   try {
-    const raw = localStorage.getItem(buildCacheKey(stopIds, mode));
+    const key = buildCacheKey(stopIds, mode);
+    const raw = localStorage.getItem(key);
     if (!raw) return null;
     const entry = JSON.parse(raw);
-    if (Date.now() - entry.savedAt > CACHE_TTL_MS) return null;
+    if (Date.now() - entry.savedAt > CACHE_TTL_MS) {
+      localStorage.removeItem(key);
+      return null;
+    }
+    entry.lastAccessedAt = Date.now();
+    try {
+      localStorage.setItem(key, JSON.stringify(entry));
+    } catch (err) {
+      // Ignore non-fatal update error
+    }
     return entry.data;
   } catch (err) {
     return null;
@@ -146,9 +255,24 @@ function readCache(stopIds, mode) {
 
 function writeCache(stopIds, mode, data) {
   try {
-    localStorage.setItem(buildCacheKey(stopIds, mode), JSON.stringify({ savedAt: Date.now(), data }));
+    const key = buildCacheKey(stopIds, mode);
+    const entry = {
+      savedAt: Date.now(),
+      lastAccessedAt: Date.now(),
+      data
+    };
+    enforceLimitAndSave(key, entry);
   } catch (err) {
-    // Non-fatal: caching is a perf optimization, not a correctness requirement.
+    // Non-fatal
+  }
+}
+
+// Automatically sweep expired cache keys on script execution if in browser
+if (typeof window !== "undefined" && typeof localStorage !== "undefined") {
+  try {
+    sweepExpiredCache();
+  } catch (err) {
+    // Non-fatal
   }
 }
 
@@ -308,7 +432,7 @@ function formatDuration(minutes) {
 const RoutePlanner = {
   ROUTE_DESTINATIONS, TRANSPORT_MODES, DESTINATION_INFO, haversineDistanceKm,
   optimizeRoute, tourLengthKm, getRoute, formatDistance, formatDuration, buildCacheKey,
-  recommendMode,
+  recommendMode, sweepExpiredCache, purgeAllRouteCaches, MAX_CACHE_ENTRIES,
 };
 
 if (typeof module !== "undefined" && module.exports) {

--- a/tests/unit/route-planner.test.js
+++ b/tests/unit/route-planner.test.js
@@ -1,0 +1,173 @@
+/**
+ * route-planner.test.js
+ * Tests for the client-side route caching, LRU eviction, and error recovery.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import RoutePlanner from '../../route-planner.js';
+
+describe('Route Planner Caching', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('buildCacheKey formats correctly', () => {
+    const key = RoutePlanner.buildCacheKey(['delhi', 'agra'], 'road');
+    expect(key).toBe('iie_route_cache_v1:road:delhi>agra');
+  });
+
+  it('readCache returns null when entry does not exist', async () => {
+    const route = await RoutePlanner.getRoute(
+      [
+        { id: 'delhi', lat: 28.6139, lng: 77.209 },
+        { id: 'agra', lat: 27.1767, lng: 78.0081 }
+      ],
+      'rail'
+    );
+    // This call should fetch/estimate and write to cache
+    expect(route.fromCache).toBe(false);
+
+    // Second call should return from cache
+    const route2 = await RoutePlanner.getRoute(
+      [
+        { id: 'delhi', lat: 28.6139, lng: 77.209 },
+        { id: 'agra', lat: 27.1767, lng: 78.0081 }
+      ],
+      'rail'
+    );
+    expect(route2.fromCache).toBe(true);
+  });
+
+  it('evicts cache entries older than TTL', async () => {
+    const stops = [
+      { id: 'delhi', lat: 28.6139, lng: 77.209 },
+      { id: 'agra', lat: 27.1767, lng: 78.0081 }
+    ];
+    
+    // First write to cache
+    await RoutePlanner.getRoute(stops, 'rail');
+    
+    const key = RoutePlanner.buildCacheKey(['delhi', 'agra'], 'rail');
+    const raw = localStorage.getItem(key);
+    expect(raw).toBeTruthy();
+    
+    // Artificially modify the saved timestamp to be 8 days ago
+    const entry = JSON.parse(raw);
+    entry.savedAt = Date.now() - (1000 * 60 * 60 * 24 * 8);
+    localStorage.setItem(key, JSON.stringify(entry));
+    
+    // Next getRoute should result in cache miss and rewrite it
+    const route = await RoutePlanner.getRoute(stops, 'rail');
+    expect(route.fromCache).toBe(false);
+  });
+
+  it('enforces maximum cache entries limit of 20 using LRU policy', async () => {
+    const limit = RoutePlanner.MAX_CACHE_ENTRIES;
+    expect(limit).toBe(20);
+
+    // Fill the cache with 20 entries
+    for (let i = 0; i < limit; i++) {
+      const stops = [
+        { id: `stop_start_${i}`, lat: 28.6, lng: 77.2 },
+        { id: `stop_end_${i}`, lat: 27.1, lng: 78.0 }
+      ];
+      await RoutePlanner.getRoute(stops, 'rail');
+    }
+
+    // Check localStorage contains exactly 20 cache entries
+    let cacheKeys = Object.keys(localStorage).filter(k => k.startsWith('iie_route_cache_v1:'));
+    expect(cacheKeys.length).toBe(20);
+
+    // Let's access the first item to update its lastAccessedAt time (make it MRU)
+    const mruStops = [
+      { id: 'stop_start_0', lat: 28.6, lng: 77.2 },
+      { id: 'stop_end_0', lat: 27.1, lng: 78.0 }
+    ];
+    // This read should hit cache and update lastAccessedAt
+    const mruRoute = await RoutePlanner.getRoute(mruStops, 'rail');
+    expect(mruRoute.fromCache).toBe(true);
+
+    // Let's write the 21st item, which should trigger eviction of the oldest (which should be index 1, not index 0 because 0 was just accessed)
+    const newStops = [
+      { id: 'stop_start_new', lat: 28.6, lng: 77.2 },
+      { id: 'stop_end_new', lat: 27.1, lng: 78.0 }
+    ];
+    await RoutePlanner.getRoute(newStops, 'rail');
+
+    // Total cache size should still be 20
+    cacheKeys = Object.keys(localStorage).filter(k => k.startsWith('iie_route_cache_v1:'));
+    expect(cacheKeys.length).toBe(20);
+
+    // The first item (index 0) should still be in cache because it was recently accessed
+    const key0 = RoutePlanner.buildCacheKey(['stop_start_0', 'stop_end_0'], 'rail');
+    expect(localStorage.getItem(key0)).toBeTruthy();
+
+    // The second item (index 1) was the oldest non-accessed item, so it should be evicted
+    const key1 = RoutePlanner.buildCacheKey(['stop_start_1', 'stop_end_1'], 'rail');
+    expect(localStorage.getItem(key1)).toBeNull();
+  });
+
+  it('purges all route caches when QuotaExceededError is thrown on setItem', async () => {
+    // Write other persistent key not matching route cache prefix
+    localStorage.setItem('theme', 'dark');
+
+    // Spy/mock localStorage.setItem to throw QuotaExceededError once
+    const originalSetItem = localStorage.setItem;
+    let throwError = false;
+
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (key, value) {
+      if (throwError && key.startsWith('iie_route_cache_v1:')) {
+        throwError = false; // Only throw once to allow retry logic to succeed
+        const err = new Error('Mock Storage Quota Exceeded');
+        err.name = 'QuotaExceededError';
+        throw err;
+      }
+      return originalSetItem.call(this, key, value);
+    });
+
+    // Populate some route cache items
+    const stops1 = [{ id: 's1', lat: 28, lng: 77 }, { id: 's2', lat: 27, lng: 78 }];
+    const stops2 = [{ id: 's3', lat: 28, lng: 77 }, { id: 's4', lat: 27, lng: 78 }];
+    
+    // Put one in cache first
+    await RoutePlanner.getRoute(stops1, 'rail');
+    expect(Object.keys(localStorage).filter(k => k.startsWith('iie_route_cache_v1:')).length).toBe(1);
+
+    // Set throwing to true before writing the second route
+    throwError = true;
+
+    // Writing the second route will throw QuotaExceededError, triggering purge of route caches, then succeeds on retry
+    await RoutePlanner.getRoute(stops2, 'rail');
+
+    // Only stops2 should be in cache now, stops1 (the old route cache) is purged
+    const routeKeys = Object.keys(localStorage).filter(k => k.startsWith('iie_route_cache_v1:'));
+    expect(routeKeys.length).toBe(1);
+    expect(routeKeys[0]).toContain('s3>s4');
+
+    // Make sure other persistent data (like theme) is unaffected!
+    expect(localStorage.getItem('theme')).toBe('dark');
+  });
+
+  it('sweepExpiredCache purges all expired keys', () => {
+    const keyActive = 'iie_route_cache_v1:rail:active1>active2';
+    const keyExpired = 'iie_route_cache_v1:rail:exp1>exp2';
+    const keyOther = 'theme';
+
+    localStorage.setItem(keyActive, JSON.stringify({ savedAt: Date.now(), data: {} }));
+    localStorage.setItem(keyExpired, JSON.stringify({ savedAt: Date.now() - (1000 * 60 * 60 * 24 * 8), data: {} }));
+    localStorage.setItem(keyOther, 'light');
+
+    RoutePlanner.sweepExpiredCache();
+
+    expect(localStorage.getItem(keyActive)).toBeTruthy();
+    expect(localStorage.getItem(keyExpired)).toBeNull();
+    expect(localStorage.getItem(keyOther)).toBe('light');
+  });
+});


### PR DESCRIPTION
This PR resolves #230 by implementing bounded caching in route-planner.js.

### Changes
- Define maximum cache entries limit as 20.
- Implement LRU eviction policy based on access order.
- Automatically sweep expired cache entries on page load.
- Safely handle QuotaExceededError and purge route-planner caches when necessary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved route-result caching with automatic expiration and recovery from storage limits.
  * Added least-recently-used eviction to prevent the cache from growing beyond its limit.
  * Preserved unrelated saved data when clearing invalid or expired route results.

* **Tests**
  * Added coverage for cache expiration, reuse, eviction, cleanup, and storage-error recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->