### PR TITLE
Add Mamostong Kangri Mountain Page

### DIFF
--- a/frontend/mamostong-kangri/mamostong-kangri.css
+++ b/frontend/mamostong-kangri/mamostong-kangri.css
@@ -1,0 +1,595 @@
+/* ============================================================
+   Mamostong Kangri Mountain Explorer — mamostong-kangri.css
+   Uses design variables defined in ../../styles.css
+   ============================================================ */
+
+.mamostong-page {
+  padding-top: var(--navbar-height);
+  overflow-x: hidden;
+}
+
+.mamostong-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* ---------- Hero Section ---------- */
+.mamostong-hero {
+  position: relative;
+  padding: 90px 24px 70px;
+  text-align: center;
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.6) 0%, rgba(15, 23, 42, 0.95) 100%),
+    url("../../assets/travel_mountains.png") center/cover no-repeat;
+}
+
+.mamostong-hero-content {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.mamostong-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--primary-saffron);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 14px;
+  transition: var(--transition-snappy);
+}
+
+.mamostong-back-link:hover {
+  text-decoration: underline;
+  transform: translateX(-3px);
+}
+
+.mamostong-hero-kicker {
+  display: inline-block;
+  padding: 6px 16px;
+  border-radius: 999px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  color: var(--primary-saffron);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-bottom: 20px;
+}
+
+.mamostong-hero h1 {
+  font-family: var(--font-heading);
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  line-height: 1.15;
+  margin-bottom: 18px;
+  color: var(--text-light);
+}
+
+.mamostong-hero h1 span {
+  background: var(--gradient-saffron-gold);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.mamostong-hero p {
+  color: var(--text-secondary);
+  font-size: 1.08rem;
+  line-height: 1.7;
+  margin-bottom: 36px;
+}
+
+.mamostong-hero-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+
+.mamostong-stat-box {
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 18px 12px;
+  transition: var(--transition-snappy);
+}
+
+.mamostong-stat-box:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-glow);
+}
+
+.mamostong-stat-box strong {
+  display: block;
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--primary-saffron);
+}
+
+.mamostong-stat-box span {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+/* ---------- Section Header ---------- */
+.mamostong-section {
+  padding: 70px 0;
+}
+
+.mamostong-section:nth-of-type(even) {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.mamostong-section-heading {
+  text-align: center;
+  max-width: 680px;
+  margin: 0 auto 44px;
+}
+
+.mamostong-section-badge {
+  display: inline-block;
+  color: var(--primary-gold);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+
+.mamostong-section-heading h2 {
+  font-family: var(--font-heading);
+  font-size: clamp(1.7rem, 3.5vw, 2.4rem);
+  color: var(--text-light);
+  margin-bottom: 14px;
+}
+
+.mamostong-section-heading p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+/* ---------- Overview Section ---------- */
+.mamostong-overview-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 36px;
+  align-items: start;
+}
+
+.mamostong-overview-text h3 {
+  font-family: var(--font-heading);
+  color: var(--primary-gold);
+  margin-bottom: 16px;
+  font-size: 1.4rem;
+}
+
+.mamostong-overview-text p {
+  color: var(--text-secondary);
+  line-height: 1.8;
+  margin-bottom: 16px;
+}
+
+.mamostong-overview-spec-card {
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 24px 28px;
+  box-shadow: var(--shadow-soft);
+}
+
+.mamostong-overview-spec-card h3 {
+  font-family: var(--font-heading);
+  color: var(--primary-gold);
+  margin-bottom: 18px;
+  font-size: 1.2rem;
+  border-bottom: 1px dashed var(--glass-border);
+  padding-bottom: 10px;
+}
+
+.mk-spec-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.mk-spec-list li {
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  font-size: 0.95rem;
+  color: var(--text-light);
+}
+
+.mk-spec-list li:last-child {
+  border-bottom: none;
+}
+
+.mk-spec-list li strong {
+  color: var(--text-muted);
+  flex-shrink: 0;
+  margin-right: 8px;
+}
+
+/* ---------- Trekking Section ---------- */
+.mamostong-trek-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 24px;
+}
+
+.mamostong-trek-card {
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 28px 24px;
+  transition: var(--transition-snappy);
+}
+
+.mamostong-trek-card:hover {
+  transform: translateY(-4px);
+  border-color: var(--primary-saffron);
+  box-shadow: var(--shadow-glow);
+}
+
+.mamostong-trek-icon {
+  font-size: 2rem;
+  margin-bottom: 14px;
+}
+
+.mamostong-trek-card h3 {
+  font-family: var(--font-heading);
+  color: var(--primary-gold);
+  font-size: 1.15rem;
+  margin-bottom: 12px;
+}
+
+.mamostong-trek-card p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+  font-size: 0.95rem;
+}
+
+/* ---------- Facts Section ---------- */
+.mamostong-fact-panel {
+  max-width: 760px;
+  margin: 0 auto;
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 40px 36px;
+  text-align: center;
+  box-shadow: var(--shadow-soft);
+}
+
+.mamostong-fact-icon {
+  font-size: 2.2rem;
+  margin-bottom: 14px;
+}
+
+#mamostong-fact-text {
+  font-family: var(--font-heading);
+  font-size: 1.15rem;
+  color: var(--text-light);
+  line-height: 1.6;
+  transition: opacity 0.2s ease;
+  min-height: 84px;
+}
+
+.mamostong-fact-dots {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.mamostong-fact-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+  background: var(--glass-border);
+  cursor: pointer;
+  transition: var(--transition-snappy);
+}
+
+.mamostong-fact-dot.active {
+  background: var(--primary-saffron);
+  width: 22px;
+  border-radius: 4px;
+}
+
+/* ---------- Interactive Map Section ---------- */
+.mamostong-map-wrap {
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow-soft);
+}
+
+#mamostong-map {
+  height: 440px;
+  width: 100%;
+  background: var(--bg-dark-deep);
+}
+
+/* ---------- Gallery Section ---------- */
+.mamostong-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 18px;
+}
+
+.mamostong-gallery-item {
+  margin: 0;
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+  cursor: pointer;
+  border: 1px solid var(--glass-border);
+  transition: var(--transition-snappy);
+  position: relative;
+}
+
+.mamostong-gallery-item:hover {
+  transform: translateY(-4px);
+  border-color: var(--primary-saffron);
+  box-shadow: var(--shadow-glow);
+}
+
+.mamostong-gallery-item img {
+  width: 100%;
+  height: 190px;
+  object-fit: cover;
+  display: block;
+}
+
+.mamostong-gallery-item figcaption {
+  padding: 10px 14px;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  background: var(--bg-dark-card);
+  border-top: 1px solid var(--glass-border);
+}
+
+/* ---------- Nearby Locations Section ---------- */
+.mamostong-nearby-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 24px;
+}
+
+.mamostong-nearby-card {
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 28px 24px;
+  transition: var(--transition-snappy);
+}
+
+.mamostong-nearby-card:hover {
+  transform: translateY(-4px);
+  border-color: var(--primary-gold);
+  box-shadow: var(--shadow-glow);
+}
+
+.mamostong-nearby-icon {
+  font-size: 2rem;
+  margin-bottom: 14px;
+}
+
+.mamostong-nearby-card h3 {
+  font-family: var(--font-heading);
+  color: var(--primary-gold);
+  font-size: 1.15rem;
+  margin-bottom: 12px;
+}
+
+.mamostong-nearby-card p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+  font-size: 0.95rem;
+  margin-bottom: 12px;
+}
+
+.mamostong-nearby-distance {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  color: var(--primary-saffron);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+/* ---------- FAQ Section ---------- */
+.mamostong-faq-container {
+  max-width: 800px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.mamostong-faq-item {
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-sm);
+  overflow: hidden;
+  transition: var(--transition-snappy);
+}
+
+.mamostong-faq-question {
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 20px 24px;
+  text-align: left;
+  font-family: var(--font-body);
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text-light);
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  transition: var(--transition-snappy);
+}
+
+.mamostong-faq-question:hover {
+  color: var(--primary-saffron);
+}
+
+.mamostong-faq-question::after {
+  content: "▼";
+  font-size: 0.8rem;
+  transition: transform 0.25s ease;
+  color: var(--text-muted);
+}
+
+.mamostong-faq-item.active {
+  border-color: var(--primary-saffron);
+  box-shadow: var(--shadow-glow);
+}
+
+.mamostong-faq-item.active .mamostong-faq-question::after {
+  transform: rotate(-180deg);
+  color: var(--primary-saffron);
+}
+
+.mamostong-faq-answer {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s cubic-bezier(0, 1, 0, 1), padding 0.3s ease;
+  padding: 0 24px;
+}
+
+.mamostong-faq-item.active .mamostong-faq-answer {
+  max-height: 500px;
+  padding-bottom: 20px;
+}
+
+.mamostong-faq-answer p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+  font-size: 0.95rem;
+}
+
+/* ---------- Lightbox Modal ---------- */
+.mamostong-lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(10, 18, 30, 0.92);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  padding: 24px;
+  backdrop-filter: blur(8px);
+}
+
+.mamostong-lightbox-overlay[hidden] {
+  display: none;
+}
+
+.mamostong-lightbox-content {
+  max-width: 800px;
+  width: 100%;
+  text-align: center;
+  position: relative;
+}
+
+.mamostong-lightbox-content img {
+  width: 100%;
+  max-height: 65vh;
+  object-fit: contain;
+  border-radius: var(--border-radius-lg);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow-soft);
+}
+
+.mamostong-lightbox-caption {
+  color: var(--text-light);
+  margin-top: 14px;
+  font-size: 0.95rem;
+}
+
+.mamostong-lightbox-close {
+  position: absolute;
+  top: -44px;
+  right: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-light);
+  font-size: 1.4rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: var(--transition-snappy);
+}
+
+.mamostong-lightbox-close:hover {
+  background: rgba(255, 255, 255, 0.2);
+  color: var(--primary-saffron);
+}
+
+.mamostong-lightbox-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-light);
+  font-size: 1.3rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: var(--transition-snappy);
+}
+
+.mamostong-lightbox-nav:hover {
+  background: rgba(255, 255, 255, 0.2);
+  color: var(--primary-saffron);
+}
+
+.mamostong-lightbox-nav.prev { left: -20px; }
+.mamostong-lightbox-nav.next { right: -20px; }
+
+/* ---------- Responsive ---------- */
+@media (max-width: 900px) {
+  .mamostong-overview-grid {
+    grid-template-columns: 1fr;
+    gap: 28px;
+  }
+}
+
+@media (max-width: 768px) {
+  .mamostong-hero-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  #mamostong-map {
+    height: 320px;
+  }
+
+  .mamostong-trek-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .mamostong-nearby-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .mamostong-lightbox-nav.prev { left: 4px; }
+  .mamostong-lightbox-nav.next { right: 4px; }
+}

