### PR TITLE
Union Territory Sorter

### DIFF
--- a/frontend/union-territory-sorter/index.html
+++ b/frontend/union-territory-sorter/index.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Test your Indian geography skills in the Union Territory Sorter game! Drag or tap to categorize all 28 states and 8 union territories into correct bins with instant feedback.">
+    <title>Union Territory Sorter | Incredible India Explorer</title>
+    <link rel="icon" href="data:,">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="union-territory-sorter.css">
+
+    <!-- Open Graph / Social Media Tags -->
+    <meta property="og:title" content="Union Territory Sorter | Incredible India Explorer">
+    <meta property="og:description" content="Sort all 28 States and 8 Union Territories into their correct categories! Drag & drop or tap to sort with instant educational feedback.">
+    <meta property="og:type" content="website">
+    <meta property="og:locale" content="en_IN">
+</head>
+
+<body class="ut-sorter-body">
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html#home" class="nav-link">Home</a>
+                <a href="../learn/learn.html" class="nav-link">Learn</a>
+                <a href="../border-neighbors-quiz/index.html" class="nav-link">Neighbors Quiz</a>
+                <a href="index.html" class="nav-link active" style="color: var(--saffron)">UT Sorter</a>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+            </nav>
+        </div>
+    </header>
+
+    <main class="sorter-main-container">
+        <!-- Hero Header -->
+        <section class="hero-banner">
+            <div class="banner-badge">🎮 Interactive Categorization Game</div>
+            <h1 class="hero-title">Union Territory Sorter</h1>
+            <p class="hero-subtitle">
+                Can you distinguish India's <strong>28 States</strong> from its <strong>8 Union Territories</strong>? Drag each region card into the correct bin, or tap the sorting buttons below!
+            </p>
+        </section>
+
+        <!-- Feedback Toast Banner -->
+        <div class="feedback-toast hidden" id="instant-feedback" aria-live="polite"></div>
+
+        <!-- Main Game Screen -->
+        <section class="game-screen" id="game-screen">
+            <!-- Stats Top Bar -->
+            <div class="stats-bar">
+                <div class="stat-box">
+                    <span class="stat-label">Progress</span>
+                    <span class="stat-value" id="card-counter">1 / 36</span>
+                </div>
+
+                <div class="stat-box">
+                    <span class="stat-label">Score</span>
+                    <span class="stat-value" id="score-value">0</span>
+                </div>
+
+                <div class="stat-box">
+                    <span class="stat-label">Streak</span>
+                    <span class="stat-value" id="streak-value">0 🔥</span>
+                </div>
+
+                <div class="stat-box">
+                    <span class="stat-label">Time</span>
+                    <span class="stat-value" id="timer-value">0:00</span>
+                </div>
+            </div>
+
+            <!-- Progress Bar Track -->
+            <div class="progress-track">
+                <div class="progress-fill" id="progress-fill" style="width: 0%"></div>
+            </div>
+
+            <!-- Playground Layout: Bins & Card Stack -->
+            <div class="playground-layout">
+                <!-- Bin 1: State Bin -->
+                <div class="sort-bin state-bin" id="state-bin" data-bin-type="state">
+                    <div class="bin-header">
+                        <span class="bin-icon">🏛️</span>
+                        <h2 class="bin-title">States Bin</h2>
+                        <span class="bin-sub">28 Indian States</span>
+                    </div>
+                    <div class="bin-drop-zone">
+                        <span>Drop State Card Here</span>
+                    </div>
+                    <button type="button" class="btn-sort btn-state-sort" id="sort-state-btn">
+                        ⬅️ Sort as STATE (S)
+                    </button>
+                </div>
+
+                <!-- Active Card Stack Container -->
+                <div class="deck-area">
+                    <div class="active-card-container" id="active-card-container">
+                        <!-- Active Region Card rendered by JS -->
+                    </div>
+                    <div class="keyboard-hint">
+                        <span>⌨️ Keyboard: Press <strong>[Left Arrow / S]</strong> for State • <strong>[Right Arrow / U]</strong> for UT</span>
+                    </div>
+                </div>
+
+                <!-- Bin 2: Union Territory Bin -->
+                <div class="sort-bin ut-bin" id="ut-bin" data-bin-type="ut">
+                    <div class="bin-header">
+                        <span class="bin-icon">🏰</span>
+                        <h2 class="bin-title">Union Territories Bin</h2>
+                        <span class="bin-sub">8 Union Territories</span>
+                    </div>
+                    <div class="bin-drop-zone">
+                        <span>Drop UT Card Here</span>
+                    </div>
+                    <button type="button" class="btn-sort btn-ut-sort" id="sort-ut-btn">
+                        Sort as UT (U) ➡️
+                    </button>
+                </div>
+            </div>
+        </section>
+
+        <!-- Final Summary Screen -->
+        <section class="summary-screen" id="summary-screen" style="display: none;">
+            <div class="summary-card">
+                <span class="summary-icon">🏆</span>
+                <h2 class="summary-title">Sorting Round Completed!</h2>
+                <p class="summary-subtitle">Here is your geographic categorization performance summary:</p>
+
+                <div class="summary-grid">
+                    <div class="summary-box">
+                        <span class="summary-label">Accuracy</span>
+                        <span class="summary-value" id="summary-accuracy">100%</span>
+                    </div>
+                    <div class="summary-box">
+                        <span class="summary-label">Total Score</span>
+                        <span class="summary-value" id="summary-score">3600 pts</span>
+                    </div>
+                    <div class="summary-box">
+                        <span class="summary-label">Grade</span>
+                        <span class="summary-value" id="summary-grade">Grade S</span>
+                    </div>
+                    <div class="summary-box">
+                        <span class="summary-label">Time Taken</span>
+                        <span class="summary-value" id="summary-time">1m 45s</span>
+                    </div>
+                </div>
+
+                <div class="summary-title-badge" id="summary-title">Master Geographer</div>
+
+                <div class="summary-actions">
+                    <button type="button" class="btn-sorter btn-primary" id="retry-btn">
+                        Play Again 🔄
+                    </button>
+                    <a href="../border-neighbors-quiz/index.html" class="btn-sorter btn-outline">
+                        Try Neighbors Quiz
+                    </a>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="sorter-footer">
+        <p>Part of <a href="../../index.html">Incredible India Explorer</a> · Learn Indian administrative geography through gameplay.</p>
+    </footer>
+
+    <script type="module" src="union-territory-sorter.js"></script>
+</body>
+</html>

