### PR TITLE
feat: add AI-assisted landmark identification page (#694)

### DIFF
--- a/js-modules/landmark-data.js
+++ b/js-modules/landmark-data.js
@@ -1,0 +1,263 @@
+/**
+ * landmark-data.js
+ * Curated reference database for the Landmark Identification feature
+ * (js-modules/landmark-recognition-engine.js + frontend/landmark-identifier).
+ *
+ * Each entry's `hash` is a precomputed 64-bit perceptual average-hash (aHash)
+ * of the reference photo in /assets, generated with an 8x8 grayscale
+ * downscale + mean threshold. The in-browser recognizer computes the same
+ * kind of hash for an uploaded photo (see landmark-identifier/script.js)
+ * and ranks reference entries by Hamming distance.
+ *
+ * This is a lightweight, fully client-side "MVP" recognizer intentionally
+ * chosen because the site has no backend/model-serving infrastructure
+ * (static HTML/JS + Firebase auth only, see api/firebase-config.js). It
+ * gives real (if approximate) image matching today, and the matching logic
+ * is isolated behind LandmarkRecognitionEngine.identify() so a real
+ * CV/embedding backend (TensorFlow.js MobileNet, ONNX, or a hosted
+ * inference API) can be dropped in later without touching the UI layer.
+ */
+(function (root) {
+  "use strict";
+
+  const landmarks = [
+    {
+      id: "taj_mahal",
+      name: "Taj Mahal",
+      aliases: ["taj", "tajmahal"],
+      image: "assets/Taj_Mahal.png",
+      hash: "1111111011111111111111110001100000000000111001100000000000000000",
+      state: "Uttar Pradesh",
+      city: "Agra",
+      category: "Mausoleum",
+      built: "1632–1653, Mughal Emperor Shah Jahan",
+      description:
+        "An ivory-white marble mausoleum built by Shah Jahan in memory of his wife Mumtaz Mahal. A UNESCO World Heritage Site and one of the New Seven Wonders of the World.",
+      significance:
+        "Widely regarded as the finest example of Mughal architecture, blending Persian, Islamic, and Indian styles.",
+      bestTimeToVisit: "October–March",
+      nearbyAttractions: ["Agra Fort", "Fatehpur Sikri", "Mehtab Bagh"]
+    },
+    {
+      id: "hawa_mahal",
+      name: "Hawa Mahal",
+      aliases: ["palace of winds"],
+      image: "assets/Hawa_Mahal.png",
+      hash: "0011111101111110011111101111111111011110110111000000000000111100",
+      state: "Rajasthan",
+      city: "Jaipur",
+      category: "Palace",
+      built: "1799, Maharaja Sawai Pratap Singh",
+      description:
+        "A five-story pink sandstone palace with 953 small windows (jharokhas), built so royal women could observe street life unseen.",
+      significance:
+        "An icon of the Pink City and a defining example of Rajput architecture.",
+      bestTimeToVisit: "October–March",
+      nearbyAttractions: ["Amber Fort", "City Palace, Jaipur", "Jantar Mantar"]
+    },
+    {
+      id: "golden_temple",
+      name: "Golden Temple (Harmandir Sahib)",
+      aliases: ["harmandir sahib", "darbar sahib"],
+      image: "assets/Golden_Temple.png",
+      hash: "0001111111111111111111111100011100000000010000111100011100000100",
+      state: "Punjab",
+      city: "Amritsar",
+      category: "Sikh Gurdwara",
+      built: "1604, Guru Arjan (rebuilt in marble and gold in the 19th century)",
+      description:
+        "The holiest Gurdwara of Sikhism, its sanctum plated in gold and set within a sacred pool, the Amrit Sarovar.",
+      significance:
+        "Famous for its Langar, the world's largest free community kitchen, serving all visitors regardless of faith.",
+      bestTimeToVisit: "October–March",
+      nearbyAttractions: ["Jallianwala Bagh", "Wagah Border ceremony"]
+    },
+    {
+      id: "meenakshi_temple",
+      name: "Meenakshi Amman Temple",
+      aliases: ["meenakshi temple"],
+      image: "assets/Meenakshi_Temple.png",
+      hash: "0001111111001111110011110000000100100000000000001000001101001111",
+      state: "Tamil Nadu",
+      city: "Madurai",
+      category: "Hindu Temple",
+      built: "Rebuilt 14th–17th century, Nayak dynasty",
+      description:
+        "A vast temple complex dedicated to Goddess Meenakshi, famed for its towering, sculpture-covered gopurams (gateway towers).",
+      significance:
+        "One of the largest temple complexes in India and a masterpiece of Dravidian temple architecture.",
+      bestTimeToVisit: "October–March",
+      nearbyAttractions: ["Thirumalai Nayakkar Mahal", "Vaigai River"]
+    },
+    {
+      id: "konark_sun_temple",
+      name: "Konark Sun Temple",
+      aliases: ["sun temple", "black pagoda"],
+      image: "assets/Konark_Sun_Temple.png",
+      hash: "0111111100111111011011111110011111000111000000000000000001000000",
+      state: "Odisha",
+      city: "Konark",
+      category: "Hindu Temple",
+      built: "13th century, King Narasimhadeva I",
+      description:
+        "Designed as a colossal stone chariot of the sun god Surya, with 24 intricately carved wheels drawn by seven horses.",
+      significance: "A UNESCO World Heritage Site celebrated for its architecture and stone carving.",
+      bestTimeToVisit: "October–February",
+      nearbyAttractions: ["Puri Jagannath Temple", "Chandrabhaga Beach"]
+    },
+    {
+      id: "mysore_palace",
+      name: "Mysore Palace",
+      aliases: ["amba vilas palace"],
+      image: "assets/Mysore_Palace.png",
+      hash: "0000000010111100101111111011111111111111111100000000000000000000",
+      state: "Karnataka",
+      city: "Mysuru",
+      category: "Palace",
+      built: "1912, Wadiyar dynasty",
+      description:
+        "The official residence of the Wadiyar dynasty, known for its Indo-Saracenic architecture and spectacular evening illumination.",
+      significance: "One of India's most visited monuments, especially famous during Mysuru Dasara.",
+      bestTimeToVisit: "October (Dasara) or November–February",
+      nearbyAttractions: ["Chamundi Hills", "Brindavan Gardens"]
+    },
+    {
+      id: "victoria_memorial",
+      name: "Victoria Memorial",
+      aliases: ["victoria memorial hall"],
+      image: "assets/Victoria_Memorial.png",
+      hash: "1111111111111111111111110111111100111100000000000000000000000000",
+      state: "West Bengal",
+      city: "Kolkata",
+      category: "Monument & Museum",
+      built: "1906–1921, British colonial era",
+      description:
+        "A grand white marble monument built in memory of Queen Victoria, now housing a museum on colonial-era Kolkata.",
+      significance: "One of Kolkata's most recognisable landmarks and a large public museum.",
+      bestTimeToVisit: "October–March",
+      nearbyAttractions: ["Indian Museum", "Howrah Bridge", "Eden Gardens"]
+    },
+    {
+      id: "brihadeeswara_temple",
+      name: "Brihadeeswara Temple",
+      aliases: ["big temple", "thanjavur temple"],
+      image: "assets/Brihadeeswara_Temple.png",
+      hash: "1111111111101111111011101110111010100110000001100000000000000000",
+      state: "Tamil Nadu",
+      city: "Thanjavur",
+      category: "Hindu Temple",
+      built: "1010 CE, Raja Raja Chola I",
+      description:
+        "A masterpiece of Chola architecture dedicated to Lord Shiva, topped by one of the tallest temple towers (vimana) in India, carved from a single granite block.",
+      significance: "A UNESCO World Heritage Site and one of the Great Living Chola Temples.",
+      bestTimeToVisit: "November–February",
+      nearbyAttractions: ["Thanjavur Royal Palace", "Saraswathi Mahal Library"]
+    },
+    {
+      id: "basilica_bom_jesus",
+      name: "Basilica of Bom Jesus",
+      aliases: ["bom jesus", "bom jesus basilica"],
+      image: "assets/Basilica_of_Bom_Jesus.png",
+      hash: "1111111111111111110110111011000100000001000000011000000000000011",
+      state: "Goa",
+      city: "Old Goa",
+      category: "Church",
+      built: "1594–1605, Portuguese colonial era",
+      description:
+        "A baroque church holding the mortal remains of St. Francis Xavier, one of the finest examples of baroque architecture in India.",
+      significance: "A UNESCO World Heritage Site and one of Goa's most visited pilgrimage sites.",
+      bestTimeToVisit: "November–February",
+      nearbyAttractions: ["Se Cathedral", "Fort Aguada"]
+    },
+    {
+      id: "hemis_monastery",
+      name: "Hemis Monastery",
+      aliases: ["hemis gompa"],
+      image: "assets/Hemis_Monastery.png",
+      hash: "1111111111111000011000100001110000001100000011000000000001000000",
+      state: "Ladakh",
+      city: "Hemis",
+      category: "Buddhist Monastery",
+      built: "1630, Stagsang Raspa Nawang Gyatso",
+      description:
+        "The largest and wealthiest monastery in Ladakh, renowned for its annual Hemis Festival with masked Cham dances.",
+      significance: "A major centre of the Drukpa Kagyu lineage of Tibetan Buddhism.",
+      bestTimeToVisit: "May–September",
+      nearbyAttractions: ["Leh Palace", "Pangong Lake", "Thiksey Monastery"]
+    },
+    {
+      id: "jama_masjid",
+      name: "Jama Masjid",
+      aliases: ["jama masjid delhi", "masjid-i jahan-numa"],
+      image: "assets/Jama_Masjid.png",
+      hash: "0011111111111111111111110000001100000000000000010110111000000000",
+      state: "Delhi",
+      city: "Delhi",
+      category: "Mosque",
+      built: "1650–1656, Mughal Emperor Shah Jahan",
+      description:
+        "One of the largest mosques in India, built of red sandstone and white marble, with a courtyard that can hold tens of thousands of worshippers.",
+      significance: "The principal mosque of Old Delhi and a major example of Mughal architecture.",
+      bestTimeToVisit: "October–March",
+      nearbyAttractions: ["Red Fort", "Chandni Chowk"]
+    },
+    {
+      id: "kedarnath",
+      name: "Kedarnath Temple",
+      aliases: ["kedarnath"],
+      image: "assets/Kedarnath.png",
+      hash: "1111111111111111000110000001111000000010000001100000000000001000",
+      state: "Uttarakhand",
+      city: "Kedarnath",
+      category: "Hindu Temple",
+      built: "Ancient origins; current structure c. 8th century, attributed to Adi Shankaracharya",
+      description:
+        "A remote Himalayan temple dedicated to Shiva, set at over 3,500 m and accessible only by foot or pony/helicopter for part of the year.",
+      significance: "One of the twelve Jyotirlingas and part of the Char Dham pilgrimage circuit.",
+      bestTimeToVisit: "May–June, September–October",
+      nearbyAttractions: ["Vasuki Tal", "Bhairav Temple", "Gaurikund"]
+    },
+    {
+      id: "ajanta_caves",
+      name: "Ajanta Caves",
+      aliases: ["ajanta"],
+      image: "assets/ajanta_caves.png",
+      hash: "1111100011111000111100001101000010010000110100111101001110000111",
+      state: "Maharashtra",
+      city: "Aurangabad district",
+      category: "Rock-cut Caves",
+      built: "2nd century BCE – 6th century CE",
+      description:
+        "A series of 30 rock-cut Buddhist cave monuments featuring some of the finest surviving examples of ancient Indian painting and sculpture.",
+      significance: "A UNESCO World Heritage Site, along with the nearby Ellora Caves.",
+      bestTimeToVisit: "November–March",
+      nearbyAttractions: ["Ellora Caves", "Bibi Ka Maqbara"]
+    },
+    {
+      id: "red_fort",
+      name: "Red Fort (Lal Qila)",
+      aliases: ["lal qila"],
+      image: "assets/red_fort.png",
+      hash: "1111111111111111111111111011110110000001100000010000000000000000",
+      state: "Delhi",
+      city: "Delhi",
+      category: "Fort",
+      built: "1638–1648, Mughal Emperor Shah Jahan",
+      description:
+        "A massive red sandstone fort that served as the main residence of Mughal emperors for nearly 200 years.",
+      significance:
+        "A UNESCO World Heritage Site; the Prime Minister of India hoists the national flag here every Independence Day.",
+      bestTimeToVisit: "October–March",
+      nearbyAttractions: ["Jama Masjid", "Chandni Chowk", "Raj Ghat"]
+    }
+  ];
+
+  const api = { landmarks };
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = api;
+  }
+  if (root) {
+    root.landmarkData = api;
+  }
+})(typeof window !== "undefined" ? window : globalThis);

