### PR TITLE
Fix: Upgrade local password hashing to salted SHA-256 with auto-upgrade

### DIFF
--- a/auth-local-users.mjs
+++ b/auth-local-users.mjs
@@ -2,7 +2,9 @@ import {
   getStoredAccounts, 
   saveAccounts, 
   normalizeEmail, 
-  hashPassword 
+  hashPassword,
+  generateSalt,
+  legacyHashPassword
 } from './auth-storage.mjs';
 import { 
   createSessionUser, 
@@ -27,9 +29,11 @@ export async function registerLocalUser({ email, password, displayName }) {
     throw error;
   }
 
+  const salt = generateSalt();
   const userRecord = {
     email: normalizedEmail,
-    passwordHash: hashPassword(password),
+    passwordHash: await hashPassword(password, salt),
+    passwordSalt: salt,
     displayName: displayName || normalizedEmail.split('@')[0],
     provider: 'local',
     role: 'free'
@@ -54,10 +58,32 @@ export async function signInLocalUser({ email, password }) {
     throw error;
   }
 
-  if (!account.passwordHash || account.passwordHash !== hashPassword(password)) {
+  let isPasswordValid = false;
+  let shouldUpgrade = false;
+
+  if (account.passwordHash) {
+    if (account.passwordSalt) {
+      const computedHash = await hashPassword(password, account.passwordSalt);
+      isPasswordValid = (account.passwordHash === computedHash);
+    } else {
+      // Legacy fallback
+      const computedLegacyHash = legacyHashPassword(password);
+      isPasswordValid = (account.passwordHash === computedLegacyHash);
+      shouldUpgrade = isPasswordValid;
+    }
+  }
+
+  if (!isPasswordValid) {
     const error = new Error('Incorrect password. Please try again.');
     error.code = 'auth/wrong-password';
     throw error;
+  }
+
+  if (shouldUpgrade) {
+    const newSalt = generateSalt();
+    account.passwordSalt = newSalt;
+    account.passwordHash = await hashPassword(password, newSalt);
+    saveAccounts(accounts);
   }
 
   const user = await createSessionUser(normalizedEmail, account.displayName || normalizedEmail.split('@')[0], 'local', account.role || 'free');

--- a/auth-storage.mjs
+++ b/auth-storage.mjs
@@ -46,10 +46,31 @@ export function normalizeEmail(email) {
   return String(email || '').trim().toLowerCase();
 }
 
-export function hashPassword(password) {
+export function legacyHashPassword(password) {
   let hash = 0;
   for (let index = 0; index < password.length; index += 1) {
     hash = (hash * 31 + password.charCodeAt(index)) >>> 0;
   }
   return hash.toString(16).padStart(8, '0');
+}
+
+export function generateSalt() {
+  const arr = new Uint8Array(16);
+  if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+    crypto.getRandomValues(arr);
+  } else {
+    for (let i = 0; i < arr.length; i++) {
+      arr[i] = Math.floor(Math.random() * 256);
+    }
+  }
+  return Array.from(arr).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+export async function hashPassword(password, salt) {
+  const encoder = new TextEncoder();
+  const saltedData = encoder.encode(password + (salt || ''));
+  const hashBuffer = await crypto.subtle.digest("SHA-256", saltedData);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
 }

--- a/tests/auth.test.mjs
+++ b/tests/auth.test.mjs
@@ -85,14 +85,19 @@ test('normalizeEmail normalizes and trims email addresses', () => {
   assert.equal(storage.normalizeEmail(null), '');
 });
 
-test('hashPassword generates consistent hash string', () => {
-  const hash1 = storage.hashPassword('my-password-123');
-  const hash2 = storage.hashPassword('my-password-123');
-  const hash3 = storage.hashPassword('other-password');
+test('hashPassword generates consistent hash string', async () => {
+  const salt1 = storage.generateSalt();
+  const salt2 = storage.generateSalt();
+  
+  const hash1 = await storage.hashPassword('my-password-123', salt1);
+  const hash2 = await storage.hashPassword('my-password-123', salt1);
+  const hash3 = await storage.hashPassword('my-password-123', salt2);
+  const hash4 = await storage.hashPassword('other-password', salt1);
   
   assert.equal(hash1, hash2);
   assert.notEqual(hash1, hash3);
-  assert.equal(hash1.length, 8);
+  assert.notEqual(hash1, hash4);
+  assert.equal(hash1.length, 64);
 });
 
 // ---------------------------------------------------------------------
@@ -156,7 +161,8 @@ test('registerLocalUser creates account and sets session user', async () => {
   const accounts = storage.getStoredAccounts();
   assert.equal(accounts.length, 1);
   assert.equal(accounts[0].email, 'test@explorer.in');
-  assert.equal(accounts[0].passwordHash, storage.hashPassword('securePassword123'));
+  assert.ok(accounts[0].passwordSalt);
+  assert.equal(accounts[0].passwordHash, await storage.hashPassword('securePassword123', accounts[0].passwordSalt));
 });
 
 test('registerLocalUser rejects weak password or existing email', async () => {
@@ -219,6 +225,51 @@ test('signInLocalUser rejects incorrect credentials', async () => {
     async () => await authApi.signInLocal({ email: 'unknown@test.com', password: 'password' }),
     (err) => err.code === 'auth/user-not-found'
   );
+});
+
+test('signInLocalUser handles legacy accounts and performs auto-upgrade', async () => {
+  resetStorage();
+  
+  // Manually seed a legacy account (using legacyHashPassword, no passwordSalt)
+  const legacyAccount = {
+    email: 'legacy@explorer.in',
+    passwordHash: storage.legacyHashPassword('legacyPassword123'),
+    displayName: 'LegacyUser',
+    provider: 'local',
+    role: 'free'
+  };
+  
+  const accounts = [legacyAccount];
+  storage.saveAccounts(accounts);
+  
+  // Try to sign in with the legacy credentials
+  const loggedIn = await authApi.signInLocal({
+    email: 'legacy@explorer.in',
+    password: 'legacyPassword123'
+  });
+  
+  assert.equal(loggedIn.email, 'legacy@explorer.in');
+  assert.equal(loggedIn.displayName, 'LegacyUser');
+  
+  // Verify that the account in storage was upgraded (now has passwordSalt and SHA-256 passwordHash)
+  const updatedAccounts = storage.getStoredAccounts();
+  assert.equal(updatedAccounts.length, 1);
+  assert.ok(updatedAccounts[0].passwordSalt);
+  assert.equal(updatedAccounts[0].passwordHash.length, 64); // SHA-256 length
+  
+  // Verify it computes the correct salted hash
+  const expectedHash = await storage.hashPassword('legacyPassword123', updatedAccounts[0].passwordSalt);
+  assert.equal(updatedAccounts[0].passwordHash, expectedHash);
+  
+  // Verify subsequent sign in works with the newly upgraded hash
+  globalThis.window.sessionStorage.clear();
+  _resetLocalSessionCache();
+  
+  const loggedInAgain = await authApi.signInLocal({
+    email: 'legacy@explorer.in',
+    password: 'legacyPassword123'
+  });
+  assert.ok(loggedInAgain);
 });
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
This PR resolves #229 by implementing secure salted SHA-256 password hashing.

### Changes
- Replace weak custom rolling polynomial hash in auth-storage.mjs with secure salted SHA-256 using crypto.subtle.digest.
- Automatically generate a unique random salt for each new account.
- Fallback to legacy password hash verification for existing accounts on login.
- Automatically upgrade legacy accounts to salted SHA-256 on their next successful login.