### PR TITLE
fix(nav): correct broken dropdown links for Handloom, Postal Stamps, and Freedom Timeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -350,9 +350,9 @@
                         <a href="frontend/music/music.html" class="dropdown-item">Music</a>
                         <a href="frontend/astronomy/astronomy.html" class="dropdown-item">Astronomy</a>
                         <a href="frontend/dance/dance.html" class="dropdown-item">Dance</a>
-                        <a href="frontend/traditional-games/index.html" class="dropdown-item">Handloom</a>
-                        <a href="frontend/traditional-games/index.html" class="dropdown-item">Postal Stamps</a>
-                        <a href="frontend/traditional-games/index.html" class="dropdown-item">Freedom Timeline</a>
+                        <a href="frontend/handloom/index.html" class="dropdown-item">Handloom</a>
+                        <a href="frontend/postal-stamps/index.html" class="dropdown-item">Postal Stamps</a>
+                        <a href="frontend/freedom-timeline/index.html" class="dropdown-item">Freedom Timeline</a>
                     </div>
                 </div>
                 <div class="nav-dropdown">


### PR DESCRIPTION
## Description

Fixes issue #538 — three navigation dropdown items ("Handloom", "Postal Stamps", "Freedom Timeline") were all incorrectly pointing to `frontend/traditional-games/index.html` due to a copy-paste error. Updated each link to its correct dedicated feature page.

## Changes Made

**`index.html`** (lines 353-355):
- `Handloom` → `frontend/handloom/index.html` (was `traditional-games/index.html`)
- `Postal Stamps` → `frontend/postal-stamps/index.html` (was `traditional-games/index.html`)
- `Freedom Timeline` → `frontend/freedom-timeline/index.html` (was `traditional-games/index.html`)

## Verification

- `frontend/handloom/index.html` — exists
- `frontend/postal-stamps/index.html` — exists
- `frontend/freedom-timeline/index.html` — exists
- All other dropdown links remain unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the “Explore More” dropdown links for Handloom, Postal Stamps, and Freedom Timeline.
  * Each option now opens its corresponding destination instead of the Traditional Games page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->