--- a/frontend/union-territory-sorter/union-territory-sorter.css
+++ b/frontend/union-territory-sorter/union-territory-sorter.css
@@ -1,0 +1,490 @@
+/**
+ * union-territory-sorter.css
+ * Styling for Union Territory Sorter in Incredible India Explorer
+ */
+
+:root {
+  --saffron: #ff9933;
+  --gold: #ffc107;
+  --emerald: #138808;
+  --navy-dark: #0d1b2a;
+  --navy-card: #1b263b;
+  --navy-bin: #24344d;
+  --text-main: #f8f9fa;
+  --text-sub: #cbd5e1;
+  --border-light: rgba(255, 255, 255, 0.12);
+
+  --success-bg: rgba(19, 136, 8, 0.25);
+  --success-border: #22c55e;
+  --danger-bg: rgba(220, 38, 38, 0.25);
+  --danger-border: #ef4444;
+}
+
+body.light-theme {
+  --navy-dark: #f1f5f9;
+  --navy-card: #ffffff;
+  --navy-bin: #f8fafc;
+  --text-main: #0f172a;
+  --text-sub: #475569;
+  --border-light: rgba(0, 0, 0, 0.12);
+}
+
+body.ut-sorter-body {
+  background-color: var(--navy-dark);
+  color: var(--text-main);
+  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  min-height: 100vh;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.sorter-main-container {
+  flex: 1;
+  max-width: 1100px;
+  margin: 90px auto 40px;
+  padding: 0 20px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* Hero Header */
+.hero-banner {
+  text-align: center;
+  margin-bottom: 24px;
+}
+
+.banner-badge {
+  display: inline-block;
+  background: rgba(255, 153, 51, 0.15);
+  color: var(--saffron);
+  border: 1px solid rgba(255, 153, 51, 0.3);
+  padding: 6px 16px;
+  border-radius: 20px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+
+.hero-title {
+  font-family: 'Playfair Display', serif;
+  font-size: 2.3rem;
+  font-weight: 800;
+  margin: 0 0 8px;
+  background: linear-gradient(135deg, var(--saffron), var(--gold), var(--emerald));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.hero-subtitle {
+  color: var(--text-sub);
+  font-size: 1rem;
+  line-height: 1.5;
+  max-width: 750px;
+  margin: 0 auto;
+}
+
+/* Instant Feedback Toast */
+.feedback-toast {
+  position: fixed;
+  top: 90px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 12px 24px;
+  border-radius: 30px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  z-index: 100;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
+  transition: all 0.3s ease;
+}
+
+.feedback-toast.hidden {
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, -20px);
+}
+
+.toast-success {
+  background: #16a34a;
+  color: #fff;
+}
+
+.toast-error {
+  background: #dc2626;
+  color: #fff;
+}
+
+/* Stats Bar */
+.stats-bar {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.stat-box {
+  background: var(--navy-card);
+  border: 1px solid var(--border-light);
+  border-radius: 14px;
+  padding: 10px 14px;
+  text-align: center;
+}
+
+.stat-label {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--text-sub);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.stat-value {
+  font-size: 1.2rem;
+  font-weight: 800;
+  color: var(--saffron);
+}
+
+.progress-track {
+  height: 6px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  overflow: hidden;
+  margin-bottom: 24px;
+}
+
+.progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--saffron), var(--emerald));
+  border-radius: 10px;
+  transition: width 0.3s ease;
+}
+
+/* Playground Layout */
+.playground-layout {
+  display: grid;
+  grid-template-columns: 1fr 1.2fr 1fr;
+  gap: 20px;
+  align-items: stretch;
+}
+
+.sort-bin {
+  background: var(--navy-card);
+  border: 2px dashed var(--border-light);
+  border-radius: 20px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  text-align: center;
+  transition: all 0.3s ease;
+}
+
+.sort-bin.drag-over {
+  border-color: var(--saffron);
+  background: rgba(255, 153, 51, 0.1);
+  transform: scale(1.02);
+}
+
+.state-bin {
+  border-color: rgba(255, 153, 51, 0.4);
+}
+
+.ut-bin {
+  border-color: rgba(19, 136, 8, 0.4);
+}
+
+.bin-header {
+  margin-bottom: 14px;
+}
+
+.bin-icon {
+  font-size: 2.5rem;
+  display: block;
+}
+
+.bin-title {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.3rem;
+  margin: 6px 0 2px;
+}
+
+.bin-sub {
+  font-size: 0.8rem;
+  color: var(--text-sub);
+}
+
+.bin-drop-zone {
+  flex: 1;
+  width: 100%;
+  min-height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--navy-bin);
+  border-radius: 14px;
+  border: 1px dashed var(--border-light);
+  margin: 14px 0;
+  font-size: 0.85rem;
+  color: var(--text-sub);
+  padding: 10px;
+  box-sizing: border-box;
+}
+
+.btn-sort {
+  width: 100%;
+  padding: 12px;
+  border-radius: 12px;
+  font-weight: 700;
+  font-size: 0.9rem;
+  cursor: pointer;
+  border: none;
+  transition: all 0.2s ease;
+}
+
+.btn-state-sort {
+  background: linear-gradient(135deg, var(--saffron), #e67e22);
+  color: #fff;
+}
+
+.btn-ut-sort {
+  background: linear-gradient(135deg, var(--emerald), #16a34a);
+  color: #fff;
+}
+
+.btn-sort:hover {
+  transform: translateY(-2px);
+  filter: brightness(1.1);
+}
+
+/* Active Deck Stack */
+.deck-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.active-card-container {
+  width: 100%;
+  perspective: 1000px;
+}
+
+.region-card {
+  background: linear-gradient(145deg, var(--navy-bin), var(--navy-card));
+  border: 2px solid var(--saffron);
+  border-radius: 20px;
+  padding: 24px 20px;
+  text-align: center;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.3);
+  cursor: grab;
+  user-select: none;
+  transition: transform 0.3s ease, opacity 0.3s ease, border-color 0.3s ease;
+}
+
+.region-card:active {
+  cursor: grabbing;
+}
+
+.region-card.dragging {
+  opacity: 0.5;
+  transform: scale(0.95);
+}
+
+.region-card.animate-correct {
+  border-color: var(--success-border);
+  background: var(--success-bg);
+  transform: translateY(-20px) scale(0.95);
+}
+
+.region-card.animate-wrong {
+  border-color: var(--danger-border);
+  background: var(--danger-bg);
+  transform: translateY(20px) scale(0.95);
+}
+
+.card-drag-handle {
+  font-size: 0.75rem;
+  color: var(--gold);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-bottom: 8px;
+}
+
+.card-badge {
+  display: inline-block;
+  background: rgba(255, 255, 255, 0.1);
+  padding: 2px 10px;
+  border-radius: 10px;
+  font-size: 0.75rem;
+  color: var(--text-sub);
+  margin-bottom: 8px;
+}
+
+.card-title {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.8rem;
+  font-weight: 800;
+  margin: 0 0 6px;
+
+  color: var(--text-main);
+}
+
+.card-capital {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: var(--saffron);
+  margin-bottom: 12px;
+}
+
+.card-hint {
+  font-size: 0.85rem;
+  color: var(--text-sub);
+  line-height: 1.4;
+  background: rgba(0, 0, 0, 0.2);
+  padding: 8px 12px;
+  border-radius: 10px;
+}
+
+.keyboard-hint {
+  margin-top: 14px;
+  font-size: 0.75rem;
+  color: var(--text-sub);
+  text-align: center;
+}
+
+/* Summary Card */
+.summary-screen {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.summary-card {
+  background: var(--navy-card);
+  border: 1px solid var(--border-light);
+  border-radius: 20px;
+  padding: 36px;
+  text-align: center;
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.3);
+}
+
+.summary-icon {
+  font-size: 3.5rem;
+  display: block;
+  margin-bottom: 10px;
+}
+
+.summary-title {
+  font-family: 'Playfair Display', serif;
+  font-size: 2rem;
+  margin: 0 0 6px;
+}
+
+.summary-subtitle {
+  color: var(--text-sub);
+  font-size: 0.95rem;
+  margin: 0 0 24px;
+}
+
+.summary-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+  margin-bottom: 20px;
+}
+
+.summary-box {
+  background: var(--navy-bin);
+  border-radius: 14px;
+  padding: 14px;
+}
+
+.summary-label {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--text-sub);
+}
+
+.summary-value {
+  font-size: 1.4rem;
+  font-weight: 800;
+  color: var(--gold);
+}
+
+.summary-title-badge {
+  font-size: 1.1rem;
+  font-weight: 800;
+  color: var(--emerald);
+  margin-bottom: 24px;
+}
+
+.summary-actions {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+}
+
+.btn-sorter {
+  padding: 12px 28px;
+  border-radius: 30px;
+  font-weight: 700;
+  font-size: 0.95rem;
+  cursor: pointer;
+  border: none;
+  transition: all 0.2s ease;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, var(--saffron), #e67e22);
+  color: #fff;
+  box-shadow: 0 4px 15px rgba(255, 153, 51, 0.3);
+}
+
+.btn-primary:hover {
+  transform: translateY(-2px);
+}
+
+.btn-outline {
+  background: transparent;
+  border: 2px solid var(--border-light);
+  color: var(--text-main);
+}
+
+.btn-outline:hover {
+  border-color: var(--saffron);
+  color: var(--saffron);
+}
+
+/* Footer */
+.sorter-footer {
+  text-align: center;
+  padding: 20px;
+  color: var(--text-sub);
+  font-size: 0.85rem;
+  border-top: 1px solid var(--border-light);
+  margin-top: auto;
+}
+
+.sorter-footer a {
+  color: var(--saffron);
+  text-decoration: none;
+}
+
+@media (max-width: 850px) {
+  .playground-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .bin-drop-zone {
+    display: none;
+  }
+
+  .stats-bar {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}

--- a/frontend/union-territory-sorter/union-territory-sorter.js
+++ b/frontend/union-territory-sorter/union-territory-sorter.js
@@ -1,0 +1,443 @@
+/**
+ * union-territory-sorter.js
+ * Union Territory Sorter for Incredible India Explorer
+ *
+ * Provides complete dataset of 28 States and 8 Union Territories of India,
+ * classification checking, scoring engine, drag-and-drop & tap sorting controls.
+ */
+
+export const REGIONS_DATASET = [
+  // --- 28 STATES ---
+  { id: "AP", name: "Andhra Pradesh", type: "state", capital: "Amaravati", info: "Southern coastal state known for Kuchipudi classical dance and Tirupati." },
+  { id: "AR", name: "Arunachal Pradesh", type: "state", capital: "Itanagar", info: "North-Eastern border state known as the Land of Dawn-Lit Mountains." },
+  { id: "AS", name: "Assam", type: "state", capital: "Dispur", info: "State famous for tea plantations, Muga silk, and Kaziranga rhinos." },
+  { id: "BR", name: "Bihar", type: "state", capital: "Patna", info: "Eastern state rich in ancient history, birthplace of Buddhism and Jainism." },
+  { id: "CT", name: "Chhattisgarh", type: "state", capital: "Raipur", info: "Central state known for dense forests, waterfalls, and tribal heritage." },
+  { id: "GA", name: "Goa", type: "state", capital: "Panaji", info: "India's smallest state by land area, famous for beaches and Portuguese history." },
+  { id: "GJ", name: "Gujarat", type: "state", capital: "Gandhinagar", info: "Westernmost state with longest coastline, home to Gir Asiatic lions." },
+  { id: "HR", name: "Haryana", type: "state", capital: "Chandigarh", info: "North Indian agrarian state surrounding Delhi on three sides." },
+  { id: "HP", name: "Himachal Pradesh", type: "state", capital: "Shimla", info: "Himalayan mountain state popular for scenic hill stations and valleys." },
+  { id: "JH", name: "Jharkhand", type: "state", capital: "Ranchi", info: "Eastern mineral-rich state carved out of Bihar in 2000." },
+  { id: "KA", name: "Karnataka", type: "state", capital: "Bengaluru", info: "Southern tech & heritage state famous for Hampi and Mysuru Palace." },
+  { id: "KL", name: "Kerala", type: "state", capital: "Thiruvananthapuram", info: "Southern coastal state known as God's Own Country, famous for backwaters." },
+  { id: "MP", name: "Madhya Pradesh", type: "state", capital: "Bhopal", info: "Heart of India central state famous for Khajuraho temples and tiger reserves." },
+  { id: "MH", name: "Maharashtra", type: "state", capital: "Mumbai", info: "India's financial hub state featuring Ajanta-Ellora caves and Western Ghats." },
+  { id: "MN", name: "Manipur", type: "state", capital: "Imphal", info: "North-Eastern state known for Manipuri classical dance and Loktak Lake." },
+  { id: "ML", name: "Meghalaya", type: "state", capital: "Shillong", info: "Abode of Clouds state home to Cherrapunji and living root bridges." },
+  { id: "MZ", name: "Mizoram", type: "state", capital: "Aizawl", info: "North-Eastern hilly state famous for bamboo dance (Cheraw)." },
+  { id: "NL", name: "Nagaland", type: "state", capital: "Kohima", info: "North-Eastern state celebrated for Hornbill Festival and diverse tribes." },
+  { id: "OR", name: "Odisha", type: "state", capital: "Bhubaneswar", info: "Eastern coastal state famous for Jagannath Temple and Konark Sun Temple." },
+  { id: "PB", name: "Punjab", type: "state", capital: "Bhagalpur", capital: "Chandigarh", info: "Land of Five Rivers state famous for the Golden Temple and Bhangra." },
+  { id: "RJ", name: "Rajasthan", type: "state", capital: "Jaipur", info: "India's largest state by land area, famous for royal forts and Thar Desert." },
+  { id: "SK", name: "Sikkim", type: "state", capital: "Gangtok", info: "Himalayan organic state home to Kangchenjunga peak." },
+  { id: "TN", name: "Tamil Nadu", type: "state", capital: "Chennai", info: "Southern state famed for Dravidian temples, Bharatanatyam, and cuisine." },
+  { id: "TS", name: "Telangana", type: "state", capital: "Hyderabad", info: "India's 28th state formed in 2014, famous for Charminar and Biryani." },
+  { id: "TR", name: "Tripura", type: "state", capital: "Agartala", info: "North-Eastern state surrounded by Bangladesh on three sides." },
+  { id: "UP", name: "Uttar Pradesh", type: "state", capital: "Lucknow", info: "India's most populous state, home to Taj Mahal, Varanasi, and Ganga." },
+  { id: "UK", name: "Uttarakhand", type: "state", capital: "Dehradun", info: "Devbhumi (Land of Gods) state featuring Char Dham and Jim Corbett." },
+  { id: "WB", name: "West Bengal", type: "state", capital: "Kolkata", info: "Eastern cultural state featuring Sundarbans, Darjeeling, and Durga Puja." },
+
+  // --- 8 UNION TERRITORIES ---
+  { id: "AN", name: "Andaman and Nicobar Islands", type: "ut", capital: "Port Blair", info: "Tropical island archipelago UT in Bay of Bengal featuring Cellular Jail." },
+  { id: "CH", name: "Chandigarh", type: "ut", capital: "Chandigarh", info: "Planned modern city UT serving as joint capital for Punjab & Haryana." },
+  { id: "DH", name: "Dadra & Nagar Haveli and Daman & Diu", type: "ut", capital: "Daman", info: "Western coastal UT formed by merger of two territories in Jan 2020." },
+  { id: "DL", name: "Delhi (NCT)", type: "ut", capital: "New Delhi", info: "National Capital Territory UT housing India's parliament and historic monuments." },
+  { id: "JK", name: "Jammu and Kashmir", type: "ut", capital: "Srinagar (Summer) / Jammu (Winter)", info: "Reorganized from a state into a Union Territory in October 2019." },
+  { id: "LA", name: "Ladakh", type: "ut", capital: "Leh", info: "High-altitude cold desert UT established in October 2019." },
+  { id: "LD", name: "Lakshadweep", type: "ut", capital: "Kavaratti", info: "Coral island archipelago UT in the Arabian Sea." },
+  { id: "PY", name: "Puducherry", type: "ut", capital: "Puducherry", info: "Union Territory comprising former French colonial enclaves." }
+];
+
+/**
+ * Validates the dataset integrity (checks 28 states + 8 UTs count).
+ *
+ * @param {Array<Object>} dataset - Dataset array
+ * @returns {Object} Validation summary { isValid: boolean, statesCount: number, utCount: number }
+ */
+export function validateDataset(dataset = REGIONS_DATASET) {
+  let statesCount = 0;
+  let utCount = 0;
+  const ids = new Set();
+  const duplicateIds = [];
+
+  dataset.forEach(item => {
+    if (ids.has(item.id)) {
+      duplicateIds.push(item.id);
+    }
+    ids.add(item.id);
+
+    if (item.type === "state") statesCount++;
+    if (item.type === "ut") utCount++;
+  });
+
+  const isValid = statesCount === 28 && utCount === 8 && duplicateIds.length === 0;
+
+  return {
+    isValid,
+    statesCount,
+    utCount,
+    totalCount: dataset.length,
+    duplicateIds
+  };
+}
+
+/**
+ * Checks whether a given target choice ('state' vs 'ut') matches the region's actual type.
+ *
+ * @param {string} regionId - ID of region (e.g. 'JK')
+ * @param {string} targetType - Choice ('state' or 'ut')
+ * @param {Array<Object>} dataset - Regions dataset
+ * @returns {Object} Classification result
+ */
+export function checkClassification(regionId, targetType, dataset = REGIONS_DATASET) {
+  const region = dataset.find(r => r.id === regionId);
+
+  if (!region) {
+    return {
+      isValidRegion: false,
+      isCorrect: false,
+      expectedType: null,
+      regionName: "Unknown Region",
+      info: ""
+    };
+  }
+
+  const normalizedTarget = (targetType || "").toLowerCase().trim();
+  const isCorrect = region.type === normalizedTarget;
+
+  return {
+    isValidRegion: true,
+    isCorrect,
+    expectedType: region.type,
+    regionName: region.name,
+    capital: region.capital,
+    info: region.info
+  };
+}
+
+/**
+ * Returns a non-mutated, randomly shuffled copy of the dataset.
+ *
+ * @param {Array<Object>} dataset
+ * @returns {Array<Object>} Shuffled dataset
+ */
+export function shuffleDataset(dataset = REGIONS_DATASET) {
+  return [...dataset].sort(() => 0.5 - Math.random());
+}
+
+/**
+ * Calculates final score and grade for the sorting game round.
+ *
+ * @param {number} correctCount - Correctly classified regions count
+ * @param {number} totalCount - Total regions sorted (e.g. 36)
+ * @param {number} timeElapsedSeconds - Time taken in seconds
+ * @returns {Object} Performance summary
+ */
+export function calculateSorterScore(correctCount, totalCount = 36, timeElapsedSeconds = 0) {
+  const safeTotal = Math.max(1, totalCount);
+  const safeCorrect = Math.min(safeTotal, Math.max(0, correctCount));
+  const accuracyPct = Math.round((safeCorrect / safeTotal) * 100);
+
+  // Time bonus (up to 200 pts bonus for fast completion under 120s)
+  let speedBonus = 0;
+  if (accuracyPct >= 80 && timeElapsedSeconds > 0 && timeElapsedSeconds <= 180) {
+    speedBonus = Math.max(0, Math.round((180 - timeElapsedSeconds) * 1.5));
+  }
+
+  const basePoints = safeCorrect * 100;
+  const totalScore = basePoints + speedBonus;
+
+  let grade = "C";
+  let title = "Explorer Trainee";
+
+  if (accuracyPct === 100) {
+    grade = "S";
+    title = "Master Geographer";
+  } else if (accuracyPct >= 90) {
+    grade = "A+";
+    title = "Territory Expert";
+  } else if (accuracyPct >= 75) {
+    grade = "A";
+    title = "Regional Scholar";
+  } else if (accuracyPct >= 60) {
+    grade = "B";
+    title = "Map Navigator";
+  }
+
+  return {
+    correctCount: safeCorrect,
+    totalCount: safeTotal,
+    accuracyPct,
+    basePoints,
+    speedBonus,
+    totalScore,
+    grade,
+    title
+  };
+}
+
+/* --- Interactive DOM Game Controller --- */
+
+class UnionTerritorySorterApp {
+  constructor() {
+    this.deck = [];
+    this.currentIndex = 0;
+    this.correctCount = 0;
+    this.wrongCount = 0;
+    this.streak = 0;
+    this.startTime = 0;
+    this.timerInterval = null;
+    this.timeElapsedSeconds = 0;
+
+    this.initElements();
+    this.bindEvents();
+    this.startGame();
+  }
+
+  initElements() {
+    this.deckContainer = document.getElementById("active-card-container");
+    this.stateBin = document.getElementById("state-bin");
+    this.utBin = document.getElementById("ut-bin");
+    
+    this.sortStateBtn = document.getElementById("sort-state-btn");
+    this.sortUtBtn = document.getElementById("sort-ut-btn");
+    
+    this.scoreValueEl = document.getElementById("score-value");
+    this.streakValueEl = document.getElementById("streak-value");
+    this.timerValueEl = document.getElementById("timer-value");
+    this.progressFillEl = document.getElementById("progress-fill");
+    this.cardCounterEl = document.getElementById("card-counter");
+    
+    this.feedbackBannerEl = document.getElementById("instant-feedback");
+    
+    this.gameScreenEl = document.getElementById("game-screen");
+    this.summaryScreenEl = document.getElementById("summary-screen");
+    this.retryBtn = document.getElementById("retry-btn");
+  }
+
+  bindEvents() {
+    // Tap sorting buttons
+    if (this.sortStateBtn) {
+      this.sortStateBtn.addEventListener("click", () => this.handleClassification("state"));
+    }
+    if (this.sortUtBtn) {
+      this.sortUtBtn.addEventListener("click", () => this.handleClassification("ut"));
+    }
+
+    // HTML5 Drag & Drop on bins
+    [this.stateBin, this.utBin].forEach(bin => {
+      if (!bin) return;
+
+      bin.addEventListener("dragover", (e) => {
+        e.preventDefault();
+        bin.classList.add("drag-over");
+      });
+
+      bin.addEventListener("dragleave", () => {
+        bin.classList.remove("drag-over");
+      });
+
+      bin.addEventListener("drop", (e) => {
+        e.preventDefault();
+        bin.classList.remove("drag-over");
+        const targetType = bin.dataset.binType;
+        if (targetType) {
+          this.handleClassification(targetType);
+        }
+      });
+    });
+
+    if (this.retryBtn) {
+      this.retryBtn.addEventListener("click", () => this.startGame());
+    }
+
+    // Keyboard accessibility shortcuts (Left Arrow / 'S' for State, Right Arrow / 'U' for UT)
+    document.addEventListener("keydown", (e) => {
+      if (this.currentIndex >= this.deck.length) return;
+      if (e.key === "ArrowLeft" || e.key === "s" || e.key === "S") {
+        this.handleClassification("state");
+      } else if (e.key === "ArrowRight" || e.key === "u" || e.key === "U") {
+        this.handleClassification("ut");
+      }
+    });
+
+    // Theme toggle if present
+    const themeBtn = document.getElementById("theme-toggle");
+    if (themeBtn) {
+      themeBtn.addEventListener("click", () => {
+        document.body.classList.toggle("light-theme");
+      });
+    }
+  }
+
+  startGame() {
+    this.deck = shuffleDataset(REGIONS_DATASET);
+    this.currentIndex = 0;
+    this.correctCount = 0;
+    this.wrongCount = 0;
+    this.streak = 0;
+    this.timeElapsedSeconds = 0;
+
+    if (this.gameScreenEl && this.summaryScreenEl) {
+      this.gameScreenEl.style.display = "block";
+      this.summaryScreenEl.style.display = "none";
+    }
+
+    this.startTimer();
+    this.updateStatsUI();
+    this.renderCurrentCard();
+  }
+
+  startTimer() {
+    if (this.timerInterval) clearInterval(this.timerInterval);
+    this.startTime = Date.now();
+    this.timerInterval = setInterval(() => {
+      this.timeElapsedSeconds = Math.floor((Date.now() - this.startTime) / 1000);
+      if (this.timerValueEl) {
+        const mins = Math.floor(this.timeElapsedSeconds / 60);
+        const secs = this.timeElapsedSeconds % 60;
+        this.timerValueEl.textContent = `${mins}:${secs < 10 ? "0" : ""}${secs}`;
+      }
+    }, 1000);
+  }
+
+  stopTimer() {
+    if (this.timerInterval) {
+      clearInterval(this.timerInterval);
+      this.timerInterval = null;
+    }
+  }
+
+  updateStatsUI() {
+    if (this.scoreValueEl) this.scoreValueEl.textContent = `${this.correctCount * 100}`;
+    if (this.streakValueEl) this.streakValueEl.textContent = `${this.streak} 🔥`;
+    if (this.cardCounterEl) this.cardCounterEl.textContent = `${this.currentIndex + 1} / ${this.deck.length}`;
+
+    if (this.progressFillEl) {
+      const pct = (this.currentIndex / this.deck.length) * 100;
+      this.progressFillEl.style.width = `${pct}%`;
+    }
+  }
+
+  renderCurrentCard() {
+    if (!this.deckContainer) return;
+    this.deckContainer.innerHTML = "";
+
+    if (this.currentIndex >= this.deck.length) {
+      this.finishGame();
+      return;
+    }
+
+    const currentRegion = this.deck[this.currentIndex];
+
+    const card = document.createElement("div");
+    card.className = "region-card";
+    card.draggable = true;
+    card.id = "active-card";
+    card.setAttribute("aria-label", `Region card: ${currentRegion.name}`);
+
+    card.innerHTML = `
+      <div class="card-drag-handle">:: Drag or Tap to Sort ::</div>
+      <div class="card-badge">${this.currentIndex + 1} of 36</div>
+      <h3 class="card-title">${currentRegion.name}</h3>
+      <div class="card-capital">Capital: ${currentRegion.capital}</div>
+      <div class="card-hint">💡 ${currentRegion.info}</div>
+    `;
+
+    // HTML5 dragstart listener
+    card.addEventListener("dragstart", (e) => {
+      card.classList.add("dragging");
+      e.dataTransfer.setData("text/plain", currentRegion.id);
+    });
+
+    card.addEventListener("dragend", () => {
+      card.classList.remove("dragging");
+    });
+
+    this.deckContainer.appendChild(card);
+    this.updateStatsUI();
+  }
+
+  handleClassification(targetType) {
+    if (this.currentIndex >= this.deck.length) return;
+
+    const currentRegion = this.deck[this.currentIndex];
+    const result = checkClassification(currentRegion.id, targetType, REGIONS_DATASET);
+
+    const activeCard = document.getElementById("active-card");
+
+    if (result.isCorrect) {
+      this.correctCount++;
+      this.streak++;
+      if (activeCard) activeCard.classList.add("animate-correct");
+      this.showFeedback(true, `Correct! ${currentRegion.name} is a ${result.expectedType === 'state' ? 'State 🏛️' : 'Union Territory 🏰'}.`);
+    } else {
+      this.wrongCount++;
+      this.streak = 0;
+      if (activeCard) activeCard.classList.add("animate-wrong");
+      const correctTypeName = result.expectedType === 'state' ? 'State' : 'Union Territory';
+      this.showFeedback(false, `Oops! ${currentRegion.name} is actually a ${correctTypeName}.`);
+    }
+
+    // Advance to next card after brief transition
+    setTimeout(() => {
+      this.currentIndex++;
+      this.renderCurrentCard();
+    }, 450);
+  }
+
+  showFeedback(isCorrect, message) {
+    if (!this.feedbackBannerEl) return;
+
+    this.feedbackBannerEl.className = `feedback-toast ${isCorrect ? 'toast-success' : 'toast-error'}`;
+    this.feedbackBannerEl.textContent = message;
+
+    setTimeout(() => {
+      this.feedbackBannerEl.className = "feedback-toast hidden";
+    }, 2000);
+  }
+
+  finishGame() {
+    this.stopTimer();
+
+    if (this.gameScreenEl) this.gameScreenEl.style.display = "none";
+    if (this.summaryScreenEl) this.summaryScreenEl.style.display = "block";
+
+    const summary = calculateSorterScore(this.correctCount, this.deck.length, this.timeElapsedSeconds);
+
+    const scorePctEl = document.getElementById("summary-accuracy");
+    const totalScoreEl = document.getElementById("summary-score");
+    const gradeBadgeEl = document.getElementById("summary-grade");
+    const titleBadgeEl = document.getElementById("summary-title");
+    const timeTakenEl = document.getElementById("summary-time");
+
+    if (scorePctEl) scorePctEl.textContent = `${summary.accuracyPct}%`;
+    if (totalScoreEl) totalScoreEl.textContent = `${summary.totalScore} pts`;
+    if (gradeBadgeEl) gradeBadgeEl.textContent = `Grade ${summary.grade}`;
+    if (titleBadgeEl) titleBadgeEl.textContent = summary.title;
+    
+    if (timeTakenEl) {
+      const mins = Math.floor(this.timeElapsedSeconds / 60);
+      const secs = this.timeElapsedSeconds % 60;
+      timeTakenEl.textContent = `${mins}m ${secs}s`;
+    }
+  }
+}
+
+// Auto-initialize on DOM load in browser
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  window.UnionTerritorySorter = {
+    REGIONS_DATASET,
+    validateDataset,
+    checkClassification,
+    shuffleDataset,
+    calculateSorterScore,
+    UnionTerritorySorterApp
+  };
+
+  document.addEventListener("DOMContentLoaded", () => {
+    if (document.getElementById("active-card-container")) {
+      new UnionTerritorySorterApp();
+    }
+  });
+}

