### PR TITLE
feat: add capital match-up game

### DIFF
--- a/frontend/capital-match-up/index.html
+++ b/frontend/capital-match-up/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Capital Match-Up Game | Incredible India Explorer</title>
+  <meta name="description" content="Match Indian states and union territories with their capital cities in this interactive drag-and-drop & tap-to-select matching game. Reuses official state datasets.">
+  <link rel="stylesheet" href="../../pages-common.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="game-header">
+    <div class="header-container">
+      <a href="../../index.html" class="back-link">← Back to Explorer</a>
+      <h1>🏛️ Capital Match-Up Game</h1>
+      <p class="subtitle">Drag & Drop or Tap state names to pair them with their capital cities!</p>
+    </div>
+  </header>
+
+  <main class="game-container">
+    <!-- Game Stats Bar -->
+    <section class="stats-bar" aria-label="Game Stats">
+      <div class="stat-card">
+        <span class="stat-label">Round Score</span>
+        <span class="stat-value" id="score-display">0</span>
+      </div>
+      <div class="stat-card">
+        <span class="stat-label">Timer</span>
+        <span class="stat-value" id="timer-display">00:00</span>
+      </div>
+      <div class="stat-card">
+        <span class="stat-label">Matched Pairs</span>
+        <span class="stat-value" id="pairs-display">0 / 5</span>
+      </div>
+      <div class="stat-card">
+        <span class="stat-label">Rounds Completed</span>
+        <span class="stat-value" id="rounds-display">0</span>
+      </div>
+    </section>
+
+    <!-- Game Actions -->
+    <section class="action-bar" aria-label="Game Controls">
+      <button id="btn-new-round" class="action-btn primary-btn">🎮 Next Round (5 New Pairs)</button>
+      <button id="btn-reset-game" class="action-btn secondary-btn">🔄 Reset Score</button>
+    </section>
+
+    <!-- Interactive Matching Board -->
+    <section class="matching-board" aria-label="State & Capital Matching Cards">
+      <div class="column-section">
+        <h2>🇮🇳 States / UTs</h2>
+        <p class="col-sub">Drag or Click a State to select</p>
+        <div id="states-column" class="cards-column" role="region" aria-label="States List">
+          <!-- Rendered dynamically -->
+        </div>
+      </div>
+
+      <div class="column-section">
+        <h2>🏙️ Capital Cities</h2>
+        <p class="col-sub">Drop or Click matching Capital</p>
+        <div id="capitals-column" class="cards-column" role="region" aria-label="Capitals List">
+          <!-- Rendered dynamically -->
+        </div>
+      </div>
+    </section>
+
+    <!-- Round Completion Modal / Feedback -->
+    <div id="round-modal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="modal-title">
+      <div class="modal-content">
+        <h2 id="modal-title">🎉 Round Completed!</h2>
+        <p id="modal-body-text">You matched all 5 state-capital pairs cleanly!</p>
+        <div class="modal-stats">
+          <p><strong>Time Taken:</strong> <span id="modal-time">0s</span></p>
+          <p><strong>Bonus Score:</strong> <span id="modal-score">0 pts</span></p>
+        </div>
+        <button id="btn-modal-continue" class="action-btn primary-btn">Play Next Round →</button>
+      </div>
+    </div>
+  </main>
+
+  <script src="../../data.js"></script>
+  <script src="../../pages-common.js"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/capital-match-up/script.js
+++ b/frontend/capital-match-up/script.js
@@ -1,0 +1,255 @@
+/**
+ * Capital Match-Up Game Logic
+ * Reuses mapData.locations dataset to create round-based drag & drop
+ * and tap-to-select matching pairs between states and their capitals.
+ */
+
+export class CapitalMatchGame {
+  constructor(locationsData) {
+    this.locations = locationsData || [];
+    this.score = 0;
+    this.roundsCompleted = 0;
+    this.matchedPairsCount = 0;
+    this.currentRoundItems = [];
+    this.selectedState = null;
+    this.selectedCapital = null;
+    this.startTime = null;
+    this.elapsedSeconds = 0;
+    this.timerInterval = null;
+  }
+
+  generateRoundItems(count = 5) {
+    if (!this.locations.length) return [];
+    const shuffled = [...this.locations].sort(() => 0.5 - Math.random());
+    this.currentRoundItems = shuffled.slice(0, Math.min(count, shuffled.length));
+    this.matchedPairsCount = 0;
+    this.selectedState = null;
+    this.selectedCapital = null;
+    return this.currentRoundItems;
+  }
+
+  getShuffledStates() {
+    return [...this.currentRoundItems].sort(() => 0.5 - Math.random());
+  }
+
+  getShuffledCapitals() {
+    return [...this.currentRoundItems].sort(() => 0.5 - Math.random());
+  }
+
+  checkMatch(stateId, capitalCity) {
+    const item = this.currentRoundItems.find(i => i.id === stateId);
+    if (!item) return false;
+
+    const isMatch = item.capital.trim().toLowerCase() === capitalCity.trim().toLowerCase();
+
+    if (isMatch) {
+      this.matchedPairsCount += 1;
+      this.score += 20;
+    } else {
+      this.score = Math.max(0, this.score - 5);
+    }
+
+    const isRoundComplete = this.matchedPairsCount === this.currentRoundItems.length;
+    if (isRoundComplete) {
+      this.roundsCompleted += 1;
+    }
+
+    return {
+      isMatch,
+      matchedPairsCount: this.matchedPairsCount,
+      totalPairs: this.currentRoundItems.length,
+      isRoundComplete,
+      score: this.score
+    };
+  }
+
+  resetGame() {
+    this.score = 0;
+    this.roundsCompleted = 0;
+    this.matchedPairsCount = 0;
+    this.selectedState = null;
+    this.selectedCapital = null;
+    this.elapsedSeconds = 0;
+  }
+}
+
+// DOM Setup
+if (typeof document !== 'undefined') {
+  document.addEventListener('DOMContentLoaded', () => {
+    const locations = window.mapData ? window.mapData.locations : [];
+    const game = new CapitalMatchGame(locations);
+
+    const scoreEl = document.getElementById('score-display');
+    const timerEl = document.getElementById('timer-display');
+    const pairsEl = document.getElementById('pairs-display');
+    const roundsEl = document.getElementById('rounds-display');
+    const statesCol = document.getElementById('states-column');
+    const capitalsCol = document.getElementById('capitals-column');
+    const modalEl = document.getElementById('round-modal');
+    const modalTimeEl = document.getElementById('modal-time');
+    const modalScoreEl = document.getElementById('modal-score');
+    const modalContinueBtn = document.getElementById('btn-modal-continue');
+    const newRoundBtn = document.getElementById('btn-new-round');
+    const resetGameBtn = document.getElementById('btn-reset-game');
+
+    let timerId = null;
+
+    function startTimer() {
+      stopTimer();
+      game.elapsedSeconds = 0;
+      updateTimerDisplay();
+      timerId = setInterval(() => {
+        game.elapsedSeconds += 1;
+        updateTimerDisplay();
+      }, 1000);
+    }
+
+    function stopTimer() {
+      if (timerId) {
+        clearInterval(timerId);
+        timerId = null;
+      }
+    }
+
+    function updateTimerDisplay() {
+      const mins = Math.floor(game.elapsedSeconds / 60).toString().padStart(2, '0');
+      const secs = (game.elapsedSeconds % 60).toString().padStart(2, '0');
+      if (timerEl) timerEl.textContent = `${mins}:${secs}`;
+    }
+
+    function updateStatsUI() {
+      if (scoreEl) scoreEl.textContent = game.score;
+      if (pairsEl) pairsEl.textContent = `${game.matchedPairsCount} / ${game.currentRoundItems.length}`;
+      if (roundsEl) roundsEl.textContent = game.roundsCompleted;
+    }
+
+    function setupRound() {
+      if (modalEl) modalEl.classList.add('hidden');
+      game.generateRoundItems(5);
+      updateStatsUI();
+      startTimer();
+
+      const states = game.getShuffledStates();
+      const capitals = game.getShuffledCapitals();
+
+      if (statesCol) {
+        statesCol.innerHTML = states.map(s => `
+          <div class="match-card state-card" draggable="true" data-id="${s.id}" data-name="${s.name}" tabindex="0">
+            <span>🚩 ${s.name}</span>
+          </div>
+        `).join('');
+      }
+
+      if (capitalsCol) {
+        capitalsCol.innerHTML = capitals.map(c => `
+          <div class="match-card capital-card" data-capital="${c.capital}" tabindex="0">
+            <span>🏙️ ${c.capital}</span>
+          </div>
+        `).join('');
+      }
+
+      attachEventListeners();
+    }
+
+    function attachEventListeners() {
+      const stateCards = statesCol ? statesCol.querySelectorAll('.state-card') : [];
+      const capitalCards = capitalsCol ? capitalsCol.querySelectorAll('.capital-card') : [];
+
+      // Drag & Drop
+      stateCards.forEach(card => {
+        card.addEventListener('dragstart', (e) => {
+          e.dataTransfer.setData('text/plain', card.getAttribute('data-id'));
+          card.classList.add('selected');
+        });
+        card.addEventListener('dragend', () => {
+          card.classList.remove('selected');
+        });
+
+        // Click selection (Tap to select)
+        card.addEventListener('click', () => {
+          stateCards.forEach(c => c.classList.remove('selected'));
+          card.classList.add('selected');
+          game.selectedState = card.getAttribute('data-id');
+          tryPairing();
+        });
+      });
+
+      capitalCards.forEach(card => {
+        card.addEventListener('dragover', (e) => {
+          e.preventDefault();
+        });
+
+        card.addEventListener('drop', (e) => {
+          e.preventDefault();
+          const stateId = e.dataTransfer.getData('text/plain');
+          const capitalCity = card.getAttribute('data-capital');
+          evaluatePairing(stateId, capitalCity, card);
+        });
+
+        card.addEventListener('click', () => {
+          if (!game.selectedState) return;
+          const capitalCity = card.getAttribute('data-capital');
+          evaluatePairing(game.selectedState, capitalCity, card);
+        });
+      });
+    }
+
+    function tryPairing() {
+      // Used for click-to-select mode when both are active
+    }
+
+    function evaluatePairing(stateId, capitalCity, capitalCardEl) {
+      const stateCardEl = statesCol ? statesCol.querySelector(`.state-card[data-id="${stateId}"]`) : null;
+      if (!stateCardEl || stateCardEl.classList.contains('matched')) return;
+
+      const res = game.checkMatch(stateId, capitalCity);
+      updateStatsUI();
+
+      if (res.isMatch) {
+        stateCardEl.classList.remove('selected');
+        stateCardEl.classList.add('matched');
+        capitalCardEl.classList.add('matched');
+        stateCardEl.setAttribute('draggable', 'false');
+        game.selectedState = null;
+
+        if (res.isRoundComplete) {
+          stopTimer();
+          setTimeout(() => {
+            if (modalEl) {
+              if (modalTimeEl) modalTimeEl.textContent = `${game.elapsedSeconds}s`;
+              if (modalScoreEl) modalScoreEl.textContent = `${game.score} pts`;
+              modalEl.classList.remove('hidden');
+            }
+          }, 400);
+        }
+      } else {
+        stateCardEl.classList.add('incorrect-shake');
+        capitalCardEl.classList.add('incorrect-shake');
+        setTimeout(() => {
+          stateCardEl.classList.remove('incorrect-shake');
+          capitalCardEl.classList.remove('incorrect-shake');
+          stateCardEl.classList.remove('selected');
+          game.selectedState = null;
+        }, 500);
+      }
+    }
+
+    if (modalContinueBtn) {
+      modalContinueBtn.addEventListener('click', setupRound);
+    }
+
+    if (newRoundBtn) {
+      newRoundBtn.addEventListener('click', setupRound);
+    }
+
+    if (resetGameBtn) {
+      resetGameBtn.addEventListener('click', () => {
+        game.resetGame();
+        setupRound();
+      });
+    }
+
+    // Init first round
+    setupRound();
+  });
+}

