### PR TITLE
fix: detect duplicate state slugs during generation

### DIFF
--- a/scripts/generate.cjs
+++ b/scripts/generate.cjs
@@ -24,10 +24,22 @@ if (!fs.existsSync(statesDir)) {
 
 // Generate State Pages
 const locations = mapData.locations;
+const generatedSlugs = new Map();
 
 locations.forEach(state => {
     // Basic slugification for URL
     const slug = state.name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+
+    // Prevent different states from generating the same output file
+    if (generatedSlugs.has(slug)) {
+        const existingState = generatedSlugs.get(slug);
+
+        throw new Error(
+            `Duplicate state slug "${slug}" generated for "${existingState}" and "${state.name}".`
+        );
+    }
+
+    generatedSlugs.set(slug, state.name);
     
     // Dynamic Content
     const title = `${state.name} | Incredible India Explorer`;


### PR DESCRIPTION
## Description

Fixes #555 by detecting duplicate state slugs before generated pages can overwrite each other.

Previously, different state names that normalized to the same slug could generate the same output filename. The later state page would silently overwrite the previously generated page.

## Changes

* Added tracking for generated state slugs.
* Detects slug collisions before writing conflicting pages.
* Throws a clear error when a duplicate slug is found.
* Reports both state names involved in the collision.
* Prevents generated pages from being silently overwritten.

## Testing

* Verified `scripts/generate.cjs` passes Node.js syntax validation.
* Verified generation works normally when all state slugs are unique.
* Verified duplicate slugs trigger a clear error instead of overwriting an existing page.

Closes #555