--- a/js-modules/landmark-recognition-engine.js
+++ b/js-modules/landmark-recognition-engine.js
@@ -1,0 +1,136 @@
+/**
+ * Landmark Recognition Engine
+ *
+ * Pure, DOM-free matching logic for the Landmark Identification feature.
+ * Takes a 64-bit perceptual hash (aHash) computed from an uploaded photo
+ * (see frontend/landmark-identifier/script.js for the canvas-based hashing
+ * step) and ranks it against a curated reference database
+ * (js-modules/landmark-data.js) using Hamming distance.
+ *
+ * Kept framework/DOM-free on purpose so it can be unit tested directly and
+ * so the matching strategy (currently: perceptual hashing) can later be
+ * swapped for a real embedding/CV model without changing the UI layer.
+ */
+
+const HASH_BITS = 64;
+const HISTORY_LIMIT = 25;
+
+export class LandmarkRecognitionEngine {
+  /**
+   * @param {Object} [options]
+   * @param {Array}  [options.landmarks] Reference landmark records, each with a `hash` string.
+   * @param {Array}  [options.history] Pre-existing search history entries.
+   * @param {number} [options.minConfidence] 0-1 threshold below which the best match is reported as unknown.
+   */
+  constructor(options = {}) {
+    this.landmarks = options.landmarks || [];
+    this.history = Array.isArray(options.history) ? options.history.slice(0, HISTORY_LIMIT) : [];
+    this.minConfidence = typeof options.minConfidence === "number" ? options.minConfidence : 0.55;
+  }
+
+  /**
+   * Hamming distance between two equal-length binary strings.
+   * Returns -1 if the inputs are invalid or of mismatched length.
+   */
+  static hammingDistance(hashA, hashB) {
+    if (typeof hashA !== "string" || typeof hashB !== "string") return -1;
+    if (hashA.length !== hashB.length || hashA.length === 0) return -1;
+    let distance = 0;
+    for (let i = 0; i < hashA.length; i++) {
+      if (hashA[i] !== hashB[i]) distance++;
+    }
+    return distance;
+  }
+
+  /**
+   * Converts a Hamming distance into a 0-1 confidence score against a
+   * hash of the given bit length.
+   */
+  static distanceToConfidence(distance, bits = HASH_BITS) {
+    if (distance < 0 || bits <= 0) return 0;
+    return Math.max(0, 1 - distance / bits);
+  }
+
+  /**
+   * Validates that a string looks like a usable binary hash.
+   */
+  static isValidHash(hash) {
+    return typeof hash === "string" && hash.length > 0 && /^[01]+$/.test(hash);
+  }
+
+  /**
+   * Ranks every reference landmark against the supplied hash.
+   * @param {string} queryHash Binary hash string computed from the uploaded image.
+   * @param {Object} [options]
+   * @param {number} [options.topN=5] Max number of ranked matches to return.
+   * @returns {{ matches: Array, best: Object|null, isConfident: boolean }}
+   */
+  identify(queryHash, options = {}) {
+    const topN = options.topN || 5;
+
+    if (!LandmarkRecognitionEngine.isValidHash(queryHash)) {
+      return { matches: [], best: null, isConfident: false, error: "invalid_hash" };
+    }
+
+    const scored = this.landmarks
+      .filter((l) => LandmarkRecognitionEngine.isValidHash(l.hash) && l.hash.length === queryHash.length)
+      .map((landmark) => {
+        const distance = LandmarkRecognitionEngine.hammingDistance(queryHash, landmark.hash);
+        const confidence = LandmarkRecognitionEngine.distanceToConfidence(distance, queryHash.length);
+        return { landmark, distance, confidence };
+      })
+      .sort((a, b) => a.distance - b.distance);
+
+    const matches = scored.slice(0, topN);
+    const best = matches[0] || null;
+    const isConfident = !!best && best.confidence >= this.minConfidence;
+
+    return { matches, best, isConfident };
+  }
+
+  /**
+   * Records a search result in-memory. Callers are responsible for
+   * persisting `getHistory()` to storage (e.g. localStorage) if desired.
+   */
+  addToHistory(entry) {
+    if (!entry || !entry.landmarkId) return null;
+    const record = {
+      landmarkId: entry.landmarkId,
+      landmarkName: entry.landmarkName || entry.landmarkId,
+      confidence: typeof entry.confidence === "number" ? entry.confidence : null,
+      timestamp: entry.timestamp || Date.now()
+    };
+    this.history.unshift(record);
+    if (this.history.length > HISTORY_LIMIT) {
+      this.history.length = HISTORY_LIMIT;
+    }
+    return record;
+  }
+
+  getHistory() {
+    return this.history.slice();
+  }
+
+  clearHistory() {
+    this.history = [];
+  }
+
+  /**
+   * Finds other curated destinations that share a state with the given
+   * landmark, for a simple "nearby attractions" recommendation. Falls back
+   * to the landmark's own curated `nearbyAttractions` list if no
+   * destinations dataset is supplied.
+   */
+  static getRelatedDestinations(landmark, destinations = []) {
+    if (!landmark) return [];
+    if (Array.isArray(destinations) && destinations.length > 0) {
+      return destinations
+        .filter((d) => d.state === landmark.state && d.name !== landmark.city)
+        .slice(0, 5)
+        .map((d) => ({ name: d.name, state: d.state, highlights: d.highlights || [] }));
+    }
+    return (landmark.nearbyAttractions || []).map((name) => ({ name, state: landmark.state, highlights: [] }));
+  }
+}
+
+export const RECOGNITION_CONSTANTS = { HASH_BITS, HISTORY_LIMIT };

