### PR TITLE
feat: Add National Highway Navigator

### DIFF
--- a/frontend/highway-navigator/README.md
+++ b/frontend/highway-navigator/README.md
@@ -1,0 +1,294 @@
+<!-- README.md -->
+# CryptoViz
+
+Interact with Cryptography, Visualised in Real-Time.
+
+![CI Status](https://img.shields.io/github/actions/workflow/status/csxark/CryptoViz/pr.yml?branch=main&label=CI)
+![License](https://img.shields.io/github/license/csxark/CryptoViz?color=blue&label=License)
+![Coverage](https://img.shields.io/badge/coverage-%E2%89%A580%25-success)
+![Lighthouse Performance](https://img.shields.io/badge/lighthouse--performance-%E2%89%A590-emerald)
+![Lighthouse Accessibility](https://img.shields.io/badge/lighthouse--accessibility-%E2%89%A595-emerald)
+![Vercel Status](https://img.shields.io/badge/deployment-Vercel-black?logo=vercel)
+
+CryptoViz is a fully static Next.js 15 cybersecurity visualizer and cryptography learning platform. It allows developers, students, and security professionals to explore cryptographic algorithms step-by-step with off-thread calculations. The platform operates client-side inside secure browser Web Workers, rendering interactive visual trace state machines.
+
+---
+
+## 🔗 Live Demo
+
+Visit the production site at [crypto-viz-liart.vercel.app](crypto-viz-liart.vercel.app). Explore the interactive visualizer ciphers, read built-in cybersecurity documentation, and browse our curated learning resources list.
+
+---
+
+## ✨ Features
+
+### 1. Cipher Visualizer
+CryptoViz supports step-by-step state animations, dynamic parameters, and off-thread execution inside Web Workers. Below is the list of supported ciphers:
+
+| Cipher | Category | Security Status | Standard |
+| :--- | :--- | :--- | :--- |
+| **Caesar** | Classical | legacy | Shift cipher |
+| **ROT13** | Classical | legacy | Fixed Caesar-13 |
+| **Vigenère** | Classical | legacy | Polyalphabetic substitution |
+| **Playfair** | Classical | legacy | 5x5 Matrix bigram cipher |
+| **Rail Fence** | Classical | legacy | Transposition zigzag cipher |
+| **Atbash** | Classical | legacy | Reversed alphabet |
+| **XOR** | Symmetric | legacy | Byte-wise XOR stream |
+| **OTP (One-Time Pad)** | Symmetric | secure (with caveats) | Perfect secrecy cipher |
+| **DES** | Symmetric | deprecated | FIPS 46-3 (64-bit block) |
+| **3DES** | Symmetric | deprecated | SP 800-67 (Triple DES) |
+| **AES-128 / AES-256** | Symmetric | secure | FIPS 197 standard |
+| **RSA-OAEP** | Asymmetric | secure | PKCS #1 v2.2 |
+| **Diffie-Hellman (DH)** | Asymmetric | secure | RFC 7919 / FIPS 196 |
+| **ECDSA P-256** | Asymmetric | secure | FIPS 186-5 (Elliptic Curve) |
+| **SHA-256** | Hash | secure | FIPS 180-4 standard |
+| **SHA-512** | Hash | secure | FIPS 180-4 standard |
+| **MD5** | Hash | broken | RFC 1321 (Educational only) |
+| **HMAC-SHA256** | Hash | secure | RFC 2104 standard |
+| **Bcrypt** | Hash | secure | Blowfish-based KDF |
+
+### 2. Docs Module
+- **Interactive Markdown (MDX)**: Custom MDX rendering with LaTeX mathematical equations.
+- **Auto-linking Ciphers**: Custom plugins that convert backtick tags directly into visualizer link pills.
+- **Reading Time & TOC**: Interactive table of contents tracking read times.
+
+### 3. Resources Module
+- **Curated Reading**: High-quality resource registry mapping tools, books, videos, and specifications.
+- **Client-side Filter**: Rapid filtering by tags, reading duration, and content types without backend requests.
+
+---
+
+## 🏛️ Architecture
+
+### High-Level Architecture Diagram
+
+```mermaid
+graph TD
+  subgraph Browser [Client Web Browser]
+    MainThread[Main UI Thread: Next.js / React / Zustand]
+    WorkerThread[Background Web Worker: cipher.worker.ts]
+    MainThread -->|postMessage: WorkerRequest| WorkerThread
+    WorkerThread -->|onmessage: WorkerResponse| MainThread
+  end
+
+  subgraph CDNElements [Build & Edge Static CDN]
+    VercelCDN[Vercel CDN Static Assets]
+    StaticBuild[Pagefind Static Search WASM]
+  end
+
+  subgraph SaaS [Additive SaaS Layer - Phase 9]
+    EdgeFunc[Vercel Serverless/Edge Functions]
+    Neon[Neon Serverless Postgres]
+    Stripe[Stripe Checkout & Billing]
+    Resend[Resend Transactional Email]
+  end
+
+  MainThread <-->|Fetch Static HTML/JS| VercelCDN
+  MainThread <-->|Query WASM Index| StaticBuild
+  MainThread <-->|HTTPS API / Auth| EdgeFunc
+  EdgeFunc <-->|Drizzle ORM| Neon
+  EdgeFunc <-->|Webhooks / API| Stripe
+  EdgeFunc <-->|SMTP Trigger| Resend
+```
+
+### Project Structure
+
+```
+cryptoviz/
+├── app/                  # Next.js App Router folders
+│   ├── (visualizer)/     # Visualizer route group
+│   ├── (docs)/           # MDX Docs route group
+│   ├── (resources)/      # Resources filter list
+│   ├── layout.tsx        # Top-level HTML and layouts
+│   └── page.tsx          # Marketing home landing page
+├── components/           # Reusable UI component blocks
+│   ├── ui/               # Radix UI wrapper primitives
+│   ├── cipher/           # Grid displays and step controls
+│   ├── docs/             # Toc layout and MDX callouts
+│   └── resources/        # Cards and tags search components
+├── lib/                  # Underlying business engines
+│   ├── cipher/           # Pure JS cryptographic implementations
+│   ├── workers/          # Web worker entry file
+│   ├── hooks/            # useCipherWorker & share URL managers
+│   ├── store/            # Visualizer application stores
+│   ├── mdx/              # MDX remark/rehype processors
+│   ├── search/           # Pagefind index loaders
+│   └── utils/            # CSS classes merging and sanitisers
+├── content/              # Raw data files
+│   ├── docs/             # MDX documents content
+│   └── resources.ts      # Statically-typed resource database
+├── public/               # Public assets and Pagefind WASM
+├── tests/                # Verification suites
+│   ├── unit/             # Vitest cipher verification
+│   ├── e2e/              # Playwright browser flows
+│   ├── a11y/             # axe-core accessibility checks
+│   └── security/         # Security header tests
+└── .github/workflows/    # CI/CD action routines
+```
+
+### Data Flow
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor User as User Interface
+  participant Store as Zustand Store
+  participant Hook as useCipherWorker()
+  participant Worker as Web Worker
+  participant Cipher as Cipher Module
+  participant Animator as Animator Store
+
+  User->>Store: Input text, select Key, & options
+  Store->>Hook: Trigger runCipher()
+  Hook->>Worker: postMessage(WorkerRequest + unique ID)
+  activate Worker
+  Worker->>Cipher: Call encrypt() / decrypt()
+  Note over Cipher: Execute instrumented<br/>vs fast execution path
+  Cipher-->>Worker: Return CipherResult + steps[]
+  Worker-->>Hook: postMessage(WorkerResponse)
+  deactivate Worker
+  Hook->>Animator: Load steps[] and output
+  Animator->>User: Render output & step-by-step state
+```
+
+1. **User input**: The user types plaintext, configures keys, and options in the visualizer UI.
+2. **State dispatch**: React fields update state in the visualizer Zustand store.
+3. **Worker handoff**: The `useCipherWorker()` hook captures input and creates a `WorkerRequest` payload with a unique ID, sending it via `postMessage()`.
+4. **Execution**: The Web Worker (`cipher.worker.ts`) acts as a router, calling the selected cipher's `encrypt` or `decrypt` module function.
+5. **Path selection**: If the UI is open, the instrumented path runs to produce `steps[]` trace data; otherwise, a fast path executes.
+6. **Worker response**: The worker returns the `WorkerResponse` with the `CipherResult` object (containing `output` and `steps[]`).
+7. **Animation trigger**: The hook resolves the promise, updates the Zustand state, and populates the `StepAnimator` UI component for display.
+
+### Key Architectural Decisions
+
+| Decision | Choice | Rationale | Trade-off |
+| :--- | :--- | :--- | :--- |
+| **Deployment Model** | Next.js Static Export (`output: 'export'`) | High scalability, zero hosting costs, and server-side safety under Vercel Free Tier. | No runtime Node.js middleware; requires static pre-generation. |
+| **Cryptography Threading** | Browser Web Workers | Offloads math operations from the UI thread to prevent browser interface freeze. | Message serialization latency between main thread and worker. |
+| **Cryptographic Primitives** | `@noble/*` Libraries | Audited, secure, dependency-free, and tree-shakeable alternative to legacy modules. | Minimal feature footprint; requires custom implementation of block modes. |
+| **Static Site Search** | Pagefind WASM | Compiles a static search index at build time, executing search directly in WASM. | Requires a local build hook step to generate indexes. |
+| **State Management** | Zustand | Lightweight state store with URL hash synchronization. | Manual sync needed to prevent SSR mismatches. |
+| **Testing Harness** | Vitest | Extremely fast, ESM-native test runner sharing Next.js configurations. | Simulates DOM APIs via jsdom. |
+| **Component System** | Radix UI Primitive wrapper | Unstyled accessible base primitives designed to be styled using Tailwind. | Requires writing custom Tailwind wrappers for each component. |
+
+### SaaS Architecture (Additive Layer)
+The SaaS layer (Phase 9) integrates seamlessly as an additive option without altering the static visualizer core:
+- **Auth**: Executed on Vercel Serverless Functions utilizing `better-auth` supporting OAuth and password flows.
+- **Database**: `Neon` Serverless PostgreSQL managed via `Drizzle ORM`.
+- **Payments**: `Stripe Checkout` redirects and customer portal webhook synchronizations.
+- **Messaging**: `Resend` APIs for transaction alerts and user confirmations.
+- **Rate Limiting**: `Upstash Redis` token-bucket rate limits on edge functions.
+
+---
+
+## 💻 Tech Stack
+
+| Category | Technology | Version | Purpose |
+| :--- | :--- | :--- | :--- |
+| **Framework** | Next.js | 15.x | Application engine and routing shell |
+| **Language** | TypeScript | 5.x | Strict-type compiler correctness |
+| **Styling** | Tailwind CSS | v4 | Utility-first cascading style engine |
+| **UI Primitives** | Radix UI | Latest | Accessible, unstyled React base controls |
+| **Animation** | Motion (Framer) | Latest | Fluid transitions and timeline animations |
+| **Crypto Primitives** | `@noble/hashes` & `@noble/curves` | Latest | Standard secure hashing, HMAC, KDF, and ECDSA |
+| **Native API** | WebCrypto API | Standard | Secure AES block encryption and key management |
+| **State Management** | Zustand | Latest | Unified UI settings and parameter synchronization |
+| **Content Render** | `next-mdx-remote` | Latest | Dynamic build-time MDX content assembly |
+| **Search Engine** | Pagefind | Latest | Statically-indexed client search module |
+| **Unit Testing** | Vitest | Latest | In-memory unit and mathematical tests |
+| **E2E Testing** | Playwright | Latest | Browser automation verification |
+| **A11y Audit** | axe-core | Latest | Automated WCAG accessibility verification |
+| **CI Workflow** | GitHub Actions | Standard | Build, lint, typecheck, and validation runner |
+| **Hosting Platform** | Vercel | Standard | Static edge hosting and preview deployment |
+| **Auth System** | `better-auth` | Latest | Multi-provider client security manager |
+| **Database Engine** | Neon Postgres | Latest | SQL server database storage |
+| **ORM Wrapper** | Drizzle ORM | Latest | Type-safe SQL schema database definitions |
+| **Payment Gateway** | Stripe API | Latest | User premium access control and checkouts |
+| **Email Relay** | Resend | Latest | Transactional notifications and verification mail |
+
+---
+
+## ⚡ Getting Started
+
+### Prerequisites
+
+Ensure you have the following installed before launching:
+
+| Utility | Minimum Version | Check Command |
+| :--- | :--- | :--- |
+| **Node.js** | 22.x LTS | `node -v` |
+| **pnpm** | 9.x | `pnpm -v` |
+| **Git** | Latest | `git --version` |
+
+### Step-by-Step Setup
+
+1. **Clone the repository**:
+   ```bash
+   git clone https://github.com/csxark/CryptoViz.git
+   cd cryptoviz
+   ```
+
+2. **Install node dependencies**:
+   ```bash
+   pnpm install
+   ```
+
+3. **Configure Environment Variables** (Required for OG metadata):
+   Create a `.env.local` file in the root directory:
+   ```bash
+   NEXT_PUBLIC_APP_URL=http://localhost:3000
+   ```
+
+4. **Launch the development server**:
+   ```bash
+   pnpm dev
+   ```
+
+Open `http://localhost:3000` in your web browser. You should see the CryptoViz landing page with the navigation bar and theme toggle fully functional.
+
+---
+
+## 🛠️ Commands Reference
+
+| Command | Description | When to use |
+| :--- | :--- | :--- |
+| `pnpm dev` | Starts development server on port 3000. | Active UI coding and development. |
+| `pnpm build` | Compiles source and exports static assets. | Production preparation or preview check. |
+| `pnpm postbuild` | Generates Pagefind WASM indexes. | Must run after `pnpm build` finishes. |
+| `pnpm lint` | Performs ESLint and Biome code verification. | Code formatting and styling check. |
+| `pnpm typecheck` | Validates TypeScript files using `tsc`. | Compile safety verification. |
+| `pnpm test` | Executes unit tests under Vitest. | Validating cipher correctness. |
+| `pnpm test:watch` | Runs Vitest tests in watch mode. | Active development of cipher test cases. |
+| `pnpm test:e2e` | Runs Playwright browser tests. | Validating overall user browser paths. |
+| `pnpm test:a11y` | Executes automated axe-core audits. | Accessibility compliance checks. |
+| `pnpm test:security` | Asserts security header structures. | Verifying CSP compliance in `vercel.json`. |
+| `pnpm audit` | Performs vulnerability scanning. | Checking npm dependencies safety. |
+| `pnpm analyze` | Triggers bundle payload analysis. | Budget validation for Javascript chunk sizes. |
+| `pnpm db:push` | Syncs local schema definitions. | Updating Neon database structure (Phase 9). |
+| `pnpm db:migrate` | Runs Drizzle SQL migration routines. | Applying DB migrations in production (Phase 9). |
+
+---
+
+
+## 🤝 Contributing
+
+We welcome contributions to CryptoViz. Please read [CONTRIBUTING.md](./CONTRIBUTING.md) and [GUIDELINES.md](./GUIDELINES.md) to understand local development protocols, code structure, and pull request rules.
+
+- **To add a new cipher**: Create a pure mathematical module, add tests, and update the Web Worker router.
+- **To add a new doc**: Add a `.mdx` file to the content path with the required Zod frontmatter fields.
+- **To add a resource**: Update the static resource array database with verified HTTPS URLs.
+
+---
+
+## 📄 License
+
+This project is licensed under the MIT License - see the [LICENSE](./LICENSE) file for details. CryptoViz is built primarily for cybersecurity education and interactive learning purposes.
+
+---
+
+## 💖 Acknowledgements
+
+- **@noble libraries**: Paulmillr's highly optimized, audited cryptographic libraries.
+- **Radix UI**: Accessible primitives enabling clean Tailwind components.
+- **Pagefind**: Fast, static indexing engine running inside WASM.
+- **NIST & IETF**: FIPS and RFC committees for publishing test vectors.

--- a/frontend/highway-navigator/app.js
+++ b/frontend/highway-navigator/app.js
@@ -1,0 +1,292 @@
+/* ============================================================
+   National Highway Navigator — application logic
+   ============================================================ */
+
+(function () {
+  "use strict";
+
+  const VB_W = 640, VB_H = 760, PAD = 26;
+
+  /* ---------- Projection: real lat/lon -> SVG coordinates ---------- */
+  const lons = INDIA_OUTLINE.map(p => p[0]);
+  const lats = INDIA_OUTLINE.map(p => p[1]);
+  const lonMin = Math.min(...lons), lonMax = Math.max(...lons);
+  const latMin = Math.min(...lats), latMax = Math.max(...lats);
+  const latMid = (latMin + latMax) / 2;
+  const cosCorrection = Math.cos(latMid * Math.PI / 180); // equirectangular correction
+
+  const spanX = (lonMax - lonMin) * cosCorrection;
+  const spanY = (latMax - latMin);
+  const scale = Math.min((VB_W - PAD * 2) / spanX, (VB_H - PAD * 2) / spanY);
+  const offX = PAD + ((VB_W - PAD * 2) - spanX * scale) / 2;
+  const offY = PAD + ((VB_H - PAD * 2) - spanY * scale) / 2;
+
+  function project(lon, lat) {
+    const x = offX + (lon - lonMin) * cosCorrection * scale;
+    const y = offY + (latMax - lat) * scale; // flip Y (north = up)
+    return [x, y];
+  }
+
+  /* ---------- Build graph ---------- */
+  const cityById = Object.fromEntries(CITIES.map(c => [c.id, c]));
+  const graph = Object.fromEntries(CITIES.map(c => [c.id, []]));
+  EDGES.forEach(([a, b, hwy, km, speed]) => {
+    graph[a].push({ to: b, hwy, km, speed });
+    graph[b].push({ to: a, hwy, km, speed });
+  });
+
+  /* ---------- Dijkstra ---------- */
+  function shortestRoute(startId, endId, metric) {
+    const dist = {}, prevEdge = {}, prevNode = {}, visited = new Set();
+    CITIES.forEach(c => (dist[c.id] = Infinity));
+    dist[startId] = 0;
+    const pq = new Set(CITIES.map(c => c.id));
+
+    while (pq.size) {
+      let u = null, best = Infinity;
+      for (const id of pq) if (dist[id] < best) { best = dist[id]; u = id; }
+      if (u === null) break;
+      pq.delete(u);
+      visited.add(u);
+      if (u === endId) break;
+
+      for (const edge of graph[u]) {
+        if (visited.has(edge.to)) continue;
+        const weight = metric === "time" ? edge.km / edge.speed : edge.km;
+        const alt = dist[u] + weight;
+        if (alt < dist[edge.to]) {
+          dist[edge.to] = alt;
+          prevEdge[edge.to] = edge;
+          prevNode[edge.to] = u;
+        }
+      }
+    }
+
+    if (dist[endId] === Infinity) return null;
+
+    const segments = [];
+    let cur = endId;
+    while (cur !== startId) {
+      const edge = prevEdge[cur];
+      const from = prevNode[cur];
+      segments.unshift({ from, to: cur, hwy: edge.hwy, km: edge.km, speed: edge.speed });
+      cur = from;
+    }
+    const totalKm = segments.reduce((s, e) => s + e.km, 0);
+    const totalHrs = segments.reduce((s, e) => s + e.km / e.speed, 0);
+    const highwaysUsed = [...new Set(segments.map(s => s.hwy))];
+    return { segments, totalKm, totalHrs, highwaysUsed };
+  }
+
+  /* ---------- SVG helpers ---------- */
+  const svg = document.getElementById("map-svg");
+  const NS = "http://www.w3.org/2000/svg";
+  function el(tag, attrs) {
+    const e = document.createElementNS(NS, tag);
+    for (const k in attrs) e.setAttribute(k, attrs[k]);
+    return e;
+  }
+
+  function outlinePath() {
+    return INDIA_OUTLINE.map((p, i) => {
+      const [x, y] = project(p[0], p[1]);
+      return (i === 0 ? "M" : "L") + x.toFixed(1) + "," + y.toFixed(1);
+    }).join(" ") + " Z";
+  }
+
+  let highlightedHwy = null;
+  let activeRoute = null;
+
+  function renderMap() {
+    svg.innerHTML = "";
+    svg.setAttribute("viewBox", `0 0 ${VB_W} ${VB_H}`);
+
+    // landmass
+    svg.appendChild(el("path", { d: outlinePath(), class: "landmass" }));
+
+    // graticule-ish subtle backdrop dots removed for clarity; draw all edges (faint)
+    const edgeLayer = el("g", { class: "edge-layer" });
+    EDGES.forEach(([a, b, hwy, km]) => {
+      const ca = cityById[a], cb = cityById[b];
+      const [x1, y1] = project(ca.lon, ca.lat);
+      const [x2, y2] = project(cb.lon, cb.lat);
+      const isHighlighted = highlightedHwy && hwy === highlightedHwy;
+      const line = el("line", {
+        x1, y1, x2, y2,
+        class: "edge" + (isHighlighted ? " edge-highlighted" : "")
+      });
+      edgeLayer.appendChild(line);
+    });
+    svg.appendChild(edgeLayer);
+
+    // active route (drawn on top, animated)
+    if (activeRoute) {
+      const routeLayer = el("g", { class: "route-layer" });
+      activeRoute.segments.forEach(seg => {
+        const ca = cityById[seg.from], cb = cityById[seg.to];
+        const [x1, y1] = project(ca.lon, ca.lat);
+        const [x2, y2] = project(cb.lon, cb.lat);
+        routeLayer.appendChild(el("line", { x1, y1, x2, y2, class: "route-line" }));
+      });
+      svg.appendChild(routeLayer);
+    }
+
+    // city nodes
+    const nodeLayer = el("g", { class: "node-layer" });
+    CITIES.forEach(c => {
+      const [x, y] = project(c.lon, c.lat);
+      const onRoute = activeRoute && activeRoute.segments.some(s => s.from === c.id || s.to === c.id);
+      const isEndpoint = activeRoute && (activeRoute.segments[0].from === c.id || activeRoute.segments[activeRoute.segments.length - 1].to === c.id);
+      const g = el("g", { class: "node" + (onRoute ? " node-on-route" : "") + (isEndpoint ? " node-endpoint" : ""), "data-city": c.id });
+      g.appendChild(el("circle", { cx: x, cy: y, r: isEndpoint ? 6.5 : onRoute ? 5 : 3.4 }));
+      const label = el("text", { x: x + 7, y: y - 6, class: "node-label" });
+      label.textContent = c.name;
+      g.appendChild(label);
+      g.addEventListener("mouseenter", () => showTooltip(c, x, y));
+      g.addEventListener("mouseleave", hideTooltip);
+      nodeLayer.appendChild(g);
+    });
+    svg.appendChild(nodeLayer);
+  }
+
+  const tooltip = document.getElementById("map-tooltip");
+  function showTooltip(city, x, y) {
+    tooltip.innerHTML = `<strong>${city.name}</strong><span>${city.state}</span>`;
+    tooltip.style.left = (x / VB_W) * 100 + "%";
+    tooltip.style.top = (y / VB_H) * 100 + "%";
+    tooltip.classList.add("visible");
+  }
+  function hideTooltip() { tooltip.classList.remove("visible"); }
+
+  /* ---------- UI wiring ---------- */
+  const fromSel = document.getElementById("from-select");
+  const toSel = document.getElementById("to-select");
+  const metricRadios = document.querySelectorAll('input[name="metric"]');
+  const planBtn = document.getElementById("plan-btn");
+  const swapBtn = document.getElementById("swap-btn");
+  const resultPanel = document.getElementById("result-panel");
+  const emptyState = document.getElementById("empty-state");
+
+  const sorted = [...CITIES].sort((a, b) => a.name.localeCompare(b.name));
+  sorted.forEach(c => {
+    const o1 = document.createElement("option");
+    o1.value = c.id; o1.textContent = `${c.name}, ${c.state}`;
+    fromSel.appendChild(o1);
+    const o2 = o1.cloneNode(true);
+    toSel.appendChild(o2);
+  });
+  fromSel.value = "delhi";
+  toSel.value = "bengaluru";
+
+  function currentMetric() {
+    return [...metricRadios].find(r => r.checked).value;
+  }
+
+  function formatHrs(hrs) {
+    const h = Math.floor(hrs);
+    const m = Math.round((hrs - h) * 60);
+    if (h === 0) return `${m} min`;
+    return `${h} h ${m.toString().padStart(2, "0")} m`;
+  }
+
+  function planRoute() {
+    const from = fromSel.value, to = toSel.value;
+    if (from === to) {
+      resultPanel.innerHTML = `<p class="notice">Pick two different cities to plan a route.</p>`;
+      resultPanel.hidden = false;
+      emptyState.hidden = true;
+      activeRoute = null;
+      renderMap();
+      return;
+    }
+    const route = shortestRoute(from, to, currentMetric());
+    if (!route) {
+      resultPanel.innerHTML = `<p class="notice">No connected highway path found between these cities in the current network.</p>`;
+      resultPanel.hidden = false;
+      emptyState.hidden = true;
+      activeRoute = null;
+      renderMap();
+      return;
+    }
+    activeRoute = route;
+    highlightedHwy = null;
+    renderMap();
+
+    const fromCity = cityById[from], toCity = cityById[to];
+    const segHtml = route.segments.map(s => {
+      const a = cityById[s.from], b = cityById[s.to];
+      return `<li class="segment">
+        <span class="shield">${s.hwy}</span>
+        <span class="segment-route">${a.name} <span class="arrow">&rarr;</span> ${b.name}</span>
+        <span class="segment-km">${s.km} km</span>
+      </li>`;
+    }).join("");
+
+    resultPanel.innerHTML = `
+      <div class="result-summary">
+        <div class="summary-stat">
+          <span class="summary-value">${Math.round(route.totalKm)}</span>
+          <span class="summary-label">kilometres</span>
+        </div>
+        <div class="summary-stat">
+          <span class="summary-value">${formatHrs(route.totalHrs)}</span>
+          <span class="summary-label">est. drive time</span>
+        </div>
+        <div class="summary-stat">
+          <span class="summary-value">${route.highwaysUsed.length}</span>
+          <span class="summary-label">highway${route.highwaysUsed.length > 1 ? "s" : ""}</span>
+        </div>
+      </div>
+      <p class="route-caption">${fromCity.name} &rarr; ${toCity.name}, optimised for ${currentMetric() === "time" ? "shortest drive time" : "shortest distance"}.</p>
+      <ol class="segment-list">${segHtml}</ol>
+      <p class="disclaimer">Distances are approximate road distances for illustrative route planning, not turn-by-turn navigation.</p>
+    `;
+    resultPanel.hidden = false;
+    emptyState.hidden = true;
+  }
+
+  planBtn.addEventListener("click", planRoute);
+  swapBtn.addEventListener("click", () => {
+    const f = fromSel.value;
+    fromSel.value = toSel.value;
+    toSel.value = f;
+    if (activeRoute) planRoute();
+  });
+  metricRadios.forEach(r => r.addEventListener("change", () => { if (activeRoute) planRoute(); }));
+
+  /* ---------- Highway directory (identification) ---------- */
+  const directory = document.getElementById("highway-directory");
+  HIGHWAYS.forEach(h => {
+    const card = document.createElement("button");
+    card.className = "hwy-card";
+    card.type = "button";
+    card.innerHTML = `
+      <span class="shield shield-lg">${h.nh}</span>
+      <span class="hwy-name">${h.name}</span>
+      <span class="hwy-meta">${h.length.toLocaleString("en-IN")} km &middot; ${h.states} states</span>
+      <span class="hwy-note">${h.note}</span>
+    `;
+    card.addEventListener("click", () => {
+      const already = highlightedHwy === h.nh;
+      document.querySelectorAll(".hwy-card").forEach(c => c.classList.remove("active"));
+      activeRoute = null;
+      resultPanel.hidden = true;
+      emptyState.hidden = false;
+      if (already) {
+        highlightedHwy = null;
+      } else {
+        highlightedHwy = h.nh;
+        card.classList.add("active");
+        emptyState.innerHTML = `<p>Highlighting <strong>${h.nh}</strong> — ${h.name} across the network.</p>`;
+      }
+      if (!highlightedHwy) {
+        emptyState.innerHTML = `<p>Choose a start and destination, then plan a route to see it here.</p>`;
+      }
+      renderMap();
+    });
+    directory.appendChild(card);
+  });
+
+  /* ---------- init ---------- */
+  renderMap();
+})();

--- a/frontend/highway-navigator/data.js
+++ b/frontend/highway-navigator/data.js
@@ -1,0 +1,181 @@
+/* ============================================================
+   National Highway Navigator — data layer
+   ------------------------------------------------------------
+   CITIES  : real-world lat/lon (WGS84) for ~40 highway junction
+             towns/cities used as routing nodes.
+   EDGES   : road segments tagged with their real NH number,
+             an approximate driving distance (km, rounded to
+             the nearest 5km from publicly known road distances)
+             and a typical cruising speed used for ETA maths.
+   HIGHWAYS: reference facts about India's major National
+             Highways (official length, termini, states) shown
+             in the "Highway Identification" directory.
+   INDIA_OUTLINE: a simplified polygon of India's coast/border,
+             built from real boundary coordinates. It is a
+             cartographic simplification (as almost every
+             schematic route map is) rather than a survey-grade
+             boundary, but every vertex is a real coordinate so
+             the silhouette and proportions stay accurate. City
+             dots are placed using the exact same projection as
+             the outline, so their positions relative to each
+             other and to the coastline are geographically true.
+   ============================================================ */
+
+const CITIES = [
+  { id: "srinagar",     name: "Srinagar",       state: "Jammu & Kashmir", lat: 34.0837, lon: 74.7973 },
+  { id: "jammu",        name: "Jammu",          state: "Jammu & Kashmir", lat: 32.7266, lon: 74.8570 },
+  { id: "amritsar",     name: "Amritsar",       state: "Punjab",          lat: 31.6340, lon: 74.8723 },
+  { id: "jalandhar",    name: "Jalandhar",      state: "Punjab",          lat: 31.3260, lon: 75.5762 },
+  { id: "ludhiana",     name: "Ludhiana",       state: "Punjab",          lat: 30.9010, lon: 75.8573 },
+  { id: "chandigarh",   name: "Chandigarh",     state: "Chandigarh",      lat: 30.7333, lon: 76.7794 },
+  { id: "ambala",       name: "Ambala",         state: "Haryana",         lat: 30.3782, lon: 76.7767 },
+  { id: "delhi",        name: "Delhi",          state: "Delhi",           lat: 28.7041, lon: 77.1025 },
+  { id: "meerut",       name: "Meerut",         state: "Uttar Pradesh",   lat: 28.9845, lon: 77.7064 },
+  { id: "agra",         name: "Agra",           state: "Uttar Pradesh",   lat: 27.1767, lon: 78.0081 },
+  { id: "jaipur",       name: "Jaipur",         state: "Rajasthan",       lat: 26.9124, lon: 75.7873 },
+  { id: "ajmer",        name: "Ajmer",          state: "Rajasthan",       lat: 26.4499, lon: 74.6399 },
+  { id: "kota",         name: "Kota",           state: "Rajasthan",       lat: 25.2138, lon: 75.8648 },
+  { id: "udaipur",      name: "Udaipur",        state: "Rajasthan",       lat: 24.5854, lon: 73.7125 },
+  { id: "ahmedabad",    name: "Ahmedabad",      state: "Gujarat",         lat: 23.0225, lon: 72.5714 },
+  { id: "rajkot",       name: "Rajkot",         state: "Gujarat",         lat: 22.3039, lon: 70.8022 },
+  { id: "vadodara",     name: "Vadodara",       state: "Gujarat",         lat: 22.3072, lon: 73.1812 },
+  { id: "surat",        name: "Surat",          state: "Gujarat",         lat: 21.1702, lon: 72.8311 },
+  { id: "mumbai",       name: "Mumbai",         state: "Maharashtra",     lat: 19.0760, lon: 72.8777 },
+  { id: "nashik",       name: "Nashik",         state: "Maharashtra",     lat: 19.9975, lon: 73.7898 },
+  { id: "pune",         name: "Pune",           state: "Maharashtra",     lat: 18.5204, lon: 73.8567 },
+  { id: "nagpur",       name: "Nagpur",         state: "Maharashtra",     lat: 21.1458, lon: 79.0882 },
+  { id: "indore",       name: "Indore",         state: "Madhya Pradesh",  lat: 22.7196, lon: 75.8577 },
+  { id: "bhopal",       name: "Bhopal",         state: "Madhya Pradesh",  lat: 23.2599, lon: 77.4126 },
+  { id: "jabalpur",     name: "Jabalpur",       state: "Madhya Pradesh",  lat: 23.1815, lon: 79.9864 },
+  { id: "gwalior",      name: "Gwalior",        state: "Madhya Pradesh",  lat: 26.2183, lon: 78.1828 },
+  { id: "jhansi",       name: "Jhansi",         state: "Uttar Pradesh",   lat: 25.4484, lon: 78.5685 },
+  { id: "kanpur",       name: "Kanpur",         state: "Uttar Pradesh",   lat: 26.4499, lon: 80.3319 },
+  { id: "lucknow",      name: "Lucknow",        state: "Uttar Pradesh",   lat: 26.8467, lon: 80.9462 },
+  { id: "prayagraj",    name: "Prayagraj",      state: "Uttar Pradesh",   lat: 25.4358, lon: 81.8463 },
+  { id: "varanasi",     name: "Varanasi",       state: "Uttar Pradesh",   lat: 25.3176, lon: 82.9739 },
+  { id: "patna",        name: "Patna",          state: "Bihar",           lat: 25.5941, lon: 85.1376 },
+  { id: "ranchi",       name: "Ranchi",         state: "Jharkhand",       lat: 23.3441, lon: 85.3096 },
+  { id: "kolkata",      name: "Kolkata",        state: "West Bengal",     lat: 22.5726, lon: 88.3639 },
+  { id: "bhubaneswar",  name: "Bhubaneswar",    state: "Odisha",          lat: 20.2961, lon: 85.8245 },
+  { id: "raipur",       name: "Raipur",         state: "Chhattisgarh",    lat: 21.2514, lon: 81.6296 },
+  { id: "hyderabad",    name: "Hyderabad",      state: "Telangana",       lat: 17.3850, lon: 78.4867 },
+  { id: "vijayawada",   name: "Vijayawada",     state: "Andhra Pradesh",  lat: 16.5062, lon: 80.6480 },
+  { id: "visakhapatnam",name: "Visakhapatnam",  state: "Andhra Pradesh",  lat: 17.6868, lon: 83.2185 },
+  { id: "kurnool",      name: "Kurnool",        state: "Andhra Pradesh",  lat: 15.8281, lon: 78.0373 },
+  { id: "bengaluru",    name: "Bengaluru",      state: "Karnataka",       lat: 12.9716, lon: 77.5946 },
+  { id: "mangaluru",    name: "Mangaluru",      state: "Karnataka",       lat: 12.9141, lon: 74.8560 },
+  { id: "goa",          name: "Panaji",         state: "Goa",             lat: 15.4909, lon: 73.8278 },
+  { id: "chennai",      name: "Chennai",        state: "Tamil Nadu",      lat: 13.0827, lon: 80.2707 },
+  { id: "krishnagiri",  name: "Krishnagiri",    state: "Tamil Nadu",      lat: 12.5186, lon: 78.2137 },
+  { id: "salem",        name: "Salem",          state: "Tamil Nadu",      lat: 11.6643, lon: 78.1460 },
+  { id: "coimbatore",   name: "Coimbatore",     state: "Tamil Nadu",      lat: 11.0168, lon: 76.9558 },
+  { id: "madurai",      name: "Madurai",        state: "Tamil Nadu",      lat: 9.9252,  lon: 78.1198 },
+  { id: "kanyakumari",  name: "Kanyakumari",    state: "Tamil Nadu",      lat: 8.0883,  lon: 77.5385 },
+  { id: "kochi",        name: "Kochi",          state: "Kerala",         lat: 9.9312,  lon: 76.2673 },
+];
+
+/* Each edge: a <-> b, real NH tag, approx road-distance (km), typical speed (km/h) for ETA */
+const EDGES = [
+  ["srinagar","jammu","NH44",270,50],
+  ["jammu","jalandhar","NH44",220,55],
+  ["jammu","amritsar","NH44",195,55],
+  ["amritsar","jalandhar","NH03",80,60],
+  ["jalandhar","ludhiana","NH44",60,65],
+  ["ludhiana","ambala","NH44",130,65],
+  ["ambala","chandigarh","NH152",45,55],
+  ["ambala","delhi","NH44",210,65],
+  ["delhi","meerut","NH58",70,70],
+  ["delhi","agra","NH44",235,80],
+  ["agra","gwalior","NH44",120,65],
+  ["gwalior","jhansi","NH44",100,65],
+  ["jhansi","nagpur","NH44",445,60],
+  ["nagpur","hyderabad","NH44",500,65],
+  ["hyderabad","kurnool","NH44",215,65],
+  ["kurnool","bengaluru","NH44",350,60],
+  ["bengaluru","krishnagiri","NH44",95,65],
+  ["krishnagiri","salem","NH44",90,60],
+  ["salem","madurai","NH44",210,55],
+  ["madurai","kanyakumari","NH44",240,55],
+
+  ["delhi","jaipur","NH48",280,75],
+  ["jaipur","ajmer","NH48",135,70],
+  ["jaipur","kota","NH52",240,60],
+  ["kota","udaipur","NH27",280,55],
+  ["ajmer","udaipur","NH48",250,60],
+  ["udaipur","ahmedabad","NH48",260,60],
+  ["ahmedabad","vadodara","NH48",110,80],
+  ["vadodara","surat","NH48",150,75],
+  ["surat","mumbai","NH48",285,65],
+  ["mumbai","pune","NH48",150,75],
+  ["pune","bengaluru","NH48",840,60],
+
+  ["agra","kanpur","NH19",285,60],
+  ["kanpur","prayagraj","NH19",200,60],
+  ["prayagraj","varanasi","NH19",125,60],
+  ["varanasi","kolkata","NH19",680,55],
+  ["kanpur","lucknow","NH27",80,65],
+  ["lucknow","varanasi","NH31",320,55],
+
+  ["kolkata","bhubaneswar","NH16",440,55],
+  ["bhubaneswar","visakhapatnam","NH16",440,55],
+  ["visakhapatnam","vijayawada","NH16",350,55],
+  ["vijayawada","chennai","NH16",450,55],
+  ["hyderabad","vijayawada","NH65",275,60],
+
+  ["mumbai","goa","NH66",590,55],
+  ["goa","mangaluru","NH66",365,55],
+  ["mangaluru","kochi","NH66",350,55],
+  ["kochi","kanyakumari","NH66",320,50],
+
+  ["rajkot","ahmedabad","NH27",215,65],
+  ["rajkot","surat","NH27",280,55],
+
+  ["indore","ahmedabad","NH47",400,55],
+  ["indore","bhopal","NH52",190,60],
+  ["bhopal","jabalpur","NH45",330,55],
+  ["jabalpur","nagpur","NH44",260,55],
+  ["bhopal","nagpur","NH69",350,55],
+
+  ["nashik","mumbai","NH160",165,60],
+  ["nashik","pune","NH60",210,55],
+  ["nashik","indore","NH52",400,55],
+
+  ["chennai","bengaluru","NH48",345,80],
+  ["chennai","coimbatore","NH544",500,60],
+  ["coimbatore","salem","NH544",160,65],
+  ["coimbatore","kochi","NH544",190,55],
+  ["madurai","coimbatore","NH785",215,55],
+
+  ["raipur","nagpur","NH53",290,60],
+  ["raipur","bhubaneswar","NH130",500,50],
+
+  ["patna","varanasi","NH19",260,55],
+  ["patna","ranchi","NH33",330,50],
+  ["ranchi","kolkata","NH19",400,55],
+];
+
+/* Reference facts for the Highway Identification directory (used for display only) */
+const HIGHWAYS = [
+  { nh: "NH44",  name: "Srinagar – Kanyakumari",  length: 4112, states: 12, note: "India's longest National Highway, formed by merging the old NH1, NH2, NH3, NH7, NH26 and NH75. Runs the full north–south length of the country." },
+  { nh: "NH48",  name: "Delhi – Chennai",         length: 2807, states: 8,  note: "One of the busiest freight corridors, linking Delhi to Mumbai via Jaipur and Ahmedabad, then on to Bengaluru and Chennai." },
+  { nh: "NH16",  name: "Kolkata – Chennai",       length: 1711, states: 5,  note: "The old NH5 / NH6, hugging the east coast through Bhubaneswar, Visakhapatnam and Vijayawada." },
+  { nh: "NH66",  name: "Panvel – Kanyakumari",    length: 1622, states: 6,  note: "The old NH17, a scenic west-coast corridor through Goa, Mangaluru and Kochi." },
+  { nh: "NH19",  name: "Delhi – Kolkata",         length: 1435, states: 6,  note: "Carries the historic Grand Trunk Road alignment through Agra, Kanpur and Varanasi." },
+  { nh: "NH27",  name: "Porbandar – Silchar",     length: 3507, states: 9,  note: "The East–West Corridor, one of the longest highways in the NHDP network, crossing the entire country." },
+  { nh: "NH65",  name: "Pune – Machilipatnam",    length: 841,  states: 3,  note: "Links Hyderabad to the east-coast port town of Machilipatnam via Vijayawada." },
+  { nh: "NH52",  name: "Sangrur – Ankola",        length: 2317, states: 6,  note: "A long diagonal corridor through Madhya Pradesh linking north India to the Karnataka coast." },
+];
+
+/* Simplified India boundary — vertices are real coastline/border coordinates (lon, lat),
+   traced clockwise from the Rann of Kutch. This is a schematic simplification (as with
+   any small-scale route map) but keeps true proportions and orientation. */
+const INDIA_OUTLINE = [
+  [68.2,23.9],[68.9,22.4],[69.6,21.6],[70.9,20.7],[72.8,21.2],[72.8,19.1],
+  [73.3,17.0],[73.8,15.5],[74.1,14.8],[74.8,12.9],[75.8,11.25],[76.2,9.9],
+  [76.9,8.5],[77.5,8.1],[78.1,8.8],[79.3,9.3],[79.8,10.8],[80.2,13.0],
+  [80.1,14.4],[83.3,17.7],[85.8,19.8],[87.5,21.6],[88.3,21.6],[88.9,22.9],
+  [88.4,26.4],[91.7,24.1],[92.0,24.9],[91.7,26.2],[97.1,27.9],[95.4,29.0],
+  [92.0,26.8],[88.9,27.3],[85.0,26.5],[83.0,27.5],[80.1,28.6],[79.0,30.9],
+  [78.0,32.0],[78.0,34.5],[77.0,35.6],[74.5,34.8],[74.0,33.0],[74.5,31.5],
+  [73.5,29.9],[70.5,28.0],[70.2,25.9],[70.0,24.3],[68.2,23.9]
+];

--- a/frontend/highway-navigator/index.html
+++ b/frontend/highway-navigator/index.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>National Highway Navigator — Incredible India Explorer</title>
+<meta name="description" content="Plan routes across India's National Highway network — identify highways, optimise routes, and calculate real driving distances.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@500;600;700&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="styles.css">
+</head>
+<body>
+
+<header class="site-header">
+  <div class="wrap header-inner">
+    <div class="brand">
+      <svg class="brand-shield" viewBox="0 0 40 44" aria-hidden="true">
+        <path d="M20 1 L38 8 V22 C38 33 30 40 20 43 C10 40 2 33 2 22 V8 Z" />
+        <text x="20" y="27">NH</text>
+      </svg>
+      <div class="brand-text">
+        <span class="brand-title">Highway Navigator</span>
+        <span class="brand-sub">Incredible India Explorer</span>
+      </div>
+    </div>
+    <a class="header-link" href="../../index.html">&larr; Back to Explorer</a>
+  </div>
+</header>
+
+<main>
+  <section class="hero wrap">
+    <p class="eyebrow">National Highway Network &middot; Route Planning Challenge</p>
+    <h1>Chart a course across India's highway grid.</h1>
+    <p class="hero-lede">Pick two cities and the navigator finds the fastest way between them across a real network of National Highways — the same NH44, NH48, NH16 and other route numbers you'd see on an actual milestone.</p>
+    <div class="hero-stats">
+      <div class="hero-stat"><span>50</span>Cities mapped</div>
+      <div class="hero-stat"><span>60+</span>Highway segments</div>
+      <div class="hero-stat"><span>4,112 km</span>Longest route, NH44</div>
+    </div>
+  </section>
+
+  <section class="planner wrap" id="planner">
+    <div class="panel planner-panel">
+      <h2 class="panel-title">Plan a route</h2>
+
+      <div class="field-row">
+        <label class="field">
+          <span class="field-label">From</span>
+          <select id="from-select"></select>
+        </label>
+        <button class="swap-btn" id="swap-btn" type="button" aria-label="Swap origin and destination">&#8646;</button>
+        <label class="field">
+          <span class="field-label">To</span>
+          <select id="to-select"></select>
+        </label>
+      </div>
+
+      <fieldset class="metric-fieldset">
+        <legend class="field-label">Optimise for</legend>
+        <label class="metric-option">
+          <input type="radio" name="metric" value="distance" checked>
+          <span>Shortest distance</span>
+        </label>
+        <label class="metric-option">
+          <input type="radio" name="metric" value="time">
+          <span>Shortest drive time</span>
+        </label>
+      </fieldset>
+
+      <button class="plan-btn" id="plan-btn" type="button">Plan route</button>
+
+      <div id="empty-state" class="empty-state">
+        <p>Choose a start and destination, then plan a route to see it here.</p>
+      </div>
+      <div id="result-panel" class="result-panel" hidden></div>
+    </div>
+
+    <div class="panel map-panel">
+      <div class="map-panel-head">
+        <h2 class="panel-title">Route map</h2>
+        <div class="map-legend">
+          <span><i class="legend-dot legend-node"></i>City</span>
+          <span><i class="legend-dot legend-endpoint"></i>Origin / destination</span>
+          <span><i class="legend-line legend-route"></i>Active route</span>
+        </div>
+      </div>
+      <div class="map-frame">
+        <svg id="map-svg" viewBox="0 0 640 760" role="img" aria-label="Map of India showing National Highway routes"></svg>
+        <div id="map-tooltip" class="map-tooltip"></div>
+      </div>
+      <p class="map-caption">A simplified route-planning outline of India — city positions are plotted from real coordinates, so proportions and directions are geographically accurate.</p>
+    </div>
+  </section>
+
+  <section class="directory wrap" id="directory">
+    <h2 class="section-title">Highway identification</h2>
+    <p class="section-lede">Every route on the map is tagged with its real National Highway number. Select one to trace its full path.</p>
+    <div class="hwy-grid" id="highway-directory"></div>
+  </section>
+</main>
+
+<footer class="site-footer">
+  <div class="wrap">
+    <p>Built for the <strong>Incredible India Explorer</strong> — feat: National Highway Navigator. Road distances are approximate and intended for exploration, not live navigation.</p>
+  </div>
+</footer>
+
+<script src="data.js"></script>
+<script src="app.js"></script>
+</body>
+</html>

--- a/frontend/highway-navigator/styles.css
+++ b/frontend/highway-navigator/styles.css
@@ -1,0 +1,407 @@
+/* ============================================================
+   National Highway Navigator — styles
+   Design language: Indian highway signage. Asphalt dark ground,
+   NH-shield green, kilometre-stone yellow, milestone-red route
+   accent. Rajdhani for signage-style display type, Inter for
+   body copy, JetBrains Mono for distance/time readouts.
+   ============================================================ */
+
+:root {
+  --asphalt: #14171a;
+  --asphalt-2: #1b2024;
+  --asphalt-3: #21262b;
+  --panel-border: #2c3237;
+  --nh-green: #0c6b3d;
+  --nh-green-dark: #084a2a;
+  --caution: #f4b93c;
+  --route-accent: #ff6a45;
+  --text: #f3f1e6;
+  --text-dim: #a3aab0;
+  --text-dim2: #6d757b;
+  --font-display: "Rajdhani", sans-serif;
+  --font-body: "Inter", sans-serif;
+  --font-mono: "JetBrains Mono", monospace;
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  background: var(--asphalt);
+  color: var(--text);
+  font-family: var(--font-body);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+body::before {
+  /* faint lane-marking texture across the whole page */
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image: repeating-linear-gradient(
+    180deg, transparent 0 38px, rgba(243,241,230,0.02) 38px 40px
+  );
+  z-index: 0;
+}
+
+.wrap {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 0 28px;
+}
+
+a { color: inherit; }
+
+/* ---------- Header ---------- */
+.site-header {
+  border-bottom: 1px solid var(--panel-border);
+  background: var(--asphalt-2);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+.header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 68px;
+}
+.brand { display: flex; align-items: center; gap: 12px; }
+.brand-shield { width: 34px; height: 37px; }
+.brand-shield path { fill: var(--nh-green); stroke: var(--caution); stroke-width: 1.4; }
+.brand-shield text {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 14px;
+  fill: var(--text);
+  text-anchor: middle;
+}
+.brand-text { display: flex; flex-direction: column; line-height: 1.15; }
+.brand-title { font-family: var(--font-display); font-weight: 700; font-size: 19px; letter-spacing: 0.02em; }
+.brand-sub { font-size: 11px; color: var(--text-dim2); letter-spacing: 0.05em; text-transform: uppercase; }
+.header-link { font-size: 13px; color: var(--text-dim); text-decoration: none; }
+.header-link:hover { color: var(--caution); }
+
+/* ---------- Hero ---------- */
+.hero { padding: 64px 28px 40px; position: relative; z-index: 1; }
+.eyebrow {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--caution);
+  margin: 0 0 14px;
+}
+.hero h1 {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: clamp(32px, 5vw, 52px);
+  line-height: 1.05;
+  margin: 0 0 18px;
+  max-width: 16ch;
+}
+.hero-lede { max-width: 60ch; color: var(--text-dim); font-size: 16px; margin: 0 0 34px; }
+.hero-stats { display: flex; flex-wrap: wrap; gap: 34px; }
+.hero-stat {
+  display: flex;
+  flex-direction: column-reverse;
+  font-size: 13px;
+  color: var(--text-dim);
+  border-left: 2px solid var(--nh-green);
+  padding-left: 12px;
+}
+.hero-stat span {
+  font-family: var(--font-mono);
+  font-size: 24px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+/* ---------- Panels ---------- */
+.panel {
+  background: var(--asphalt-2);
+  border: 1px solid var(--panel-border);
+  border-radius: 10px;
+  padding: 24px;
+}
+.panel-title {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 20px;
+  margin: 0 0 20px;
+  letter-spacing: 0.01em;
+}
+
+/* ---------- Planner layout ---------- */
+.planner {
+  display: grid;
+  grid-template-columns: 340px 1fr;
+  gap: 22px;
+  padding: 10px 28px 70px;
+  position: relative;
+  z-index: 1;
+  align-items: start;
+}
+
+.field-row { display: flex; align-items: flex-end; gap: 8px; margin-bottom: 18px; }
+.field { flex: 1; display: flex; flex-direction: column; gap: 6px; min-width: 0; }
+.field-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-dim2);
+}
+select {
+  width: 100%;
+  background: var(--asphalt-3);
+  border: 1px solid var(--panel-border);
+  color: var(--text);
+  font-family: var(--font-body);
+  font-size: 14px;
+  padding: 10px 10px;
+  border-radius: 6px;
+  appearance: none;
+}
+select:focus-visible, button:focus-visible, .metric-option input:focus-visible + span {
+  outline: 2px solid var(--caution);
+  outline-offset: 2px;
+}
+.swap-btn {
+  background: var(--asphalt-3);
+  border: 1px solid var(--panel-border);
+  color: var(--caution);
+  width: 38px;
+  height: 38px;
+  border-radius: 6px;
+  font-size: 17px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.swap-btn:hover { border-color: var(--caution); }
+
+.metric-fieldset {
+  border: none;
+  padding: 0;
+  margin: 0 0 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.metric-fieldset legend { margin-bottom: 8px; }
+.metric-option { display: flex; align-items: center; gap: 8px; font-size: 14px; cursor: pointer; }
+.metric-option input { accent-color: var(--nh-green); width: 15px; height: 15px; }
+
+.plan-btn {
+  width: 100%;
+  background: var(--nh-green);
+  color: var(--text);
+  border: none;
+  border-top: 3px solid var(--caution);
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 16px;
+  letter-spacing: 0.03em;
+  padding: 13px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+.plan-btn:hover { background: var(--nh-green-dark); }
+
+.empty-state { margin-top: 20px; color: var(--text-dim2); font-size: 13.5px; }
+.notice { color: var(--caution); font-size: 13.5px; }
+
+/* ---------- Result panel ---------- */
+.result-panel { margin-top: 22px; }
+.result-summary {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  margin-bottom: 14px;
+}
+.summary-stat {
+  background: var(--asphalt-3);
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  padding: 12px 8px;
+  text-align: center;
+}
+.summary-value {
+  display: block;
+  font-family: var(--font-mono);
+  font-weight: 600;
+  font-size: 18px;
+  color: var(--caution);
+}
+.summary-label { font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--text-dim2); }
+.route-caption { font-size: 13px; color: var(--text-dim); margin: 0 0 14px; }
+
+.segment-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+.segment {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 10px;
+  background: var(--asphalt-3);
+  border: 1px solid var(--panel-border);
+  border-left: 3px solid var(--route-accent);
+  border-radius: 6px;
+  padding: 9px 10px;
+  font-size: 13px;
+}
+.segment-route { color: var(--text-dim); min-width: 0; }
+.arrow { color: var(--text-dim2); }
+.segment-km { font-family: var(--font-mono); font-size: 12.5px; color: var(--text); white-space: nowrap; }
+.disclaimer { font-size: 11.5px; color: var(--text-dim2); margin-top: 14px; }
+
+/* ---------- Shield badge (signature element) ---------- */
+.shield {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 11.5px;
+  letter-spacing: 0.02em;
+  color: #fff;
+  background: var(--nh-green);
+  border-top: 2px solid var(--caution);
+  border-radius: 3px;
+  padding: 3px 7px;
+  white-space: nowrap;
+}
+.shield-lg { font-size: 15px; padding: 6px 12px; border-radius: 4px; }
+
+/* ---------- Map ---------- */
+.map-panel-head { display: flex; align-items: baseline; justify-content: space-between; flex-wrap: wrap; gap: 10px; margin-bottom: 6px; }
+.map-panel-head .panel-title { margin-bottom: 0; }
+.map-legend { display: flex; gap: 16px; font-size: 12px; color: var(--text-dim); flex-wrap: wrap; }
+.map-legend span { display: inline-flex; align-items: center; gap: 6px; }
+.legend-dot { width: 9px; height: 9px; border-radius: 50%; display: inline-block; }
+.legend-node { background: var(--text-dim); }
+.legend-endpoint { background: var(--caution); }
+.legend-line { width: 16px; height: 3px; border-radius: 2px; display: inline-block; }
+.legend-route { background: var(--route-accent); }
+
+.map-frame { position: relative; margin-top: 14px; }
+#map-svg {
+  width: 100%;
+  height: auto;
+  aspect-ratio: 640 / 760;
+  display: block;
+  background: radial-gradient(ellipse at 50% 35%, #1d3327 0%, var(--asphalt-2) 68%);
+  border-radius: 8px;
+}
+.landmass { fill: #223129; stroke: #3a5443; stroke-width: 1.4; }
+.edge { stroke: #3d444a; stroke-width: 1.1; }
+.edge-highlighted { stroke: var(--caution); stroke-width: 2.4; }
+.route-line {
+  stroke: var(--route-accent);
+  stroke-width: 3.2;
+  stroke-linecap: round;
+  stroke-dasharray: 7 6;
+  animation: dash-move 1.1s linear infinite;
+}
+@keyframes dash-move { to { stroke-dashoffset: -26; } }
+
+.node circle { fill: var(--text-dim2); stroke: var(--asphalt-2); stroke-width: 1; transition: r 0.15s ease; }
+.node-on-route circle { fill: var(--route-accent); }
+.node-endpoint circle { fill: var(--caution); stroke: var(--asphalt); stroke-width: 1.5; }
+.node-label {
+  font-family: var(--font-body);
+  font-size: 8.5px;
+  fill: var(--text-dim);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+.node-on-route .node-label, .node-endpoint .node-label { opacity: 1; fill: var(--text); font-weight: 600; }
+.node:hover .node-label { opacity: 1; }
+.node { cursor: pointer; }
+.node:hover circle { r: 6; }
+
+.map-tooltip {
+  position: absolute;
+  transform: translate(-50%, -140%);
+  background: var(--asphalt);
+  border: 1px solid var(--caution);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font-size: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.1s ease;
+  white-space: nowrap;
+  z-index: 5;
+}
+.map-tooltip strong { font-family: var(--font-display); font-size: 13px; }
+.map-tooltip span { color: var(--text-dim2); font-size: 10.5px; }
+.map-tooltip.visible { opacity: 1; }
+
+.map-caption { margin-top: 12px; font-size: 12px; color: var(--text-dim2); }
+
+/* ---------- Directory ---------- */
+.directory { padding: 20px 28px 90px; position: relative; z-index: 1; }
+.section-title { font-family: var(--font-display); font-weight: 700; font-size: 26px; margin: 0 0 8px; }
+.section-lede { color: var(--text-dim); max-width: 60ch; margin: 0 0 28px; }
+
+.hwy-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 14px;
+}
+.hwy-card {
+  text-align: left;
+  background: var(--asphalt-2);
+  border: 1px solid var(--panel-border);
+  border-radius: 8px;
+  padding: 16px;
+  color: var(--text);
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-family: var(--font-body);
+  transition: border-color 0.15s ease, transform 0.15s ease;
+}
+.hwy-card:hover { border-color: var(--caution); transform: translateY(-2px); }
+.hwy-card.active { border-color: var(--route-accent); box-shadow: 0 0 0 1px var(--route-accent); }
+.hwy-name { font-family: var(--font-display); font-weight: 600; font-size: 16px; margin-top: 4px; }
+.hwy-meta { font-family: var(--font-mono); font-size: 11.5px; color: var(--caution); }
+.hwy-note { font-size: 12.5px; color: var(--text-dim); line-height: 1.45; }
+
+/* ---------- Footer ---------- */
+.site-footer {
+  border-top: 1px solid var(--panel-border);
+  padding: 26px 28px 40px;
+  color: var(--text-dim2);
+  font-size: 12.5px;
+  position: relative;
+  z-index: 1;
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 880px) {
+  .planner { grid-template-columns: 1fr; }
+  .hero { padding-top: 44px; }
+}
+@media (max-width: 520px) {
+  .wrap { padding: 0 18px; }
+  .field-row { flex-direction: column; align-items: stretch; }
+  .swap-btn { align-self: flex-end; }
+  .result-summary { grid-template-columns: 1fr; }
+}
+
+/* ---------- Reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  .route-line { animation: none; }
+  .hwy-card:hover { transform: none; }
+}


### PR DESCRIPTION
Summary

Adds a route-planning challenge built on India's National Highway network, as requested in the issue. Lives in frontend/highway-navigator/ and follows the repo's existing conventions — plain HTML/CSS/JS, no build tools required.

Closes #<issue-number>

Features
Highway identification — a directory of major NHs (NH44, NH48, NH16, NH66, NH19, NH27, NH65, NH52) showing their real official length, terminal cities, and states. Selecting a highway traces its full path on the map.
Route optimization — a Dijkstra shortest-path implementation over a graph of 50 real cities and 60+ real highway segments, solvable for either shortest distance or shortest estimated drive time.
Distance calculation — each planned route returns total kilometres, an estimated drive time, and a turn-by-turn breakdown of which NH to take between each city pair.
Map interface — an inline SVG map of India. City markers are plotted from real latitude/longitude using an equirectangular projection, so relative positions and proportions are geographically accurate. The coastline/border is a simplified cartographic outline built from real boundary coordinates (kept lightweight and dependency-free rather than pulling in a full GIS library).
Design

Visual identity is grounded in actual Indian highway signage — NH shield badges in green/yellow, asphalt tones, kilometre-stone accent colors, and Rajdhani/Inter/JetBrains Mono typography — rather than a generic dashboard look.

Files added
frontend/highway-navigator/
├── index.html   — page structure
├── styles.css   — highway-signage-inspired design system
├── data.js      — city coordinates, highway graph, highway reference facts, India outline
├── app.js       — projection math, Dijkstra routing, SVG rendering, UI wiring
└── README.md    — feature documentation
Data accuracy notes
City coordinates and highway numbers/termini are real and verified.
Segment distances are rounded, publicly-known approximate road distances — intended for exploration/education, not turn-by-turn navigation. This is called out directly in the UI.
Graph connectivity was validated (all 50 cities reachable, no orphaned nodes) before submission.
How to test

Open frontend/highway-navigator/index.html directly in a browser, or serve the folder with any static server (e.g. VS Code Live Server, python3 -m http.server). No build step needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a National Highway Navigator for exploring routes across India.
  * Plan routes between cities by distance or estimated travel time.
  * View interactive map routes, segment details, travel summaries, and highway information.
  * Added highway directory cards with route highlighting and responsive layouts.

* **Documentation**
  * Added comprehensive project documentation covering features, architecture, setup, commands, contribution guidance, and licensing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

closes #457