### PR TITLE
feat: Create Middle Andaman Explorer

### DIFF
--- a/frontend/islands/islands.js
+++ b/frontend/islands/islands.js
@@ -21,6 +21,48 @@ const ISLANDS_DATA = [
     image: "../../assets/travel_beaches.png"
   },
   {
+    id: "great-nicobar",
+    name: "Great Nicobar Island",
+    group: "Andaman & Nicobar",
+    location: "Nicobar Islands, Bay of Bengal",
+    state: "Union Territory",
+    lat: 6.95,
+    lng: 93.87,
+    islandCount: "1 island",
+    tagline: "India's southernmost island, home to Indira Point",
+    description: "The largest island in the Nicobar group and India's southernmost territory, home to Indira Point, Campbell Bay National Park, and rare endemic wildlife.",
+    highlights: ["Indira Point — southernmost tip of India", "Campbell Bay National Park", "UNESCO Biosphere Reserve (2013)", "Nesting ground for Giant Leatherback turtles"],
+    image: "../../assets/travel_hidden.png"
+  },
+  {
+    id: "south-andaman",
+    name: "South Andaman",
+    group: "Andaman & Nicobar",
+    location: "Andaman Islands, Bay of Bengal",
+    state: "Union Territory",
+    lat: 11.6234,
+    lng: 92.7265,
+    islandCount: "1 island",
+    tagline: "Gateway to the Andamans — Port Blair, Cellular Jail & Ross Island",
+    description: "Home to Port Blair, the capital of Andaman & Nicobar Islands, South Andaman blends colonial history, museums, and coastal scenery — from the Cellular Jail to Chidiya Tapu's sunsets and the ruins of Ross Island.",
+    highlights: ["Cellular Jail National Memorial", "Ross Island's British colonial ruins", "Chidiya Tapu — Bird Island & sunset point", "Anthropological & Samudrika Marine Museums"],
+    image: "../../assets/travel_beaches.png"
+  },
+  {
+    id: "middle-andaman",
+    name: "Middle Andaman",
+    group: "Andaman & Nicobar",
+    location: "Andaman Islands, Bay of Bengal",
+    state: "Union Territory",
+    lat: 12.55,
+    lng: 92.85,
+    islandCount: "1 island",
+    tagline: "Limestone caves, mangrove creeks & quiet beaches",
+    description: "Home to Baratang's limestone caves and mud volcanoes, sprawling mangrove forests, and the towns of Rangat and Mayabunder, Middle Andaman offers a quieter, nature-focused side of the archipelago.",
+    highlights: ["Limestone Caves, Baratang Island", "Mangrove creek boat rides", "Karmatang Beach — sea turtle nesting site", "Rangat & Mayabunder villages"],
+    image: "../../assets/travel_hidden.png"
+  },
+  {
     id: "lakshadweep",
     name: "Lakshadweep Islands",
     group: "Lakshadweep",
@@ -243,6 +285,16 @@ function initSearchAndFilters() {
 function openModal(islandId) {
   const island = ISLANDS_DATA.find((i) => i.id === islandId);
   if (!island) return;
+
+  if (island.id === "great-nicobar" || island.id === "south-andaman" || island.id === "middle-andaman") {
+    const pageMap = {
+      "great-nicobar": "../great-nicobar/great-nicobar.html",
+      "south-andaman": "../south-andaman/south-andaman.html",
+      "middle-andaman": "../middle-andaman/middle-andaman.html"
+    };
+    window.location.href = pageMap[island.id];
+    return;
+  }
 
   document.getElementById("island-modal-title").textContent = island.name;
   document.getElementById("island-modal-location").textContent = island.location;

--- a/frontend/middle-andaman/middle-andaman.css
+++ b/frontend/middle-andaman/middle-andaman.css
@@ -1,0 +1,411 @@
+/* ============================================================
+   Middle Andaman Explorer — middle-andaman.css
+   Uses the shared design tokens defined in ../../styles.css
+   ============================================================ */
+
+.mandaman-page {
+  padding-top: var(--navbar-height);
+  overflow-x: hidden;
+}
+
+.mandaman-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* ---------- Hero ---------- */
+.mandaman-hero {
+  position: relative;
+  padding: 90px 24px 70px;
+  text-align: center;
+  background:
+    linear-gradient(180deg, rgba(4, 23, 42, 0.55) 0%, rgba(4, 23, 42, 0.92) 100%),
+    url("../../assets/travel_hidden.png") center/cover no-repeat;
+}
+
+.mandaman-hero-content {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.mandaman-hero-kicker {
+  display: inline-block;
+  padding: 6px 16px;
+  border-radius: 999px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  color: var(--primary-saffron);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-bottom: 20px;
+}
+
+.mandaman-hero h1 {
+  font-family: var(--font-heading);
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  line-height: 1.15;
+  margin-bottom: 18px;
+  color: var(--text-light);
+}
+
+.mandaman-hero h1 span {
+  background: var(--gradient-saffron-gold);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.mandaman-hero p {
+  color: var(--text-secondary);
+  font-size: 1.08rem;
+  line-height: 1.7;
+  margin-bottom: 36px;
+}
+
+.mandaman-hero-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+
+.mandaman-stat-box {
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 18px 12px;
+  transition: var(--transition-snappy);
+}
+
+.mandaman-stat-box:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-glow);
+}
+
+.mandaman-stat-box strong {
+  display: block;
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--primary-saffron);
+}
+
+.mandaman-stat-box span {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+/* ---------- Section heading ---------- */
+.mandaman-section {
+  padding: 70px 0;
+}
+
+.mandaman-section-heading {
+  text-align: center;
+  max-width: 680px;
+  margin: 0 auto 44px;
+}
+
+.mandaman-section-badge {
+  display: inline-block;
+  color: var(--primary-gold);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+
+.mandaman-section-heading h2 {
+  font-family: var(--font-heading);
+  font-size: clamp(1.7rem, 3.5vw, 2.4rem);
+  color: var(--text-light);
+  margin-bottom: 14px;
+}
+
+.mandaman-section-heading p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+/* ---------- Tabs (Limestone Caves / Mangroves / Beaches / Villages / Flora & Fauna) ---------- */
+.mandaman-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  margin-bottom: 32px;
+}
+
+.mandaman-tab-btn {
+  padding: 10px 20px;
+  border-radius: 999px;
+  border: 1px solid var(--glass-border);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: var(--transition-snappy);
+}
+
+.mandaman-tab-btn:hover {
+  border-color: var(--primary-saffron);
+  color: var(--text-light);
+}
+
+.mandaman-tab-btn.active {
+  background: var(--gradient-saffron-gold);
+  color: #1a1200;
+  border-color: transparent;
+  font-weight: 600;
+}
+
+.mandaman-tab-panel {
+  display: none;
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 32px;
+  animation: mandaman-fade-in 0.3s ease;
+}
+
+.mandaman-tab-panel.active {
+  display: block;
+}
+
+@keyframes mandaman-fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.mandaman-tab-panel h3 {
+  font-family: var(--font-heading);
+  color: var(--primary-gold);
+  margin-bottom: 14px;
+  font-size: 1.3rem;
+}
+
+.mandaman-tab-panel p {
+  color: var(--text-secondary);
+  line-height: 1.8;
+  margin-bottom: 14px;
+}
+
+.mandaman-tab-panel ul {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.mandaman-tab-panel ul li {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  padding-left: 24px;
+  position: relative;
+  line-height: 1.6;
+}
+
+.mandaman-tab-panel ul li::before {
+  content: "🌿";
+  position: absolute;
+  left: 0;
+}
+
+/* ---------- Map ---------- */
+.mandaman-map-wrap {
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow-soft);
+}
+
+#mandaman-map {
+  height: 440px;
+  width: 100%;
+  background: var(--bg-dark-deep);
+}
+
+/* ---------- Gallery ---------- */
+.mandaman-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 18px;
+}
+
+.mandaman-gallery-item {
+  margin: 0;
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+  cursor: pointer;
+  border: 1px solid var(--glass-border);
+  transition: var(--transition-snappy);
+  position: relative;
+}
+
+.mandaman-gallery-item:hover {
+  transform: translateY(-4px);
+  border-color: var(--primary-saffron);
+  box-shadow: var(--shadow-glow);
+}
+
+.mandaman-gallery-item img {
+  width: 100%;
+  height: 190px;
+  object-fit: cover;
+  display: block;
+}
+
+.mandaman-gallery-item figcaption {
+  padding: 10px 14px;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  background: var(--bg-dark-card);
+}
+
+/* ---------- Lightbox ---------- */
+.mandaman-lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 10, 20, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 24px;
+}
+
+.mandaman-lightbox-overlay[hidden] {
+  display: none;
+}
+
+.mandaman-lightbox-content {
+  max-width: 800px;
+  width: 100%;
+  text-align: center;
+  position: relative;
+}
+
+.mandaman-lightbox-content img {
+  width: 100%;
+  max-height: 65vh;
+  object-fit: contain;
+  border-radius: var(--border-radius-lg);
+}
+
+.mandaman-lightbox-caption {
+  color: var(--text-light);
+  margin-top: 14px;
+  font-size: 0.95rem;
+}
+
+.mandaman-lightbox-close {
+  position: absolute;
+  top: -44px;
+  right: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-light);
+  font-size: 1.4rem;
+  cursor: pointer;
+}
+
+.mandaman-lightbox-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-light);
+  font-size: 1.3rem;
+  cursor: pointer;
+}
+
+.mandaman-lightbox-nav.prev { left: -20px; }
+.mandaman-lightbox-nav.next { right: -20px; }
+
+/* ---------- Did You Know ---------- */
+.mandaman-fact-panel {
+  max-width: 760px;
+  margin: 0 auto;
+  background: var(--gradient-card-border);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 40px 36px;
+  text-align: center;
+}
+
+.mandaman-fact-icon {
+  font-size: 2.2rem;
+  margin-bottom: 14px;
+}
+
+#mandaman-fact-text {
+  font-family: var(--font-heading);
+  font-size: 1.15rem;
+  color: var(--text-light);
+  line-height: 1.6;
+  transition: opacity 0.2s ease;
+  min-height: 84px;
+}
+
+.mandaman-fact-dots {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.mandaman-fact-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+  background: var(--glass-border);
+  cursor: pointer;
+  transition: var(--transition-snappy);
+}
+
+.mandaman-fact-dot.active {
+  background: var(--primary-saffron);
+  width: 22px;
+  border-radius: 4px;
+}
+
+/* ---------- Back to Islands link ---------- */
+.mandaman-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--primary-saffron);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 14px;
+}
+
+.mandaman-back-link:hover {
+  text-decoration: underline;
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 768px) {
+  .mandaman-hero-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  #mandaman-map {
+    height: 320px;
+  }
+
+  .mandaman-lightbox-nav.prev { left: 4px; }
+  .mandaman-lightbox-nav.next { right: 4px; }
+}

