### PR TITLE
feat: Add Uttar Pradesh Handicrafts Showcase (#485)

### DIFF
--- a/frontend/handicrafts-showcase/index.html
+++ b/frontend/handicrafts-showcase/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>UP Handicrafts Showcase | Incredible India Explorer</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&family=Cormorant+Garamond:ital,wght@0,500;0,600;1,500&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<header class="hc-navbar">
+  <a href="../../index.html" class="back-link">&larr; Back to Home</a>
+  <div class="nav-brand">
+    <span class="saffron">Incredible</span>
+    <span class="gold">India</span>
+    <span class="green">Explorer</span>
+  </div>
+</header>
+
+<section class="hero-section">
+  <div class="hero-pattern-strip"></div>
+  <span class="section-badge">Woven Heritage • Living Traditions</span>
+  <h1>🧵 Uttar Pradesh Handicrafts Showcase</h1>
+  <p class="hero-text">From the needle-fine threads of Lucknow's Chikankari to the gleaming brassware of Moradabad — journey through the districts that keep UP's centuries-old craft traditions alive.</p>
+  <div class="hero-stats">
+    <div class="hero-stat"><span id="totalCraftsStat">0</span><label>Crafts</label></div>
+    <div class="hero-stat"><span id="totalDistrictsStat">0</span><label>Districts</label></div>
+    <div class="hero-stat"><span>GI</span><label>Tagged Heritage</label></div>
+  </div>
+  <div class="hero-pattern-strip"></div>
+</section>
+
+<div class="container">
+
+  <div class="layout-grid">
+
+    <!-- District Sidebar -->
+    <aside class="district-sidebar">
+      <h3 class="sidebar-title">📍 Filter by District</h3>
+      <div class="district-list" id="districtList">
+        <button class="district-btn active" data-district="all">
+          <span class="district-name">All Districts</span>
+        </button>
+      </div>
+
+      <h3 class="sidebar-title" style="margin-top: 24px;">🏷️ Craft Category</h3>
+      <div class="category-list" id="categoryList">
+        <button class="category-btn active" data-category="all">All Categories</button>
+        <button class="category-btn" data-category="textile">Textile & Weaving</button>
+        <button class="category-btn" data-category="metal">Metalwork</button>
+        <button class="category-btn" data-category="wood">Woodcraft</button>
+        <button class="category-btn" data-category="glass">Glass & Pottery</button>
+        <button class="category-btn" data-category="carpet">Carpets & Rugs</button>
+      </div>
+    </aside>
+
+    <!-- Main Content -->
+    <main class="craft-main">
+      <div class="search-row">
+        <div class="search-box">
+          <span class="search-icon">🔍</span>
+          <input type="text" id="searchInput" placeholder="Search crafts, districts, artisans...">
+        </div>
+        <span class="results-count" id="resultsCount">Showing 15 crafts</span>
+      </div>
+
+      <div class="craft-grid" id="craftGrid"></div>
+
+      <div id="noResults" class="no-results hidden">
+        <span class="no-results-icon">🧶</span>
+        <p>No crafts match your search. Try a different district, category, or keyword.</p>
+      </div>
+    </main>
+
+    <!-- Detail Side Panel -->
+    <aside class="detail-panel" id="detailPanel">
+      <div class="detail-panel-empty" id="detailEmpty">
+        <span class="empty-icon">🪡</span>
+        <p>Select a craft to explore its history, artisans, and district story.</p>
+      </div>
+
+      <div class="detail-panel-content hidden" id="detailContent">
+        <button class="detail-close-btn" id="detailCloseBtn">&times;</button>
+        <div class="detail-icon" id="detailIcon">🧵</div>
+        <span class="detail-district-tag" id="detailDistrictTag">Lucknow</span>
+        <h2 class="detail-title" id="detailTitle">Craft Name</h2>
+        <p class="detail-description" id="detailDescription">Description here.</p>
+
+        <div class="detail-section">
+          <h4>📜 Traditional History</h4>
+          <p id="detailHistory">History here.</p>
+        </div>
+
+        <div class="detail-section">
+          <h4>👩‍🎨 Artisan Insight</h4>
+          <p id="detailArtisan">Artisan info here.</p>
+        </div>
+
+        <div class="detail-section">
+          <h4>🗺️ District Story</h4>
+          <p id="detailDistrictStory">District story here.</p>
+        </div>
+      </div>
+    </aside>
+
+  </div>
+</div>
+
+<footer class="hc-footer">
+  <p>&copy; 2026 Incredible India Explorer. Uttar Pradesh Handicrafts Showcase.</p>
+</footer>
+
+<script src="script.js"></script>
+</body>
+</html>

--- a/frontend/handicrafts-showcase/script.js
+++ b/frontend/handicrafts-showcase/script.js
@@ -1,0 +1,326 @@
+// ---------- Handicrafts Data (16 crafts across UP districts) ----------
+const allCrafts = [
+  {
+    name: "Lucknow Chikankari",
+    icon: "🪡",
+    district: "Lucknow",
+    category: "textile",
+    tags: ["GI Tagged", "Embroidery"],
+    description: "A delicate white-thread embroidery style done on fine fabrics like muslin, chiffon, and organza.",
+    history: "Chikankari traces its roots to the Mughal era, with the word 'chikan' derived from a Persian term for fabric fashioned by embroidery. It flourished under Awadh's Nawabs and reached its artistic peak in Lucknow.",
+    artisan: "Skilled chikan artisans, many of them women working from home, use techniques like 'bakhia', 'murri', and 'keel kangan' to create over 30 distinct stitch styles, often passed down through generations.",
+    districtStory: "Lucknow remains the beating heart of chikankari, with entire neighbourhoods of artisan families dedicated to hand-embroidering sarees, kurtas, and dupattas for markets across India and abroad."
+  },
+  {
+    name: "Moradabad Brassware",
+    icon: "🏺",
+    district: "Moradabad",
+    category: "metal",
+    tags: ["GI Tagged", "Metalwork"],
+    description: "Intricately engraved brass, copper, and aluminium items known for ornamental and utilitarian craftsmanship.",
+    history: "Moradabad has been a metalworking hub for centuries, earning the nickname 'Peetal Nagri' (Brass City) of India for its dominance in decorative and export-quality metal crafts.",
+    artisan: "Artisans use two primary engraving techniques — 'Naqashi' (done on a tinned surface) and 'Khudai' (done on lac-coated unpolished brass) — to create vases, idols, trays, and contemporary bowls.",
+    districtStory: "Moradabad exports brassware to countries around the world, making it one of India's most significant handicraft export centres, employing thousands of skilled metal artisans."
+  },
+  {
+    name: "Bhadohi Carpets",
+    icon: "🧶",
+    district: "Bhadohi",
+    category: "carpet",
+    tags: ["GI Tagged", "Hand-knotted"],
+    description: "Hand-knotted wool and silk carpets known worldwide for intricate designs and remarkable durability.",
+    history: "Bhadohi's carpet-weaving tradition dates back centuries and the region is often referred to as the 'Carpet City' of India, supplying premium hand-knotted rugs to global markets.",
+    artisan: "Weavers use traditional knotting techniques passed through generations, with a single large carpet sometimes taking several artisans many months of patient, meticulous work to complete.",
+    districtStory: "Bhadohi, along with neighbouring Mirzapur, forms the largest hand-knotted carpet weaving belt in India, contributing significantly to the country's handicraft exports."
+  },
+  {
+    name: "Firozabad Glassware",
+    icon: "🔮",
+    district: "Firozabad",
+    category: "glass",
+    tags: ["GI Tagged", "Glasswork"],
+    description: "Decorative glass bangles, beads, and lighting pieces that showcase the region's centuries-old glassblowing tradition.",
+    history: "Firozabad's glass industry is believed to have flourished under Mughal patronage, and the city has since become synonymous with glass bangles across India.",
+    artisan: "Glassblowers work near furnaces at extreme temperatures, shaping molten glass into bangles, chandeliers, and decorative pieces with techniques refined over many generations.",
+    districtStory: "Firozabad is often called the 'Glass City' of India, and its bangle industry alone supports a vast network of artisan families and small workshops."
+  },
+  {
+    name: "Saharanpur Wood Carving",
+    icon: "🪵",
+    district: "Saharanpur",
+    category: "wood",
+    tags: ["GI Tagged", "Woodcraft"],
+    description: "Ornamental wooden furniture and decorative objects carved with intricate floral and geometric designs.",
+    history: "Saharanpur's woodcraft tradition is believed to have been influenced by Kashmiri settlers, blending Kashmiri carving patterns with local craftsmanship on teak, sheesham, and deodar wood.",
+    artisan: "Master carvers, known locally for their inlay and jali work, spend years perfecting the fine detailing seen on furniture, screens, and decorative panels.",
+    districtStory: "Saharanpur's wood carving industry contributes significantly to India's handicraft exports, with pieces finding their way into homes and galleries worldwide."
+  },
+  {
+    name: "Banarasi Silk Saree",
+    icon: "🧵",
+    district: "Varanasi",
+    category: "textile",
+    tags: ["GI Tagged", "Silk"],
+    description: "Luxurious silk sarees woven with intricate gold and silver zari work, considered among India's finest textiles.",
+    history: "Banarasi silk weaving is thought to have flourished during the Mughal era, when Persian motifs blended with Indian silk weaving traditions to create the distinctive Banarasi style.",
+    artisan: "Weaver families in Varanasi work on traditional handlooms, sometimes taking weeks to complete a single saree with elaborate brocade patterns and zari borders.",
+    districtStory: "Varanasi holds the highest number of GI-tagged products of any Indian city, with Banarasi silk remaining its most globally recognised textile export."
+  },
+  {
+    name: "Varanasi Zardozi",
+    icon: "✨",
+    district: "Varanasi",
+    category: "textile",
+    tags: ["Embroidery", "Metallic Thread"],
+    description: "Opulent gold and silver thread embroidery used to create lavish, intricate designs on fabric.",
+    history: "Zardozi embroidery has roots in royal Mughal courts, where artisans embellished garments and tapestries for royalty using real gold and silver threads.",
+    artisan: "Zardozi artisans use fine metallic threads, sequins, and beads, stitching elaborate patterns onto silk and velvet, often for bridal wear and ceremonial garments.",
+    districtStory: "Varanasi's zardozi workshops continue a centuries-old tradition, with many artisan families still practising skills inherited from their ancestors."
+  },
+  {
+    name: "Khurja Pottery",
+    icon: "🏺",
+    district: "Bulandshahr",
+    category: "glass",
+    tags: ["GI Tagged", "Ceramics"],
+    description: "Refined ceramic pottery known for its distinctive blue, green, and brown glazes, often called India's ceramics capital craft.",
+    history: "Khurja's pottery tradition developed with influences from Persian ceramic styles, evolving over centuries into a distinctly Indian glazed pottery art form.",
+    artisan: "Potters shape refined clay on traditional wheels before hand-painting and glazing each piece, a process requiring both technical skill and artistic patience.",
+    districtStory: "Khurja town, near Bulandshahr, is widely known as the 'Ceramics Capital of India', with generations of potter families keeping the tradition alive."
+  },
+  {
+    name: "Kannauj Attar",
+    icon: "🌸",
+    district: "Kannauj",
+    category: "textile",
+    tags: ["GI Tagged", "Perfumery"],
+    description: "Traditional natural perfumes distilled from flowers, herbs, and spices using centuries-old techniques.",
+    history: "Kannauj's perfumery tradition is believed to be centuries old, earning the town the title 'Perfume Capital of India' for its natural attar-making heritage.",
+    artisan: "Perfumers use the traditional 'deg-bhapka' distillation method, capturing floral essences in sandalwood oil over long, carefully monitored processes.",
+    districtStory: "Kannauj remains home to hundreds of small-scale attar distilleries, exporting natural perfumes to markets across India and the Middle East."
+  },
+  {
+    name: "Agra Stone Inlay",
+    icon: "🗿",
+    district: "Agra",
+    category: "wood",
+    tags: ["Stonecraft", "Pietra Dura"],
+    description: "Fine marble stone-carving and inlay work inspired by the decorative techniques seen on the Taj Mahal.",
+    history: "Agra's stone inlay craft, known as 'Pietra Dura', developed alongside the construction of Mughal monuments, with artisan families continuing techniques used on the Taj Mahal itself.",
+    artisan: "Craftsmen embed semi-precious stones into white marble to create intricate floral patterns, a painstaking process requiring extreme precision.",
+    districtStory: "Many of today's Agra stone-inlay artisans trace their lineage directly back to craftsmen who worked on the Taj Mahal centuries ago."
+  },
+  {
+    name: "Mainpuri Tarkashi",
+    icon: "🪞",
+    district: "Mainpuri",
+    category: "wood",
+    tags: ["Wire Inlay", "Woodwork"],
+    description: "A unique craft of inlaying fine brass wire into wooden furniture and decorative boxes.",
+    history: "Tarkashi, meaning wire craft, developed in Mainpuri as artisans began embedding thin brass wires into wood to create striking geometric and floral patterns.",
+    artisan: "Artisans carve fine grooves into wood before carefully hammering brass wire into place, creating a shimmering contrast against the dark wood surface.",
+    districtStory: "Mainpuri remains one of the few places in India where this delicate wire-inlay woodcraft tradition is still actively practised and taught."
+  },
+  {
+    name: "Varanasi Wooden Toys",
+    icon: "🧸",
+    district: "Varanasi",
+    category: "wood",
+    tags: ["Toys", "Lacquerware"],
+    description: "Brightly lacquered wooden toys and figurines handcrafted using traditional turning and painting techniques.",
+    history: "Varanasi's wooden toy-making tradition has been passed down for generations, with artisans crafting figurines, spinning tops, and decorative pieces for both play and display.",
+    artisan: "Craftsmen shape soft wood on manual lathes before hand-painting each toy with vivid natural and synthetic colours in traditional patterns.",
+    districtStory: "Varanasi's toy-making clusters continue to supply colourful wooden toys to markets across northern India, keeping a centuries-old craft alive."
+  },
+  {
+    name: "Meerut Scissors & Tools",
+    icon: "✂️",
+    district: "Meerut",
+    category: "metal",
+    tags: ["GI Tagged", "Tool-making"],
+    description: "Precision-made scissors and cutting tools known for their sharpness and durability.",
+    history: "Meerut's metal tool-making tradition developed over generations, establishing the city as a major centre for scissors and cutlery production in North India.",
+    artisan: "Skilled metalworkers forge, sharpen, and finish each tool by hand, combining traditional blacksmithing techniques with modern precision finishing.",
+    districtStory: "Meerut remains one of India's largest hubs for scissors and cutting-tool manufacturing, exporting to both domestic and international markets."
+  },
+  {
+    name: "Kanpur Leathercraft",
+    icon: "👞",
+    district: "Kanpur",
+    category: "textile",
+    tags: ["Leather", "Footwear"],
+    description: "High-quality leather goods including footwear, saddles, and harnesses known for durability and fine finishing.",
+    history: "Kanpur's leather industry grew rapidly during the colonial era, evolving into one of India's most significant leather manufacturing and export hubs.",
+    artisan: "Leather artisans in Kanpur combine traditional tanning and stitching methods with modern techniques to produce footwear and goods valued for their craftsmanship.",
+    districtStory: "Kanpur is often referred to as the 'Leather City' of India, home to hundreds of tanneries and workshops supplying products worldwide."
+  },
+  {
+    name: "Farrukhabad Hand-Block Printing",
+    icon: "🖨️",
+    district: "Farrukhabad",
+    category: "textile",
+    tags: ["Block Printing", "Textile Art"],
+    description: "Vibrant hand-block printed textiles known for bold colours and distinctive traditional patterns.",
+    history: "Farrukhabad's block-printing tradition developed as a distinct regional style, with hand-carved wooden blocks used to stamp intricate patterns onto fabric.",
+    artisan: "Printers carve detailed wooden blocks before hand-stamping fabric in layered colours, a process requiring precise alignment and a steady hand.",
+    districtStory: "Farrukhabad's textile printing clusters continue to produce fabrics that are popular across India for their distinctive and vibrant regional patterns."
+  },
+  {
+    name: "Agra Durries",
+    icon: "🧵",
+    district: "Agra",
+    category: "carpet",
+    tags: ["Flat-weave", "Cotton Rugs"],
+    description: "Flat-woven cotton rugs known for bright geometric patterns and everyday comfort.",
+    history: "Durrie weaving in Agra developed as a practical craft, producing sturdy, colourful floor coverings suited to daily household use across North India.",
+    artisan: "Weavers use traditional handlooms to interlace cotton threads into bold geometric patterns, creating durable rugs prized for both function and design.",
+    districtStory: "Agra's durrie-weaving communities continue producing these versatile rugs, popular in both traditional homes and modern interior design."
+  }
+];
+
+const districtLabels = {};
+allCrafts.forEach(c => { districtLabels[c.district] = c.district; });
+
+// ---------- State ----------
+let activeDistrict = "all";
+let activeCategory = "all";
+let searchQuery = "";
+let selectedCraftName = null;
+
+// ---------- DOM References ----------
+const craftGrid = document.getElementById("craftGrid");
+const noResults = document.getElementById("noResults");
+const resultsCount = document.getElementById("resultsCount");
+const searchInput = document.getElementById("searchInput");
+const districtList = document.getElementById("districtList");
+const categoryList = document.getElementById("categoryList");
+
+const totalCraftsStat = document.getElementById("totalCraftsStat");
+const totalDistrictsStat = document.getElementById("totalDistrictsStat");
+
+const detailEmpty = document.getElementById("detailEmpty");
+const detailContent = document.getElementById("detailContent");
+const detailCloseBtn = document.getElementById("detailCloseBtn");
+const detailIcon = document.getElementById("detailIcon");
+const detailDistrictTag = document.getElementById("detailDistrictTag");
+const detailTitle = document.getElementById("detailTitle");
+const detailDescription = document.getElementById("detailDescription");
+const detailHistory = document.getElementById("detailHistory");
+const detailArtisan = document.getElementById("detailArtisan");
+const detailDistrictStory = document.getElementById("detailDistrictStory");
+
+// ---------- Build District Filter Buttons ----------
+function buildDistrictButtons() {
+  const uniqueDistricts = [...new Set(allCrafts.map(c => c.district))].sort();
+  uniqueDistricts.forEach(district => {
+    const btn = document.createElement("button");
+    btn.className = "district-btn";
+    btn.dataset.district = district;
+    btn.innerHTML = `<span class="district-name">${district}</span>`;
+    districtList.appendChild(btn);
+  });
+}
+
+// ---------- Render Crafts ----------
+function renderCrafts() {
+  const filtered = allCrafts.filter(craft => {
+    const matchesDistrict = activeDistrict === "all" || craft.district === activeDistrict;
+    const matchesCategory = activeCategory === "all" || craft.category === activeCategory;
+    const matchesSearch =
+      searchQuery === "" ||
+      craft.name.toLowerCase().includes(searchQuery) ||
+      craft.district.toLowerCase().includes(searchQuery) ||
+      craft.description.toLowerCase().includes(searchQuery);
+    return matchesDistrict && matchesCategory && matchesSearch;
+  });
+
+  resultsCount.textContent = `Showing ${filtered.length} craft${filtered.length !== 1 ? "s" : ""}`;
+
+  if (filtered.length === 0) {
+    craftGrid.innerHTML = "";
+    noResults.classList.remove("hidden");
+    return;
+  }
+
+  noResults.classList.add("hidden");
+  craftGrid.innerHTML = "";
+
+  filtered.forEach(craft => {
+    const card = document.createElement("div");
+    card.className = "craft-card" + (craft.name === selectedCraftName ? " selected" : "");
+    card.innerHTML = `
+      <span class="craft-card-icon">${craft.icon}</span>
+      <span class="craft-card-district">${craft.district}</span>
+      <h3 class="craft-card-name">${craft.name}</h3>
+      <p class="craft-card-desc">${craft.description}</p>
+      <div class="craft-card-tags">
+        ${craft.tags.map(t => `<span class="craft-tag">${t}</span>`).join("")}
+      </div>
+    `;
+    card.addEventListener("click", () => showDetail(craft));
+    craftGrid.appendChild(card);
+  });
+}
+
+// ---------- Detail Panel ----------
+function showDetail(craft) {
+  selectedCraftName = craft.name;
+
+  detailIcon.textContent = craft.icon;
+  detailDistrictTag.textContent = craft.district;
+  detailTitle.textContent = craft.name;
+  detailDescription.textContent = craft.description;
+  detailHistory.textContent = craft.history;
+  detailArtisan.textContent = craft.artisan;
+  detailDistrictStory.textContent = craft.districtStory;
+
+  detailEmpty.classList.add("hidden");
+  detailContent.classList.remove("hidden");
+
+  renderCrafts();
+}
+
+function closeDetail() {
+  selectedCraftName = null;
+  detailContent.classList.add("hidden");
+  detailEmpty.classList.remove("hidden");
+  renderCrafts();
+}
+
+detailCloseBtn.addEventListener("click", closeDetail);
+
+// ---------- Filters ----------
+districtList.addEventListener("click", (e) => {
+  const btn = e.target.closest(".district-btn");
+  if (!btn) return;
+  districtList.querySelectorAll(".district-btn").forEach(b => b.classList.remove("active"));
+  btn.classList.add("active");
+  activeDistrict = btn.dataset.district;
+  renderCrafts();
+});
+
+categoryList.addEventListener("click", (e) => {
+  const btn = e.target.closest(".category-btn");
+  if (!btn) return;
+  categoryList.querySelectorAll(".category-btn").forEach(b => b.classList.remove("active"));
+  btn.classList.add("active");
+  activeCategory = btn.dataset.category;
+  renderCrafts();
+});
+
+// ---------- Search ----------
+searchInput.addEventListener("input", (e) => {
+  searchQuery = e.target.value.trim().toLowerCase();
+  renderCrafts();
+});
+
+// ---------- Stats ----------
+function updateStats() {
+  totalCraftsStat.textContent = allCrafts.length;
+  totalDistrictsStat.textContent = new Set(allCrafts.map(c => c.district)).size;
+}
+
+// ---------- Init ----------
+buildDistrictButtons();
+updateStats();
+renderCrafts();

--- a/frontend/handicrafts-showcase/style.css
+++ b/frontend/handicrafts-showcase/style.css
@@ -1,0 +1,437 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  font-family: 'Outfit', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+:root {
+  --indigo: #6b7fd7;
+  --indigo-light: #8b9ce8;
+  --brass: #d9a84e;
+  --brass-light: #f0c878;
+  --terracotta: #e0784f;
+  --ivory: #16181d;
+  --ivory-card: #1e2128;
+  --border-subtle: rgba(217, 168, 78, 0.14);
+  --text-primary: #ece9e2;
+  --text-secondary: #9a9690;
+}
+
+body {
+  background:
+    radial-gradient(circle at top, #1e2128 0%, #16181d 55%, #101216 100%);
+  min-height: 100vh;
+  color: var(--text-primary);
+}
+/* ---------- Navbar ---------- */
+.hc-navbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 30px;
+  background: rgba(22, 24, 29, 0.94);
+  border-bottom: 2px solid var(--brass-light);
+  backdrop-filter: blur(10px);
+  position: sticky;
+  top: 0;
+  z-index: 30;
+}
+
+.back-link {
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  transition: color 0.2s ease;
+}
+.back-link:hover { color: var(--terracotta); }
+
+.nav-brand {
+  font-family: 'Playfair Display', serif;
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+.nav-brand .saffron { color: #d9720f; }
+.nav-brand .gold { color: var(--brass); }
+.nav-brand .green { color: #3e7d4a; }
+
+/* ---------- Hero ---------- */
+.hero-section {
+  text-align: center;
+  padding: 44px 20px 34px;
+  position: relative;
+}
+
+.hero-pattern-strip {
+  height: 6px;
+  max-width: 260px;
+  margin: 0 auto 20px;
+  background: repeating-linear-gradient(
+    90deg,
+    var(--brass) 0px, var(--brass) 8px,
+    var(--terracotta) 8px, var(--terracotta) 16px,
+    var(--indigo) 16px, var(--indigo) 24px
+  );
+  border-radius: 4px;
+}
+
+.section-badge {
+  display: inline-block;
+  color: var(--terracotta);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+
+.hero-section h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: 2.05rem;
+  font-weight: 700;
+  margin-bottom: 14px;
+  color: var(--indigo);
+}
+
+.hero-text {
+  color: var(--text-secondary);
+  max-width: 600px;
+  margin: 0 auto 26px;
+  line-height: 1.7;
+  font-size: 0.98rem;
+}
+
+.hero-stats {
+  display: flex;
+  justify-content: center;
+  gap: 34px;
+  margin-bottom: 24px;
+}
+
+.hero-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.hero-stat span {
+  font-family: 'Cormorant Garamond', serif;
+  font-size: 2rem;
+  font-weight: 700;
+  color: var(--brass);
+}
+
+.hero-stat label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+/* ---------- Container / Layout ---------- */
+.container {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 10px 20px 60px;
+}
+
+.layout-grid {
+  display: grid;
+  grid-template-columns: 220px 1fr 320px;
+  gap: 22px;
+  align-items: start;
+}
+
+/* ---------- Sidebar ---------- */
+.district-sidebar {
+  background: var(--ivory-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: 16px;
+  padding: 20px 16px;
+  position: sticky;
+  top: 90px;
+  box-shadow: 0 4px 16px rgba(43, 58, 103, 0.06);
+}
+
+.sidebar-title {
+  font-size: 0.85rem;
+  color: var(--indigo);
+  margin-bottom: 12px;
+  font-weight: 700;
+}
+
+.district-list, .category-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.district-btn, .category-btn {
+  text-align: left;
+  background: transparent;
+  border: 1px solid transparent;
+  padding: 8px 12px;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-weight: 500;
+  transition: all 0.18s ease;
+}
+
+.district-btn:hover, .category-btn:hover {
+  background: rgba(184, 134, 43, 0.08);
+  color: var(--text-primary);
+}
+
+.district-btn.active, .category-btn.active {
+  background: var(--indigo);
+  color: #fff;
+  font-weight: 600;
+}
+
+/* ---------- Main / Search ---------- */
+.search-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+  margin-bottom: 18px;
+}
+
+.search-box {
+  flex: 1;
+  min-width: 220px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: var(--ivory-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  padding: 10px 16px;
+}
+
+.search-icon { opacity: 0.6; }
+
+.search-box input {
+  flex: 1;
+  background: none;
+  border: none;
+  outline: none;
+  color: var(--text-primary);
+  font-size: 0.92rem;
+}
+.search-box input::placeholder { color: var(--text-secondary); }
+
+.results-count {
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+/* ---------- Craft Grid ---------- */
+.craft-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+  gap: 16px;
+}
+
+.craft-card {
+  background: var(--ivory-card);
+  border: 1px solid var(--border-subtle);
+  border-left: 4px solid var(--brass);
+  border-radius: 12px;
+  padding: 20px 18px;
+  cursor: pointer;
+  transition: transform 0.16s ease, box-shadow 0.16s ease, border-left-color 0.2s ease;
+  box-shadow: 0 3px 10px rgba(43, 58, 103, 0.05);
+}
+
+.craft-card:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 10px 22px rgba(43, 58, 103, 0.12);
+  border-left-color: var(--terracotta);
+}
+
+.craft-card.selected {
+  border-left-color: var(--indigo);
+  background: linear-gradient(135deg, #fffaf0, #f3ecdc);
+}
+
+.craft-card-icon {
+  font-size: 2rem;
+  margin-bottom: 8px;
+  display: block;
+}
+
+.craft-card-district {
+  display: inline-block;
+  font-size: 0.66rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--indigo);
+  background: rgba(43, 58, 103, 0.08);
+  padding: 3px 10px;
+  border-radius: 10px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.craft-card-name {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.08rem;
+  font-weight: 700;
+  margin-bottom: 6px;
+  color: var(--text-primary);
+}
+
+.craft-card-desc {
+  font-size: 0.83rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.craft-card-tags {
+  margin-top: 10px;
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.craft-tag {
+  font-size: 0.68rem;
+  background: rgba(181, 80, 47, 0.09);
+  color: var(--terracotta);
+  padding: 2px 9px;
+  border-radius: 10px;
+  font-weight: 600;
+}
+
+/* ---------- No Results ---------- */
+.no-results {
+  text-align: center;
+  padding: 60px 20px;
+  color: var(--text-secondary);
+}
+.no-results-icon { font-size: 2.4rem; display: block; margin-bottom: 10px; }
+
+/* ---------- Detail Panel ---------- */
+.detail-panel {
+  background: var(--ivory-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: 16px;
+  padding: 26px 22px;
+  position: sticky;
+  top: 90px;
+  min-height: 320px;
+  box-shadow: 0 4px 16px rgba(43, 58, 103, 0.06);
+}
+
+.detail-panel-empty {
+  text-align: center;
+  padding: 40px 10px;
+  color: var(--text-secondary);
+}
+.empty-icon { font-size: 2.2rem; display: block; margin-bottom: 10px; }
+
+.detail-panel-content {
+  position: relative;
+}
+
+.detail-close-btn {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  background: rgba(43, 58, 103, 0.08);
+  border: none;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  font-size: 1.1rem;
+  cursor: pointer;
+  color: var(--text-primary);
+}
+.detail-close-btn:hover { background: rgba(43, 58, 103, 0.16); }
+
+.detail-icon {
+  font-size: 2.6rem;
+  margin-bottom: 8px;
+}
+
+.detail-district-tag {
+  display: inline-block;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--indigo);
+  background: rgba(43, 58, 103, 0.08);
+  padding: 4px 12px;
+  border-radius: 12px;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+
+.detail-title {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.35rem;
+  font-weight: 700;
+  margin-bottom: 10px;
+  color: var(--text-primary);
+}
+
+.detail-description {
+  color: var(--text-secondary);
+  line-height: 1.65;
+  margin-bottom: 20px;
+  font-size: 0.9rem;
+}
+
+.detail-section {
+  margin-bottom: 18px;
+  padding-top: 14px;
+  border-top: 1px dashed var(--border-subtle);
+}
+
+.detail-section h4 {
+  font-size: 0.85rem;
+  color: var(--indigo);
+  margin-bottom: 6px;
+}
+
+.detail-section p {
+  font-size: 0.86rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+/* ---------- Footer ---------- */
+.hc-footer {
+  text-align: center;
+  padding: 24px;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  border-top: 1px solid var(--border-subtle);
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 980px) {
+  .layout-grid {
+    grid-template-columns: 1fr;
+  }
+  .district-sidebar, .detail-panel {
+    position: static;
+  }
+}
+
+@media (max-width: 560px) {
+  .hero-section h1 { font-size: 1.5rem; }
+  .hero-stats { gap: 20px; }
+  .craft-grid { grid-template-columns: 1fr; }
+}

--- a/index.html
+++ b/index.html
@@ -325,6 +325,7 @@
                  <div class="nav-dropdown">
                     <button class="nav-link dropdown-toggle" id="link-explore-more">Explore More ▾</button>
                     <div class="dropdown-menu">
+                        <a href="frontend/handicrafts-showcase/index.html" class="dropdown-item"> UP Handicrafts</a>
                         <a href="frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
                         <a href="frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
                         <a href="frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>


### PR DESCRIPTION
Closes #485

Added Uttar Pradesh Handicrafts Showcase — an interactive craft gallery featuring 16 traditional handicrafts across 13 districts. Features:
- Craft gallery with district and category filters
- Live search across craft names, districts, and descriptions
- Detail panel with traditional history, artisan insight, and district story for each craft
- Dark charcoal-grey themed design
- Responsive layout
- Linked in homepage navbar 

Screenshot: 
<img width="1440" height="852" alt="Screenshot 2026-07-24 121626" src="https://github.com/user-attachments/assets/d521f8c3-f6ec-4b4c-aae1-5409517f8081" />
