### PR TITLE
feat: Create South Andaman Explorer

### DIFF
--- a/frontend/islands/islands.js
+++ b/frontend/islands/islands.js
@@ -21,6 +21,34 @@ const ISLANDS_DATA = [
     image: "../../assets/travel_beaches.png"
   },
   {
+    id: "great-nicobar",
+    name: "Great Nicobar Island",
+    group: "Andaman & Nicobar",
+    location: "Nicobar Islands, Bay of Bengal",
+    state: "Union Territory",
+    lat: 6.95,
+    lng: 93.87,
+    islandCount: "1 island",
+    tagline: "India's southernmost island, home to Indira Point",
+    description: "The largest island in the Nicobar group and India's southernmost territory, home to Indira Point, Campbell Bay National Park, and rare endemic wildlife.",
+    highlights: ["Indira Point — southernmost tip of India", "Campbell Bay National Park", "UNESCO Biosphere Reserve (2013)", "Nesting ground for Giant Leatherback turtles"],
+    image: "../../assets/travel_hidden.png"
+  },
+  {
+    id: "south-andaman",
+    name: "South Andaman",
+    group: "Andaman & Nicobar",
+    location: "Andaman Islands, Bay of Bengal",
+    state: "Union Territory",
+    lat: 11.6234,
+    lng: 92.7265,
+    islandCount: "1 island",
+    tagline: "Gateway to the Andamans — Port Blair, Cellular Jail & Ross Island",
+    description: "Home to Port Blair, the capital of Andaman & Nicobar Islands, South Andaman blends colonial history, museums, and coastal scenery — from the Cellular Jail to Chidiya Tapu's sunsets and the ruins of Ross Island.",
+    highlights: ["Cellular Jail National Memorial", "Ross Island's British colonial ruins", "Chidiya Tapu — Bird Island & sunset point", "Anthropological & Samudrika Marine Museums"],
+    image: "../../assets/travel_beaches.png"
+  },
+  {
     id: "lakshadweep",
     name: "Lakshadweep Islands",
     group: "Lakshadweep",
@@ -243,6 +271,13 @@ function initSearchAndFilters() {
 function openModal(islandId) {
   const island = ISLANDS_DATA.find((i) => i.id === islandId);
   if (!island) return;
+
+  if (island.id === "great-nicobar" || island.id === "south-andaman") {
+    window.location.href = island.id === "great-nicobar"
+      ? "../great-nicobar/great-nicobar.html"
+      : "../south-andaman/south-andaman.html";
+    return;
+  }
 
   document.getElementById("island-modal-title").textContent = island.name;
   document.getElementById("island-modal-location").textContent = island.location;

--- a/frontend/south-andaman/south-andaman.css
+++ b/frontend/south-andaman/south-andaman.css
@@ -1,0 +1,411 @@
+/* ============================================================
+   South Andaman Explorer — south-andaman.css
+   Uses the shared design tokens defined in ../../styles.css
+   ============================================================ */
+
+.andaman-page {
+  padding-top: var(--navbar-height);
+  overflow-x: hidden;
+}
+
+.andaman-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* ---------- Hero ---------- */
+.andaman-hero {
+  position: relative;
+  padding: 90px 24px 70px;
+  text-align: center;
+  background:
+    linear-gradient(180deg, rgba(4, 23, 42, 0.55) 0%, rgba(4, 23, 42, 0.92) 100%),
+    url("../../assets/travel_beaches.png") center/cover no-repeat;
+}
+
+.andaman-hero-content {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.andaman-hero-kicker {
+  display: inline-block;
+  padding: 6px 16px;
+  border-radius: 999px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  color: var(--primary-saffron);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-bottom: 20px;
+}
+
+.andaman-hero h1 {
+  font-family: var(--font-heading);
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  line-height: 1.15;
+  margin-bottom: 18px;
+  color: var(--text-light);
+}
+
+.andaman-hero h1 span {
+  background: var(--gradient-saffron-gold);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.andaman-hero p {
+  color: var(--text-secondary);
+  font-size: 1.08rem;
+  line-height: 1.7;
+  margin-bottom: 36px;
+}
+
+.andaman-hero-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+
+.andaman-stat-box {
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 18px 12px;
+  transition: var(--transition-snappy);
+}
+
+.andaman-stat-box:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-glow);
+}
+
+.andaman-stat-box strong {
+  display: block;
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--primary-saffron);
+}
+
+.andaman-stat-box span {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+/* ---------- Section heading ---------- */
+.andaman-section {
+  padding: 70px 0;
+}
+
+.andaman-section-heading {
+  text-align: center;
+  max-width: 680px;
+  margin: 0 auto 44px;
+}
+
+.andaman-section-badge {
+  display: inline-block;
+  color: var(--primary-gold);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+
+.andaman-section-heading h2 {
+  font-family: var(--font-heading);
+  font-size: clamp(1.7rem, 3.5vw, 2.4rem);
+  color: var(--text-light);
+  margin-bottom: 14px;
+}
+
+.andaman-section-heading p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+/* ---------- Tabs (Port Blair / Cellular Jail / Chidiya Tapu / Ross Island / Museums / Tourism) ---------- */
+.andaman-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  margin-bottom: 32px;
+}
+
+.andaman-tab-btn {
+  padding: 10px 20px;
+  border-radius: 999px;
+  border: 1px solid var(--glass-border);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: var(--transition-snappy);
+}
+
+.andaman-tab-btn:hover {
+  border-color: var(--primary-saffron);
+  color: var(--text-light);
+}
+
+.andaman-tab-btn.active {
+  background: var(--gradient-saffron-gold);
+  color: #1a1200;
+  border-color: transparent;
+  font-weight: 600;
+}
+
+.andaman-tab-panel {
+  display: none;
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 32px;
+  animation: andaman-fade-in 0.3s ease;
+}
+
+.andaman-tab-panel.active {
+  display: block;
+}
+
+@keyframes andaman-fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.andaman-tab-panel h3 {
+  font-family: var(--font-heading);
+  color: var(--primary-gold);
+  margin-bottom: 14px;
+  font-size: 1.3rem;
+}
+
+.andaman-tab-panel p {
+  color: var(--text-secondary);
+  line-height: 1.8;
+  margin-bottom: 14px;
+}
+
+.andaman-tab-panel ul {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.andaman-tab-panel ul li {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  padding-left: 24px;
+  position: relative;
+  line-height: 1.6;
+}
+
+.andaman-tab-panel ul li::before {
+  content: "🏝️";
+  position: absolute;
+  left: 0;
+}
+
+/* ---------- Map ---------- */
+.andaman-map-wrap {
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow-soft);
+}
+
+#andaman-map {
+  height: 440px;
+  width: 100%;
+  background: var(--bg-dark-deep);
+}
+
+/* ---------- Gallery ---------- */
+.andaman-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 18px;
+}
+
+.andaman-gallery-item {
+  margin: 0;
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+  cursor: pointer;
+  border: 1px solid var(--glass-border);
+  transition: var(--transition-snappy);
+  position: relative;
+}
+
+.andaman-gallery-item:hover {
+  transform: translateY(-4px);
+  border-color: var(--primary-saffron);
+  box-shadow: var(--shadow-glow);
+}
+
+.andaman-gallery-item img {
+  width: 100%;
+  height: 190px;
+  object-fit: cover;
+  display: block;
+}
+
+.andaman-gallery-item figcaption {
+  padding: 10px 14px;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  background: var(--bg-dark-card);
+}
+
+/* ---------- Lightbox ---------- */
+.andaman-lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 10, 20, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 24px;
+}
+
+.andaman-lightbox-overlay[hidden] {
+  display: none;
+}
+
+.andaman-lightbox-content {
+  max-width: 800px;
+  width: 100%;
+  text-align: center;
+  position: relative;
+}
+
+.andaman-lightbox-content img {
+  width: 100%;
+  max-height: 65vh;
+  object-fit: contain;
+  border-radius: var(--border-radius-lg);
+}
+
+.andaman-lightbox-caption {
+  color: var(--text-light);
+  margin-top: 14px;
+  font-size: 0.95rem;
+}
+
+.andaman-lightbox-close {
+  position: absolute;
+  top: -44px;
+  right: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-light);
+  font-size: 1.4rem;
+  cursor: pointer;
+}
+
+.andaman-lightbox-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-light);
+  font-size: 1.3rem;
+  cursor: pointer;
+}
+
+.andaman-lightbox-nav.prev { left: -20px; }
+.andaman-lightbox-nav.next { right: -20px; }
+
+/* ---------- Did You Know ---------- */
+.andaman-fact-panel {
+  max-width: 760px;
+  margin: 0 auto;
+  background: var(--gradient-card-border);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 40px 36px;
+  text-align: center;
+}
+
+.andaman-fact-icon {
+  font-size: 2.2rem;
+  margin-bottom: 14px;
+}
+
+#andaman-fact-text {
+  font-family: var(--font-heading);
+  font-size: 1.15rem;
+  color: var(--text-light);
+  line-height: 1.6;
+  transition: opacity 0.2s ease;
+  min-height: 84px;
+}
+
+.andaman-fact-dots {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.andaman-fact-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+  background: var(--glass-border);
+  cursor: pointer;
+  transition: var(--transition-snappy);
+}
+
+.andaman-fact-dot.active {
+  background: var(--primary-saffron);
+  width: 22px;
+  border-radius: 4px;
+}
+
+/* ---------- Back to Islands link ---------- */
+.andaman-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--primary-saffron);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 14px;
+}
+
+.andaman-back-link:hover {
+  text-decoration: underline;
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 768px) {
+  .andaman-hero-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  #andaman-map {
+    height: 320px;
+  }
+
+  .andaman-lightbox-nav.prev { left: 4px; }
+  .andaman-lightbox-nav.next { right: 4px; }
+}

