### PR TITLE
fix: trim leading and trailing hyphens from state slugs

### DIFF
--- a/scripts/generate.cjs
+++ b/scripts/generate.cjs
@@ -27,7 +27,10 @@ const locations = mapData.locations;
 
 locations.forEach(state => {
     // Basic slugification for URL
-    const slug = state.name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+    const slug = state.name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
     
     // Dynamic Content
     const title = `${state.name} | Incredible India Explorer`;


### PR DESCRIPTION
## Description

Fixes state slug generation so generated URLs no longer contain unnecessary leading or trailing hyphens.

Previously, groups of non-alphanumeric characters were replaced with hyphens, but hyphens at the beginning or end of the resulting slug were not removed.

## Changes

* Preserved the existing lowercase slug normalization.
* Preserved replacement of non-alphanumeric character groups with hyphens.
* Added trimming of leading and trailing hyphens.
* Produces cleaner and more consistent state page URLs.

## Testing

* Verified `scripts/generate.cjs` passes Node.js syntax validation.
* Verified normal state names continue to generate valid slugs.
* Verified leading spaces or special characters do not create leading hyphens.
* Verified trailing spaces or special characters do not create trailing hyphens.

Closes #552


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reformatted internal page-generation logic without changing functionality.
  * Adjusted the placement of the static site generation completion message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->