--- a/landmark-identifier/index.html
+++ b/landmark-identifier/index.html
@@ -1,0 +1,167 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Landmark Identifier | Incredible India Explorer</title>
+  <meta name="description" content="Upload a photo of a monument, temple, or historical site and identify famous Indian landmarks with confidence scores, history, and nearby attractions.">
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="navbar scrolled" id="navbar">
+    <div class="nav-container">
+      <a href="../../index.html#home" class="nav-logo">
+        <span class="saffron">Incredible</span>
+        <span class="gold">India</span>
+        <span class="green">Explorer</span>
+      </a>
+
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+        <span class="bar"></span>
+        <span class="bar"></span>
+        <span class="bar"></span>
+      </button>
+
+      <nav class="nav-menu" id="nav-menu">
+        <a href="../../index.html#home" class="nav-link">Home</a>
+        <a href="../../travel.html" class="nav-link">Travel</a>
+        <a href="index.html" class="nav-link" style="color: var(--saffron)">Landmark Identifier</a>
+        <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+      </nav>
+    </div>
+  </header>
+
+  <main class="landmark-page">
+    <section class="landmark-hero">
+      <div class="hero-content">
+        <span class="hero-kicker">AI-assisted photo recognition · confidence scored</span>
+        <h1>Landmark <span>Identifier</span></h1>
+        <p>
+          Upload a photo of a monument, temple, fort, or historical site and we'll match it against
+          a curated database of famous Indian landmarks &mdash; with history, significance, and
+          nearby places to explore.
+        </p>
+      </div>
+    </section>
+
+    <section class="identify-section" id="identify">
+      <div class="identify-container">
+        <div class="section-heading">
+          <span class="section-badge">Step 1</span>
+          <h2>Upload a landmark photo</h2>
+          <p>Supports JPG, PNG, and WEBP images up to 8&nbsp;MB. Your photo is analyzed entirely in your browser.</p>
+        </div>
+
+        <form id="upload-form" class="upload-card">
+          <label for="landmark-file" class="drop-zone" id="drop-zone">
+            <input type="file" id="landmark-file" name="landmark-file" accept="image/jpeg,image/png,image/webp" hidden>
+            <div class="drop-zone-inner" id="drop-zone-inner">
+              <span class="drop-icon" aria-hidden="true">📷</span>
+              <strong>Click to choose a photo</strong>
+              <span>or drag and drop it here</span>
+            </div>
+            <img id="preview-image" class="preview-image" alt="" hidden>
+          </label>
+
+          <div class="upload-actions">
+            <button type="submit" id="identify-btn" class="btn-primary" disabled>Identify landmark</button>
+            <button type="button" id="clear-btn" class="btn-secondary" hidden>Choose a different photo</button>
+          </div>
+
+          <p class="upload-status" id="upload-status" role="status" aria-live="polite"></p>
+        </form>
+      </div>
+    </section>
+
+    <section class="results-section" id="results-section" hidden>
+      <div class="results-container">
+        <div class="section-heading">
+          <span class="section-badge">Step 2</span>
+          <h2>Results</h2>
+        </div>
+
+        <article class="result-card" id="best-match-card" hidden>
+          <div class="result-media">
+            <img id="result-image" src="" alt="">
+          </div>
+          <div class="result-body">
+            <div class="confidence-row">
+              <span class="confidence-badge" id="confidence-badge">--% match</span>
+              <span class="result-category" id="result-category"></span>
+            </div>
+            <h3 id="result-name">--</h3>
+            <p class="result-location" id="result-location"></p>
+            <p id="result-description"></p>
+
+            <div class="info-grid">
+              <div>
+                <span>Built</span>
+                <strong id="result-built">--</strong>
+              </div>
+              <div>
+                <span>Best time to visit</span>
+                <strong id="result-best-time">--</strong>
+              </div>
+            </div>
+
+            <div class="significance-box">
+              <h4>Why it matters</h4>
+              <p id="result-significance"></p>
+            </div>
+
+            <div class="nearby-box">
+              <h4>Nearby attractions</h4>
+              <ul id="nearby-list"></ul>
+            </div>
+          </div>
+        </article>
+
+        <div class="low-confidence-notice" id="low-confidence-notice" role="status" hidden>
+          <strong>No confident match found.</strong>
+          <p>The closest matches are shown below, but none met our confidence threshold. Try a clearer, closer-up photo of the landmark's main facade.</p>
+        </div>
+
+        <div class="alt-matches" id="alt-matches" hidden>
+          <h4>Other possible matches</h4>
+          <div class="alt-match-grid" id="alt-match-grid"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="history-section" id="history-section">
+      <div class="history-container">
+        <div class="history-heading">
+          <h3>Recent searches</h3>
+          <button id="clear-history-btn" type="button">Clear history</button>
+        </div>
+        <p class="history-empty" id="history-empty">No searches yet &mdash; identify a landmark to see it here.</p>
+        <ul class="history-list" id="history-list"></ul>
+      </div>
+    </section>
+
+    <section class="landmark-library" id="library">
+      <div class="library-container">
+        <div class="section-heading">
+          <span class="section-badge">Reference database</span>
+          <h2>Landmarks we can currently recognize</h2>
+          <p>This curated set will keep growing &mdash; more monuments, temples, and natural sites are added over time.</p>
+        </div>
+        <div class="library-grid" id="library-grid"></div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="landmark-footer">
+    <p>
+      Part of <a href="../../index.html">Incredible India Explorer</a> · Landmark photos are matched locally in your browser against a curated reference set.
+    </p>
+  </footer>
+
+  <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+  <script src="../../app.js"></script>
+  <script src="../../trip-data.js"></script>
+  <script src="../../js-modules/landmark-data.js"></script>
+  <script type="module" src="script.js"></script>
+</body>
+</html>