--- a/frontend/south-andaman/south-andaman.html
+++ b/frontend/south-andaman/south-andaman.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Explore South Andaman — Port Blair, the Cellular Jail, Chidiya Tapu, Ross Island, museums and tourism, with an interactive map and image gallery.">
+    <title>South Andaman Explorer | Incredible India</title>
+    <link rel="icon" href="data:,">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="south-andaman.css">
+
+    <!-- Open Graph / Social Media Tags -->
+    <meta property="og:title" content="South Andaman Explorer | Incredible India Explorer">
+    <meta property="og:description" content="Port Blair, the Cellular Jail, Chidiya Tapu, Ross Island, museums and tourism — explore South Andaman with an interactive map and gallery.">
+    <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/assets/travel_beaches.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/south-andaman/south-andaman.html">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Incredible India Explorer">
+    <meta property="og:locale" content="en_IN">
+
+    <!-- Twitter Card Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="South Andaman Explorer | Incredible India Explorer">
+    <meta name="twitter:description" content="Port Blair, Cellular Jail, Chidiya Tapu, Ross Island, museums and tourism in South Andaman.">
+    <meta name="twitter:image" content="https://incredibleindiaexplorer.gov.in/assets/travel_beaches.png">
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/south-andaman/south-andaman.html">
+</head>
+
+<body class="andaman-body">
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html#home" class="nav-link" id="link-home">Home</a>
+                <a href="../../index.html#map" class="nav-link" id="link-map">Interactive Map</a>
+                <a href="../islands/islands.html" class="nav-link">Islands</a>
+                <a href="south-andaman.html" class="nav-link active" style="color: var(--saffron)">South Andaman</a>
+
+                <div class="nav-dropdown">
+                    <button class="nav-link dropdown-toggle" id="link-explore-more">
+                        Explore More ▾
+                    </button>
+                    <div class="dropdown-menu">
+                        <a href="../travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                        <a href="../wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                        <a href="../coastal-india/coastal-india.html" class="dropdown-item">Coastal India</a>
+                        <a href="../heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    </div>
+                </div>
+
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
+                    ☀️
+                </button>
+                <a href="../../login.html" class="nav-link" id="link-login">Login</a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="andaman-page">
+        <!-- Hero -->
+        <section class="andaman-hero">
+            <div class="andaman-hero-content">
+                <a href="../islands/islands.html" class="andaman-back-link">← Back to Islands of India</a>
+                <span class="andaman-hero-kicker">🏝️ Gateway to the Andamans</span>
+                <h1>South <span>Andaman</span></h1>
+                <p>Home to Port Blair, the capital of the Andaman & Nicobar Islands — where colonial history, freedom-struggle memorials, museums and coastal scenery meet.</p>
+
+                <div class="andaman-hero-stats">
+                    <div class="andaman-stat-box">
+                        <strong>1896</strong>
+                        <span>Cellular Jail Built</span>
+                    </div>
+                    <div class="andaman-stat-box">
+                        <strong>698</strong>
+                        <span>Cells in the Jail</span>
+                    </div>
+                    <div class="andaman-stat-box">
+                        <strong>25 km</strong>
+                        <span>Port Blair to Chidiya Tapu</span>
+                    </div>
+                    <div class="andaman-stat-box">
+                        <strong>4+</strong>
+                        <span>Museums in Port Blair</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Tabbed info -->
+        <section class="andaman-section" id="andaman-explore">
+            <div class="andaman-container">
+                <div class="andaman-section-heading">
+                    <span class="andaman-section-badge">Explore South Andaman</span>
+                    <h2>Port Blair, History &amp; Nature</h2>
+                    <p>Select a tab to learn more.</p>
+                </div>
+
+                <div class="andaman-tabs" role="tablist">
+                    <button type="button" class="andaman-tab-btn active" data-tab="port-blair">Port Blair</button>
+                    <button type="button" class="andaman-tab-btn" data-tab="cellular-jail">Cellular Jail</button>
+                    <button type="button" class="andaman-tab-btn" data-tab="chidiya-tapu">Chidiya Tapu</button>
+                    <button type="button" class="andaman-tab-btn" data-tab="ross-island">Ross Island</button>
+                    <button type="button" class="andaman-tab-btn" data-tab="museums">Museums</button>
+                    <button type="button" class="andaman-tab-btn" data-tab="tourism">Tourism</button>
+                </div>
+
+                <div class="andaman-tab-panel active" id="tab-port-blair">
+                    <h3>🏙️ Port Blair</h3>
+                    <p>Port Blair is the capital of the Andaman & Nicobar Islands and the main gateway for visitors arriving by air or sea. Often called "Mini India" for the diversity of communities settled there, the city blends colonial-era landmarks with everyday island life — markets, seafood, and a laid-back coastal pace.</p>
+                    <p>Direct flights connect Port Blair to Delhi, Kolkata, Chennai, Bengaluru and Mumbai, while passenger ships from Kolkata and Chennai take 3–4 days.</p>
+                </div>
+
+                <div class="andaman-tab-panel" id="tab-cellular-jail">
+                    <h3>⛓️ Cellular Jail</h3>
+                    <p>Also known as Kala Pani, the Cellular Jail is a colonial-era prison built in 1896 that once held Indian freedom fighters in solitary confinement. Its three-storeyed building originally had 698 cells arranged in a radiating, starfish-like layout, designed so no prisoner could see or speak with another.</p>
+                    <p>Today it stands as a National Memorial and museum, with an evening Light & Sound Show retelling the story of India's freedom struggle at the site itself.</p>
+                    <ul>
+                        <li>Open 9 AM – 5 PM, all days except national holidays</li>
+                        <li>Evening Light & Sound Show</li>
+                        <li>Adjacent museum galleries on the freedom movement</li>
+                    </ul>
+                </div>
+
+                <div class="andaman-tab-panel" id="tab-chidiya-tapu">
+                    <h3>🐦 Chidiya Tapu</h3>
+                    <p>Known as "Bird Island," Chidiya Tapu lies about 25 km south of Port Blair and is renowned as one of the best sunset viewpoints in the Andamans, alongside nature trails and mangrove boardwalks.</p>
+                    <ul>
+                        <li>Home to over 46 species of birds</li>
+                        <li>Munda Pahad viewpoint, also called Suicide Point, for panoramic sunsets</li>
+                        <li>Chidiya Tapu Biological Park for local flora and fauna</li>
+                    </ul>
+                </div>
+
+                <div class="andaman-tab-panel" id="tab-ross-island">
+                    <h3>🏛️ Ross Island</h3>
+                    <p>Officially renamed Netaji Subhas Chandra Bose Dweep, Ross Island was the British administrative headquarters for the entire Andaman & Nicobar Islands before India's independence. Today its colonial-era buildings stand in atmospheric ruin, wrapped in the roots of giant banyan and rubber trees.</p>
+                    <ul>
+                        <li>Ruins of the former British Chief Commissioner's residence, church and bakery</li>
+                        <li>Resident deer and peacocks roaming the grounds</li>
+                        <li>Reachable by a short boat ride from Port Blair, often combined with North Bay Island</li>
+                    </ul>
+                </div>
+
+                <div class="andaman-tab-panel" id="tab-museums">
+                    <h3>🏺 Museums</h3>
+                    <p>Port Blair is home to several museums that together give a rounded picture of the islands' history, ecology and indigenous cultures.</p>
+                    <ul>
+                        <li><strong>Anthropological Museum</strong> — artifacts, tools and photographs of the islands' indigenous tribes</li>
+                        <li><strong>Samudrika Naval Marine Museum</strong> — marine life, shells and island geography</li>
+                        <li><strong>Fisheries (Marine) Museum</strong> — aquatic species of the surrounding seas</li>
+                        <li><strong>Cellular Jail Museum</strong> — exhibits on the freedom struggle</li>
+                    </ul>
+                </div>
+
+                <div class="andaman-tab-panel" id="tab-tourism">
+                    <h3>🧭 Tourism</h3>
+                    <p>South Andaman offers a mix of history, beaches and water sports. Along with Port Blair's core sights, nearby attractions include Corbyn's Cove Beach, the Mahatma Gandhi Marine National Park, Chatham Saw Mill (Asia's oldest sawmill), and Wandoor Beach.</p>
+                    <p>The best time to visit is between October and May, with January to April offering the most reliable weather for water sports such as snorkelling, scuba diving and sea walking.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Interactive Map -->
+        <section class="andaman-section" id="andaman-map-section">
+            <div class="andaman-container">
+                <div class="andaman-section-heading">
+                    <span class="andaman-section-badge">Interactive Map</span>
+                    <h2>Key Locations in South Andaman</h2>
+                    <p>Click a marker to learn about that location.</p>
+                </div>
+                <div class="andaman-map-wrap">
+                    <div id="andaman-map"></div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Image Gallery -->
+        <section class="andaman-section" id="andaman-gallery-section">
+            <div class="andaman-container">
+                <div class="andaman-section-heading">
+                    <span class="andaman-section-badge">Image Gallery</span>
+                    <h2>Glimpses of South Andaman</h2>
+                    <p>Click an image to view it larger.</p>
+                </div>
+                <div id="andaman-gallery-grid" class="andaman-gallery-grid"></div>
+            </div>
+        </section>
+
+        <!-- Interesting Facts -->
+        <section class="andaman-section">
+            <div class="andaman-container">
+                <div class="andaman-section-heading">
+                    <span class="andaman-section-badge">Did You Know?</span>
+                    <h2>Interesting Facts</h2>
+                </div>
+                <div class="andaman-fact-panel">
+                    <div class="andaman-fact-icon">💡</div>
+                    <p id="andaman-fact-text">Loading fact...</p>
+                    <div class="andaman-fact-dots" id="andaman-fact-dots"></div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <!-- Lightbox -->
+    <div class="andaman-lightbox-overlay" id="andaman-lightbox" hidden>
+        <div class="andaman-lightbox-content">
+            <button class="andaman-lightbox-close" data-close-lightbox="true" aria-label="Close">&times;</button>
+            <button class="andaman-lightbox-nav prev" id="andaman-lightbox-prev" aria-label="Previous image">‹</button>
+            <img id="andaman-lightbox-image" src="" alt="">
+            <button class="andaman-lightbox-nav next" id="andaman-lightbox-next" aria-label="Next image">›</button>
+            <p class="andaman-lightbox-caption" id="andaman-lightbox-caption"></p>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <footer class="site-footer">
+        <div class="footer-container">
+            <div class="footer-brand">
+                <a href="../../index.html#home" class="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <p>Preserving and celebrating India's rich island territories, coastlines and culture.</p>
+            </div>
+            <div class="footer-links">
+                <h4>Quick Links</h4>
+                <a href="../../index.html#home">Home</a>
+                <a href="../islands/islands.html">Islands of India</a>
+                <a href="../wildlife/wildlife.html">Nature & Wildlife</a>
+                <a href="south-andaman.html">South Andaman</a>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2026 Incredible India Explorer. Open Source Cultural Heritage Initiative.</p>
+        </div>
+    </footer>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+    <script type="module" src="south-andaman.js"></script>
+    <script src="../../pages-common.js"></script>
+</body>
+</html>

--- a/frontend/south-andaman/south-andaman.js
+++ b/frontend/south-andaman/south-andaman.js
@@ -1,0 +1,214 @@
+/* ============================================================
+   South Andaman Explorer — south-andaman.js
+   Handles: tab navigation, image gallery lightbox, facts
+   rotator, and the Leaflet map with key-location markers.
+   ============================================================ */
+
+// ---------- 1. KEY LOCATIONS FOR THE MAP ----------
+const ANDAMAN_LOCATIONS = [
+  {
+    name: "Port Blair",
+    lat: 11.6234,
+    lng: 92.7265,
+    description: "Capital of the Andaman & Nicobar Islands and the main gateway for visitors."
+  },
+  {
+    name: "Cellular Jail",
+    lat: 11.6742,
+    lng: 92.7458,
+    description: "Colonial-era prison, now a national memorial to India's freedom fighters."
+  },
+  {
+    name: "Ross Island (Netaji Subhas Chandra Bose Dweep)",
+    lat: 11.6775,
+    lng: 92.7572,
+    description: "Former British administrative headquarters, now atmospheric colonial ruins."
+  },
+  {
+    name: "Chidiya Tapu",
+    lat: 11.4926,
+    lng: 92.6280,
+    description: "Known as 'Bird Island' — a birdwatching haven and popular sunset point."
+  },
+  {
+    name: "Corbyn's Cove Beach",
+    lat: 11.6395,
+    lng: 92.7469,
+    description: "A palm-fringed beach close to Port Blair, popular for swimming and water sports."
+  }
+];
+
+// ---------- 2. IMAGE GALLERY ----------
+const ANDAMAN_GALLERY = [
+  { src: "../../assets/travel_beaches.png", caption: "Corbyn's Cove Beach, Port Blair" },
+  { src: "../../assets/Taj_Mahal.png", caption: "Cellular Jail National Memorial" },
+  { src: "../../assets/travel_hidden.png", caption: "Colonial ruins on Ross Island" },
+  { src: "../../assets/travel_mountains.png", caption: "Sunset view from Chidiya Tapu" }
+];
+
+// ---------- 3. INTERESTING FACTS ----------
+const ANDAMAN_FACTS = [
+  "The Cellular Jail's three-storeyed building originally had 698 cells arranged in a starfish shape, designed so no prisoner could see or communicate with another.",
+  "Ross Island served as the British administrative headquarters for the entire Andaman & Nicobar Islands before Independence, and is now officially renamed Netaji Subhas Chandra Bose Dweep.",
+  "Chidiya Tapu, meaning 'Bird Island,' is home to over 46 species of birds and is one of the best sunset points in the Andamans.",
+  "Port Blair is also nicknamed 'Mini India' for the diversity of communities who settled there from across the mainland.",
+  "The Cellular Jail's evening Light & Sound Show retells the story of India's freedom struggle at the very site where many freedom fighters were imprisoned.",
+  "Samudrika Naval Marine Museum in Port Blair displays marine life, shells, and the geography of the Andaman & Nicobar Islands.",
+  "Ross Island's old buildings are now entwined with the roots of giant banyan and rubber trees, reclaimed slowly by the forest."
+];
+
+// ---------- 4. STATE ----------
+let map;
+let currentGalleryIndex = 0;
+let factIndex = 0;
+
+// ---------- 5. DOM READY ----------
+document.addEventListener("DOMContentLoaded", () => {
+  initTabs();
+  initGallery();
+  initFactsRotator();
+  initMap();
+  initLightbox();
+});
+
+// ---------- 6. TAB NAVIGATION ----------
+function initTabs() {
+  const tabButtons = document.querySelectorAll(".andaman-tab-btn");
+  const tabPanels = document.querySelectorAll(".andaman-tab-panel");
+
+  tabButtons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const target = btn.getAttribute("data-tab");
+
+      tabButtons.forEach((b) => b.classList.remove("active"));
+      btn.classList.add("active");
+
+      tabPanels.forEach((panel) => {
+        panel.classList.toggle("active", panel.id === "tab-" + target);
+      });
+    });
+  });
+}
+
+// ---------- 7. IMAGE GALLERY ----------
+function initGallery() {
+  const galleryGrid = document.getElementById("andaman-gallery-grid");
+  if (!galleryGrid) return;
+
+  galleryGrid.innerHTML = "";
+  ANDAMAN_GALLERY.forEach((item, index) => {
+    const fig = document.createElement("figure");
+    fig.className = "andaman-gallery-item";
+    fig.innerHTML = `
+      <img src="${item.src}" alt="${item.caption}" loading="lazy">
+      <figcaption>${item.caption}</figcaption>
+    `;
+    fig.addEventListener("click", () => openLightbox(index));
+    galleryGrid.appendChild(fig);
+  });
+}
+
+// ---------- 8. LIGHTBOX ----------
+function initLightbox() {
+  document.querySelectorAll("[data-close-lightbox]").forEach((el) => {
+    el.addEventListener("click", closeLightbox);
+  });
+  const prevBtn = document.getElementById("andaman-lightbox-prev");
+  const nextBtn = document.getElementById("andaman-lightbox-next");
+  if (prevBtn) prevBtn.addEventListener("click", () => showGalleryImage(currentGalleryIndex - 1));
+  if (nextBtn) nextBtn.addEventListener("click", () => showGalleryImage(currentGalleryIndex + 1));
+
+  document.addEventListener("keydown", (e) => {
+    const lightbox = document.getElementById("andaman-lightbox");
+    if (!lightbox || lightbox.hidden) return;
+    if (e.key === "Escape") closeLightbox();
+    if (e.key === "ArrowRight") showGalleryImage(currentGalleryIndex + 1);
+    if (e.key === "ArrowLeft") showGalleryImage(currentGalleryIndex - 1);
+  });
+}
+
+function openLightbox(index) {
+  const lightbox = document.getElementById("andaman-lightbox");
+  if (!lightbox) return;
+  lightbox.hidden = false;
+  document.body.style.overflow = "hidden";
+  showGalleryImage(index);
+}
+
+function closeLightbox() {
+  const lightbox = document.getElementById("andaman-lightbox");
+  if (!lightbox) return;
+  lightbox.hidden = true;
+  document.body.style.overflow = "";
+}
+
+function showGalleryImage(index) {
+  const total = ANDAMAN_GALLERY.length;
+  currentGalleryIndex = (index + total) % total;
+  const item = ANDAMAN_GALLERY[currentGalleryIndex];
+  const img = document.getElementById("andaman-lightbox-image");
+  const caption = document.getElementById("andaman-lightbox-caption");
+  if (img) img.src = item.src;
+  if (img) img.alt = item.caption;
+  if (caption) caption.textContent = item.caption;
+}
+
+// ---------- 9. FACTS ROTATOR ----------
+function initFactsRotator() {
+  const factEl = document.getElementById("andaman-fact-text");
+  const dotsWrap = document.getElementById("andaman-fact-dots");
+  if (!factEl) return;
+
+  if (dotsWrap) {
+    ANDAMAN_FACTS.forEach((_, i) => {
+      const dot = document.createElement("button");
+      dot.className = "andaman-fact-dot" + (i === 0 ? " active" : "");
+      dot.setAttribute("aria-label", "Show fact " + (i + 1));
+      dot.addEventListener("click", () => showFact(i));
+      dotsWrap.appendChild(dot);
+    });
+  }
+
+  function showFact(i) {
+    factIndex = i;
+    factEl.style.opacity = "0";
+    setTimeout(() => {
+      factEl.textContent = ANDAMAN_FACTS[factIndex];
+      factEl.style.opacity = "1";
+    }, 200);
+    if (dotsWrap) {
+      [...dotsWrap.children].forEach((dot, di) => dot.classList.toggle("active", di === factIndex));
+    }
+  }
+
+  showFact(0);
+  setInterval(() => showFact((factIndex + 1) % ANDAMAN_FACTS.length), 6000);
+}
+
+// ---------- 10. LEAFLET MAP ----------
+function initMap() {
+  const mapContainer = document.getElementById("andaman-map");
+  if (!mapContainer || typeof L === "undefined") return;
+
+  map = L.map("andaman-map", {
+    scrollWheelZoom: false,
+    minZoom: 8,
+  }).setView([11.62, 92.72], 11);
+
+  L.tileLayer("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png", {
+    attribution: "&copy; OpenStreetMap contributors &copy; CARTO",
+    maxZoom: 18,
+  }).addTo(map);
+
+  ANDAMAN_LOCATIONS.forEach((loc) => {
+    const marker = L.circleMarker([loc.lat, loc.lng], {
+      radius: 8,
+      color: "#ff9933",
+      fillColor: "#ffb01f",
+      fillOpacity: 0.85,
+      weight: 2,
+    }).addTo(map);
+
+    marker.bindPopup(`<strong>${loc.name}</strong><br>${loc.description}`);
+  });
+}


### PR DESCRIPTION
## What this PR does
Adds a dedicated "South Andaman Explorer" page as requested in #679, covering Port Blair, Cellular Jail, Chidiya Tapu, Ross Island, museums, and tourism information.

### New files
- frontend/south-andaman/south-andaman.html
- frontend/south-andaman/south-andaman.css
- frontend/south-andaman/south-andaman.js

### Modified files
- frontend/islands/islands.js — added a "South Andaman" card to the Islands Landing Page, linking directly to the new page

## Features included
- Tabbed sections for Port Blair, Cellular Jail, Chidiya Tapu, Ross Island, Museums, and Tourism
- Interactive map marking key South Andaman locations
- Image gallery with lightbox viewer
- Rotating "Interesting Facts" section
- Landing Page integration — new South Andaman card on the Islands Landing Page
- Fully responsive design, consistent with the site's existing theme

Fixes #679 

https://github.com/user-attachments/assets/0d405e1b-c79e-4e2f-8583-a17e420bc1f3


I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.