### PR TITLE
refactor: replace inline styles in JavaScript template literals with CSS classes

### DIFF
--- a/js-modules/initMap.js
+++ b/js-modules/initMap.js
@@ -277,39 +277,39 @@ function initInteractiveMap() {
             return `
                 <div style="margin-top:20px;">
                     <div style="margin-bottom:12px;">
-                        <div style="display:flex; justify-content:space-between; font-size:0.85rem; margin-bottom:4px; font-weight:600; color:var(--muted-text);">
+                        <div class="meter-label-row">
                             <span>Heritage Richness</span>
                             <span>${metrics.heritage}/10</span>
                         </div>
-                        <div style="background:rgba(255,255,255,0.08); height:6px; border-radius:3px; overflow:hidden;">
-                            <div style="background:var(--saffron); width:${metrics.heritage * 10}%; height:100%; border-radius:3px;"></div>
+                        <div class="meter-track">
+                            <div class="meter-bar meter-bar-saffron" style="width:${metrics.heritage * 10}%;"></div>
                         </div>
                     </div>
                     <div style="margin-bottom:12px;">
-                        <div style="display:flex; justify-content:space-between; font-size:0.85rem; margin-bottom:4px; font-weight:600; color:var(--muted-text);">
+                        <div class="meter-label-row">
                             <span>Culinary Diversity</span>
                             <span>${metrics.cuisine}/10</span>
                         </div>
-                        <div style="background:rgba(255,255,255,0.08); height:6px; border-radius:3px; overflow:hidden;">
-                            <div style="background:var(--primary-gold); width:${metrics.cuisine * 10}%; height:100%; border-radius:3px;"></div>
+                        <div class="meter-track">
+                            <div class="meter-bar meter-bar-gold" style="width:${metrics.cuisine * 10}%;"></div>
                         </div>
                     </div>
                     <div style="margin-bottom:12px;">
-                        <div style="display:flex; justify-content:space-between; font-size:0.85rem; margin-bottom:4px; font-weight:600; color:var(--muted-text);">
+                        <div class="meter-label-row">
                             <span>Tourist Access & Transit</span>
                             <span>${metrics.access}/10</span>
                         </div>
-                        <div style="background:rgba(255,255,255,0.08); height:6px; border-radius:3px; overflow:hidden;">
-                            <div style="background:#00f2fe; width:${metrics.access * 10}%; height:100%; border-radius:3px;"></div>
+                        <div class="meter-track">
+                            <div class="meter-bar meter-bar-cyan" style="width:${metrics.access * 10}%;"></div>
                         </div>
                     </div>
                     <div style="margin-bottom:20px;">
-                        <div style="display:flex; justify-content:space-between; font-size:0.85rem; margin-bottom:4px; font-weight:600; color:var(--muted-text);">
+                        <div class="meter-label-row">
                             <span>Artistic Traditions</span>
                             <span>${metrics.art}/10</span>
                         </div>
-                        <div style="background:rgba(255,255,255,0.08); height:6px; border-radius:3px; overflow:hidden;">
-                            <div style="background:var(--green); width:${metrics.art * 10}%; height:100%; border-radius:3px;"></div>
+                        <div class="meter-track">
+                            <div class="meter-bar meter-bar-green" style="width:${metrics.art * 10}%;"></div>
                         </div>
                     </div>
                 </div>

--- a/router.js
+++ b/router.js
@@ -1063,7 +1063,7 @@ function createSearchModal() {
                         <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
                     </svg>
                     <input type="text" id="global-search-input" placeholder="Search states, cuisines, monuments, wildlife..." aria-label="Search website content" autocomplete="off" />
-                    <button id="global-search-clear" class="btn-search-clear" aria-label="Clear search" style="display: none;">✕</button>
+                    <button id="global-search-clear" class="btn-search-clear" aria-label="Clear search" hidden>✕</button>
                 </div>
                 <button id="global-search-close" class="btn-search-close" aria-label="Close search">✕</button>
             </div>
@@ -1299,7 +1299,7 @@ function performSearch(query) {
         resultsContainer.innerHTML = `
             <div class="search-no-results">
                 <p>No results found for "${query}"</p>
-                <p style="font-size: 0.9rem; margin-top: 5px;">Try searching for states, cuisines, monuments, or festivals.</p>
+                <p class="search-hint-subtext">Try searching for states, cuisines, monuments, or festivals.</p>
             </div>
         `;
         return;

--- a/styles.css
+++ b/styles.css
@@ -2519,6 +2519,49 @@ button {
     gap: 14px;
 }
 
+/* Custom Utility Classes for JS Templates */
+.meter-label-row {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.85rem;
+    margin-bottom: 4px;
+    font-weight: 600;
+    color: var(--muted-text);
+}
+
+.meter-track {
+    background: rgba(255, 255, 255, 0.08);
+    height: 6px;
+    border-radius: 3px;
+    overflow: hidden;
+}
+
+.meter-bar {
+    height: 100%;
+    border-radius: 3px;
+}
+
+.meter-bar-saffron {
+    background: var(--saffron);
+}
+
+.meter-bar-gold {
+    background: var(--primary-gold);
+}
+
+.meter-bar-cyan {
+    background: #00f2fe;
+}
+
+.meter-bar-green {
+    background: var(--green);
+}
+
+.search-hint-subtext {
+    font-size: 0.9rem;
+    margin-top: 5px;
+}
+
 .modal-stat {
     padding: 14px 16px;
     border-radius: 14px;


### PR DESCRIPTION
## Description
This PR addresses Issue #541 by extracting hardcoded inline CSS style attributes embedded within JavaScript template literals into clean, reusable CSS classes in `styles.css`.

## Key Changes
- Added `.meter-label-row`, `.meter-track`, `.meter-bar`, `.search-hint-subtext` and color utility variants to `styles.css`.
- Updated `makeMeters` template in `js-modules/initMap.js` to utilize CSS classes instead of inline `style="..."` string attributes.
- Removed inline style attributes from `router.js` search modal and 404 fallback templates.

## Related Issue
- Closes #541

## How to Test
1. Checkout `refactor/inline-styles-template-literals`.
2. Open the state comparison tool on the interactive map and verify comparison metric progress bars render correctly with saffron, gold, cyan, and green indicator bars.
3. Open global search modal and search for missing terms to verify empty search hints and search clear button display correctly.