--- a/landmark-identifier/script.js
+++ b/landmark-identifier/script.js
@@ -1,0 +1,317 @@
+import { LandmarkRecognitionEngine } from "../../js-modules/landmark-recognition-engine.js";
+
+const HASH_SIZE = 8; // 8x8 -> 64-bit hash, matches js-modules/landmark-data.js
+const MAX_FILE_BYTES = 8 * 1024 * 1024; // 8 MB
+const ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/webp"];
+const HISTORY_STORAGE_KEY = "landmarkIdentifier.history.v1";
+
+const landmarks = (window.landmarkData && window.landmarkData.landmarks) || [];
+const tripDestinations = window.tripDestinations || [];
+
+function loadStoredHistory() {
+  try {
+    const raw = localStorage.getItem(HISTORY_STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (err) {
+    return [];
+  }
+}
+
+function persistHistory(engine) {
+  try {
+    localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(engine.getHistory()));
+  } catch (err) {
+    // Storage may be unavailable (private browsing, quota); fail silently.
+  }
+}
+
+const engine = new LandmarkRecognitionEngine({
+  landmarks,
+  history: loadStoredHistory(),
+  minConfidence: 0.55
+});
+
+/**
+ * Computes a 64-bit average-hash (aHash) for an <img> element using a
+ * canvas: downscale to 8x8, convert to grayscale, threshold at the mean.
+ * Mirrors the offline hashing used to generate js-modules/landmark-data.js.
+ */
+function computeImageHash(imgEl) {
+  const canvas = document.createElement("canvas");
+  canvas.width = HASH_SIZE;
+  canvas.height = HASH_SIZE;
+  const ctx = canvas.getContext("2d");
+  ctx.drawImage(imgEl, 0, 0, HASH_SIZE, HASH_SIZE);
+
+  const { data } = ctx.getImageData(0, 0, HASH_SIZE, HASH_SIZE);
+  const grays = [];
+  for (let i = 0; i < data.length; i += 4) {
+    const [r, g, b] = [data[i], data[i + 1], data[i + 2]];
+    // Standard luma weights.
+    grays.push(0.299 * r + 0.587 * g + 0.114 * b);
+  }
+
+  const avg = grays.reduce((sum, v) => sum + v, 0) / grays.length;
+  return grays.map((v) => (v >= avg ? "1" : "0")).join("");
+}
+
+function fileToImage(file) {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => resolve({ img, url });
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error("Could not read this image file."));
+    };
+    img.src = url;
+  });
+}
+
+function confidenceLabel(confidence) {
+  if (confidence >= 0.75) return "confidence-high";
+  if (confidence >= 0.55) return "confidence-medium";
+  return "confidence-low";
+}
+
+function renderResult(match, isConfident) {
+  const { landmark, confidence } = match;
+  const card = document.getElementById("best-match-card");
+  const badge = document.getElementById("confidence-badge");
+
+  document.getElementById("result-image").src = landmark.image;
+  document.getElementById("result-image").alt = landmark.name;
+  document.getElementById("result-name").textContent = landmark.name;
+  document.getElementById("result-category").textContent = landmark.category || "";
+  document.getElementById("result-location").textContent = [landmark.city, landmark.state].filter(Boolean).join(", ");
+  document.getElementById("result-description").textContent = landmark.description || "";
+  document.getElementById("result-built").textContent = landmark.built || "Unknown";
+  document.getElementById("result-best-time").textContent = landmark.bestTimeToVisit || "Year-round";
+  document.getElementById("result-significance").textContent = landmark.significance || "";
+
+  badge.textContent = `${Math.round(confidence * 100)}% match`;
+  badge.className = "confidence-badge " + confidenceLabel(confidence);
+
+  const related = LandmarkRecognitionEngine.getRelatedDestinations(landmark, tripDestinations);
+  const nearbyNames = related.length
+    ? related.flatMap((r) => (r.highlights && r.highlights.length ? r.highlights : [r.name]))
+    : landmark.nearbyAttractions || [];
+  const nearbyList = document.getElementById("nearby-list");
+  nearbyList.innerHTML = "";
+  (nearbyNames.length ? nearbyNames : ["No nearby attractions on file yet"]).slice(0, 6).forEach((name) => {
+    const li = document.createElement("li");
+    li.textContent = name;
+    nearbyList.appendChild(li);
+  });
+
+  card.hidden = false;
+  document.getElementById("low-confidence-notice").hidden = isConfident;
+}
+
+function renderAltMatches(matches, skipId) {
+  const wrap = document.getElementById("alt-matches");
+  const grid = document.getElementById("alt-match-grid");
+  grid.innerHTML = "";
+
+  const alts = matches.filter((m) => m.landmark.id !== skipId).slice(0, 4);
+  if (alts.length === 0) {
+    wrap.hidden = true;
+    return;
+  }
+
+  alts.forEach(({ landmark, confidence }) => {
+    const card = document.createElement("div");
+    card.className = "alt-match-card";
+    card.innerHTML = `
+      <img src="${landmark.image}" alt="${landmark.name}">
+      <div class="alt-match-info">
+        <strong>${landmark.name}</strong>
+        <span>${Math.round(confidence * 100)}% match</span>
+      </div>
+    `;
+    grid.appendChild(card);
+  });
+
+  wrap.hidden = false;
+}
+
+function renderHistory() {
+  const list = document.getElementById("history-list");
+  const empty = document.getElementById("history-empty");
+  const history = engine.getHistory();
+
+  list.innerHTML = "";
+  if (history.length === 0) {
+    empty.hidden = false;
+    list.hidden = true;
+    return;
+  }
+
+  empty.hidden = true;
+  list.hidden = false;
+  history.forEach((entry) => {
+    const li = document.createElement("li");
+    const date = new Date(entry.timestamp);
+    const confidenceText = typeof entry.confidence === "number" ? `${Math.round(entry.confidence * 100)}%` : "--";
+    li.innerHTML = `
+      <span>${entry.landmarkName}</span>
+      <span class="history-confidence">${confidenceText} · ${date.toLocaleDateString()}</span>
+    `;
+    list.appendChild(li);
+  });
+}
+
+function renderLibrary() {
+  const grid = document.getElementById("library-grid");
+  grid.innerHTML = "";
+  landmarks.forEach((landmark) => {
+    const card = document.createElement("div");
+    card.className = "library-card";
+    card.innerHTML = `
+      <img src="${landmark.image}" alt="${landmark.name}" loading="lazy">
+      <div class="library-info">
+        <strong>${landmark.name}</strong>
+        <span>${landmark.state}</span>
+      </div>
+    `;
+    grid.appendChild(card);
+  });
+}
+
+function setStatus(message, isError = false) {
+  const status = document.getElementById("upload-status");
+  status.textContent = message;
+  status.classList.toggle("is-error", isError);
+}
+
+function validateFile(file) {
+  if (!file) return "Please choose an image file.";
+  if (!ACCEPTED_TYPES.includes(file.type)) return "Unsupported format. Please upload a JPG, PNG, or WEBP image.";
+  if (file.size > MAX_FILE_BYTES) return "That image is larger than 8 MB. Please choose a smaller file.";
+  return null;
+}
+
+function init() {
+  renderLibrary();
+  renderHistory();
+
+  const fileInput = document.getElementById("landmark-file");
+  const dropZone = document.getElementById("drop-zone");
+  const dropZoneInner = document.getElementById("drop-zone-inner");
+  const previewImage = document.getElementById("preview-image");
+  const identifyBtn = document.getElementById("identify-btn");
+  const clearBtn = document.getElementById("clear-btn");
+  const form = document.getElementById("upload-form");
+  const resultsSection = document.getElementById("results-section");
+
+  let currentFile = null;
+  let currentObjectUrl = null;
+
+  function resetUpload() {
+    currentFile = null;
+    if (currentObjectUrl) URL.revokeObjectURL(currentObjectUrl);
+    currentObjectUrl = null;
+    fileInput.value = "";
+    previewImage.hidden = true;
+    previewImage.src = "";
+    dropZoneInner.hidden = false;
+    identifyBtn.disabled = true;
+    clearBtn.hidden = true;
+    setStatus("");
+  }
+
+  function handleFile(file) {
+    const error = validateFile(file);
+    if (error) {
+      setStatus(error, true);
+      return;
+    }
+    currentFile = file;
+    if (currentObjectUrl) URL.revokeObjectURL(currentObjectUrl);
+    currentObjectUrl = URL.createObjectURL(file);
+    previewImage.src = currentObjectUrl;
+    previewImage.hidden = false;
+    dropZoneInner.hidden = true;
+    identifyBtn.disabled = false;
+    clearBtn.hidden = false;
+    setStatus(`Ready to identify "${file.name}".`);
+  }
+
+  fileInput.addEventListener("change", (e) => {
+    const file = e.target.files && e.target.files[0];
+    if (file) handleFile(file);
+  });
+
+  ["dragenter", "dragover"].forEach((evt) => {
+    dropZone.addEventListener(evt, (e) => {
+      e.preventDefault();
+      dropZone.classList.add("drag-active");
+    });
+  });
+
+  ["dragleave", "drop"].forEach((evt) => {
+    dropZone.addEventListener(evt, (e) => {
+      e.preventDefault();
+      dropZone.classList.remove("drag-active");
+    });
+  });
+
+  dropZone.addEventListener("drop", (e) => {
+    const file = e.dataTransfer.files && e.dataTransfer.files[0];
+    if (file) handleFile(file);
+  });
+
+  clearBtn.addEventListener("click", resetUpload);
+
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    if (!currentFile) return;
+
+    identifyBtn.disabled = true;
+    setStatus("Analyzing image…");
+
+    try {
+      const { img } = await fileToImage(currentFile);
+      const hash = computeImageHash(img);
+      const { matches, best, isConfident } = engine.identify(hash, { topN: 5 });
+
+      if (!best) {
+        setStatus("No landmarks in our database could be compared to this image.", true);
+        resultsSection.hidden = true;
+        return;
+      }
+
+      renderResult(best, isConfident);
+      renderAltMatches(matches, best.landmark.id);
+
+      engine.addToHistory({
+        landmarkId: best.landmark.id,
+        landmarkName: best.landmark.name,
+        confidence: best.confidence
+      });
+      persistHistory(engine);
+      renderHistory();
+
+      resultsSection.hidden = false;
+      resultsSection.scrollIntoView({ behavior: "smooth", block: "start" });
+      setStatus(isConfident ? "Match found!" : "Best-effort match shown below (low confidence).");
+    } catch (err) {
+      setStatus(err.message || "Something went wrong while analyzing the image.", true);
+    } finally {
+      identifyBtn.disabled = false;
+    }
+  });
+
+  document.getElementById("clear-history-btn").addEventListener("click", () => {
+    engine.clearHistory();
+    persistHistory(engine);
+    renderHistory();
+  });
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", init);
+} else {
+  init();
+}