--- a/search-index.js
+++ b/search-index.js
@@ -821,6 +821,18 @@ window.indiaSearchIndex = [
     description: "Test your geographic and cultural trivia knowledge of India's states to unlock border crossings.",
     url: "frontend/state-challenge/state-challenge.html?mode=trivia"
   },
+  {
+    title: "Border Neighbors Quiz",
+    category: "Interactive Quizzes",
+    description: "Name and select all states sharing a land border with a target Indian state. Earn partial-credit points!",
+    url: "frontend/border-neighbors-quiz/index.html"
+  },
+  {
+    title: "Union Territory Sorter",
+    category: "Interactive Games",
+    description: "Drag or tap to categorize all 28 States and 8 Union Territories into their correct bins with instant feedback.",
+    url: "frontend/union-territory-sorter/index.html"
+  },
   // --- Ancient Trade Routes ---
   {
     title: "Ancient Indian Trade Network",

--- a/tests/unit/union-territory-sorter.test.js
+++ b/tests/unit/union-territory-sorter.test.js
@@ -1,0 +1,138 @@
+/**
+ * union-territory-sorter.test.js
+ * Unit tests for Union Territory Sorter dataset validation (28 states + 8 UTs),
+ * classification checking, shuffling, and score calculation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  REGIONS_DATASET,
+  validateDataset,
+  checkClassification,
+  shuffleDataset,
+  calculateSorterScore
+} from '../../frontend/union-territory-sorter/union-territory-sorter.js';
+
+describe('Union Territory Sorter Dataset Integrity', () => {
+  it('contains exactly 36 regions in total', () => {
+    expect(REGIONS_DATASET.length).toBe(36);
+  });
+
+  it('validates exactly 28 states and 8 union territories', () => {
+    const summary = validateDataset(REGIONS_DATASET);
+    expect(summary.isValid).toBe(true);
+    expect(summary.statesCount).toBe(28);
+    expect(summary.utCount).toBe(8);
+    expect(summary.totalCount).toBe(36);
+    expect(summary.duplicateIds).toEqual([]);
+  });
+
+  it('every entry has non-empty required fields (id, name, type, capital, info)', () => {
+    REGIONS_DATASET.forEach(item => {
+      expect(item).toHaveProperty('id');
+      expect(item).toHaveProperty('name');
+      expect(item).toHaveProperty('type');
+      expect(item).toHaveProperty('capital');
+      expect(item).toHaveProperty('info');
+
+      expect(typeof item.id).toBe('string');
+      expect(typeof item.name).toBe('string');
+      expect(typeof item.capital).toBe('string');
+      expect(typeof item.info).toBe('string');
+      expect(['state', 'ut']).toContain(item.type);
+
+      expect(item.id.trim().length).toBeGreaterThan(0);
+      expect(item.name.trim().length).toBeGreaterThan(0);
+      expect(item.capital.trim().length).toBeGreaterThan(0);
+    });
+  });
+
+  it('all 8 Union Territories are correctly cataloged', () => {
+    const expectedUtIds = ['AN', 'CH', 'DH', 'DL', 'JK', 'LA', 'LD', 'PY'];
+    const actualUtIds = REGIONS_DATASET.filter(r => r.type === 'ut').map(r => r.id);
+
+    expect(actualUtIds.length).toBe(8);
+    expectedUtIds.forEach(utId => {
+      expect(actualUtIds).toContain(utId);
+    });
+  });
+});
+
+describe('Classification Logic', () => {
+  it('correctly classifies Jammu and Kashmir as a Union Territory', () => {
+    const resCorrect = checkClassification('JK', 'ut');
+    expect(resCorrect.isValidRegion).toBe(true);
+    expect(resCorrect.isCorrect).toBe(true);
+    expect(resCorrect.expectedType).toBe('ut');
+
+    const resWrong = checkClassification('JK', 'state');
+    expect(resWrong.isCorrect).toBe(false);
+  });
+
+  it('correctly classifies Maharashtra as a State', () => {
+    const resCorrect = checkClassification('MH', 'state');
+    expect(resCorrect.isCorrect).toBe(true);
+    expect(resCorrect.expectedType).toBe('state');
+
+    const resWrong = checkClassification('MH', 'ut');
+    expect(resWrong.isCorrect).toBe(false);
+  });
+
+  it('handles case-insensitivity and whitespace in target choices', () => {
+    expect(checkClassification('DL', ' UT ').isCorrect).toBe(true);
+    expect(checkClassification('RJ', ' STATE ').isCorrect).toBe(true);
+  });
+
+  it('returns invalid region result for non-existent region ID', () => {
+    const res = checkClassification('INVALID_ID', 'state');
+    expect(res.isValidRegion).toBe(false);
+    expect(res.isCorrect).toBe(false);
+    expect(res.expectedType).toBeNull();
+  });
+});
+
+describe('Deck Shuffling', () => {
+  it('returns a new array of 36 items without mutating original dataset', () => {
+    const shuffled = shuffleDataset(REGIONS_DATASET);
+    expect(shuffled.length).toBe(36);
+    expect(shuffled).not.toBe(REGIONS_DATASET);
+
+    const originalIds = REGIONS_DATASET.map(r => r.id).sort();
+    const shuffledIds = shuffled.map(r => r.id).sort();
+    expect(shuffledIds).toEqual(originalIds);
+  });
+});
+
+describe('Sorter Scoring Engine', () => {
+  it('calculates perfect score, grade S, and speed bonus for 36/36 in 90 seconds', () => {
+    const res = calculateSorterScore(36, 36, 90);
+    expect(res.accuracyPct).toBe(100);
+    expect(res.basePoints).toBe(3600);
+    expect(res.speedBonus).toBeGreaterThan(0);
+    expect(res.grade).toBe('S');
+    expect(res.title).toBe('Master Geographer');
+  });
+
+  it('calculates Grade A for 75% accuracy (27/36 correct)', () => {
+    const res = calculateSorterScore(27, 36, 120);
+    expect(res.accuracyPct).toBe(75);
+    expect(res.grade).toBe('A');
+    expect(res.title).toBe('Regional Scholar');
+  });
+
+  it('handles 0 correct answers gracefully', () => {
+    const res = calculateSorterScore(0, 36, 150);
+    expect(res.accuracyPct).toBe(0);
+    expect(res.totalScore).toBe(0);
+    expect(res.grade).toBe('C');
+    expect(res.title).toBe('Explorer Trainee');
+  });
+
+  it('safely bounds out-of-range counts', () => {
+    const resOver = calculateSorterScore(50, 36, 10);
+    expect(resOver.correctCount).toBe(36);
+
+    const resUnder = calculateSorterScore(-5, 36, 10);
+    expect(resUnder.correctCount).toBe(0);
+  });
+});


### PR DESCRIPTION
Key Implementation Details:
Full Dataset (28 States + 8 UTs):

Created dataset in 

union-territory-sorter.js
 covering all 28 Indian States and 8 Union Territories with capitals and historical context notes.
Two-Bin Sorting Mechanics with Instant Feedback:

Implemented drag-and-drop mechanics onto "State Bin" and "Union Territory Bin" alongside mobile tap buttons ("🏛️ State" vs "🏰 Union Territory") and keyboard shortcuts ([Left Arrow/S] for State, [Right Arrow/U] for UT).
Real-time feedback toasts display instant success/error feedback with educational explanations for mistakes (e.g. "Jammu & Kashmir is a Union Territory since 2019").


closes #528

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Union Territory Sorter educational game.
  * Sort Indian regions into States or Union Territories using buttons, drag-and-drop, or keyboard controls.
  * Added progress, score, streak, timer, instant feedback, and end-of-round results.
  * Added light-theme support and responsive layouts.
  * Added the game to the site’s search index under Interactive Games.

* **Tests**
  * Added coverage for dataset accuracy, classification, shuffling, and scoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->