### PR TITLE
fix: remove dead storage event listener in subscribeToLocalAuth

### DIFF
--- a/js-modules/auth/auth-session.mjs
+++ b/js-modules/auth/auth-session.mjs
@@ -92,19 +92,11 @@ export function subscribeToLocalAuth(listener) {
     listener(event.detail);
   };
 
-  const handleStorage = (event) => {
-    if (event.key === AUTH_USER_KEY) {
-      listener(getStoredAuthUser());
-    }
-  };
-
   window.addEventListener('incredible-india:auth-change', handleCustomEvent);
-  window.addEventListener('storage', handleStorage);
-  
+
   listener(getStoredAuthUser());
 
   return () => {
     window.removeEventListener('incredible-india:auth-change', handleCustomEvent);
-    window.removeEventListener('storage', handleStorage);
   };
 }


### PR DESCRIPTION
# Pull Request

## Description

In `js-modules/auth/auth-session.mjs`, `subscribeToLocalAuth` registered a `window.addEventListener('storage', handleStorage)` listener to synchronise auth state changes. However, the local authentication system reads and writes to **sessionStorage** (via `getSessionStorage()`).

According to browser specifications, `storage` events are **only** fired when a `localStorage` area is modified from another document context (tab/window). They are **never** fired for changes made in `sessionStorage`. Consequently, this event listener was dead code that could never trigger.

**What was removed:**
- The `handleStorage` function (lines 95-99)
- `window.addEventListener('storage', handleStorage)` registration
- `window.removeEventListener('storage', handleStorage)` cleanup

**What remains:**
- The custom `incredible-india:auth-change` event mechanism via `dispatchSessionUpdate()` — this is the correct synchronisation approach that already works for same-tab auth state updates.

Fixes #547

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?

- [X] Tested locally in browser
- [ ] Tested in both dark and light themes
- [ ] Tested at mobile viewport widths
- [X] Verified no console errors
- [X] Ran full auth test suite — 29/29 tests pass with no regressions

## Checklist

- [X] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings or errors
- [ ] I have tested responsive layout (if UI change)
- [ ] I have considered accessibility (aria labels, keyboard nav, focus)

## Screenshots (if applicable)

N/A — This is a code cleanup with no user-facing visual changes.