--- a/frontend/mamostong-kangri/mamostong-kangri.html
+++ b/frontend/mamostong-kangri/mamostong-kangri.html
@@ -1,0 +1,321 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Explore Mamostong Kangri, a 7,516 m high peak in the Karakoram range of Ladakh. Discover facts, map locations, image gallery, and trek details.">
+    <title>Mamostong Kangri Mountain Explorer | Incredible India</title>
+    <link rel="icon" href="data:,">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap" rel="stylesheet">
+
+    <!-- Leaflet CSS for Map -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="mamostong-kangri.css">
+
+    <!-- Open Graph / Social Media Tags -->
+    <meta property="og:title" content="Mamostong Kangri Mountain Explorer | Incredible India Explorer">
+    <meta property="og:description" content="Explore Mamostong Kangri, a 7,516 m high peak in the Karakoram range of Ladakh. Discover facts, map locations, image gallery, and trek details.">
+    <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/assets/travel_mountains.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/mamostong-kangri/mamostong-kangri.html">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Incredible India Explorer">
+    <meta property="og:locale" content="en_IN">
+
+    <!-- Twitter Card Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Mamostong Kangri Mountain Explorer | Incredible India Explorer">
+    <meta name="twitter:description" content="Explore Mamostong Kangri, a 7,516 m high peak in the Karakoram range of Ladakh. Discover facts, map locations, image gallery, and trek details.">
+    <meta name="twitter:image" content="https://incredibleindiaexplorer.gov.in/assets/travel_mountains.png">
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/mamostong-kangri/mamostong-kangri.html">
+</head>
+
+<body class="mamostong-body-wrapper">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html#home" class="nav-link" id="link-home">Home</a>
+                <a href="../../index.html#map" class="nav-link" id="link-map">Interactive Map</a>
+                <a href="../travel/travel.html" class="nav-link" id="link-travel">Travel</a>
+                <a href="mamostong-kangri.html" class="nav-link active" style="color: var(--saffron)">Mamostong Kangri</a>
+
+                <div class="nav-dropdown">
+                    <button class="nav-link dropdown-toggle" id="link-explore-more">
+                        Explore More ▾
+                    </button>
+                    <div class="dropdown-menu">
+                        <a href="../travel/travel.html" class="dropdown-item">Travel &amp; Destinations</a>
+                        <a href="../wildlife/wildlife.html" class="dropdown-item">Nature &amp; Wildlife</a>
+                        <a href="../coastal-india/coastal-india.html" class="dropdown-item">Coastal India</a>
+                        <a href="../heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    </div>
+                </div>
+
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
+                    ☀️
+                </button>
+                <a href="../../login.html" class="nav-link" id="link-login">Login</a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="mamostong-page" id="app-root">
+        <!-- Hero Section -->
+        <section class="mamostong-hero">
+            <div class="mamostong-hero-content">
+                <a href="../mountain-expedition/index.html" class="mamostong-back-link">← Back to Mountain Expedition</a>
+                <span class="mamostong-hero-kicker">🏔️ Karakoram Range, Ladakh</span>
+                <h1>Mamostong Kangri <span>Explorer</span></h1>
+                <p>Rising to 7,516 metres in the remote Siachen area of the Karakoram range in Ladakh, Mamostong Kangri is one of the highest and most challenging peaks in the region. Its imposing glaciated slopes and strategic location near the Siachen Glacier make it a peak of immense geographical and military significance.</p>
+
+                <div class="mamostong-hero-stats">
+                    <div class="mamostong-stat-box">
+                        <strong>7,516 m</strong>
+                        <span>Peak Elevation</span>
+                    </div>
+                    <div class="mamostong-stat-box">
+                        <strong>Ladakh</strong>
+                        <span>Union Territory</span>
+                    </div>
+                    <div class="mamostong-stat-box">
+                        <strong>Karakoram</strong>
+                        <span>Mountain Range</span>
+                    </div>
+                    <div class="mamostong-stat-box">
+                        <strong>Siachen</strong>
+                        <span>Glacier Region</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Overview Section -->
+        <section class="mamostong-section" id="mamostong-overview">
+            <div class="mamostong-container">
+                <div class="mamostong-section-heading">
+                    <span class="mamostong-section-badge">Peak Profile</span>
+                    <h2>Geography, Glaciers &amp; Significance</h2>
+                </div>
+
+                <div class="mamostong-overview-grid">
+                    <div class="mamostong-overview-text">
+                        <h3>The Sentinel of the Karakoram</h3>
+                        <p>Mamostong Kangri stands in the Nubra Valley region of Ladakh, near the northernmost tip of Indian-controlled territory in the Karakoram range. The peak is situated close to the Siachen Glacier — the world's longest non-polar glacier — and lies in a region of extreme geopolitical significance where India's borders meet those of Pakistan and China.</p>
+                        <p>The name "Mamostong" is believed to derive from local Balti or Ladakhi terms, though its exact etymology is debated among scholars. The peak's massive glaciated flanks feed several tributaries that eventually flow into the Nubra and Shyok rivers, contributing to the Indus river system. Its remote location and harsh weather conditions make it one of the least-climbed peaks of its height in the Indian Himalayas.</p>
+                        <p>The first recorded ascent was made in 1981 by an Indo-Japanese expedition, marking a significant achievement in Indian mountaineering. Due to its proximity to the Siachen conflict zone, climbing activity here has been limited, and the peak remains relatively obscure compared to other 7,000-metre summits in the Indian Himalaya.</p>
+                    </div>
+                    <div class="mamostong-overview-spec-card">
+                        <h3>Technical Specifications</h3>
+                        <ul class="mk-spec-list">
+                            <li><strong>Elevation:</strong> 7,516 m (24,659 ft)</li>
+                            <li><strong>Prominence:</strong> 1,240 m</li>
+                            <li><strong>Coordinates:</strong> 35°41'N 77°04'E</li>
+                            <li><strong>Climbing Grade:</strong> Alpine PD+/D</li>
+                            <li><strong>First Ascent:</strong> 1981 (Indo-Japanese Expedition)</li>
+                            <li><strong>District:</strong> Leh, Ladakh</li>
+                            <li><strong>Glacier:</strong> Siachen / Mamostong</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Quick Facts Section -->
+        <section class="mamostong-section" id="mamostong-facts-section">
+            <div class="mamostong-container">
+                <div class="mamostong-section-heading">
+                    <span class="mamostong-section-badge">Did You Know?</span>
+                    <h2>Interesting Facts</h2>
+                </div>
+                <div class="mamostong-fact-panel">
+                    <div class="mamostong-fact-icon">💡</div>
+                    <p id="mamostong-fact-text" aria-live="polite">Loading fact...</p>
+                    <div class="mamostong-fact-dots" id="mamostong-fact-dots"></div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Trekking Details Section -->
+        <section class="mamostong-section" id="mamostong-trekking">
+            <div class="mamostong-container">
+                <div class="mamostong-section-heading">
+                    <span class="mamostong-section-badge">Expedition Guide</span>
+                    <h2>Routes, Camps &amp; Conditions</h2>
+                    <p>Essential information for planning a safe and rewarding Mamostong Kangri expedition.</p>
+                </div>
+
+                <div class="mamostong-trek-grid">
+                    <div class="mamostong-trek-card">
+                        <div class="mamostong-trek-icon">🥾</div>
+                        <h3>Base Route</h3>
+                        <p>The standard approach begins from Leh, proceeding north through the Nubra Valley via the Khardung La pass. From the last road-head near Sasoma or Saser La base camp, expeditions trek through glacial moraine and ice fields to establish high camps on the Mamostong glacier system.</p>
+                    </div>
+                    <div class="mamostong-trek-card">
+                        <div class="mamostong-trek-icon">⛺</div>
+                        <h3>Camp Strategy</h3>
+                        <p>A three-camp structure is typically used: Camp 1 at ~5,600 m on the glacier flat, Camp 2 at ~6,200 m on the icefall zone, and Camp 3 at ~6,800 m on the upper snow plateau. Summit pushes are launched before dawn from Camp 3 for stable snow conditions.</p>
+                    </div>
+                    <div class="mamostong-trek-card">
+                        <div class="mamostong-trek-icon">🗓️</div>
+                        <h3>Best Season</h3>
+                        <p>June–August (summer monsoon-avoidance window) is the only practical climbing season. The Karakoram receives less monsoon rain than the western Himalaya, but extreme cold and wind persist year-round. Winter expeditions are virtually impossible due to temperatures below -40°C.</p>
+                    </div>
+                    <div class="mamostong-trek-card">
+                        <div class="mamostong-trek-icon">📋</div>
+                        <h3>Permits &amp; Logistics</h3>
+                        <p>Due to the peak's location in the Siachen conflict zone, special military and government permits are required from the Ministry of Defence and the Ladakh administration. An expedition fee and NOC from the Indian Army are mandatory. All logistics must be arranged through approved Ladakhi expedition operators.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Interactive Map Section -->
+        <section class="mamostong-section" id="mamostong-map-section">
+            <div class="mamostong-container">
+                <div class="mamostong-section-heading">
+                    <span class="mamostong-section-badge">Interactive Map</span>
+                    <h2>Key Locations Around Mamostong Kangri</h2>
+                    <p>Click on any marker to learn about that geographic landmark.</p>
+                </div>
+                <div class="mamostong-map-wrap">
+                    <div id="mamostong-map" aria-label="Interactive Leaflet Map showing Mamostong Kangri and surrounding landmarks"></div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Image Gallery Section -->
+        <section class="mamostong-section" id="mamostong-gallery-section">
+            <div class="mamostong-container">
+                <div class="mamostong-section-heading">
+                    <span class="mamostong-section-badge">Image Gallery</span>
+                    <h2>Views of the Karakoram &amp; Siachen Region</h2>
+                    <p>Explore the peaks and glaciers of the eastern Karakoram. Click an image to view it larger.</p>
+                </div>
+                <div id="mamostong-gallery-grid" class="mamostong-gallery-grid"></div>
+            </div>
+        </section>
+
+        <!-- Nearby Locations Section -->
+        <section class="mamostong-section" id="mamostong-nearby-section">
+            <div class="mamostong-container">
+                <div class="mamostong-section-heading">
+                    <span class="mamostong-section-badge">Nearby Locations</span>
+                    <h2>Explore the Surrounding Region</h2>
+                    <p>Discover remarkable destinations within reach of the Mamostong Kangri area.</p>
+                </div>
+                <div class="mamostong-nearby-grid">
+                    <div class="mamostong-nearby-card">
+                        <div class="mamostong-nearby-icon">🏔️</div>
+                        <h3>Siachen Glacier</h3>
+                        <p>The world's longest non-polar glacier at 76 km, flowing south from the Indira Col. Known as the "Third Pole" for its massive ice reserves and strategic military importance.</p>
+                        <span class="mamostong-nearby-distance">~15 km away</span>
+                    </div>
+                    <div class="mamostong-nearby-card">
+                        <div class="mamostong-nearby-icon">🏔️</div>
+                        <h3>Saser Kangri</h3>
+                        <p>A massif of six peaks in the eastern Karakoram, with the highest reaching 7,672 m. Saser Kangri I is the highest peak entirely within Indian-administered Ladakh.</p>
+                        <span class="mamostong-nearby-distance">~25 km away</span>
+                    </div>
+                    <div class="mamostong-nearby-card">
+                        <div class="mamostong-nearby-icon">🏜️</div>
+                        <h3>Nubra Valley</h3>
+                        <p>A high-altitude cold desert valley at the confluence of the Shyok and Nubra rivers, famous for its Bactrian camel sand dunes and ancient Buddhist monasteries.</p>
+                        <span class="mamostong-nearby-distance">~70 km away</span>
+                    </div>
+                    <div class="mamostong-nearby-card">
+                        <div class="mamostong-nearby-icon">🏯</div>
+                        <h3>Leh</h3>
+                        <p>The historic capital of Ladakh, situated at 3,500 m, known for the iconic Leh Palace, Shanti Stupa, and as the gateway to the Karakoram and Siachen regions.</p>
+                        <span class="mamostong-nearby-distance">~200 km away</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- FAQs Section -->
+        <section class="mamostong-section" id="mamostong-faq-section">
+            <div class="mamostong-container">
+                <div class="mamostong-section-heading">
+                    <span class="mamostong-section-badge">FAQ</span>
+                    <h2>Frequently Asked Questions</h2>
+                </div>
+                <div class="mamostong-faq-container" id="mamostong-faq-accordion">
+                    <!-- Populated via JS for modularity and keyboard support -->
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <!-- Lightbox Modal -->
+    <div class="mamostong-lightbox-overlay" id="mamostong-lightbox" hidden role="dialog" aria-modal="true" aria-label="Image Lightbox">
+        <div class="mamostong-lightbox-content">
+            <button class="mamostong-lightbox-close" data-close-lightbox="true" aria-label="Close Lightbox">&times;</button>
+            <button class="mamostong-lightbox-nav prev" id="mamostong-lightbox-prev" aria-label="Previous image">‹</button>
+            <img id="mamostong-lightbox-image" src="" alt="">
+            <button class="mamostong-lightbox-nav next" id="mamostong-lightbox-next" aria-label="Next image">›</button>
+            <p class="mamostong-lightbox-caption" id="mamostong-lightbox-caption"></p>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <footer class="site-footer">
+        <div class="footer-container">
+            <div class="footer-brand">
+                <a href="../../index.html#home" class="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <p>Highlighting and documenting India's magnificent geography, mountains, and cultural heritage.</p>
+            </div>
+            <div class="footer-links">
+                <h4>Quick Links</h4>
+                <a href="../../index.html#home">Home</a>
+                <a href="../mountain-expedition/index.html">Mountain Expedition</a>
+                <a href="../travel/travel.html">Travel &amp; Destinations</a>
+                <a href="mamostong-kangri.html">Mamostong Kangri Explorer</a>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2026 Incredible India Explorer. Developed with Vanilla Web Tech.</p>
+        </div>
+    </footer>
+
+    <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+
+    <!-- Leaflet JS for Map -->
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+
+    <!-- Local Javascript Module -->
+    <script type="module" src="mamostong-kangri.js"></script>
+    <script src="../../pages-common.js"></script>
+</body>
+</html>