--- a/frontend/middle-andaman/middle-andaman.html
+++ b/frontend/middle-andaman/middle-andaman.html
@@ -1,0 +1,257 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Explore Middle Andaman — Baratang's limestone caves, mangrove forests, beaches, villages, and flora & fauna, with an interactive map and image gallery.">
+    <title>Middle Andaman Explorer | Incredible India</title>
+    <link rel="icon" href="data:,">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="middle-andaman.css">
+
+    <!-- Open Graph / Social Media Tags -->
+    <meta property="og:title" content="Middle Andaman Explorer | Incredible India Explorer">
+    <meta property="og:description" content="Baratang's limestone caves, mangrove forests, beaches, villages, and flora & fauna — explore Middle Andaman with an interactive map and gallery.">
+    <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/assets/travel_hidden.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/middle-andaman/middle-andaman.html">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Incredible India Explorer">
+    <meta property="og:locale" content="en_IN">
+
+    <!-- Twitter Card Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Middle Andaman Explorer | Incredible India Explorer">
+    <meta name="twitter:description" content="Limestone caves, mangrove forests, beaches, villages, and flora & fauna of Middle Andaman.">
+    <meta name="twitter:image" content="https://incredibleindiaexplorer.gov.in/assets/travel_hidden.png">
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/middle-andaman/middle-andaman.html">
+</head>
+
+<body class="mandaman-body">
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html#home" class="nav-link" id="link-home">Home</a>
+                <a href="../../index.html#map" class="nav-link" id="link-map">Interactive Map</a>
+                <a href="../islands/islands.html" class="nav-link">Islands</a>
+                <a href="middle-andaman.html" class="nav-link active" style="color: var(--saffron)">Middle Andaman</a>
+
+                <div class="nav-dropdown">
+                    <button class="nav-link dropdown-toggle" id="link-explore-more">
+                        Explore More ▾
+                    </button>
+                    <div class="dropdown-menu">
+                        <a href="../travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                        <a href="../wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                        <a href="../coastal-india/coastal-india.html" class="dropdown-item">Coastal India</a>
+                        <a href="../heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    </div>
+                </div>
+
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
+                    ☀️
+                </button>
+                <a href="../../login.html" class="nav-link" id="link-login">Login</a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="mandaman-page">
+        <!-- Hero -->
+        <section class="mandaman-hero">
+            <div class="mandaman-hero-content">
+                <a href="../islands/islands.html" class="mandaman-back-link">← Back to Islands of India</a>
+                <span class="mandaman-hero-kicker">🌿 Caves, Creeks & Coastline</span>
+                <h1>Middle <span>Andaman</span></h1>
+                <p>Tucked between North and South Andaman, Middle Andaman is known for Baratang's limestone caves and mud volcanoes, sprawling mangrove forests, quiet beaches, and the small towns of Rangat and Mayabunder.</p>
+
+                <div class="mandaman-hero-stats">
+                    <div class="mandaman-stat-box">
+                        <strong>~110 km</strong>
+                        <span>Baratang from Port Blair</span>
+                    </div>
+                    <div class="mandaman-stat-box">
+                        <strong>240 m</strong>
+                        <span>Mangrove Boardwalk to Caves</span>
+                    </div>
+                    <div class="mandaman-stat-box">
+                        <strong>2</strong>
+                        <span>Main Towns — Rangat &amp; Mayabunder</span>
+                    </div>
+                    <div class="mandaman-stat-box">
+                        <strong>1</strong>
+                        <span>Active Mud Volcano Site</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Tabbed info -->
+        <section class="mandaman-section" id="mandaman-explore">
+            <div class="mandaman-container">
+                <div class="mandaman-section-heading">
+                    <span class="mandaman-section-badge">Explore Middle Andaman</span>
+                    <h2>Caves, Mangroves, Beaches &amp; Villages</h2>
+                    <p>Select a tab to learn more.</p>
+                </div>
+
+                <div class="mandaman-tabs" role="tablist">
+                    <button type="button" class="mandaman-tab-btn active" data-tab="limestone-caves">Limestone Caves</button>
+                    <button type="button" class="mandaman-tab-btn" data-tab="mangroves">Mangrove Forests</button>
+                    <button type="button" class="mandaman-tab-btn" data-tab="beaches">Beaches</button>
+                    <button type="button" class="mandaman-tab-btn" data-tab="villages">Villages</button>
+                    <button type="button" class="mandaman-tab-btn" data-tab="wildlife">Flora &amp; Fauna</button>
+                </div>
+
+                <div class="mandaman-tab-panel active" id="tab-limestone-caves">
+                    <h3>🪨 Limestone Caves</h3>
+                    <p>The limestone caves of Baratang Island are one of Middle Andaman's best-known natural wonders. Formed over thousands of years by the gradual deposition of calcium carbonate, the caves hold intricate stalactite and stalagmite formations sculpted from ancient marine deposits.</p>
+                    <p>Reaching the caves is part of the adventure: a boat ride from Nilambur Jetty winds through narrow mangrove creeks to Nayadera Jetty, followed by a walk of about 1.5 km through tropical forest — including a boardwalk stretch of roughly 240 metres through the mangroves.</p>
+                    <ul>
+                        <li>Boat ride through mangrove creeks from Nilambur Jetty</li>
+                        <li>Short jungle trek to reach the cave entrance</li>
+                        <li>Visits require Forest Department permission and a local guide</li>
+                    </ul>
+                </div>
+
+                <div class="mandaman-tab-panel" id="tab-mangroves">
+                    <h3>🌱 Mangrove Forests</h3>
+                    <p>Middle Andaman is threaded with some of the most extensive mangrove creeks in the islands, particularly around Baratang. Boat rides through these narrow, arching waterways reveal a rich ecosystem of fish, crabs and birdlife, and are often described as one of the most memorable parts of a visit.</p>
+                    <p>The mangroves also serve an important ecological role, stabilising the coastline and acting as a nursery for marine life before it moves out to open water.</p>
+                </div>
+
+                <div class="mandaman-tab-panel" id="tab-beaches">
+                    <h3>🏖️ Beaches</h3>
+                    <p>While less crowded than South Andaman's beaches, Middle Andaman has its own quiet stretches of coastline, including Amkunj Beach and Dhani Nallah Beach near Rangat, and Karmatang Beach near Mayabunder — a known sea turtle nesting site.</p>
+                </div>
+
+                <div class="mandaman-tab-panel" id="tab-villages">
+                    <h3>🏘️ Villages</h3>
+                    <p>Rangat and Mayabunder are the two principal towns of Middle Andaman, both encircled by lush greenery and small farming and fishing settlements. The Andaman Trunk Road links these towns to Port Blair via Baratang, passing through the Jarawa Tribal Reserve in escorted vehicle convoys out of respect for the indigenous community's protected status.</p>
+                </div>
+
+                <div class="mandaman-tab-panel" id="tab-wildlife">
+                    <h3>🦜 Flora &amp; Fauna</h3>
+                    <p>Middle Andaman's mix of tropical evergreen forest, mangrove creeks and coastline supports rich biodiversity. Boat rides through the mangroves often turn up sightings of exotic birds, while the surrounding forests are home to native Andaman wildlife.</p>
+                    <ul>
+                        <li>Dense tropical evergreen and mangrove forest cover</li>
+                        <li>Sea turtle nesting along Karmatang Beach</li>
+                        <li>Rich birdlife spotted along the mangrove creeks</li>
+                        <li>Active mud volcanoes at Baratang, a rare geological feature</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <!-- Interactive Map -->
+        <section class="mandaman-section" id="mandaman-map-section">
+            <div class="mandaman-container">
+                <div class="mandaman-section-heading">
+                    <span class="mandaman-section-badge">Interactive Map</span>
+                    <h2>Key Locations in Middle Andaman</h2>
+                    <p>Click a marker to learn about that location.</p>
+                </div>
+                <div class="mandaman-map-wrap">
+                    <div id="mandaman-map"></div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Image Gallery -->
+        <section class="mandaman-section" id="mandaman-gallery-section">
+            <div class="mandaman-container">
+                <div class="mandaman-section-heading">
+                    <span class="mandaman-section-badge">Image Gallery</span>
+                    <h2>Glimpses of Middle Andaman</h2>
+                    <p>Click an image to view it larger.</p>
+                </div>
+                <div id="mandaman-gallery-grid" class="mandaman-gallery-grid"></div>
+            </div>
+        </section>
+
+        <!-- Interesting Facts -->
+        <section class="mandaman-section">
+            <div class="mandaman-container">
+                <div class="mandaman-section-heading">
+                    <span class="mandaman-section-badge">Did You Know?</span>
+                    <h2>Interesting Facts</h2>
+                </div>
+                <div class="mandaman-fact-panel">
+                    <div class="mandaman-fact-icon">💡</div>
+                    <p id="mandaman-fact-text">Loading fact...</p>
+                    <div class="mandaman-fact-dots" id="mandaman-fact-dots"></div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <!-- Lightbox -->
+    <div class="mandaman-lightbox-overlay" id="mandaman-lightbox" hidden>
+        <div class="mandaman-lightbox-content">
+            <button class="mandaman-lightbox-close" data-close-lightbox="true" aria-label="Close">&times;</button>
+            <button class="mandaman-lightbox-nav prev" id="mandaman-lightbox-prev" aria-label="Previous image">‹</button>
+            <img id="mandaman-lightbox-image" src="" alt="">
+            <button class="mandaman-lightbox-nav next" id="mandaman-lightbox-next" aria-label="Next image">›</button>
+            <p class="mandaman-lightbox-caption" id="mandaman-lightbox-caption"></p>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <footer class="site-footer">
+        <div class="footer-container">
+            <div class="footer-brand">
+                <a href="../../index.html#home" class="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <p>Preserving and celebrating India's rich island territories, coastlines and culture.</p>
+            </div>
+            <div class="footer-links">
+                <h4>Quick Links</h4>
+                <a href="../../index.html#home">Home</a>
+                <a href="../islands/islands.html">Islands of India</a>
+                <a href="../wildlife/wildlife.html">Nature & Wildlife</a>
+                <a href="middle-andaman.html">Middle Andaman</a>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2026 Incredible India Explorer. Open Source Cultural Heritage Initiative.</p>
+        </div>
+    </footer>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+    <script type="module" src="middle-andaman.js"></script>
+    <script src="../../pages-common.js"></script>
+</body>
+</html>