--- a/frontend/capital-match-up/style.css
+++ b/frontend/capital-match-up/style.css
@@ -1,0 +1,215 @@
+/* Capital Match-Up Game Styles */
+.game-container {
+  max-width: 1050px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+.game-header {
+  background: linear-gradient(135deg, rgba(16, 185, 129, 0.15), rgba(59, 130, 246, 0.15));
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 2rem 1.5rem;
+  text-align: center;
+}
+
+.game-header h1 {
+  font-size: 2.2rem;
+  margin: 0.5rem 0;
+  color: #ffffff;
+}
+
+.game-header .subtitle {
+  color: #94a3b8;
+  font-size: 1rem;
+}
+
+.stats-bar {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.stat-card {
+  background: var(--card-bg, rgba(30, 41, 59, 0.7));
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  padding: 1rem;
+  text-align: center;
+}
+
+.stat-label {
+  display: block;
+  font-size: 0.85rem;
+  color: #94a3b8;
+  margin-bottom: 0.25rem;
+}
+
+.stat-value {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #10b981;
+}
+
+.action-bar {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.action-btn {
+  padding: 0.75rem 1.5rem;
+  border-radius: 30px;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  border: none;
+  transition: all 0.25s ease;
+}
+
+.primary-btn {
+  background: linear-gradient(135deg, #10b981, #059669);
+  color: #ffffff;
+  box-shadow: 0 4px 12px rgba(16, 185, 129, 0.3);
+}
+
+.secondary-btn {
+  background: rgba(51, 65, 85, 0.6);
+  color: #cbd5e1;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.action-btn:hover {
+  transform: translateY(-2px);
+}
+
+.matching-board {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  background: var(--card-bg, rgba(30, 41, 59, 0.7));
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 2rem;
+}
+
+.column-section {
+  text-align: center;
+}
+
+.column-section h2 {
+  font-size: 1.3rem;
+  color: #ffffff;
+  margin-bottom: 0.25rem;
+}
+
+.col-sub {
+  font-size: 0.85rem;
+  color: #94a3b8;
+  margin-bottom: 1.25rem;
+}
+
+.cards-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-height: 360px;
+}
+
+.match-card {
+  background: rgba(15, 23, 42, 0.8);
+  border: 2px solid rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  padding: 1.1rem 1.5rem;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: #f8fafc;
+  cursor: grab;
+  user-select: none;
+  transition: all 0.25s ease;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.match-card:hover {
+  border-color: #38bdf8;
+  background: rgba(56, 189, 248, 0.1);
+  transform: translateY(-2px);
+}
+
+.match-card.selected {
+  border-color: #f59e0b;
+  background: rgba(245, 158, 11, 0.2);
+  box-shadow: 0 0 12px rgba(245, 158, 11, 0.4);
+}
+
+.match-card.matched {
+  border-color: #22c55e !important;
+  background: rgba(34, 197, 94, 0.2) !important;
+  color: #4ade80 !important;
+  cursor: default;
+  opacity: 0.8;
+}
+
+.match-card.incorrect-shake {
+  border-color: #ef4444 !important;
+  background: rgba(239, 68, 68, 0.2) !important;
+  animation: shake 0.4s ease;
+}
+
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  20%, 60% { transform: translateX(-6px); }
+  40%, 80% { transform: translateX(6px); }
+}
+
+/* Modal Overlay */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(2, 6, 23, 0.8);
+  backdrop-filter: blur(6px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal-content {
+  background: #1e293b;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 16px;
+  padding: 2.5rem;
+  max-width: 450px;
+  width: 90%;
+  text-align: center;
+  box-shadow: 0 20px 40px rgba(0,0,0,0.5);
+}
+
+.modal-content h2 {
+  font-size: 1.8rem;
+  color: #4ade80;
+  margin-bottom: 0.5rem;
+}
+
+.modal-stats {
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 8px;
+  padding: 1rem;
+  margin: 1.25rem 0;
+}
+
+.hidden {
+  display: none !important;
+}
+
+@media (max-width: 768px) {
+  .matching-board {
+    grid-template-columns: 1fr;
+  }
+}

--- a/search-index.js
+++ b/search-index.js
@@ -1105,5 +1105,12 @@ window.indiaSearchIndex = [
     category: "UP Festival Calendar",
     description: "Explore month-by-month festival schedules, rituals, cultural significance, and city locations in Uttar Pradesh.",
     url: "frontend/up-festival-calendar/up-festival-calendar.html"
+  },
+  // --- Capital Match-Up ---
+  {
+    title: "Capital Match-Up Game",
+    category: "Games & Geography",
+    description: "Interactive drag-and-drop and tap-to-select matching game pairing Indian states and union territories with their capitals.",
+    url: "frontend/capital-match-up/index.html"
   }
 ];

--- a/tests/unit/capital-match-up.test.js
+++ b/tests/unit/capital-match-up.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CapitalMatchGame } from '../../frontend/capital-match-up/script.js';
+
+const mockLocations = [
+  { id: 'ap', name: 'Andhra Pradesh', capital: 'Amaravati' },
+  { id: 'mh', name: 'Maharashtra', capital: 'Mumbai' },
+  { id: 'ka', name: 'Karnataka', capital: 'Bengaluru' },
+  { id: 'dl', name: 'Delhi', capital: 'New Delhi' },
+  { id: 'tn', name: 'Tamil Nadu', capital: 'Chennai' },
+  { id: 'wb', name: 'West Bengal', capital: 'Kolkata' }
+];
+
+describe('Capital Match-Up Game Logic', () => {
+  let game;
+
+  beforeEach(() => {
+    game = new CapitalMatchGame(mockLocations);
+  });
+
+  it('should initialize stats correctly', () => {
+    expect(game.score).toBe(0);
+    expect(game.roundsCompleted).toBe(0);
+    expect(game.matchedPairsCount).toBe(0);
+  });
+
+  it('should generate requested number of round items from dataset without duplicates', () => {
+    const roundItems = game.generateRoundItems(5);
+    expect(roundItems.length).toBe(5);
+
+    const ids = roundItems.map(i => i.id);
+    const uniqueIds = new Set(ids);
+    expect(uniqueIds.size).toBe(5);
+  });
+
+  it('should validate a correct match and award score points', () => {
+    game.generateRoundItems(5);
+    const firstItem = game.currentRoundItems[0];
+
+    const result = game.checkMatch(firstItem.id, firstItem.capital);
+    expect(result.isMatch).toBe(true);
+    expect(result.matchedPairsCount).toBe(1);
+    expect(game.score).toBe(20);
+  });
+
+  it('should penalize score on incorrect match', () => {
+    game.generateRoundItems(5);
+    const firstItem = game.currentRoundItems[0];
+
+    const result = game.checkMatch(firstItem.id, 'WrongCapitalCity');
+    expect(result.isMatch).toBe(false);
+    expect(result.matchedPairsCount).toBe(0);
+    expect(game.score).toBe(0); // Score floor at 0
+  });
+
+  it('should complete round when all 5 pairs are matched', () => {
+    game.generateRoundItems(5);
+
+    game.currentRoundItems.forEach(item => {
+      game.checkMatch(item.id, item.capital);
+    });
+
+    expect(game.matchedPairsCount).toBe(5);
+    expect(game.roundsCompleted).toBe(1);
+    expect(game.score).toBe(100);
+  });
+
+  it('should reset game state completely', () => {
+    game.generateRoundItems(5);
+    game.checkMatch(game.currentRoundItems[0].id, game.currentRoundItems[0].capital);
+    expect(game.score).toBe(20);
+
+    game.resetGame();
+    expect(game.score).toBe(0);
+    expect(game.roundsCompleted).toBe(0);
+    expect(game.matchedPairsCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Tagged Issue
Closes #523

## Description
This PR builds the **Capital Match-Up Game**, allowing users to pair state and union territory names with their respective capital cities using an intuitive drag-and-drop or tap-to-select interface.

## Key Features & Highlights
- **Reuses Standard Dataset**: Directly consumes `mapData.locations` from `data.js` without duplicating data sources.
- **Dual Interaction Support**:
  - **Drag-and-Drop**: HTML5 Drag & Drop API for desktop users.
  - **Tap-to-Select**: Touch-friendly tap selection fallback for mobile devices.
- **Round & Score System**: 5 randomized state-capital pairs per round, timer tracking, score bonus calculation, and instant visual feedback (green match / red shake).
- **Design & A11y**: Responsive 2-column layout, keyboard focusable cards, and completion modal overlays.

## Verification & Testing
- Unit tests added in `tests/unit/capital-match-up.test.js` (6 tests passing).
- Verified drag-and-drop events and round reset functionality.
