### PR TITLE
fix: escape dynamic state data in generated HTML

### DIFF
--- a/scripts/generate.cjs
+++ b/scripts/generate.cjs
@@ -22,35 +22,55 @@ if (!fs.existsSync(statesDir)) {
     fs.mkdirSync(statesDir);
 }
 
+// Escape dynamic text before inserting it into generated HTML
+function escapeHtml(value) {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
 // Generate State Pages
 const locations = mapData.locations;
 
 locations.forEach(state => {
     // Basic slugification for URL
     const slug = state.name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
-    
+
+    // Escape dynamic state data
+    const safeName = escapeHtml(state.name);
+    const safeCapital = escapeHtml(state.capital);
+    const safeFood = escapeHtml(state.food);
+    const safeFestival = escapeHtml(state.festival);
+    const safeDescription = escapeHtml(
+        state.description || `Explore ${state.name} in India`
+    );
+    const safeStory = escapeHtml(state.story);
+
     // Dynamic Content
-    const title = `${state.name} | Incredible India Explorer`;
-    const description = state.description || `Explore ${state.name} in India`;
+    const title = `${safeName} | Incredible India Explorer`;
+    const description = safeDescription;
     const relativePath = '../../'; // since it will be in dist/states/
     const BASE_URL = 'https://incredibleindiaexplorer.gov.in';
     const ogImage = `${BASE_URL}/assets/Brihadeeswara_Temple.png`;
     const ogUrl = `${BASE_URL}/states/${slug}.html`;
     const ogType = 'place';
-    
+
     let content = `
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
-        <h1>${state.name}</h1>
-        <p><strong>Capital:</strong> ${state.capital}</p>
-        <p><strong>Famous Food:</strong> ${state.food}</p>
-        <p><strong>Major Festival:</strong> ${state.festival}</p>
+        <h1>${safeName}</h1>
+        <p><strong>Capital:</strong> ${safeCapital}</p>
+        <p><strong>Famous Food:</strong> ${safeFood}</p>
+        <p><strong>Major Festival:</strong> ${safeFestival}</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
-            <p>${state.description}</p>
+            <p>${safeDescription}</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>${state.story.replace(/\n/g, '<br>')}</p>
+            <p>${safeStory.replace(/\n/g, '<br>')}</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>


### PR DESCRIPTION
## Description

Fixes #554 by HTML-escaping dynamic state data before inserting it into generated pages.

Previously, state values were interpolated directly into HTML. Special characters or embedded markup could alter the generated document structure or introduce unwanted HTML.

## Changes

* Added a reusable HTML-escaping helper.
* Escaped state name, capital, food, festival, description, and story values.
* Safely handles characters such as `&`, `<`, `>`, quotes, and apostrophes.
* Preserved intended story line breaks after escaping.
* Kept URL slug generation separate from HTML escaping.

## Testing

* Verified `scripts/generate.cjs` passes Node.js syntax validation.
* Verified normal state data continues to render correctly.
* Verified HTML-like content is rendered as text instead of markup.
* Verified special characters are safely encoded in generated pages.

Closes #554


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by safely escaping state information displayed in generated pages.
  * Updated page metadata to prevent special characters from affecting titles and social sharing details.
  * Missing story content now displays as blank instead of showing a fallback message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->