--- a/frontend/mamostong-kangri/mamostong-kangri.js
+++ b/frontend/mamostong-kangri/mamostong-kangri.js
@@ -1,0 +1,317 @@
+/* ============================================================
+   Mamostong Kangri Mountain Explorer — mamostong-kangri.js
+   Handles: Leaflet map, auto-rotating facts, gallery lightbox,
+   and accessible FAQ accordion.
+   ============================================================ */
+
+// ---------- 1. MAP LOCATIONS ----------
+const MAMOSTONG_LOCATIONS = [
+  {
+    name: "Mamostong Kangri Summit",
+    lat: 35.6833,
+    lng: 77.0667,
+    description: "The main summit of Mamostong Kangri, standing at 7,516 metres. A remote and challenging peak in the eastern Karakoram range of Ladakh."
+  },
+  {
+    name: "Siachen Glacier",
+    lat: 35.5833,
+    lng: 77.1000,
+    description: "The world's longest non-polar glacier at 76 km, flowing south from the Indira Col. A strategically vital and extreme high-altitude zone."
+  },
+  {
+    name: "Saser Kangri",
+    lat: 35.5500,
+    lng: 77.2167,
+    description: "A massif of six peaks in the eastern Karakoram. Saser Kangri I (7,672 m) is the highest peak entirely within Indian-administered Ladakh."
+  },
+  {
+    name: "Nubra Valley",
+    lat: 34.7500,
+    lng: 77.6000,
+    description: "A high-altitude cold desert valley at the confluence of the Shyok and Nubra rivers, known for Bactrian camels and ancient Buddhist monasteries."
+  },
+  {
+    name: "Khardung La",
+    lat: 35.0333,
+    lng: 77.6500,
+    description: "One of the world's highest motorable passes at 5,359 m, serving as the gateway from Leh to the Nubra Valley and Siachen region."
+  }
+];
+
+// ---------- 2. IMAGE GALLERY ----------
+const MAMOSTONG_GALLERY = [
+  { src: "../../assets/travel_mountains.png", caption: "The glaciated flanks of Mamostong Kangri rising in the eastern Karakoram range of Ladakh." },
+  { src: "../../assets/Hemis_Monastery.png", caption: "Panoramic Himalayan vistas characteristic of the Ladakh and Karakoram region." },
+  { src: "../../assets/Kedarnath.png", caption: "Dramatic mountain terrain and glacial valleys of the Siachen region." },
+  { src: "../../assets/Manalileh.png", caption: "High-altitude Karakoram landscape on the approach to the Siachen area." }
+];
+
+// ---------- 3. DID YOU KNOW FACTS ----------
+const MAMOSTONG_FACTS = [
+  "Mamostong Kangri at 7,516 m is one of the highest peaks in the eastern Karakoram and among the tallest mountains entirely within Indian-administered territory.",
+  "The peak lies near the Siachen Glacier — the world's longest non-polar glacier at 76 km — often called the 'Third Pole' for its massive ice reserves.",
+  "The first recorded ascent was achieved in 1981 by an Indo-Japanese expedition, a landmark achievement in Indian high-altitude mountaineering.",
+  "Due to its location in the Siachen conflict zone, special military and government permits are required to mount any expedition to Mamostong Kangri.",
+  "The peak's glaciated flanks feed tributaries of the Nubra and Shyok rivers, which ultimately join the Indus — the lifeline of Ladakh.",
+  "Mamostong Kangri sees far fewer climbing attempts than other 7,000-metre peaks due to its extreme remoteness and the logistical challenges of operating near the world's highest battlefield."
+];
+
+// ---------- 4. FAQ ACCORDION DATA ----------
+const MAMOSTONG_FAQS = [
+  {
+    question: "Where is Mamostong Kangri located?",
+    answer: "Mamostong Kangri is located in the eastern Karakoram range in the Leh district of Ladakh, India. It stands near the Siachen Glacier and the Nubra Valley, in one of the most remote and geopolitically sensitive regions of the Indian Himalaya."
+  },
+  {
+    question: "What is the elevation of Mamostong Kangri?",
+    answer: "Mamostong Kangri stands at 7,516 metres (24,659 feet) above sea level, making it one of the highest peaks in the Karakoram range and among the tallest mountains entirely within Indian-administered territory."
+  },
+  {
+    question: "When was Mamostong Kangri first climbed?",
+    answer: "The first recorded ascent was made in 1981 by a joint Indo-Japanese expedition, marking a significant milestone in Indian mountaineering history."
+  },
+  {
+    question: "What permits are required to climb Mamostong Kangri?",
+    answer: "Due to its proximity to the Siachen conflict zone, climbers need special permits from the Indian Ministry of Defence, the Ladakh administration, and an NOC from the Indian Army. All logistics must be arranged through approved Ladakhi expedition operators."
+  },
+  {
+    question: "What is the best time to attempt Mamostong Kangri?",
+    answer: "The optimal climbing window is June to August, when the Karakoram receives relatively less precipitation and temperatures are marginally less extreme. The peak is virtually inaccessible during winter due to temperatures dropping below -40°C and extreme wind conditions."
+  }
+];
+
+// ---------- 5. STATE ----------
+let map = null;
+let currentGalleryIndex = 0;
+let factIndex = 0;
+let factIntervalId = null;
+let lightboxKeydownHandler = null;
+
+// ---------- 6. INITIALIZATION ----------
+function init() {
+  initAccordion();
+  initGallery();
+  initFactsRotator();
+  initMap();
+  initLightbox();
+}
+
+if (document.readyState !== "loading") {
+  init();
+} else {
+  document.addEventListener("DOMContentLoaded", init);
+}
+
+if (window.appLifecycle) {
+  window.appLifecycle.registerCleanup(() => {
+    if (factIntervalId) {
+      clearInterval(factIntervalId);
+      factIntervalId = null;
+    }
+
+    if (lightboxKeydownHandler) {
+      document.removeEventListener("keydown", lightboxKeydownHandler);
+      lightboxKeydownHandler = null;
+    }
+
+    if (map) {
+      map.remove();
+      map = null;
+    }
+  });
+}
+
+// ---------- 7. FAQ ACCORDION ----------
+function initAccordion() {
+  const container = document.getElementById("mamostong-faq-accordion");
+  if (!container) return;
+
+  container.innerHTML = "";
+  MAMOSTONG_FAQS.forEach((faq, index) => {
+    const item = document.createElement("div");
+    item.className = "mamostong-faq-item";
+
+    item.innerHTML = `
+      <button class="mamostong-faq-question" id="faq-q-${index}" aria-expanded="false" aria-controls="faq-a-${index}">
+        ${faq.question}
+      </button>
+      <div class="mamostong-faq-answer" id="faq-a-${index}" role="region" aria-labelledby="faq-q-${index}">
+        <p>${faq.answer}</p>
+      </div>
+    `;
+
+    const button = item.querySelector(".mamostong-faq-question");
+    button.addEventListener("click", () => {
+      const isActive = item.classList.contains("active");
+
+      container.querySelectorAll(".mamostong-faq-item").forEach((otherItem) => {
+        otherItem.classList.remove("active");
+        otherItem.querySelector(".mamostong-faq-question").setAttribute("aria-expanded", "false");
+      });
+
+      if (!isActive) {
+        item.classList.add("active");
+        button.setAttribute("aria-expanded", "true");
+      }
+    });
+
+    container.appendChild(item);
+  });
+}
+
+// ---------- 8. GALLERY GRID ----------
+function initGallery() {
+  const grid = document.getElementById("mamostong-gallery-grid");
+  if (!grid) return;
+
+  grid.innerHTML = "";
+  MAMOSTONG_GALLERY.forEach((item, index) => {
+    const figure = document.createElement("figure");
+    figure.className = "mamostong-gallery-item";
+    figure.setAttribute("tabindex", "0");
+    figure.setAttribute("role", "button");
+    figure.setAttribute("aria-label", `Open image: ${item.caption}`);
+    figure.innerHTML = `
+      <img src="${item.src}" alt="${item.caption}" loading="lazy">
+      <figcaption>${item.caption}</figcaption>
+    `;
+
+    figure.addEventListener("click", () => openLightbox(index));
+    figure.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        openLightbox(index);
+      }
+    });
+
+    grid.appendChild(figure);
+  });
+}
+
+// ---------- 9. LIGHTBOX ----------
+function initLightbox() {
+  const lightbox = document.getElementById("mamostong-lightbox");
+  if (!lightbox) return;
+
+  document.querySelectorAll("[data-close-lightbox]").forEach((el) => {
+    el.addEventListener("click", closeLightbox);
+  });
+
+  const prevBtn = document.getElementById("mamostong-lightbox-prev");
+  const nextBtn = document.getElementById("mamostong-lightbox-next");
+
+  if (prevBtn) prevBtn.addEventListener("click", () => showGalleryImage(currentGalleryIndex - 1));
+  if (nextBtn) nextBtn.addEventListener("click", () => showGalleryImage(currentGalleryIndex + 1));
+
+  lightboxKeydownHandler = (e) => {
+    if (lightbox.hidden) return;
+
+    if (e.key === "Escape") closeLightbox();
+    if (e.key === "ArrowRight") showGalleryImage(currentGalleryIndex + 1);
+    if (e.key === "ArrowLeft") showGalleryImage(currentGalleryIndex - 1);
+  };
+
+  document.addEventListener("keydown", lightboxKeydownHandler);
+}
+
+function openLightbox(index) {
+  const lightbox = document.getElementById("mamostong-lightbox");
+  if (!lightbox) return;
+  lightbox.hidden = false;
+  document.body.style.overflow = "hidden";
+  showGalleryImage(index);
+}
+
+function closeLightbox() {
+  const lightbox = document.getElementById("mamostong-lightbox");
+  if (!lightbox) return;
+  lightbox.hidden = true;
+  document.body.style.overflow = "";
+}
+
+function showGalleryImage(index) {
+  const total = MAMOSTONG_GALLERY.length;
+  currentGalleryIndex = (index + total) % total;
+  const item = MAMOSTONG_GALLERY[currentGalleryIndex];
+
+  const img = document.getElementById("mamostong-lightbox-image");
+  const caption = document.getElementById("mamostong-lightbox-caption");
+
+  if (img) img.src = item.src;
+  if (img) img.alt = item.caption;
+  if (caption) caption.textContent = item.caption;
+}
+
+// ---------- 10. FACTS ROTATOR ----------
+function initFactsRotator() {
+  const factEl = document.getElementById("mamostong-fact-text");
+  const dotsWrap = document.getElementById("mamostong-fact-dots");
+  if (!factEl) return;
+
+  if (dotsWrap) dotsWrap.innerHTML = "";
+  if (factIntervalId) clearInterval(factIntervalId);
+
+  if (dotsWrap) {
+    MAMOSTONG_FACTS.forEach((_, i) => {
+      const dot = document.createElement("button");
+      dot.className = "mamostong-fact-dot" + (i === 0 ? " active" : "");
+      dot.setAttribute("aria-label", "Show fact " + (i + 1));
+      dot.addEventListener("click", () => showFact(i));
+      dotsWrap.appendChild(dot);
+    });
+  }
+
+  function showFact(i) {
+    factIndex = i;
+    factEl.style.opacity = "0";
+    setTimeout(() => {
+      factEl.textContent = MAMOSTONG_FACTS[factIndex];
+      factEl.style.opacity = "1";
+    }, 200);
+    if (dotsWrap) {
+      [...dotsWrap.children].forEach((dot, di) => dot.classList.toggle("active", di === factIndex));
+    }
+  }
+
+  showFact(0);
+  factIntervalId = setInterval(() => showFact((factIndex + 1) % MAMOSTONG_FACTS.length), 6000);
+}
+
+// ---------- 11. LEAFLET MAP ----------
+function initMap() {
+  const mapContainer = document.getElementById("mamostong-map");
+  if (!mapContainer || typeof L === "undefined") return;
+
+  if (map !== null) {
+    try {
+      map.remove();
+    } catch (e) {
+      console.warn("Failed to remove old map instance", e);
+    }
+    map = null;
+  }
+
+  // Center on Mamostong Kangri coordinates (35.6833° N, 77.0667° E)
+  map = L.map("mamostong-map", {
+    scrollWheelZoom: false,
+    minZoom: 6,
+  }).setView([35.6833, 77.0667], 10);
+
+  L.tileLayer("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png", {
+    attribution: "&copy; OpenStreetMap contributors &copy; CARTO",
+    maxZoom: 18,
+  }).addTo(map);
+
+  MAMOSTONG_LOCATIONS.forEach((loc) => {
+    const isPeak = loc.name.includes("Summit");
+    const marker = L.circleMarker([loc.lat, loc.lng], {
+      radius: isPeak ? 9 : 7,
+      color: isPeak ? "#ff9933" : "#0284c7",
+      fillColor: isPeak ? "#ffb01f" : "#38bdf8",
+      fillOpacity: 0.85,
+      weight: 2,
+    }).addTo(map);
+
+    marker.bindPopup(`<strong>${loc.name}</strong><br>${loc.description}`);
+  });
+}