--- a/landmark-identifier/style.css
+++ b/landmark-identifier/style.css
@@ -1,0 +1,495 @@
+:root {
+  --li-accent: var(--saffron, #ff9933);
+  --li-green: var(--green, #138808);
+  --li-surface: var(--glass-bg, rgba(255, 255, 255, 0.08));
+  --li-border: var(--glass-border, rgba(255, 255, 255, 0.14));
+  --li-text: var(--text-primary, #f8fafc);
+  --li-muted: var(--text-secondary, #cbd5e1);
+  --li-shadow: 0 18px 50px rgba(0, 0, 0, 0.16);
+}
+
+.landmark-page {
+  min-height: 100vh;
+  color: var(--li-text);
+}
+
+/* Hero */
+.landmark-hero {
+  min-height: 52vh;
+  display: grid;
+  place-items: center;
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(120deg, rgba(16, 24, 44, 0.95), rgba(92, 52, 20, 0.7)),
+    url("../../assets/kailasa_temple_banner.png") center / cover no-repeat;
+}
+
+.landmark-hero .hero-content {
+  position: relative;
+  z-index: 1;
+  width: min(880px, 92%);
+  padding: 140px 0 70px;
+  text-align: center;
+  color: #fff;
+}
+
+.landmark-hero .hero-kicker {
+  display: inline-block;
+  padding: 8px 15px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.25);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.landmark-hero h1 {
+  margin: 18px 0;
+  font-family: var(--font-heading, serif);
+  font-size: clamp(2.1rem, 4.5vw, 3.2rem);
+}
+
+.landmark-hero h1 span {
+  color: var(--li-accent);
+}
+
+.landmark-hero p {
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 1.02rem;
+  line-height: 1.6;
+}
+
+/* Section shell shared by identify/results/history/library */
+.identify-section,
+.results-section,
+.history-section,
+.landmark-library {
+  padding: 60px 0;
+}
+
+.identify-container,
+.results-container,
+.history-container,
+.library-container {
+  width: min(920px, 92%);
+  margin: 0 auto;
+}
+
+.section-heading {
+  text-align: center;
+  margin-bottom: 32px;
+}
+
+.section-badge {
+  display: inline-block;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(255, 153, 51, 0.14);
+  color: var(--li-accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.section-heading h2 {
+  margin: 12px 0 8px;
+  font-family: var(--font-heading, serif);
+  font-size: clamp(1.5rem, 3vw, 2rem);
+}
+
+.section-heading p {
+  color: var(--li-muted);
+}
+
+/* Upload card */
+.upload-card {
+  background: var(--li-surface);
+  border: 1px solid var(--li-border);
+  border-radius: var(--border-radius-lg, 18px);
+  padding: 28px;
+  box-shadow: var(--li-shadow);
+}
+
+.drop-zone {
+  display: block;
+  cursor: pointer;
+  border: 2px dashed var(--li-border);
+  border-radius: var(--border-radius-sm, 8px);
+  padding: 40px 20px;
+  text-align: center;
+  transition: var(--transition-snappy, all 0.25s ease);
+}
+
+.drop-zone:hover,
+.drop-zone.drag-active {
+  border-color: var(--li-accent);
+  background: rgba(255, 153, 51, 0.06);
+}
+
+.drop-zone-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  color: var(--li-muted);
+}
+
+.drop-icon {
+  font-size: 2.4rem;
+}
+
+.drop-zone-inner strong {
+  color: var(--li-text);
+  font-size: 1.05rem;
+}
+
+.preview-image {
+  max-width: 100%;
+  max-height: 340px;
+  border-radius: var(--border-radius-sm, 8px);
+  margin: 0 auto;
+  display: block;
+}
+
+.upload-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  margin-top: 22px;
+  flex-wrap: wrap;
+}
+
+.btn-primary,
+.btn-secondary {
+  padding: 12px 26px;
+  border-radius: 999px;
+  font-weight: 700;
+  border: none;
+  cursor: pointer;
+  transition: var(--transition-snappy, all 0.25s ease);
+}
+
+.btn-primary {
+  background: var(--gradient-saffron-gold, var(--li-accent));
+  color: #1a1200;
+}
+
+.btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  background: transparent;
+  border: 1px solid var(--li-border);
+  color: var(--li-text);
+}
+
+.upload-status {
+  text-align: center;
+  margin-top: 14px;
+  min-height: 1.2em;
+  color: var(--li-muted);
+  font-size: 0.9rem;
+}
+
+.upload-status.is-error {
+  color: #ff6b6b;
+}
+
+/* Results */
+.result-card {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 24px;
+  background: var(--li-surface);
+  border: 1px solid var(--li-border);
+  border-radius: var(--border-radius-lg, 18px);
+  overflow: hidden;
+  box-shadow: var(--li-shadow);
+}
+
+.result-media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  min-height: 220px;
+}
+
+.result-body {
+  padding: 24px 24px 24px 0;
+}
+
+.confidence-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+  flex-wrap: wrap;
+}
+
+.confidence-badge {
+  display: inline-block;
+  padding: 5px 12px;
+  border-radius: 999px;
+  background: rgba(19, 136, 8, 0.16);
+  color: var(--li-green);
+  font-weight: 800;
+  font-size: 0.82rem;
+}
+
+.confidence-badge.confidence-low {
+  background: rgba(255, 107, 107, 0.16);
+  color: #ff6b6b;
+}
+
+.confidence-badge.confidence-medium {
+  background: rgba(255, 153, 51, 0.16);
+  color: var(--li-accent);
+}
+
+.result-category {
+  color: var(--li-muted);
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.result-body h3 {
+  font-family: var(--font-heading, serif);
+  font-size: 1.5rem;
+  margin: 4px 0;
+}
+
+.result-location {
+  color: var(--li-muted);
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+.result-body .info-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+  margin: 18px 0;
+}
+
+.result-body .info-grid div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.result-body .info-grid span {
+  color: var(--li-muted);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.significance-box,
+.nearby-box {
+  margin-top: 18px;
+  padding-top: 14px;
+  border-top: 1px solid var(--li-border);
+}
+
+.significance-box h4,
+.nearby-box h4 {
+  font-size: 0.9rem;
+  margin-bottom: 6px;
+  color: var(--li-accent);
+}
+
+.nearby-box ul {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 0;
+  margin: 0;
+}
+
+.nearby-box li {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--li-border);
+  padding: 5px 12px;
+  border-radius: 999px;
+  font-size: 0.82rem;
+}
+
+.low-confidence-notice {
+  background: rgba(255, 107, 107, 0.1);
+  border: 1px solid rgba(255, 107, 107, 0.3);
+  border-radius: var(--border-radius-sm, 8px);
+  padding: 16px 20px;
+  margin-top: 20px;
+}
+
+.low-confidence-notice p {
+  color: var(--li-muted);
+  margin-top: 4px;
+}
+
+.alt-matches {
+  margin-top: 24px;
+}
+
+.alt-matches h4 {
+  margin-bottom: 12px;
+  color: var(--li-muted);
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.alt-match-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 14px;
+}
+
+.alt-match-card {
+  background: var(--li-surface);
+  border: 1px solid var(--li-border);
+  border-radius: var(--border-radius-sm, 8px);
+  overflow: hidden;
+  text-align: center;
+}
+
+.alt-match-card img {
+  width: 100%;
+  height: 90px;
+  object-fit: cover;
+}
+
+.alt-match-card .alt-match-info {
+  padding: 8px;
+}
+
+.alt-match-card strong {
+  display: block;
+  font-size: 0.85rem;
+}
+
+.alt-match-card span {
+  color: var(--li-muted);
+  font-size: 0.75rem;
+}
+
+/* History */
+.history-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.history-heading h3 {
+  font-family: var(--font-heading, serif);
+}
+
+.history-heading button {
+  background: none;
+  border: 1px solid var(--li-border);
+  color: var(--li-muted);
+  padding: 6px 14px;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.history-empty {
+  color: var(--li-muted);
+  font-size: 0.9rem;
+}
+
+.history-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.history-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--li-surface);
+  border: 1px solid var(--li-border);
+  border-radius: var(--border-radius-sm, 8px);
+  padding: 10px 14px;
+  font-size: 0.9rem;
+}
+
+.history-list .history-confidence {
+  color: var(--li-muted);
+  font-size: 0.8rem;
+}
+
+/* Library grid */
+.library-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+  gap: 16px;
+}
+
+.library-card {
+  background: var(--li-surface);
+  border: 1px solid var(--li-border);
+  border-radius: var(--border-radius-sm, 8px);
+  overflow: hidden;
+  text-align: center;
+}
+
+.library-card img {
+  width: 100%;
+  height: 120px;
+  object-fit: cover;
+}
+
+.library-card .library-info {
+  padding: 10px;
+}
+
+.library-card strong {
+  display: block;
+  font-size: 0.88rem;
+}
+
+.library-card span {
+  color: var(--li-muted);
+  font-size: 0.78rem;
+}
+
+.landmark-footer {
+  text-align: center;
+  padding: 26px 16px;
+  color: var(--li-muted);
+  font-size: 0.85rem;
+  border-top: 1px solid var(--li-border);
+}
+
+.landmark-footer a {
+  color: var(--li-accent);
+}
+
+@media (max-width: 720px) {
+  .result-card {
+    grid-template-columns: 1fr;
+  }
+
+  .result-media img {
+    min-height: 180px;
+  }
+
+  .result-body {
+    padding: 20px;
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,317 @@
+import { LandmarkRecognitionEngine } from "../../js-modules/landmark-recognition-engine.js";
+
+const HASH_SIZE = 8; // 8x8 -> 64-bit hash, matches js-modules/landmark-data.js
+const MAX_FILE_BYTES = 8 * 1024 * 1024; // 8 MB
+const ACCEPTED_TYPES = ["image/jpeg", "image/png", "image/webp"];
+const HISTORY_STORAGE_KEY = "landmarkIdentifier.history.v1";
+
+const landmarks = (window.landmarkData && window.landmarkData.landmarks) || [];
+const tripDestinations = window.tripDestinations || [];
+
+function loadStoredHistory() {
+  try {
+    const raw = localStorage.getItem(HISTORY_STORAGE_KEY);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (err) {
+    return [];
+  }
+}
+
+function persistHistory(engine) {
+  try {
+    localStorage.setItem(HISTORY_STORAGE_KEY, JSON.stringify(engine.getHistory()));
+  } catch (err) {
+    // Storage may be unavailable (private browsing, quota); fail silently.
+  }
+}
+
+const engine = new LandmarkRecognitionEngine({
+  landmarks,
+  history: loadStoredHistory(),
+  minConfidence: 0.55
+});
+
+/**
+ * Computes a 64-bit average-hash (aHash) for an <img> element using a
+ * canvas: downscale to 8x8, convert to grayscale, threshold at the mean.
+ * Mirrors the offline hashing used to generate js-modules/landmark-data.js.
+ */
+function computeImageHash(imgEl) {
+  const canvas = document.createElement("canvas");
+  canvas.width = HASH_SIZE;
+  canvas.height = HASH_SIZE;
+  const ctx = canvas.getContext("2d");
+  ctx.drawImage(imgEl, 0, 0, HASH_SIZE, HASH_SIZE);
+
+  const { data } = ctx.getImageData(0, 0, HASH_SIZE, HASH_SIZE);
+  const grays = [];
+  for (let i = 0; i < data.length; i += 4) {
+    const [r, g, b] = [data[i], data[i + 1], data[i + 2]];
+    // Standard luma weights.
+    grays.push(0.299 * r + 0.587 * g + 0.114 * b);
+  }
+
+  const avg = grays.reduce((sum, v) => sum + v, 0) / grays.length;
+  return grays.map((v) => (v >= avg ? "1" : "0")).join("");
+}
+
+function fileToImage(file) {
+  return new Promise((resolve, reject) => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => resolve({ img, url });
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      reject(new Error("Could not read this image file."));
+    };
+    img.src = url;
+  });
+}
+
+function confidenceLabel(confidence) {
+  if (confidence >= 0.75) return "confidence-high";
+  if (confidence >= 0.55) return "confidence-medium";
+  return "confidence-low";
+}
+
+function renderResult(match, isConfident) {
+  const { landmark, confidence } = match;
+  const card = document.getElementById("best-match-card");
+  const badge = document.getElementById("confidence-badge");
+
+  document.getElementById("result-image").src = landmark.image;
+  document.getElementById("result-image").alt = landmark.name;
+  document.getElementById("result-name").textContent = landmark.name;
+  document.getElementById("result-category").textContent = landmark.category || "";
+  document.getElementById("result-location").textContent = [landmark.city, landmark.state].filter(Boolean).join(", ");
+  document.getElementById("result-description").textContent = landmark.description || "";
+  document.getElementById("result-built").textContent = landmark.built || "Unknown";
+  document.getElementById("result-best-time").textContent = landmark.bestTimeToVisit || "Year-round";
+  document.getElementById("result-significance").textContent = landmark.significance || "";
+
+  badge.textContent = `${Math.round(confidence * 100)}% match`;
+  badge.className = "confidence-badge " + confidenceLabel(confidence);
+
+  const related = LandmarkRecognitionEngine.getRelatedDestinations(landmark, tripDestinations);
+  const nearbyNames = related.length
+    ? related.flatMap((r) => (r.highlights && r.highlights.length ? r.highlights : [r.name]))
+    : landmark.nearbyAttractions || [];
+  const nearbyList = document.getElementById("nearby-list");
+  nearbyList.innerHTML = "";
+  (nearbyNames.length ? nearbyNames : ["No nearby attractions on file yet"]).slice(0, 6).forEach((name) => {
+    const li = document.createElement("li");
+    li.textContent = name;
+    nearbyList.appendChild(li);
+  });
+
+  card.hidden = false;
+  document.getElementById("low-confidence-notice").hidden = isConfident;
+}
+
+function renderAltMatches(matches, skipId) {
+  const wrap = document.getElementById("alt-matches");
+  const grid = document.getElementById("alt-match-grid");
+  grid.innerHTML = "";
+
+  const alts = matches.filter((m) => m.landmark.id !== skipId).slice(0, 4);
+  if (alts.length === 0) {
+    wrap.hidden = true;
+    return;
+  }
+
+  alts.forEach(({ landmark, confidence }) => {
+    const card = document.createElement("div");
+    card.className = "alt-match-card";
+    card.innerHTML = `
+      <img src="${landmark.image}" alt="${landmark.name}">
+      <div class="alt-match-info">
+        <strong>${landmark.name}</strong>
+        <span>${Math.round(confidence * 100)}% match</span>
+      </div>
+    `;
+    grid.appendChild(card);
+  });
+
+  wrap.hidden = false;
+}
+
+function renderHistory() {
+  const list = document.getElementById("history-list");
+  const empty = document.getElementById("history-empty");
+  const history = engine.getHistory();
+
+  list.innerHTML = "";
+  if (history.length === 0) {
+    empty.hidden = false;
+    list.hidden = true;
+    return;
+  }
+
+  empty.hidden = true;
+  list.hidden = false;
+  history.forEach((entry) => {
+    const li = document.createElement("li");
+    const date = new Date(entry.timestamp);
+    const confidenceText = typeof entry.confidence === "number" ? `${Math.round(entry.confidence * 100)}%` : "--";
+    li.innerHTML = `
+      <span>${entry.landmarkName}</span>
+      <span class="history-confidence">${confidenceText} · ${date.toLocaleDateString()}</span>
+    `;
+    list.appendChild(li);
+  });
+}
+
+function renderLibrary() {
+  const grid = document.getElementById("library-grid");
+  grid.innerHTML = "";
+  landmarks.forEach((landmark) => {
+    const card = document.createElement("div");
+    card.className = "library-card";
+    card.innerHTML = `
+      <img src="${landmark.image}" alt="${landmark.name}" loading="lazy">
+      <div class="library-info">
+        <strong>${landmark.name}</strong>
+        <span>${landmark.state}</span>
+      </div>
+    `;
+    grid.appendChild(card);
+  });
+}
+
+function setStatus(message, isError = false) {
+  const status = document.getElementById("upload-status");
+  status.textContent = message;
+  status.classList.toggle("is-error", isError);
+}
+
+function validateFile(file) {
+  if (!file) return "Please choose an image file.";
+  if (!ACCEPTED_TYPES.includes(file.type)) return "Unsupported format. Please upload a JPG, PNG, or WEBP image.";
+  if (file.size > MAX_FILE_BYTES) return "That image is larger than 8 MB. Please choose a smaller file.";
+  return null;
+}
+
+function init() {
+  renderLibrary();
+  renderHistory();
+
+  const fileInput = document.getElementById("landmark-file");
+  const dropZone = document.getElementById("drop-zone");
+  const dropZoneInner = document.getElementById("drop-zone-inner");
+  const previewImage = document.getElementById("preview-image");
+  const identifyBtn = document.getElementById("identify-btn");
+  const clearBtn = document.getElementById("clear-btn");
+  const form = document.getElementById("upload-form");
+  const resultsSection = document.getElementById("results-section");
+
+  let currentFile = null;
+  let currentObjectUrl = null;
+
+  function resetUpload() {
+    currentFile = null;
+    if (currentObjectUrl) URL.revokeObjectURL(currentObjectUrl);
+    currentObjectUrl = null;
+    fileInput.value = "";
+    previewImage.hidden = true;
+    previewImage.src = "";
+    dropZoneInner.hidden = false;
+    identifyBtn.disabled = true;
+    clearBtn.hidden = true;
+    setStatus("");
+  }
+
+  function handleFile(file) {
+    const error = validateFile(file);
+    if (error) {
+      setStatus(error, true);
+      return;
+    }
+    currentFile = file;
+    if (currentObjectUrl) URL.revokeObjectURL(currentObjectUrl);
+    currentObjectUrl = URL.createObjectURL(file);
+    previewImage.src = currentObjectUrl;
+    previewImage.hidden = false;
+    dropZoneInner.hidden = true;
+    identifyBtn.disabled = false;
+    clearBtn.hidden = false;
+    setStatus(`Ready to identify "${file.name}".`);
+  }
+
+  fileInput.addEventListener("change", (e) => {
+    const file = e.target.files && e.target.files[0];
+    if (file) handleFile(file);
+  });
+
+  ["dragenter", "dragover"].forEach((evt) => {
+    dropZone.addEventListener(evt, (e) => {
+      e.preventDefault();
+      dropZone.classList.add("drag-active");
+    });
+  });
+
+  ["dragleave", "drop"].forEach((evt) => {
+    dropZone.addEventListener(evt, (e) => {
+      e.preventDefault();
+      dropZone.classList.remove("drag-active");
+    });
+  });
+
+  dropZone.addEventListener("drop", (e) => {
+    const file = e.dataTransfer.files && e.dataTransfer.files[0];
+    if (file) handleFile(file);
+  });
+
+  clearBtn.addEventListener("click", resetUpload);
+
+  form.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    if (!currentFile) return;
+
+    identifyBtn.disabled = true;
+    setStatus("Analyzing image…");
+
+    try {
+      const { img } = await fileToImage(currentFile);
+      const hash = computeImageHash(img);
+      const { matches, best, isConfident } = engine.identify(hash, { topN: 5 });
+
+      if (!best) {
+        setStatus("No landmarks in our database could be compared to this image.", true);
+        resultsSection.hidden = true;
+        return;
+      }
+
+      renderResult(best, isConfident);
+      renderAltMatches(matches, best.landmark.id);
+
+      engine.addToHistory({
+        landmarkId: best.landmark.id,
+        landmarkName: best.landmark.name,
+        confidence: best.confidence
+      });
+      persistHistory(engine);
+      renderHistory();
+
+      resultsSection.hidden = false;
+      resultsSection.scrollIntoView({ behavior: "smooth", block: "start" });
+      setStatus(isConfident ? "Match found!" : "Best-effort match shown below (low confidence).");
+    } catch (err) {
+      setStatus(err.message || "Something went wrong while analyzing the image.", true);
+    } finally {
+      identifyBtn.disabled = false;
+    }
+  });
+
+  document.getElementById("clear-history-btn").addEventListener("click", () => {
+    engine.clearHistory();
+    persistHistory(engine);
+    renderHistory();
+  });
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", init);
+} else {
+  init();
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,495 @@
+:root {
+  --li-accent: var(--saffron, #ff9933);
+  --li-green: var(--green, #138808);
+  --li-surface: var(--glass-bg, rgba(255, 255, 255, 0.08));
+  --li-border: var(--glass-border, rgba(255, 255, 255, 0.14));
+  --li-text: var(--text-primary, #f8fafc);
+  --li-muted: var(--text-secondary, #cbd5e1);
+  --li-shadow: 0 18px 50px rgba(0, 0, 0, 0.16);
+}
+
+.landmark-page {
+  min-height: 100vh;
+  color: var(--li-text);
+}
+
+/* Hero */
+.landmark-hero {
+  min-height: 52vh;
+  display: grid;
+  place-items: center;
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(120deg, rgba(16, 24, 44, 0.95), rgba(92, 52, 20, 0.7)),
+    url("../../assets/kailasa_temple_banner.png") center / cover no-repeat;
+}
+
+.landmark-hero .hero-content {
+  position: relative;
+  z-index: 1;
+  width: min(880px, 92%);
+  padding: 140px 0 70px;
+  text-align: center;
+  color: #fff;
+}
+
+.landmark-hero .hero-kicker {
+  display: inline-block;
+  padding: 8px 15px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.25);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.landmark-hero h1 {
+  margin: 18px 0;
+  font-family: var(--font-heading, serif);
+  font-size: clamp(2.1rem, 4.5vw, 3.2rem);
+}
+
+.landmark-hero h1 span {
+  color: var(--li-accent);
+}
+
+.landmark-hero p {
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 1.02rem;
+  line-height: 1.6;
+}
+
+/* Section shell shared by identify/results/history/library */
+.identify-section,
+.results-section,
+.history-section,
+.landmark-library {
+  padding: 60px 0;
+}
+
+.identify-container,
+.results-container,
+.history-container,
+.library-container {
+  width: min(920px, 92%);
+  margin: 0 auto;
+}
+
+.section-heading {
+  text-align: center;
+  margin-bottom: 32px;
+}
+
+.section-badge {
+  display: inline-block;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(255, 153, 51, 0.14);
+  color: var(--li-accent);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.section-heading h2 {
+  margin: 12px 0 8px;
+  font-family: var(--font-heading, serif);
+  font-size: clamp(1.5rem, 3vw, 2rem);
+}
+
+.section-heading p {
+  color: var(--li-muted);
+}
+
+/* Upload card */
+.upload-card {
+  background: var(--li-surface);
+  border: 1px solid var(--li-border);
+  border-radius: var(--border-radius-lg, 18px);
+  padding: 28px;
+  box-shadow: var(--li-shadow);
+}
+
+.drop-zone {
+  display: block;
+  cursor: pointer;
+  border: 2px dashed var(--li-border);
+  border-radius: var(--border-radius-sm, 8px);
+  padding: 40px 20px;
+  text-align: center;
+  transition: var(--transition-snappy, all 0.25s ease);
+}
+
+.drop-zone:hover,
+.drop-zone.drag-active {
+  border-color: var(--li-accent);
+  background: rgba(255, 153, 51, 0.06);
+}
+
+.drop-zone-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  color: var(--li-muted);
+}
+
+.drop-icon {
+  font-size: 2.4rem;
+}
+
+.drop-zone-inner strong {
+  color: var(--li-text);
+  font-size: 1.05rem;
+}
+
+.preview-image {
+  max-width: 100%;
+  max-height: 340px;
+  border-radius: var(--border-radius-sm, 8px);
+  margin: 0 auto;
+  display: block;
+}
+
+.upload-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  margin-top: 22px;
+  flex-wrap: wrap;
+}
+
+.btn-primary,
+.btn-secondary {
+  padding: 12px 26px;
+  border-radius: 999px;
+  font-weight: 700;
+  border: none;
+  cursor: pointer;
+  transition: var(--transition-snappy, all 0.25s ease);
+}
+
+.btn-primary {
+  background: var(--gradient-saffron-gold, var(--li-accent));
+  color: #1a1200;
+}
+
+.btn-primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-secondary {
+  background: transparent;
+  border: 1px solid var(--li-border);
+  color: var(--li-text);
+}
+
+.upload-status {
+  text-align: center;
+  margin-top: 14px;
+  min-height: 1.2em;
+  color: var(--li-muted);
+  font-size: 0.9rem;
+}
+
+.upload-status.is-error {
+  color: #ff6b6b;
+}
+
+/* Results */
+.result-card {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 24px;
+  background: var(--li-surface);
+  border: 1px solid var(--li-border);
+  border-radius: var(--border-radius-lg, 18px);
+  overflow: hidden;
+  box-shadow: var(--li-shadow);
+}
+
+.result-media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  min-height: 220px;
+}
+
+.result-body {
+  padding: 24px 24px 24px 0;
+}
+
+.confidence-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 8px;
+  flex-wrap: wrap;
+}
+
+.confidence-badge {
+  display: inline-block;
+  padding: 5px 12px;
+  border-radius: 999px;
+  background: rgba(19, 136, 8, 0.16);
+  color: var(--li-green);
+  font-weight: 800;
+  font-size: 0.82rem;
+}
+
+.confidence-badge.confidence-low {
+  background: rgba(255, 107, 107, 0.16);
+  color: #ff6b6b;
+}
+
+.confidence-badge.confidence-medium {
+  background: rgba(255, 153, 51, 0.16);
+  color: var(--li-accent);
+}
+
+.result-category {
+  color: var(--li-muted);
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.result-body h3 {
+  font-family: var(--font-heading, serif);
+  font-size: 1.5rem;
+  margin: 4px 0;
+}
+
+.result-location {
+  color: var(--li-muted);
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+.result-body .info-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+  margin: 18px 0;
+}
+
+.result-body .info-grid div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.result-body .info-grid span {
+  color: var(--li-muted);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.significance-box,
+.nearby-box {
+  margin-top: 18px;
+  padding-top: 14px;
+  border-top: 1px solid var(--li-border);
+}
+
+.significance-box h4,
+.nearby-box h4 {
+  font-size: 0.9rem;
+  margin-bottom: 6px;
+  color: var(--li-accent);
+}
+
+.nearby-box ul {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 0;
+  margin: 0;
+}
+
+.nearby-box li {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--li-border);
+  padding: 5px 12px;
+  border-radius: 999px;
+  font-size: 0.82rem;
+}
+
+.low-confidence-notice {
+  background: rgba(255, 107, 107, 0.1);
+  border: 1px solid rgba(255, 107, 107, 0.3);
+  border-radius: var(--border-radius-sm, 8px);
+  padding: 16px 20px;
+  margin-top: 20px;
+}
+
+.low-confidence-notice p {
+  color: var(--li-muted);
+  margin-top: 4px;
+}
+
+.alt-matches {
+  margin-top: 24px;
+}
+
+.alt-matches h4 {
+  margin-bottom: 12px;
+  color: var(--li-muted);
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.alt-match-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 14px;
+}
+
+.alt-match-card {
+  background: var(--li-surface);
+  border: 1px solid var(--li-border);
+  border-radius: var(--border-radius-sm, 8px);
+  overflow: hidden;
+  text-align: center;
+}
+
+.alt-match-card img {
+  width: 100%;
+  height: 90px;
+  object-fit: cover;
+}
+
+.alt-match-card .alt-match-info {
+  padding: 8px;
+}
+
+.alt-match-card strong {
+  display: block;
+  font-size: 0.85rem;
+}
+
+.alt-match-card span {
+  color: var(--li-muted);
+  font-size: 0.75rem;
+}
+
+/* History */
+.history-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.history-heading h3 {
+  font-family: var(--font-heading, serif);
+}
+
+.history-heading button {
+  background: none;
+  border: 1px solid var(--li-border);
+  color: var(--li-muted);
+  padding: 6px 14px;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.history-empty {
+  color: var(--li-muted);
+  font-size: 0.9rem;
+}
+
+.history-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.history-list li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--li-surface);
+  border: 1px solid var(--li-border);
+  border-radius: var(--border-radius-sm, 8px);
+  padding: 10px 14px;
+  font-size: 0.9rem;
+}
+
+.history-list .history-confidence {
+  color: var(--li-muted);
+  font-size: 0.8rem;
+}
+
+/* Library grid */
+.library-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+  gap: 16px;
+}
+
+.library-card {
+  background: var(--li-surface);
+  border: 1px solid var(--li-border);
+  border-radius: var(--border-radius-sm, 8px);
+  overflow: hidden;
+  text-align: center;
+}
+
+.library-card img {
+  width: 100%;
+  height: 120px;
+  object-fit: cover;
+}
+
+.library-card .library-info {
+  padding: 10px;
+}
+
+.library-card strong {
+  display: block;
+  font-size: 0.88rem;
+}
+
+.library-card span {
+  color: var(--li-muted);
+  font-size: 0.78rem;
+}
+
+.landmark-footer {
+  text-align: center;
+  padding: 26px 16px;
+  color: var(--li-muted);
+  font-size: 0.85rem;
+  border-top: 1px solid var(--li-border);
+}
+
+.landmark-footer a {
+  color: var(--li-accent);
+}
+
+@media (max-width: 720px) {
+  .result-card {
+    grid-template-columns: 1fr;
+  }
+
+  .result-media img {
+    min-height: 180px;
+  }
+
+  .result-body {
+    padding: 20px;
+  }
+}

--- a/tests/unit/landmark-recognition-engine.test.js
+++ b/tests/unit/landmark-recognition-engine.test.js
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { LandmarkRecognitionEngine } from '../../js-modules/landmark-recognition-engine.js';
+
+const TAJ_HASH = '1111111011111111111111110001100000000000111001100000000000000000'.slice(0, 64);
+const HAWA_HASH = '0011111101111110011111101111111111011110110111000000000000111100';
+
+const sampleLandmarks = [
+  { id: 'taj_mahal', name: 'Taj Mahal', state: 'Uttar Pradesh', city: 'Agra', hash: TAJ_HASH, nearbyAttractions: ['Agra Fort'] },
+  { id: 'hawa_mahal', name: 'Hawa Mahal', state: 'Rajasthan', city: 'Jaipur', hash: HAWA_HASH, nearbyAttractions: ['Amber Fort'] }
+];
+
+describe('LandmarkRecognitionEngine.hammingDistance', () => {
+  it('returns 0 for identical hashes', () => {
+    expect(LandmarkRecognitionEngine.hammingDistance('1010', '1010')).toBe(0);
+  });
+
+  it('counts differing bits', () => {
+    expect(LandmarkRecognitionEngine.hammingDistance('1010', '0010')).toBe(1);
+    expect(LandmarkRecognitionEngine.hammingDistance('1111', '0000')).toBe(4);
+  });
+
+  it('returns -1 for mismatched lengths or invalid input', () => {
+    expect(LandmarkRecognitionEngine.hammingDistance('101', '10')).toBe(-1);
+    expect(LandmarkRecognitionEngine.hammingDistance(null, '10')).toBe(-1);
+    expect(LandmarkRecognitionEngine.hammingDistance('', '')).toBe(-1);
+  });
+});
+
+describe('LandmarkRecognitionEngine.distanceToConfidence', () => {
+  it('gives full confidence for zero distance', () => {
+    expect(LandmarkRecognitionEngine.distanceToConfidence(0, 64)).toBe(1);
+  });
+
+  it('gives zero confidence for maximal distance', () => {
+    expect(LandmarkRecognitionEngine.distanceToConfidence(64, 64)).toBe(0);
+  });
+
+  it('scales linearly between 0 and 1', () => {
+    expect(LandmarkRecognitionEngine.distanceToConfidence(16, 64)).toBeCloseTo(0.75, 5);
+  });
+});
+
+describe('LandmarkRecognitionEngine.isValidHash', () => {
+  it('accepts binary strings', () => {
+    expect(LandmarkRecognitionEngine.isValidHash('0101')).toBe(true);
+  });
+
+  it('rejects non-binary or empty strings', () => {
+    expect(LandmarkRecognitionEngine.isValidHash('abcd')).toBe(false);
+    expect(LandmarkRecognitionEngine.isValidHash('')).toBe(false);
+    expect(LandmarkRecognitionEngine.isValidHash(null)).toBe(false);
+  });
+});
+
+describe('LandmarkRecognitionEngine#identify', () => {
+  let engine;
+
+  beforeEach(() => {
+    engine = new LandmarkRecognitionEngine({ landmarks: sampleLandmarks, minConfidence: 0.55 });
+  });
+
+  it('returns an exact match with full confidence', () => {
+    const result = engine.identify(TAJ_HASH);
+    expect(result.best.landmark.id).toBe('taj_mahal');
+    expect(result.best.confidence).toBe(1);
+    expect(result.isConfident).toBe(true);
+  });
+
+  it('ranks matches best-first by distance', () => {
+    const result = engine.identify(TAJ_HASH);
+    expect(result.matches[0].landmark.id).toBe('taj_mahal');
+    expect(result.matches.length).toBe(2);
+    expect(result.matches[0].distance).toBeLessThanOrEqual(result.matches[1].distance);
+  });
+
+  it('flags low-confidence results as not confident', () => {
+    // A hash maximally different from both references.
+    const inverted = TAJ_HASH.split('').map((b) => (b === '1' ? '0' : '1')).join('');
+    const result = engine.identify(inverted);
+    expect(result.isConfident).toBe(false);
+  });
+
+  it('returns an error for an invalid query hash', () => {
+    const result = engine.identify('not-a-hash');
+    expect(result.error).toBe('invalid_hash');
+    expect(result.best).toBeNull();
+  });
+
+  it('respects the topN option', () => {
+    const result = engine.identify(TAJ_HASH, { topN: 1 });
+    expect(result.matches.length).toBe(1);
+  });
+});
+
+describe('LandmarkRecognitionEngine history', () => {
+  let engine;
+
+  beforeEach(() => {
+    engine = new LandmarkRecognitionEngine({ landmarks: sampleLandmarks });
+  });
+
+  it('adds valid entries to history, most recent first', () => {
+    engine.addToHistory({ landmarkId: 'taj_mahal', landmarkName: 'Taj Mahal', confidence: 0.9 });
+    engine.addToHistory({ landmarkId: 'hawa_mahal', landmarkName: 'Hawa Mahal', confidence: 0.8 });
+    const history = engine.getHistory();
+    expect(history.length).toBe(2);
+    expect(history[0].landmarkId).toBe('hawa_mahal');
+  });
+
+  it('ignores entries without a landmarkId', () => {
+    expect(engine.addToHistory({ confidence: 0.9 })).toBeNull();
+    expect(engine.getHistory().length).toBe(0);
+  });
+
+  it('caps history at the configured limit', () => {
+    for (let i = 0; i < 30; i++) {
+      engine.addToHistory({ landmarkId: `landmark_${i}`, landmarkName: `Landmark ${i}` });
+    }
+    expect(engine.getHistory().length).toBeLessThanOrEqual(25);
+  });
+
+  it('clears history', () => {
+    engine.addToHistory({ landmarkId: 'taj_mahal', landmarkName: 'Taj Mahal' });
+    engine.clearHistory();
+    expect(engine.getHistory().length).toBe(0);
+  });
+});
+
+describe('LandmarkRecognitionEngine.getRelatedDestinations', () => {
+  it('falls back to curated nearbyAttractions when no destinations dataset is given', () => {
+    const related = LandmarkRecognitionEngine.getRelatedDestinations(sampleLandmarks[0]);
+    expect(related.map((r) => r.name)).toEqual(['Agra Fort']);
+  });
+
+  it('filters a destinations dataset by matching state', () => {
+    const destinations = [
+      { name: 'Agra', state: 'Uttar Pradesh', highlights: ['Taj Mahal'] },
+      { name: 'Varanasi', state: 'Uttar Pradesh', highlights: ['Ganga Aarti'] },
+      { name: 'Jaipur', state: 'Rajasthan', highlights: ['Hawa Mahal'] }
+    ];
+    const related = LandmarkRecognitionEngine.getRelatedDestinations(sampleLandmarks[0], destinations);
+    expect(related.map((r) => r.name)).toEqual(['Varanasi']);
+  });
+
+  it('returns an empty array for a missing landmark', () => {
+    expect(LandmarkRecognitionEngine.getRelatedDestinations(null)).toEqual([]);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description
Adds intelligent multi-day route optimization for road trips. The existing
Route Planner already optimized *stop order* (nearest-neighbor + 2-opt) and
estimated distance/time for road/rail/air, but had no concept of "days" —
users had to manually figure out where to split a long itinerary and where
to stay overnight.

This adds a new `multi-day-planner.js` module that:
- Splits an optimized route into days against a configurable daily driving
  limit (Relaxed 4h / Standard 6h / Fast 8h presets)
- Suggests an overnight stay at whichever stop the daily limit is reached
- Flags estimated arrivals that fall outside typical sightseeing hours
  (09:00–18:00), assuming a 09:00 daily departure and ~2.5h per stop
- Offers alternative-pace comparisons so users can see day-count tradeoffs
  before committing to one
- Exports the resulting itinerary as a downloadable `.txt` file for offline
  use, consistent with this project's static/no-backend architecture
- Recalculates automatically whenever stops, transport mode, or pace change

The module is kept pure and DOM-free (mirroring `route-planner.js`), wired
into the existing UI via `route-planner-ui.js`, with 14 Node-runnable unit
tests in `docs/multi-day-planner.test.js`.

Fixes #693

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?
- [x] Tested locally in browser
- [ ] Tested in both dark and light themes
- [ ] Tested at mobile viewport widths
- [x] Verified no console errors
- [x] Unit tests added (`docs/multi-day-planner.test.js`) covering
      day-splitting correctness, overnight placement, pace comparisons,
      export format, and edge cases (single stop, empty legs)

## Checklist
- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [ ] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)

## Screenshots (if applicable)
_(add a screenshot of the "Multi-Day Plan" panel — day cards, pace selector,
and export button — from `route-planner.html` here)_

## Notes for reviewers
- `docs/*.test.js` (including the pre-existing `route-planner.test.js`)
  currently fail with `require is not defined` on Node versions where
  `package.json`'s `"type": "module"` changes `require`-of-ESM behavior.
  This is a pre-existing issue, not introduced by this PR — logic was
  verified by direct execution instead. Worth a small follow-up issue.