### PR TITLE
fix: create output directories recursively

### DIFF
--- a/scripts/generate.cjs
+++ b/scripts/generate.cjs
@@ -14,13 +14,8 @@ const layoutTemplate = fs.readFileSync(layoutPath, 'utf8');
 const distDir = path.join(__dirname, '..', 'dist');
 const statesDir = path.join(distDir, 'states');
 
-// Ensure directories exist
-if (!fs.existsSync(distDir)) {
-    fs.mkdirSync(distDir);
-}
-if (!fs.existsSync(statesDir)) {
-    fs.mkdirSync(statesDir);
-}
+// Ensure output directory exists
+fs.mkdirSync(statesDir, { recursive: true });
 
 // Generate State Pages
 const locations = mapData.locations;


### PR DESCRIPTION
## Description

Fixes #556 by simplifying and improving output directory creation during static page generation.

Previously, the generator created `dist` and `dist/states` separately, making the setup dependent on the parent directory being created first.

## Changes

* Replaced separate directory existence checks with recursive directory creation.
* Uses `fs.mkdirSync(statesDir, { recursive: true })`.
* Automatically creates any missing parent directories.
* Simplifies the directory setup logic.

## Testing

* Verified `scripts/generate.cjs` passes Node.js syntax validation.
* Verified static page generation runs successfully.
* Verified the output directory hierarchy is created recursively when needed.

Closes #556