### PR DESCRIPTION
## Description

Closes #754

Creates a dedicated page for Mamostong Kangri (7,516 m) featuring its geography, significance, and surrounding region in the Karakoram range of Ladakh.

## Problem Statement

Visitors should be able to learn about this remote Himalayan peak.

## Expected Solution

Implemented a structured and informative page following the existing Bandarpoonch mountain page pattern.

## Features Implemented

- **Hero Section** — Peak name, elevation (7,516 m), location (Ladakh), and key stats
- **Overview Section** — Geography, glaciology, historical significance, and technical specifications
- **Quick Facts** — Auto-rotating did-you-know facts with interactive dots
- **Trekking Guide** — Base route, camp strategy, best season, and permit details
- **Interactive Map** — Leaflet map with markers for Mamostong Kangri, Siachen Glacier, Saser Kangri, Nubra Valley, and Khardung La
- **Image Gallery** — Gallery grid with lightbox modal and keyboard navigation
- **Nearby Locations** — Cards for Siachen Glacier, Saser Kangri, Nubra Valley, and Leh
- **FAQ Section** — Accessible accordion with 5 questions

## Technical Notes

- Uses reusable UI components and design variables from `../../styles.css`
- Follows the same file structure as Bandarpoonch (`html`, `css`, `js` in a dedicated folder)
- All CSS classes are prefixed with `mamostong-` to avoid conflicts
- Accessible: ARIA attributes, keyboard navigation, semantic HTML

## Acceptance Criteria

- [x] Responsive implementation (900px, 768px breakpoints)
- [x] Content complete (Hero, Overview, Facts, Map, Gallery, Nearby, FAQ)
- [x] Navigation working (back link to Mountain Expedition, active nav link)

## Additional Information

- Height: 7,516 m | Range: Karakoram | Location: Ladakh, India | First Ascent: 1981