### PR TITLE
fix: correct ES module import paths for monsoon-game and river-game (#545)

### DIFF
--- a/frontend/monsoon-game/monsoon-game.js
+++ b/frontend/monsoon-game/monsoon-game.js
@@ -1,4 +1,4 @@
-import { monsoonEngine } from './js-modules/monsoon-engine.js';
+import { monsoonEngine } from '../../js-modules/monsoon-engine.js';
 
 document.addEventListener('DOMContentLoaded', () => {
     initUI();

--- a/frontend/river-game/river-game.js
+++ b/frontend/river-game/river-game.js
@@ -1,4 +1,4 @@
-import { RiverEngine } from './js-modules/river-engine.js';
+import { RiverEngine } from '../../js-modules/river-engine.js';
 
 let engine;
 let canvas, ctx;


### PR DESCRIPTION
# Pull Request

## Description

Fixes broken ES module import paths in `monsoon-game.js` and `river-game.js`. Both files were importing from `./js-modules/...` which resolved to `frontend/monsoon-game/js-modules/` and `frontend/river-game/js-modules/` respectively — neither of which exists. Corrected the relative paths to `../../js-modules/...` to properly reference the root-level `js-modules/` directory.

Fixes #545

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Tested locally in browser
- [ ] Tested in both dark and light themes
- [ ] Tested at mobile viewport widths
- [x] Verified no console errors

## Checklist

- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [ ] I have tested responsive layout (if UI change)
- [ ] I have considered accessibility (aria labels, keyboard nav, focus)

## Screenshots (if applicable)

N/A — This is a two-line path correction with no visual changes.
