### PR TITLE
feat: add shareable card deep links

### DIFF
--- a/bazaars.html
+++ b/bazaars.html
@@ -16,6 +16,7 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="bazaars.css">
   <link rel="stylesheet" href="compare-drawer.css">
+  <link rel="stylesheet" href="card-deeplink.css">
 </head>
 <body>
   <header class="navbar scrolled" id="navbar">
@@ -146,5 +147,6 @@
   <script src="bazaars.js" defer></script>
   <script src="compare-drawer.js"></script>
     <script type="module" src="auth.js"></script>
+  <script src="card-deeplink.js"></script>
 </body>
 </html>

--- a/butterfly.html
+++ b/butterfly.html
@@ -16,6 +16,7 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="butterfly.css">
   <link rel="stylesheet" href="compare-drawer.css">
+  <link rel="stylesheet" href="card-deeplink.css">
 </head>
 <body>
   <header class="navbar scrolled" id="navbar">
@@ -151,5 +152,6 @@
   <script src="butterfly.js" defer></script>
   <script src="compare-drawer.js"></script>
     <script type="module" src="auth.js"></script>
+  <script src="card-deeplink.js"></script>
 </body>
 </html>

--- a/card-deeplink.css
+++ b/card-deeplink.css
@@ -1,0 +1,165 @@
+/* Issue #248 — Shareable Deep Links for Explorer Cards */
+
+:root {
+  --deeplink-accent: var(--saffron, #ff9933);
+  --deeplink-green: var(--green, #138808);
+  --deeplink-border: var(--glass-border, rgba(255,255,255,.16));
+  --deeplink-shadow: 0 20px 58px rgba(0,0,0,.28);
+}
+
+.card-deeplink-action {
+  border: 1px solid rgba(255,255,255,.28);
+  border-radius: 999px;
+  padding: 8px 12px;
+  background: rgba(0,0,0,.55);
+  color: #fff;
+  font: inherit;
+  font-size: .78rem;
+  font-weight: 900;
+  cursor: pointer;
+  backdrop-filter: blur(8px);
+  transition: transform .2s ease, background .2s ease, border-color .2s ease;
+}
+
+.card-deeplink-action:hover,
+.card-deeplink-action:focus-visible {
+  outline: none;
+  transform: translateY(-1px);
+  border-color: var(--deeplink-accent);
+  background: rgba(255,153,51,.24);
+}
+
+.card-deeplink-action.is-copied {
+  background: linear-gradient(135deg, var(--deeplink-accent), var(--deeplink-green));
+  border-color: transparent;
+}
+
+.card-deeplink-target {
+  scroll-margin-top: 96px;
+}
+
+.card-deeplink-highlight {
+  position: relative;
+  animation: cardDeeplinkPulse 1.6s ease-out 1;
+  outline: 3px solid rgba(255,153,51,.68);
+  outline-offset: 5px;
+  scroll-margin-top: 96px;
+}
+
+.card-deeplink-toast {
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  z-index: 5200;
+  max-width: min(440px, calc(100vw - 30px));
+  transform: translateX(-50%) translateY(20px);
+  border: 1px solid var(--deeplink-border);
+  border-radius: 999px;
+  padding: 11px 16px;
+  background: rgba(12,15,24,.96);
+  color: #fff;
+  font-weight: 800;
+  box-shadow: var(--deeplink-shadow);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity .2s ease, transform .2s ease;
+}
+
+.card-deeplink-toast.is-visible {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+.card-deeplink-fallback {
+  position: fixed;
+  right: 20px;
+  bottom: 22px;
+  z-index: 5100;
+  width: min(380px, calc(100vw - 32px));
+  border: 1px solid var(--deeplink-border);
+  border-radius: 20px;
+  padding: 16px;
+  background: rgba(14,18,28,.97);
+  color: #fff;
+  box-shadow: var(--deeplink-shadow);
+}
+
+.card-deeplink-fallback h3 {
+  margin: 0 0 6px;
+  font-size: 1rem;
+}
+
+.card-deeplink-fallback p {
+  margin: 0 0 12px;
+  color: rgba(255,255,255,.72);
+  line-height: 1.5;
+}
+
+.card-deeplink-fallback button {
+  border: 1px solid rgba(255,255,255,.18);
+  border-radius: 999px;
+  padding: 8px 12px;
+  background: transparent;
+  color: #fff;
+  font: inherit;
+  font-size: .82rem;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.card-deeplink-fallback button:hover,
+.card-deeplink-fallback button:focus-visible {
+  outline: none;
+  border-color: var(--deeplink-accent);
+}
+
+body.light-theme .card-deeplink-toast,
+body.light-theme .card-deeplink-fallback {
+  background: rgba(255,255,255,.97);
+  color: #172033;
+}
+
+body.light-theme .card-deeplink-fallback p {
+  color: #64748b;
+}
+
+body.light-theme .card-deeplink-fallback button {
+  color: #172033;
+  border-color: rgba(15,23,42,.14);
+}
+
+@keyframes cardDeeplinkPulse {
+  0% {
+    box-shadow: 0 0 0 0 rgba(255,153,51,.68), 0 0 0 0 rgba(19,136,8,.24);
+  }
+  60% {
+    box-shadow: 0 0 0 12px rgba(255,153,51,0), 0 0 0 22px rgba(19,136,8,0);
+  }
+  100% {
+    box-shadow: 0 0 0 0 rgba(255,153,51,0), 0 0 0 0 rgba(19,136,8,0);
+  }
+}
+
+@media (max-width: 640px) {
+  .card-deeplink-fallback {
+    left: 14px;
+    right: 14px;
+    bottom: 14px;
+    width: auto;
+  }
+
+  .card-deeplink-toast {
+    bottom: 18px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card-deeplink-action,
+  .card-deeplink-toast {
+    transition: none;
+  }
+
+  .card-deeplink-highlight {
+    animation: none;
+  }
+}

--- a/card-deeplink.js
+++ b/card-deeplink.js
@@ -1,0 +1,294 @@
+/* Issue #248 — Shareable Deep Links for Explorer Cards */
+
+(function () {
+  "use strict";
+
+  const CONFIG = {
+    cardSelector:
+      "[data-deeplink-card], [data-recent-item], [data-compare-item], .heritage-card, .wildlife-card, .textile-card, .water-card, .instrument-card, .butterfly-card, .bazaar-card, .script-card, .glossary-card, .destination-card, .festival-card, .cuisine-card, .university-card, .plant-card, .wonder-card, .tree-card, .unesco-card",
+    titleSelector: "h1, h2, h3, .card-title, .title",
+    buttonMountSelector:
+      ".heritage-media, .wildlife-media, .textile-media, .water-media, .instrument-media, .butterfly-media, .bazaar-media, .script-media, .destination-media, .festival-media, .cuisine-media, .media, figure",
+    openButtonSelector:
+      ".explore-button, [data-open-modal], button[aria-label*='details' i], button[aria-label*='explore' i]",
+    modalSelector:
+      ".heritage-modal, .wildlife-modal, .textile-modal, .water-modal, .instrument-modal, .butterfly-modal, .bazaar-modal, .script-modal, .modal, [role='dialog']",
+  };
+
+  let toastTimer;
+  let fallbackTimer;
+
+  const escapeHtml = (value) =>
+    String(value ?? "")
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+
+  const slugify = (value) =>
+    String(value || "item")
+      .toLowerCase()
+      .trim()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+
+  function prefersReducedMotion() {
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  }
+
+  function getCardTitle(card) {
+    const explicit =
+      card.getAttribute("data-deeplink-title") ||
+      card.getAttribute("data-recent-title") ||
+      card.getAttribute("data-compare-title");
+
+    if (explicit) return explicit;
+
+    const title = card.querySelector(CONFIG.titleSelector);
+    return title ? title.textContent.trim().replace(/\s+/g, " ") : "Explorer card";
+  }
+
+  function getPageSlug() {
+    const fileName = location.pathname.split("/").pop().replace(".html", "");
+    if (fileName) return fileName;
+
+    const title = document.title.replace(" | Incredible India", "").trim();
+    return slugify(title || "explorer");
+  }
+
+  function ensureCardId(card) {
+    if (card.id) {
+      card.classList.add("card-deeplink-target");
+      return card.id;
+    }
+
+    const existing =
+      card.getAttribute("data-deeplink-id") ||
+      card.dataset.id ||
+      card.dataset.recentResolvedId ||
+      card.dataset.compareResolvedId;
+
+    const base = slugify(existing || `${getPageSlug()}-${getCardTitle(card)}`);
+    let candidate = base || `card-${Math.random().toString(36).slice(2, 8)}`;
+    let counter = 2;
+
+    while (document.getElementById(candidate)) {
+      candidate = `${base}-${counter}`;
+      counter += 1;
+    }
+
+    card.id = candidate;
+    card.classList.add("card-deeplink-target");
+    return candidate;
+  }
+
+  function getCardUrl(card) {
+    const id = ensureCardId(card);
+    return `${location.origin}${location.pathname}${location.search}#${encodeURIComponent(id)}`;
+  }
+
+  async function copyText(text) {
+    if (navigator.clipboard && window.isSecureContext) {
+      await navigator.clipboard.writeText(text);
+      return;
+    }
+
+    const area = document.createElement("textarea");
+    area.value = text;
+    area.setAttribute("readonly", "");
+    area.style.position = "fixed";
+    area.style.left = "-9999px";
+    document.body.append(area);
+    area.select();
+
+    const ok = document.execCommand("copy");
+    area.remove();
+
+    if (!ok) throw new Error("Copy command failed");
+  }
+
+  function showToast(message) {
+    let toast = document.querySelector(".card-deeplink-toast");
+
+    if (!toast) {
+      toast = document.createElement("div");
+      toast.className = "card-deeplink-toast";
+      toast.setAttribute("role", "status");
+      toast.setAttribute("aria-live", "polite");
+      document.body.append(toast);
+    }
+
+    toast.textContent = message;
+    toast.classList.add("is-visible");
+
+    clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => {
+      toast.classList.remove("is-visible");
+    }, 2200);
+  }
+
+  function showInvalidHashFallback(hash) {
+    let fallback = document.querySelector(".card-deeplink-fallback");
+
+    if (!fallback) {
+      fallback = document.createElement("div");
+      fallback.className = "card-deeplink-fallback";
+      fallback.setAttribute("role", "status");
+      document.body.append(fallback);
+    }
+
+    fallback.innerHTML = `
+      <h3>Card link not found</h3>
+      <p>The link target <strong>${escapeHtml(hash)}</strong> does not match a card on this page.</p>
+      <button type="button">Dismiss</button>
+    `;
+
+    fallback.querySelector("button").addEventListener("click", () => fallback.remove());
+
+    clearTimeout(fallbackTimer);
+    fallbackTimer = setTimeout(() => {
+      fallback.remove();
+    }, 7000);
+  }
+
+  function highlightCard(card) {
+    card.classList.remove("card-deeplink-highlight");
+    void card.offsetWidth;
+    card.classList.add("card-deeplink-highlight");
+
+    setTimeout(() => {
+      card.classList.remove("card-deeplink-highlight");
+    }, 2200);
+  }
+
+  function scrollToCard(card) {
+    card.scrollIntoView({
+      behavior: prefersReducedMotion() ? "auto" : "smooth",
+      block: "start",
+    });
+
+    highlightCard(card);
+  }
+
+  function tryOpenCardModal(card) {
+    const openButton = card.querySelector(CONFIG.openButtonSelector);
+    if (!openButton) return false;
+
+    const beforeModal = Array.from(document.querySelectorAll(CONFIG.modalSelector))
+      .some((modal) => modal.hidden === false || modal.classList.contains("active") || modal.classList.contains("show"));
+
+    openButton.click();
+
+    const afterModal = Array.from(document.querySelectorAll(CONFIG.modalSelector))
+      .some((modal) => modal.hidden === false || modal.classList.contains("active") || modal.classList.contains("show"));
+
+    return afterModal || beforeModal;
+  }
+
+  function handleHashTarget() {
+    if (!location.hash) return;
+
+    const decodedHash = decodeURIComponent(location.hash.slice(1));
+    if (!decodedHash) return;
+
+    const target = document.getElementById(decodedHash);
+
+    if (!target) {
+      showInvalidHashFallback(`#${decodedHash}`);
+      return;
+    }
+
+    if (!target.matches(CONFIG.cardSelector) && !target.closest(CONFIG.cardSelector)) {
+      target.scrollIntoView({
+        behavior: prefersReducedMotion() ? "auto" : "smooth",
+        block: "start",
+      });
+      return;
+    }
+
+    const card = target.matches(CONFIG.cardSelector) ? target : target.closest(CONFIG.cardSelector);
+
+    setTimeout(() => {
+      scrollToCard(card);
+      tryOpenCardModal(card);
+    }, 180);
+  }
+
+  function injectCopyButtons() {
+    const cards = Array.from(document.querySelectorAll(CONFIG.cardSelector));
+
+    cards.forEach((card) => {
+      if (card.dataset.deeplinkReady === "true") return;
+
+      ensureCardId(card);
+      card.dataset.deeplinkReady = "true";
+
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "card-deeplink-action";
+      button.textContent = "🔗 Copy link";
+      button.setAttribute("aria-label", `Copy link to ${getCardTitle(card)}`);
+
+      button.addEventListener("click", async (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+
+        const url = getCardUrl(card);
+
+        try {
+          await copyText(url);
+          history.replaceState(null, "", `#${card.id}`);
+          showToast("Card link copied.");
+          button.classList.add("is-copied");
+          button.textContent = "✓ Copied";
+          setTimeout(() => {
+            button.classList.remove("is-copied");
+            button.textContent = "🔗 Copy link";
+          }, 1600);
+        } catch {
+          showToast("Copy failed. URL updated in the address bar.");
+          location.hash = card.id;
+        }
+      });
+
+      const mount = card.querySelector(CONFIG.buttonMountSelector) || card;
+      mount.append(button);
+    });
+  }
+
+  function observeNewCards() {
+    const observer = new MutationObserver((mutations) => {
+      if (mutations.some((mutation) => mutation.addedNodes.length > 0)) {
+        injectCopyButtons();
+      }
+    });
+
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  function initCardDeeplinks() {
+    if (document.body.dataset.disableCardDeeplinks === "true") return;
+
+    injectCopyButtons();
+    handleHashTarget();
+    observeNewCards();
+
+    window.addEventListener("hashchange", handleHashTarget);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initCardDeeplinks);
+  } else {
+    initCardDeeplinks();
+  }
+
+  window.CardDeepLinks = {
+    refresh: injectCopyButtons,
+    openHash: handleHashTarget,
+    getUrlForCard: getCardUrl,
+  };
+})();

--- a/culture.html
+++ b/culture.html
@@ -22,6 +22,7 @@
     <!-- Custom Stylesheet -->
     <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="page-progress.css">
+  <link rel="stylesheet" href="card-deeplink.css">
 </head>
 <body class="culture-page-body">
 
@@ -164,6 +165,7 @@
     <script type="module" src="auth.js"></script>
     <script src="router.js" defer></script>
   <script src="page-progress.js"></script>
+  <script src="card-deeplink.js"></script>
 </body>
 </html>
 

--- a/glossary.html
+++ b/glossary.html
@@ -7,6 +7,7 @@
   <meta name="description" content="A beginner-friendly glossary of Indian culture, history, geography, architecture, music, nature, food, and literature terms.">
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="glossary.css">
+  <link rel="stylesheet" href="card-deeplink.css">
 </head>
 <body>
   <header class="navbar scrolled" id="navbar">
@@ -99,5 +100,6 @@
   <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
   <script src="app.js"></script>
   <script src="glossary.js"></script>
+  <script src="card-deeplink.js"></script>
 </body>
 </html>

--- a/heritage.html
+++ b/heritage.html
@@ -72,6 +72,7 @@
     </style>
   <link rel="stylesheet" href="compare-drawer.css">
   <link rel="stylesheet" href="page-progress.css">
+  <link rel="stylesheet" href="card-deeplink.css">
 </head>
 <body>
     <header class="navbar" id="navbar">
@@ -249,5 +250,6 @@
     <script src="router.js" defer></script>
   <script src="compare-drawer.js"></script>
   <script src="page-progress.js"></script>
+  <script src="card-deeplink.js"></script>
 </body>
 </html>

--- a/musical-instruments.html
+++ b/musical-instruments.html
@@ -16,6 +16,7 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="musical-instruments.css">
   <link rel="stylesheet" href="compare-drawer.css">
+  <link rel="stylesheet" href="card-deeplink.css">
 </head>
 <body>
   <header class="navbar scrolled" id="navbar">
@@ -134,5 +135,6 @@
   <script src="musical-instruments.js" defer></script>
   <script src="compare-drawer.js"></script>
     <script type="module" src="auth.js"></script>
+  <script src="card-deeplink.js"></script>
 </body>
 </html>

--- a/scripts.html
+++ b/scripts.html
@@ -16,6 +16,7 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="scripts.css">
   <link rel="stylesheet" href="compare-drawer.css">
+  <link rel="stylesheet" href="card-deeplink.css">
 </head>
 <body>
   <header class="navbar scrolled" id="navbar">
@@ -139,5 +140,6 @@
   <script src="scripts.js" defer></script>
   <script src="compare-drawer.js"></script>
     <script type="module" src="auth.js"></script>
+  <script src="card-deeplink.js"></script>
 </body>
 </html>

--- a/textiles.html
+++ b/textiles.html
@@ -16,6 +16,7 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="textiles.css">
   <link rel="stylesheet" href="compare-drawer.css">
+  <link rel="stylesheet" href="card-deeplink.css">
 </head>
 <body>
   <header class="navbar scrolled" id="navbar">
@@ -138,5 +139,6 @@
   <script src="textiles.js" defer></script>
   <script src="compare-drawer.js"></script>
     <script type="module" src="auth.js"></script>
+  <script src="card-deeplink.js"></script>
 </body>
 </html>

--- a/travel.html
+++ b/travel.html
@@ -266,6 +266,7 @@
 }
     </style>
   <link rel="stylesheet" href="page-progress.css">
+  <link rel="stylesheet" href="card-deeplink.css">
 </head>
 <body>
 <!-- Sticky Navigation Bar -->
@@ -587,5 +588,6 @@
     <script src="travel-recommend.js" defer></script>
     <script src="travel-journey.js" defer></script>
   <script src="page-progress.js"></script>
+  <script src="card-deeplink.js"></script>
 </body>
 </html>

--- a/water-systems.html
+++ b/water-systems.html
@@ -16,6 +16,7 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="stylesheet" href="water-systems.css">
   <link rel="stylesheet" href="compare-drawer.css">
+  <link rel="stylesheet" href="card-deeplink.css">
 </head>
 <body>
   <header class="navbar scrolled" id="navbar">
@@ -145,5 +146,6 @@
   <script src="water-systems.js" defer></script>
   <script src="compare-drawer.js"></script>
     <script type="module" src="auth.js"></script>
+  <script src="card-deeplink.js"></script>
 </body>
 </html>

--- a/wildlife.html
+++ b/wildlife.html
@@ -218,6 +218,7 @@
             font-size: 0.95rem;
         }
     </style>
+  <link rel="stylesheet" href="card-deeplink.css">
 </head>
 <body>
 <header class="navbar scrolled" id="navbar">
@@ -807,5 +808,6 @@
 <script src="compare-drawer.js" defer></script>
 <script src="page-progress.js" defer></script>
 <script src="wildlife-filter.js" defer></script>
+  <script src="card-deeplink.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Description

Fixes #248

This PR adds a reusable **Shareable Deep Links for Explorer Cards** feature that allows users to copy and open direct links to individual explorer cards.

### Summary

* Added `card-deeplink.css`.
* Added `card-deeplink.js`.
* Added reusable copy-link buttons for explorer cards.
* Added URL hash support such as `page.html#card-id`.
* Added automatic card ID generation when a card does not already have an ID.
* Added full URL copy behavior.
* Added fallback copy support for non-secure/local contexts.
* Added URL hash update after copying a card link.
* Added auto-scroll to matching card on page load.
* Added temporary highlight animation for linked cards.
* Added optional modal auto-open when a linked card has an existing explore/details button.
* Added invalid-hash fallback message.
* Added MutationObserver support so dynamically rendered cards also receive copy-link buttons.
* Added dark/light theme compatibility.
* Added responsive mobile-safe fallback UI.
* Kept the feature reusable for future explorer pages.

## Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Documentation update

## Testing

Manually verified:

* Copy link button appears on supported explorer cards.
* Clicking copy link copies the full URL.
* URL hash updates after copying.
* Opening `page.html#card-id` scrolls to the correct card.
* Target card gets a temporary highlight animation.
* Existing modal/detail button opens when available.
* Invalid hash shows a friendly fallback message.
* Dynamically rendered cards receive copy-link buttons.
* Dark/light theme compatibility works.
* Desktop responsiveness works.
* Tablet responsiveness works.
* Mobile responsiveness works.
* Browser console shows no JavaScript errors.

## Checklist

* [x] My code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] My changes generate no new warnings.
* [x] The feature is reusable across explorer pages.
* [x] The implementation does not require a backend.
 
## Screenshots
<img width="1919" height="992" alt="Screenshot 2026-07-19 214222" src="https://github.com/user-attachments/assets/04bc2d35-8949-43d5-a995-c2477fcf84fc" />
<img width="1904" height="954" alt="Screenshot 2026-07-19 214202" src="https://github.com/user-attachments/assets/71062015-fe9e-4f8b-88a7-308335438df2" />
<img width="1919" height="992" alt="Screenshot 2026-07-19 214222" src="https://github.com/user-attachments/assets/e3f0d12b-1e48-42c0-92e6-bdad22e0d654" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added shareable links for Explorer Cards across supported pages.
  - Users can copy a card’s direct link and return to the exact card later.
  - Opening a card link automatically scrolls to and highlights the card, with related details opened when available.
  - Added clear success and error notifications, including a fallback when a linked card cannot be found.
- **Accessibility & Experience**
  - Added responsive styling, light-theme support, and reduced-motion handling for deep-link interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->