### PR TITLE
Fix: Secure local auth tokens with HMAC-SHA256 signature verification

### DIFF
--- a/auth-session.mjs
+++ b/auth-session.mjs
@@ -69,6 +69,13 @@ export async function verifyLocalSession() {
   const claims = await verifySignedToken(user.token);
   if (!claims) {
     clearStoredAuthUser();
+    if (typeof window !== 'undefined' && window.location) {
+      try {
+        window.location.href = 'login.html';
+      } catch (err) {
+        // Safe fallback for testing environment
+      }
+    }
     return null;
   }
   

--- a/auth-token.mjs
+++ b/auth-token.mjs
@@ -23,42 +23,100 @@ export function base64UrlToArrayBuffer(base64Url) {
   return bytes.buffer;
 }
 
+let cachedKey = null;
+
+export function _resetSigningKey() {
+  cachedKey = null;
+}
+
+async function getSigningKey() {
+  if (cachedKey) return cachedKey;
+
+  const keyStorageKey = 'incredible-india-auth-signing-secret';
+  let rawSecret = null;
+  
+  if (typeof window !== 'undefined' && window.localStorage) {
+    try {
+      rawSecret = window.localStorage.getItem(keyStorageKey);
+    } catch (e) {}
+  }
+
+  if (!rawSecret) {
+    const array = new Uint8Array(32);
+    if (typeof crypto !== 'undefined' && crypto.getRandomValues) {
+      crypto.getRandomValues(array);
+    } else {
+      for (let i = 0; i < array.length; i++) {
+        array[i] = Math.floor(Math.random() * 256);
+      }
+    }
+    rawSecret = Array.from(array).map(b => b.toString(16).padStart(2, '0')).join('');
+    if (typeof window !== 'undefined' && window.localStorage) {
+      try {
+        window.localStorage.setItem(keyStorageKey, rawSecret);
+      } catch (e) {}
+    }
+  }
+
+  const encoder = new TextEncoder();
+  const keyData = encoder.encode(rawSecret);
+  
+  cachedKey = await crypto.subtle.importKey(
+    "raw",
+    keyData,
+    { name: "HMAC", hash: { name: "SHA-256" } },
+    false,
+    ["sign", "verify"]
+  );
+  
+  return cachedKey;
+}
+
 /**
- * Generates a signed token that acts as a non-security integrity marker.
- * It uses Web Crypto SHA-256 digest on the client side (no secret keys needed).
+ * Generates a signed token that acts as a secure integrity marker.
+ * It uses Web Crypto HMAC-SHA256 signature with a locally-stored secret.
  */
 export async function generateSignedToken(payload) {
-  const header = { alg: "SHA256", typ: "JWT" };
+  const header = { alg: "HS256", typ: "JWT" };
   const headerB64 = arrayBufferToBase64Url(new TextEncoder().encode(JSON.stringify(header)));
   const payloadB64 = arrayBufferToBase64Url(new TextEncoder().encode(JSON.stringify(payload)));
   
   const signInput = `${headerB64}.${payloadB64}`;
+  const key = await getSigningKey();
   
-  // Calculate SHA-256 hash as an integrity marker
-  const hashBuffer = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(signInput));
-  const integrityMarker = arrayBufferToBase64Url(hashBuffer);
+  const signatureBuffer = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(signInput)
+  );
+  const signature = arrayBufferToBase64Url(signatureBuffer);
   
-  return `${signInput}.${integrityMarker}`;
+  return `${signInput}.${signature}`;
 }
 
 /**
- * Verifies the integrity of a signed token using SHA-256.
+ * Verifies the integrity of a signed token using HMAC-SHA256.
  */
 export async function verifySignedToken(token) {
   if (!token) return null;
   const parts = token.split('.');
   if (parts.length !== 3) return null;
   
-  const [headerB64, payloadB64, integrityMarker] = parts;
+  const [headerB64, payloadB64, signature] = parts;
   try {
     const signInput = `${headerB64}.${payloadB64}`;
+    const key = await getSigningKey();
+    const signatureBuffer = base64UrlToArrayBuffer(signature);
     
-    // Recalculate SHA-256 hash to verify payload integrity
-    const hashBuffer = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(signInput));
-    const expectedMarker = arrayBufferToBase64Url(hashBuffer);
+    const isValid = await crypto.subtle.verify(
+      "HMAC",
+      key,
+      signatureBuffer,
+      new TextEncoder().encode(signInput)
+    );
     
-    if (integrityMarker !== expectedMarker) {
-      console.error("Token verification failed: Integrity marker mismatch");
+    if (!isValid) {
+      console.error("Token verification failed: Signature mismatch");
       return null;
     }
     

--- a/tests/auth.test.mjs
+++ b/tests/auth.test.mjs
@@ -72,6 +72,9 @@ function resetStorage() {
   globalThis.window.localStorage.clear();
   globalThis.window.sessionStorage.clear();
   _resetLocalSessionCache();
+  if (tokenModule._resetSigningKey) {
+    tokenModule._resetSigningKey();
+  }
   mockEvents.length = 0;
   eventListeners.clear();
 }
@@ -228,6 +231,12 @@ test('signInLocalUser rejects incorrect credentials', async () => {
 test('verifySession validates active local user session', async () => {
   resetStorage();
   
+  let redirectedUrl = null;
+  globalThis.window.location = {
+    set href(val) { redirectedUrl = val; },
+    get href() { return redirectedUrl; }
+  };
+  
   const user = await authApi.registerLocal({
     email: 'session@test.com',
     password: 'password123'
@@ -235,6 +244,7 @@ test('verifySession validates active local user session', async () => {
   
   const verifiedUser = await authApi.verifySession();
   assert.deepEqual(verifiedUser, user);
+  assert.equal(redirectedUrl, null);
   
   // Manually corrupt token in session storage
   const corruptedUser = { ...user, token: 'corrupted.jwt.token' };
@@ -246,6 +256,9 @@ test('verifySession validates active local user session', async () => {
   const failedVerification = await authApi.verifySession();
   assert.equal(failedVerification, null);
   assert.equal(authApi.getStoredAuthUser(), null);
+  assert.equal(redirectedUrl, 'login.html');
+  
+  delete globalThis.window.location;
 });
 
 test('signOut clears active user session', async () => {


### PR DESCRIPTION
This PR resolves #228 by securing local session tokens against signature forgery.

### Changes
- Use Web Crypto API's HMAC-SHA256 for token signing and validation in auth-token.mjs.
- Generate a persistent random secret key saved in localStorage if it doesn't exist, preventing simple client-side forgery.
- Update verifyLocalSession in auth-session.mjs to clear stored user session and redirect the user back to login.html on token signature verification failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved authentication token protection with HMAC-SHA256 signatures.
  * Invalid or tampered session tokens are rejected and stored authentication data is cleared.

* **Bug Fixes**
  * Invalid local sessions now redirect to the login page in browser environments.
  * Session verification remains safe in non-browser and testing environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->