### PR TITLE
fix: handle missing state story during static generation

### DIFF
--- a/scripts/generate.cjs
+++ b/scripts/generate.cjs
@@ -32,6 +32,7 @@ locations.forEach(state => {
     // Dynamic Content
     const title = `${state.name} | Incredible India Explorer`;
     const description = state.description || `Explore ${state.name} in India`;
+    const story = state.story || `Discover the story and heritage of ${state.name}.`;
     const relativePath = '../../'; // since it will be in dist/states/
     const BASE_URL = 'https://incredibleindiaexplorer.gov.in';
     const ogImage = `${BASE_URL}/assets/Brihadeeswara_Temple.png`;
@@ -50,7 +51,7 @@ locations.forEach(state => {
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>${state.story.replace(/\n/g, '<br>')}</p>
+            <p>${story.replace(/\n/g, '<br>')}</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>


### PR DESCRIPTION
## Description

Fixes #553 by preventing static page generation from crashing when a state's story content is missing, null, or undefined.

Previously, the generator called `.replace()` directly on `state.story`. If the story was unavailable, this could throw an error and stop the entire generation process.

## Changes

* Added fallback content for missing state stories.
* Applies newline replacement to the safe story value.
* Preserves existing story rendering when story content is available.
* Prevents missing story data from interrupting static site generation.

## Testing

* Verified `scripts/generate.cjs` passes Node.js syntax validation.
* Verified existing story content continues to render correctly.
* Verified missing story content uses the fallback without crashing generation.

Closes #553