--- a/frontend/middle-andaman/middle-andaman.js
+++ b/frontend/middle-andaman/middle-andaman.js
@@ -1,0 +1,214 @@
+/* ============================================================
+   Middle Andaman Explorer — middle-andaman.js
+   Handles: tab navigation, image gallery lightbox, facts
+   rotator, and the Leaflet map with key-location markers.
+   ============================================================ */
+
+// ---------- 1. KEY LOCATIONS FOR THE MAP ----------
+const MIDDLE_ANDAMAN_LOCATIONS = [
+  {
+    name: "Baratang Island",
+    lat: 12.1167,
+    lng: 92.7500,
+    description: "Known for its limestone caves, mud volcanoes and mangrove creeks."
+  },
+  {
+    name: "Limestone Caves, Baratang",
+    lat: 12.1500,
+    lng: 92.8167,
+    description: "Reached via a boat ride through mangrove creeks followed by a jungle walk to Nayadera Jetty."
+  },
+  {
+    name: "Rangat",
+    lat: 12.4667,
+    lng: 92.9333,
+    description: "A quiet town surrounded by greenery, gateway to Amkunj and Dhani Nallah beaches."
+  },
+  {
+    name: "Mayabunder",
+    lat: 12.9167,
+    lng: 92.9333,
+    description: "A coastal town on the northern edge of Middle Andaman, close to Karmatang Beach."
+  },
+  {
+    name: "Karmatang Beach",
+    lat: 12.9333,
+    lng: 92.9500,
+    description: "A long sandy beach near Mayabunder, an important sea turtle nesting site."
+  }
+];
+
+// ---------- 2. IMAGE GALLERY ----------
+const MIDDLE_ANDAMAN_GALLERY = [
+  { src: "../../assets/travel_hidden.png", caption: "Limestone Caves, Baratang Island" },
+  { src: "../../assets/river6.png", caption: "Mangrove creek boat ride, Baratang" },
+  { src: "../../assets/travel_beaches.png", caption: "Karmatang Beach, near Mayabunder" },
+  { src: "../../assets/travel_mountains.png", caption: "Tropical forest along the Andaman Trunk Road" }
+];
+
+// ---------- 3. INTERESTING FACTS ----------
+const MIDDLE_ANDAMAN_FACTS = [
+  "The Baratang limestone caves were formed over thousands of years by the slow deposition of calcium carbonate, creating stalactite and stalagmite formations.",
+  "Reaching the limestone caves involves a boat ride through narrow mangrove creeks followed by a jungle walk — often described by visitors as feeling like a survival show.",
+  "Baratang is also home to active mud volcanoes, where mud and gases bubble up naturally from underground.",
+  "The Andaman Trunk Road connecting Middle Andaman to Port Blair passes through the Jarawa Tribal Reserve, and vehicles must travel in escorted convoys.",
+  "Karmatang Beach near Mayabunder is an important nesting site for sea turtles.",
+  "Middle Andaman's mangrove forests are among the most extensive in India, forming a rich nursery habitat for fish, crabs and birds.",
+  "Rangat and Mayabunder are the two main towns of Middle Andaman, both surrounded by dense tropical forest and small fishing and farming villages."
+];
+
+// ---------- 4. STATE ----------
+let map;
+let currentGalleryIndex = 0;
+let factIndex = 0;
+
+// ---------- 5. DOM READY ----------
+document.addEventListener("DOMContentLoaded", () => {
+  initTabs();
+  initGallery();
+  initFactsRotator();
+  initMap();
+  initLightbox();
+});
+
+// ---------- 6. TAB NAVIGATION ----------
+function initTabs() {
+  const tabButtons = document.querySelectorAll(".mandaman-tab-btn");
+  const tabPanels = document.querySelectorAll(".mandaman-tab-panel");
+
+  tabButtons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const target = btn.getAttribute("data-tab");
+
+      tabButtons.forEach((b) => b.classList.remove("active"));
+      btn.classList.add("active");
+
+      tabPanels.forEach((panel) => {
+        panel.classList.toggle("active", panel.id === "tab-" + target);
+      });
+    });
+  });
+}
+
+// ---------- 7. IMAGE GALLERY ----------
+function initGallery() {
+  const galleryGrid = document.getElementById("mandaman-gallery-grid");
+  if (!galleryGrid) return;
+
+  galleryGrid.innerHTML = "";
+  MIDDLE_ANDAMAN_GALLERY.forEach((item, index) => {
+    const fig = document.createElement("figure");
+    fig.className = "mandaman-gallery-item";
+    fig.innerHTML = `
+      <img src="${item.src}" alt="${item.caption}" loading="lazy">
+      <figcaption>${item.caption}</figcaption>
+    `;
+    fig.addEventListener("click", () => openLightbox(index));
+    galleryGrid.appendChild(fig);
+  });
+}
+
+// ---------- 8. LIGHTBOX ----------
+function initLightbox() {
+  document.querySelectorAll("[data-close-lightbox]").forEach((el) => {
+    el.addEventListener("click", closeLightbox);
+  });
+  const prevBtn = document.getElementById("mandaman-lightbox-prev");
+  const nextBtn = document.getElementById("mandaman-lightbox-next");
+  if (prevBtn) prevBtn.addEventListener("click", () => showGalleryImage(currentGalleryIndex - 1));
+  if (nextBtn) nextBtn.addEventListener("click", () => showGalleryImage(currentGalleryIndex + 1));
+
+  document.addEventListener("keydown", (e) => {
+    const lightbox = document.getElementById("mandaman-lightbox");
+    if (!lightbox || lightbox.hidden) return;
+    if (e.key === "Escape") closeLightbox();
+    if (e.key === "ArrowRight") showGalleryImage(currentGalleryIndex + 1);
+    if (e.key === "ArrowLeft") showGalleryImage(currentGalleryIndex - 1);
+  });
+}
+
+function openLightbox(index) {
+  const lightbox = document.getElementById("mandaman-lightbox");
+  if (!lightbox) return;
+  lightbox.hidden = false;
+  document.body.style.overflow = "hidden";
+  showGalleryImage(index);
+}
+
+function closeLightbox() {
+  const lightbox = document.getElementById("mandaman-lightbox");
+  if (!lightbox) return;
+  lightbox.hidden = true;
+  document.body.style.overflow = "";
+}
+
+function showGalleryImage(index) {
+  const total = MIDDLE_ANDAMAN_GALLERY.length;
+  currentGalleryIndex = (index + total) % total;
+  const item = MIDDLE_ANDAMAN_GALLERY[currentGalleryIndex];
+  const img = document.getElementById("mandaman-lightbox-image");
+  const caption = document.getElementById("mandaman-lightbox-caption");
+  if (img) img.src = item.src;
+  if (img) img.alt = item.caption;
+  if (caption) caption.textContent = item.caption;
+}
+
+// ---------- 9. FACTS ROTATOR ----------
+function initFactsRotator() {
+  const factEl = document.getElementById("mandaman-fact-text");
+  const dotsWrap = document.getElementById("mandaman-fact-dots");
+  if (!factEl) return;
+
+  if (dotsWrap) {
+    MIDDLE_ANDAMAN_FACTS.forEach((_, i) => {
+      const dot = document.createElement("button");
+      dot.className = "mandaman-fact-dot" + (i === 0 ? " active" : "");
+      dot.setAttribute("aria-label", "Show fact " + (i + 1));
+      dot.addEventListener("click", () => showFact(i));
+      dotsWrap.appendChild(dot);
+    });
+  }
+
+  function showFact(i) {
+    factIndex = i;
+    factEl.style.opacity = "0";
+    setTimeout(() => {
+      factEl.textContent = MIDDLE_ANDAMAN_FACTS[factIndex];
+      factEl.style.opacity = "1";
+    }, 200);
+    if (dotsWrap) {
+      [...dotsWrap.children].forEach((dot, di) => dot.classList.toggle("active", di === factIndex));
+    }
+  }
+
+  showFact(0);
+  setInterval(() => showFact((factIndex + 1) % MIDDLE_ANDAMAN_FACTS.length), 6000);
+}
+
+// ---------- 10. LEAFLET MAP ----------
+function initMap() {
+  const mapContainer = document.getElementById("mandaman-map");
+  if (!mapContainer || typeof L === "undefined") return;
+
+  map = L.map("mandaman-map", {
+    scrollWheelZoom: false,
+    minZoom: 7,
+  }).setView([12.55, 92.85], 9);
+
+  L.tileLayer("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png", {
+    attribution: "&copy; OpenStreetMap contributors &copy; CARTO",
+    maxZoom: 18,
+  }).addTo(map);
+
+  MIDDLE_ANDAMAN_LOCATIONS.forEach((loc) => {
+    const marker = L.circleMarker([loc.lat, loc.lng], {
+      radius: 8,
+      color: "#ff9933",
+      fillColor: "#ffb01f",
+      fillOpacity: 0.85,
+      weight: 2,
+    }).addTo(map);
+
+    marker.bindPopup(`<strong>${loc.name}</strong><br>${loc.description}`);
+  });
+}


### PR DESCRIPTION
## What this PR does
Adds a dedicated "Middle Andaman Explorer" page as requested in #678, covering limestone caves, mangrove forests, beaches, villages, and flora & fauna.

### New files
- frontend/middle-andaman/middle-andaman.html
- frontend/middle-andaman/middle-andaman.css
- frontend/middle-andaman/middle-andaman.js

### Modified files
- frontend/islands/islands.js — added a "Middle Andaman" card to the Islands Landing Page, linking directly to the new page

## Features included
- Tabbed sections for Limestone Caves (Baratang), Mangrove Forests, Beaches, Villages, and Flora & Fauna
- Interactive map marking Baratang Island, the Limestone Caves, Rangat, Mayabunder, and Karmatang Beach
- Image gallery with lightbox viewer
- Rotating "Interesting Facts" section
- Landing Page integration — new Middle Andaman card on the Islands Landing Page
- Fully responsive design, consistent with the site's existing theme

Fixes #678 

https://github.com/user-attachments/assets/d856e9f1-f9bf-49b9-913c-b6a7a0bdf4ad


I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.