### PR TITLE
feat: create Swaraj Dweep (Havelock Island) Explorer

### DIFF
--- a/frontend/islands/islands.js
+++ b/frontend/islands/islands.js
@@ -77,6 +77,20 @@ const ISLANDS_DATA = [
     image: "../../assets/travel_islands.png"
   },
   {
+    id: "swaraj-dweep",
+    name: "Swaraj Dweep (Havelock Island)",
+    group: "Andaman & Nicobar",
+    location: "Andaman Islands, Bay of Bengal",
+    state: "Union Territory",
+    lat: 11.96,
+    lng: 92.98,
+    islandCount: "1 island",
+    tagline: "Home of Radhanagar Beach, Asia's Best Beach",
+    description: "Formerly Havelock Island, renamed Swaraj Dweep in 2018 — the Andamans' premier tourism hub, famed for Radhanagar and Elephant Beach, accessible coral reefs, rich marine life, and some of the best scuba diving in India.",
+    highlights: ["Radhanagar Beach — Asia's Best Beach (Time, 2004)", "Elephant Beach snorkelling & water sports", "20+ scuba diving sites, incl. Dixon's Pinnacle", "Renamed Swaraj Dweep in 2018 to honour Netaji Subhas Chandra Bose"],
+    image: "../../assets/travel_beaches.png"
+  },
+  {
     id: "lakshadweep",
     name: "Lakshadweep Islands",
     group: "Lakshadweep",
@@ -300,12 +314,13 @@ function openModal(islandId) {
   const island = ISLANDS_DATA.find((i) => i.id === islandId);
   if (!island) return;
 
-  if (island.id === "great-nicobar" || island.id === "south-andaman" || island.id === "middle-andaman" || island.id === "shaheed-dweep") {
+  if (island.id === "great-nicobar" || island.id === "south-andaman" || island.id === "middle-andaman" || island.id === "shaheed-dweep" || island.id === "swaraj-dweep") {
     const pageMap = {
       "great-nicobar": "../great-nicobar/great-nicobar.html",
       "south-andaman": "../south-andaman/south-andaman.html",
       "middle-andaman": "../middle-andaman/middle-andaman.html",
-      "shaheed-dweep": "../shaheed-dweep/shaheed-dweep.html"
+      "shaheed-dweep": "../shaheed-dweep/shaheed-dweep.html",
+      "swaraj-dweep": "../swaraj-dweep/swaraj-dweep.html"
     };
     window.location.href = pageMap[island.id];
     return;

--- a/frontend/swaraj-dweep/swaraj-dweep.css
+++ b/frontend/swaraj-dweep/swaraj-dweep.css
@@ -1,0 +1,411 @@
+/* ============================================================
+   Swaraj Dweep (Havelock Island) Explorer — swaraj-dweep.css
+   Uses the shared design tokens defined in ../../styles.css
+   ============================================================ */
+
+.swaraj-page {
+  padding-top: var(--navbar-height);
+  overflow-x: hidden;
+}
+
+.swaraj-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* ---------- Hero ---------- */
+.swaraj-hero {
+  position: relative;
+  padding: 90px 24px 70px;
+  text-align: center;
+  background:
+    linear-gradient(180deg, rgba(4, 23, 42, 0.55) 0%, rgba(4, 23, 42, 0.92) 100%),
+    url("../../assets/travel_beaches.png") center/cover no-repeat;
+}
+
+.swaraj-hero-content {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.swaraj-hero-kicker {
+  display: inline-block;
+  padding: 6px 16px;
+  border-radius: 999px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  color: var(--primary-saffron);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-bottom: 20px;
+}
+
+.swaraj-hero h1 {
+  font-family: var(--font-heading);
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  line-height: 1.15;
+  margin-bottom: 18px;
+  color: var(--text-light);
+}
+
+.swaraj-hero h1 span {
+  background: var(--gradient-saffron-gold);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.swaraj-hero p {
+  color: var(--text-secondary);
+  font-size: 1.08rem;
+  line-height: 1.7;
+  margin-bottom: 36px;
+}
+
+.swaraj-hero-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+
+.swaraj-stat-box {
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 18px 12px;
+  transition: var(--transition-snappy);
+}
+
+.swaraj-stat-box:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-glow);
+}
+
+.swaraj-stat-box strong {
+  display: block;
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--primary-saffron);
+}
+
+.swaraj-stat-box span {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+/* ---------- Section heading ---------- */
+.swaraj-section {
+  padding: 70px 0;
+}
+
+.swaraj-section-heading {
+  text-align: center;
+  max-width: 680px;
+  margin: 0 auto 44px;
+}
+
+.swaraj-section-badge {
+  display: inline-block;
+  color: var(--primary-gold);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+
+.swaraj-section-heading h2 {
+  font-family: var(--font-heading);
+  font-size: clamp(1.7rem, 3.5vw, 2.4rem);
+  color: var(--text-light);
+  margin-bottom: 14px;
+}
+
+.swaraj-section-heading p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+/* ---------- Tabs (History / Beaches / Coral Reefs / Marine Life / Water Sports / Tourism) ---------- */
+.swaraj-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  margin-bottom: 32px;
+}
+
+.swaraj-tab-btn {
+  padding: 10px 20px;
+  border-radius: 999px;
+  border: 1px solid var(--glass-border);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: var(--transition-snappy);
+}
+
+.swaraj-tab-btn:hover {
+  border-color: var(--primary-saffron);
+  color: var(--text-light);
+}
+
+.swaraj-tab-btn.active {
+  background: var(--gradient-saffron-gold);
+  color: #1a1200;
+  border-color: transparent;
+  font-weight: 600;
+}
+
+.swaraj-tab-panel {
+  display: none;
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 32px;
+  animation: swaraj-fade-in 0.3s ease;
+}
+
+.swaraj-tab-panel.active {
+  display: block;
+}
+
+@keyframes swaraj-fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.swaraj-tab-panel h3 {
+  font-family: var(--font-heading);
+  color: var(--primary-gold);
+  margin-bottom: 14px;
+  font-size: 1.3rem;
+}
+
+.swaraj-tab-panel p {
+  color: var(--text-secondary);
+  line-height: 1.8;
+  margin-bottom: 14px;
+}
+
+.swaraj-tab-panel ul {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.swaraj-tab-panel ul li {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  padding-left: 24px;
+  position: relative;
+  line-height: 1.6;
+}
+
+.swaraj-tab-panel ul li::before {
+  content: "🏝️";
+  position: absolute;
+  left: 0;
+}
+
+/* ---------- Map ---------- */
+.swaraj-map-wrap {
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow-soft);
+}
+
+#swaraj-map {
+  height: 440px;
+  width: 100%;
+  background: var(--bg-dark-deep);
+}
+
+/* ---------- Gallery ---------- */
+.swaraj-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 18px;
+}
+
+.swaraj-gallery-item {
+  margin: 0;
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+  cursor: pointer;
+  border: 1px solid var(--glass-border);
+  transition: var(--transition-snappy);
+  position: relative;
+}
+
+.swaraj-gallery-item:hover {
+  transform: translateY(-4px);
+  border-color: var(--primary-saffron);
+  box-shadow: var(--shadow-glow);
+}
+
+.swaraj-gallery-item img {
+  width: 100%;
+  height: 190px;
+  object-fit: cover;
+  display: block;
+}
+
+.swaraj-gallery-item figcaption {
+  padding: 10px 14px;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  background: var(--bg-dark-card);
+}
+
+/* ---------- Lightbox ---------- */
+.swaraj-lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 10, 20, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 24px;
+}
+
+.swaraj-lightbox-overlay[hidden] {
+  display: none;
+}
+
+.swaraj-lightbox-content {
+  max-width: 800px;
+  width: 100%;
+  text-align: center;
+  position: relative;
+}
+
+.swaraj-lightbox-content img {
+  width: 100%;
+  max-height: 65vh;
+  object-fit: contain;
+  border-radius: var(--border-radius-lg);
+}
+
+.swaraj-lightbox-caption {
+  color: var(--text-light);
+  margin-top: 14px;
+  font-size: 0.95rem;
+}
+
+.swaraj-lightbox-close {
+  position: absolute;
+  top: -44px;
+  right: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-light);
+  font-size: 1.4rem;
+  cursor: pointer;
+}
+
+.swaraj-lightbox-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-light);
+  font-size: 1.3rem;
+  cursor: pointer;
+}
+
+.swaraj-lightbox-nav.prev { left: -20px; }
+.swaraj-lightbox-nav.next { right: -20px; }
+
+/* ---------- Did You Know ---------- */
+.swaraj-fact-panel {
+  max-width: 760px;
+  margin: 0 auto;
+  background: var(--gradient-card-border);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 40px 36px;
+  text-align: center;
+}
+
+.swaraj-fact-icon {
+  font-size: 2.2rem;
+  margin-bottom: 14px;
+}
+
+#swaraj-fact-text {
+  font-family: var(--font-heading);
+  font-size: 1.15rem;
+  color: var(--text-light);
+  line-height: 1.6;
+  transition: opacity 0.2s ease;
+  min-height: 84px;
+}
+
+.swaraj-fact-dots {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.swaraj-fact-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+  background: var(--glass-border);
+  cursor: pointer;
+  transition: var(--transition-snappy);
+}
+
+.swaraj-fact-dot.active {
+  background: var(--primary-saffron);
+  width: 22px;
+  border-radius: 4px;
+}
+
+/* ---------- Back to Islands link ---------- */
+.swaraj-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--primary-saffron);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 14px;
+}
+
+.swaraj-back-link:hover {
+  text-decoration: underline;
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 768px) {
+  .swaraj-hero-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  #swaraj-map {
+    height: 320px;
+  }
+
+  .swaraj-lightbox-nav.prev { left: 4px; }
+  .swaraj-lightbox-nav.next { right: 4px; }
+}

--- a/frontend/swaraj-dweep/swaraj-dweep.html
+++ b/frontend/swaraj-dweep/swaraj-dweep.html
@@ -1,0 +1,285 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Explore Swaraj Dweep (Havelock Island) — Radhanagar and Elephant Beach, coral reefs, marine life, scuba diving and water sports, and the island's history, with an interactive map and image gallery.">
+    <title>Swaraj Dweep (Havelock Island) Explorer | Incredible India</title>
+    <link rel="icon" href="data:,">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="swaraj-dweep.css">
+
+    <!-- Open Graph / Social Media Tags -->
+    <meta property="og:title" content="Swaraj Dweep (Havelock Island) Explorer | Incredible India Explorer">
+    <meta property="og:description" content="Radhanagar and Elephant Beach, coral reefs, marine life, scuba diving and water sports — explore Swaraj Dweep with an interactive map and gallery.">
+    <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/assets/travel_beaches.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/swaraj-dweep/swaraj-dweep.html">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Incredible India Explorer">
+    <meta property="og:locale" content="en_IN">
+
+    <!-- Twitter Card Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Swaraj Dweep (Havelock Island) Explorer | Incredible India Explorer">
+    <meta name="twitter:description" content="Radhanagar Beach, coral reefs, marine life and water sports on Swaraj Dweep (Havelock Island).">
+    <meta name="twitter:image" content="https://incredibleindiaexplorer.gov.in/assets/travel_beaches.png">
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/swaraj-dweep/swaraj-dweep.html">
+</head>
+
+<body class="swaraj-body">
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html#home" class="nav-link" id="link-home">Home</a>
+                <a href="../../index.html#map" class="nav-link" id="link-map">Interactive Map</a>
+                <a href="../islands/islands.html" class="nav-link">Islands</a>
+                <a href="swaraj-dweep.html" class="nav-link active" style="color: var(--saffron)">Swaraj Dweep</a>
+
+                <div class="nav-dropdown">
+                    <button class="nav-link dropdown-toggle" id="link-explore-more">
+                        Explore More ▾
+                    </button>
+                    <div class="dropdown-menu">
+                        <a href="../travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                        <a href="../wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                        <a href="../coastal-india/coastal-india.html" class="dropdown-item">Coastal India</a>
+                        <a href="../heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    </div>
+                </div>
+
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
+                    ☀️
+                </button>
+                <a href="../../login.html" class="nav-link" id="link-login">Login</a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="swaraj-page">
+        <!-- Hero -->
+        <section class="swaraj-hero">
+            <div class="swaraj-hero-content">
+                <a href="../islands/islands.html" class="swaraj-back-link">← Back to Islands of India</a>
+                <span class="swaraj-hero-kicker">🏖️ Home of Asia's Best Beach</span>
+                <h1>Swaraj <span>Dweep</span></h1>
+                <p>Formerly Havelock Island, renamed Swaraj Dweep in 2018 — the Andamans' premier tourism hub, famed for Radhanagar Beach, world-class coral reefs and scuba diving, and some of the richest marine life in the archipelago.</p>
+
+                <div class="swaraj-hero-stats">
+                    <div class="swaraj-stat-box">
+                        <strong>92.2 km²</strong>
+                        <span>Total Island Area</span>
+                    </div>
+                    <div class="swaraj-stat-box">
+                        <strong>5+</strong>
+                        <span>Major Beaches</span>
+                    </div>
+                    <div class="swaraj-stat-box">
+                        <strong>~2 hrs</strong>
+                        <span>Ferry from Port Blair</span>
+                    </div>
+                    <div class="swaraj-stat-box">
+                        <strong>2018</strong>
+                        <span>Renamed Swaraj Dweep</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Tabbed info -->
+        <section class="swaraj-section" id="swaraj-explore">
+            <div class="swaraj-container">
+                <div class="swaraj-section-heading">
+                    <span class="swaraj-section-badge">Explore Swaraj Dweep</span>
+                    <h2>History, Beaches &amp; Life Above &amp; Below the Water</h2>
+                    <p>Select a tab to learn more.</p>
+                </div>
+
+                <div class="swaraj-tabs" role="tablist">
+                    <button type="button" class="swaraj-tab-btn active" data-tab="history">History</button>
+                    <button type="button" class="swaraj-tab-btn" data-tab="beaches">Beaches</button>
+                    <button type="button" class="swaraj-tab-btn" data-tab="coral-reefs">Coral Reefs</button>
+                    <button type="button" class="swaraj-tab-btn" data-tab="marine-life">Marine Life</button>
+                    <button type="button" class="swaraj-tab-btn" data-tab="water-sports">Water Sports</button>
+                    <button type="button" class="swaraj-tab-btn" data-tab="tourism">Tourism</button>
+                </div>
+
+                <div class="swaraj-tab-panel active" id="tab-history">
+                    <h3>📜 History</h3>
+                    <p>Havelock Island is one of the largest islands in Ritchie's Archipelago, east of Great Andaman, and was originally named after Sir Henry Havelock, a British general who served in colonial India. Long before that, the island and its surrounding waters were part of the traditional territory of the Andamanese tribes, including the Onge and Jarawa.</p>
+                    <p>After India's independence, the Indian government resettled Bengali refugee families here following the Partition of India in 1947 — the island's six villages, including Govinda Nagar and Radha Nagar, are still home to their descendants today.</p>
+                    <p>In December 2018, Prime Minister Narendra Modi renamed the island Swaraj Dweep ("Independence Island"), during the 75th-anniversary commemoration of Netaji Subhas Chandra Bose hoisting the Indian flag at Port Blair on 30 December 1943 — the moment Bose declared the Andamans the first Indian territory freed from British rule. Neighbouring Ross Island and Neil Island were renamed Netaji Subhas Chandra Bose Dweep and Shaheed Dweep in the same ceremony.</p>
+                    <ul>
+                        <li>Part of Ritchie's Archipelago, within the South Andaman administrative district</li>
+                        <li>Renamed in December 2018 to honour Netaji Subhas Chandra Bose</li>
+                        <li>Population of roughly 6,350 (2011 census), largely Bengali settler families</li>
+                        <li>Escaped major damage from the 2004 Indian Ocean earthquake and tsunami</li>
+                    </ul>
+                </div>
+
+                <div class="swaraj-tab-panel" id="tab-beaches">
+                    <h3>🏝️ Beaches</h3>
+                    <p>Havelock is home to around seven numbered beaches, each with its own character, connected by a single cross-island road running out from the main jetty at Govind Nagar.</p>
+                    <ul>
+                        <li><strong>Radhanagar Beach (Beach No. 7)</strong> — a 2 km stretch of powder-white sand backed by forest, named Asia's Best Beach by Time magazine in 2004 and awarded Blue Flag certification in 2020</li>
+                        <li><strong>Elephant Beach</strong> — on the northwest coast, the island's water-sports hub, reached by boat or a forest trek, known for shallow snorkelling reefs</li>
+                        <li><strong>Kalapathar Beach</strong> — on the southeastern coast, named for the large black rocks along its white-sand shoreline, popular for sunrise</li>
+                        <li><strong>Govind Nagar &amp; Vijaynagar Beaches</strong> — long, lagoon-like stretches near the jetty, lined with dive shops, cafés and beach resorts</li>
+                    </ul>
+                </div>
+
+                <div class="swaraj-tab-panel" id="tab-coral-reefs">
+                    <h3>🪸 Coral Reefs</h3>
+                    <p>Swaraj Dweep sits over fringing coral reefs that make it one of the most accessible reef destinations in the Andamans, ranging from shallow beginner-friendly beds to deeper dive sites offshore.</p>
+                    <ul>
+                        <li>Shallow coral gardens off Elephant Beach, easily explored by snorkelling or glass-bottom boat</li>
+                        <li>Nemo Reef near Govind Nagar — a popular beginner dive and snorkel site named for its clownfish</li>
+                        <li>Deeper offshore sites such as Dixon's Pinnacle, featuring walls, pinnacles and swim-throughs for certified divers</li>
+                        <li>Reefs are sensitive to coral bleaching; operators encourage reef-safe sunscreen and a strict no-touch approach to snorkelling and diving</li>
+                    </ul>
+                </div>
+
+                <div class="swaraj-tab-panel" id="tab-marine-life">
+                    <h3>🐢 Marine Life</h3>
+                    <p>The waters around Swaraj Dweep support some of the richest marine biodiversity in the Andamans, drawing snorkellers and certified divers alike.</p>
+                    <ul>
+                        <li>Reef regulars such as parrotfish, clownfish, moray eels and sea anemones in the shallows</li>
+                        <li>Sea turtles, reef sharks, manta rays, dugongs and barracuda at the island's deeper dive sites</li>
+                        <li>Large schools of tropical fish moving through the coral gardens off Elephant Beach</li>
+                        <li>The island was once home to Rajan, a beloved elephant famous for swimming in the open sea — a favourite figure in Andaman folklore</li>
+                    </ul>
+                </div>
+
+                <div class="swaraj-tab-panel" id="tab-water-sports">
+                    <h3>🤿 Water Sports</h3>
+                    <p>As the Andamans' premier adventure-tourism island, Swaraj Dweep offers access to more than 20 dive sites and a full range of water sports, mostly centred around Elephant Beach and Govind Nagar.</p>
+                    <ul>
+                        <li>Scuba diving — PADI and SSI dive schools offer everything from a first Discover Scuba dive to full instructor certification</li>
+                        <li>Snorkelling — shallow reef access at Elephant Beach and Nemo Reef, gear rentable near the jetty</li>
+                        <li>Sea walking — a helmet-diving activity that lets non-swimmers walk the seabed among reef fish</li>
+                        <li>Kayaking through the island's mangrove creeks, plus jet-skiing and glass-bottom boat rides</li>
+                        <li>Best diving season is October–May, peaking December–March, with 15–30 m visibility and water temperatures of 26–29°C year-round</li>
+                    </ul>
+                </div>
+
+                <div class="swaraj-tab-panel" id="tab-tourism">
+                    <h3>🧭 Tourism</h3>
+                    <p>Swaraj Dweep is the most visited island in the Andaman &amp; Nicobar archipelago, reached by roughly 1.5–2 hour government and private catamaran ferries (including Makruzz and Nautika) from Port Blair, with further ferry connections on to Shaheed Dweep (Neil Island).</p>
+                    <p>Its tourism infrastructure spans budget guesthouses to luxury beachfront resorts, dive centres, cafés and restaurants — most concentrated around Govind Nagar, Vijaynagar and Radhanagar. Auto-rickshaws, local buses and rented scooters or bicycles connect the beaches along the island's single cross-island road.</p>
+                    <p>The best time to visit is between October and May; the June–September southwest monsoon brings rougher seas and reduced ferry and dive-boat operations.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Interactive Map -->
+        <section class="swaraj-section" id="swaraj-map-section">
+            <div class="swaraj-container">
+                <div class="swaraj-section-heading">
+                    <span class="swaraj-section-badge">Interactive Map</span>
+                    <h2>Key Locations on Swaraj Dweep</h2>
+                    <p>Click a marker to learn about that location.</p>
+                </div>
+                <div class="swaraj-map-wrap">
+                    <div id="swaraj-map"></div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Image Gallery -->
+        <section class="swaraj-section" id="swaraj-gallery-section">
+            <div class="swaraj-container">
+                <div class="swaraj-section-heading">
+                    <span class="swaraj-section-badge">Image Gallery</span>
+                    <h2>Glimpses of Swaraj Dweep</h2>
+                    <p>Click an image to view it larger.</p>
+                </div>
+                <div id="swaraj-gallery-grid" class="swaraj-gallery-grid"></div>
+            </div>
+        </section>
+
+        <!-- Interesting Facts -->
+        <section class="swaraj-section">
+            <div class="swaraj-container">
+                <div class="swaraj-section-heading">
+                    <span class="swaraj-section-badge">Did You Know?</span>
+                    <h2>Interesting Facts</h2>
+                </div>
+                <div class="swaraj-fact-panel">
+                    <div class="swaraj-fact-icon">💡</div>
+                    <p id="swaraj-fact-text">Loading fact...</p>
+                    <div class="swaraj-fact-dots" id="swaraj-fact-dots"></div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <!-- Lightbox -->
+    <div class="swaraj-lightbox-overlay" id="swaraj-lightbox" hidden>
+        <div class="swaraj-lightbox-content">
+            <button class="swaraj-lightbox-close" data-close-lightbox="true" aria-label="Close">&times;</button>
+            <button class="swaraj-lightbox-nav prev" id="swaraj-lightbox-prev" aria-label="Previous image">‹</button>
+            <img id="swaraj-lightbox-image" src="" alt="">
+            <button class="swaraj-lightbox-nav next" id="swaraj-lightbox-next" aria-label="Next image">›</button>
+            <p class="swaraj-lightbox-caption" id="swaraj-lightbox-caption"></p>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <footer class="site-footer">
+        <div class="footer-container">
+            <div class="footer-brand">
+                <a href="../../index.html#home" class="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <p>Preserving and celebrating India's rich island territories, coastlines and culture.</p>
+            </div>
+            <div class="footer-links">
+                <h4>Quick Links</h4>
+                <a href="../../index.html#home">Home</a>
+                <a href="../islands/islands.html">Islands of India</a>
+                <a href="../wildlife/wildlife.html">Nature & Wildlife</a>
+                <a href="swaraj-dweep.html">Swaraj Dweep</a>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2026 Incredible India Explorer. Open Source Cultural Heritage Initiative.</p>
+        </div>
+    </footer>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+    <script type="module" src="swaraj-dweep.js"></script>
+    <script src="../../pages-common.js"></script>
+</body>
+</html>

--- a/frontend/swaraj-dweep/swaraj-dweep.js
+++ b/frontend/swaraj-dweep/swaraj-dweep.js
@@ -1,0 +1,213 @@
+/* ============================================================
+   Swaraj Dweep (Havelock Island) Explorer — swaraj-dweep.js
+   Handles: tab navigation, image gallery lightbox, facts
+   rotator, and the Leaflet map with key-location markers.
+   ============================================================ */
+
+// ---------- 1. KEY LOCATIONS FOR THE MAP ----------
+const SWARAJ_LOCATIONS = [
+  {
+    name: "Radhanagar Beach (Beach No. 7)",
+    lat: 11.982,
+    lng: 92.964,
+    description: "Named Asia's Best Beach by Time magazine in 2004 and Blue Flag certified in 2020 — 2 km of white sand backed by forest, best known for its sunsets."
+  },
+  {
+    name: "Elephant Beach",
+    lat: 12.0097,
+    lng: 92.9477,
+    description: "The island's water-sports hub on the northwest coast, reached by boat or forest trek, with shallow coral gardens ideal for snorkelling."
+  },
+  {
+    name: "Kalapathar Beach",
+    lat: 12.001,
+    lng: 93.033,
+    description: "A quieter beach on the southeastern coast, named for the large black rocks along its white-sand shoreline — a favourite sunrise spot."
+  },
+  {
+    name: "Govind Nagar Jetty & Market",
+    lat: 12.033,
+    lng: 92.986,
+    description: "The island's main jetty, market and transport hub, connected to Port Blair and Shaheed Dweep (Neil Island) by regular ferries."
+  },
+  {
+    name: "Nemo Reef",
+    lat: 12.02,
+    lng: 92.978,
+    description: "A popular beginner-friendly dive and snorkel site near Govind Nagar, named for the clownfish that live among its coral."
+  }
+];
+
+// ---------- 2. IMAGE GALLERY ----------
+const SWARAJ_GALLERY = [
+  { src: "../../assets/travel_beaches.png", caption: "Radhanagar Beach, Swaraj Dweep" },
+  { src: "../../assets/travel_islands.png", caption: "Coastline near Elephant Beach" },
+  { src: "../../assets/travel_hidden.png", caption: "Lush forest interior, a short trek from the beaches" }
+];
+
+// ---------- 3. INTERESTING FACTS ----------
+const SWARAJ_FACTS = [
+  "Havelock Island was renamed Swaraj Dweep ('Independence Island') in December 2018, on the 75th anniversary of Netaji Subhas Chandra Bose hoisting the Indian flag at Port Blair.",
+  "Radhanagar Beach was named Asia's Best Beach by Time magazine in 2004 and earned international Blue Flag certification in 2020.",
+  "Swaraj Dweep offers access to more than 20 scuba diving sites, making it the most popular diving destination in the Andaman Islands.",
+  "The island's six villages are still home to descendants of Bengali refugee families resettled here after the Partition of India in 1947.",
+  "Elephant Beach gets its name from elephants once used in logging that would swim across to the beach — the island later became famous for Rajan, a beloved swimming elephant.",
+  "Underwater visibility around Swaraj Dweep can reach 15 to 30 metres during the October–May dive season.",
+  "Swaraj Dweep and neighbouring Shaheed Dweep (Neil Island) are both part of Ritchie's Archipelago and are connected to each other by daily ferries."
+];
+
+// ---------- 4. STATE ----------
+let map;
+let currentGalleryIndex = 0;
+let factIndex = 0;
+
+// ---------- 5. DOM READY ----------
+document.addEventListener("DOMContentLoaded", () => {
+  initTabs();
+  initGallery();
+  initFactsRotator();
+  initMap();
+  initLightbox();
+});
+
+// ---------- 6. TAB NAVIGATION ----------
+function initTabs() {
+  const tabButtons = document.querySelectorAll(".swaraj-tab-btn");
+  const tabPanels = document.querySelectorAll(".swaraj-tab-panel");
+
+  tabButtons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const target = btn.getAttribute("data-tab");
+
+      tabButtons.forEach((b) => b.classList.remove("active"));
+      btn.classList.add("active");
+
+      tabPanels.forEach((panel) => {
+        panel.classList.toggle("active", panel.id === "tab-" + target);
+      });
+    });
+  });
+}
+
+// ---------- 7. IMAGE GALLERY ----------
+function initGallery() {
+  const galleryGrid = document.getElementById("swaraj-gallery-grid");
+  if (!galleryGrid) return;
+
+  galleryGrid.innerHTML = "";
+  SWARAJ_GALLERY.forEach((item, index) => {
+    const fig = document.createElement("figure");
+    fig.className = "swaraj-gallery-item";
+    fig.innerHTML = `
+      <img src="${item.src}" alt="${item.caption}" loading="lazy">
+      <figcaption>${item.caption}</figcaption>
+    `;
+    fig.addEventListener("click", () => openLightbox(index));
+    galleryGrid.appendChild(fig);
+  });
+}
+
+// ---------- 8. LIGHTBOX ----------
+function initLightbox() {
+  document.querySelectorAll("[data-close-lightbox]").forEach((el) => {
+    el.addEventListener("click", closeLightbox);
+  });
+  const prevBtn = document.getElementById("swaraj-lightbox-prev");
+  const nextBtn = document.getElementById("swaraj-lightbox-next");
+  if (prevBtn) prevBtn.addEventListener("click", () => showGalleryImage(currentGalleryIndex - 1));
+  if (nextBtn) nextBtn.addEventListener("click", () => showGalleryImage(currentGalleryIndex + 1));
+
+  document.addEventListener("keydown", (e) => {
+    const lightbox = document.getElementById("swaraj-lightbox");
+    if (!lightbox || lightbox.hidden) return;
+    if (e.key === "Escape") closeLightbox();
+    if (e.key === "ArrowRight") showGalleryImage(currentGalleryIndex + 1);
+    if (e.key === "ArrowLeft") showGalleryImage(currentGalleryIndex - 1);
+  });
+}
+
+function openLightbox(index) {
+  const lightbox = document.getElementById("swaraj-lightbox");
+  if (!lightbox) return;
+  lightbox.hidden = false;
+  document.body.style.overflow = "hidden";
+  showGalleryImage(index);
+}
+
+function closeLightbox() {
+  const lightbox = document.getElementById("swaraj-lightbox");
+  if (!lightbox) return;
+  lightbox.hidden = true;
+  document.body.style.overflow = "";
+}
+
+function showGalleryImage(index) {
+  const total = SWARAJ_GALLERY.length;
+  currentGalleryIndex = (index + total) % total;
+  const item = SWARAJ_GALLERY[currentGalleryIndex];
+  const img = document.getElementById("swaraj-lightbox-image");
+  const caption = document.getElementById("swaraj-lightbox-caption");
+  if (img) img.src = item.src;
+  if (img) img.alt = item.caption;
+  if (caption) caption.textContent = item.caption;
+}
+
+// ---------- 9. FACTS ROTATOR ----------
+function initFactsRotator() {
+  const factEl = document.getElementById("swaraj-fact-text");
+  const dotsWrap = document.getElementById("swaraj-fact-dots");
+  if (!factEl) return;
+
+  if (dotsWrap) {
+    SWARAJ_FACTS.forEach((_, i) => {
+      const dot = document.createElement("button");
+      dot.className = "swaraj-fact-dot" + (i === 0 ? " active" : "");
+      dot.setAttribute("aria-label", "Show fact " + (i + 1));
+      dot.addEventListener("click", () => showFact(i));
+      dotsWrap.appendChild(dot);
+    });
+  }
+
+  function showFact(i) {
+    factIndex = i;
+    factEl.style.opacity = "0";
+    setTimeout(() => {
+      factEl.textContent = SWARAJ_FACTS[factIndex];
+      factEl.style.opacity = "1";
+    }, 200);
+    if (dotsWrap) {
+      [...dotsWrap.children].forEach((dot, di) => dot.classList.toggle("active", di === factIndex));
+    }
+  }
+
+  showFact(0);
+  setInterval(() => showFact((factIndex + 1) % SWARAJ_FACTS.length), 6000);
+}
+
+// ---------- 10. LEAFLET MAP ----------
+function initMap() {
+  const mapContainer = document.getElementById("swaraj-map");
+  if (!mapContainer || typeof L === "undefined") return;
+
+  map = L.map("swaraj-map", {
+    scrollWheelZoom: false,
+    minZoom: 8,
+  }).setView([12.0, 92.98], 12);
+
+  L.tileLayer("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png", {
+    attribution: "&copy; OpenStreetMap contributors &copy; CARTO",
+    maxZoom: 18,
+  }).addTo(map);
+
+  SWARAJ_LOCATIONS.forEach((loc) => {
+    const marker = L.circleMarker([loc.lat, loc.lng], {
+      radius: 8,
+      color: "#ff9933",
+      fillColor: "#ffb01f",
+      fillOpacity: 0.85,
+      weight: 2,
+    }).addTo(map);
+
+    marker.bindPopup(`<strong>${loc.name}</strong><br>${loc.description}`);
+  });
+}


### PR DESCRIPTION
# Pull Request

## Description

Adds a dedicated educational explorer page for Swaraj Dweep (Havelock Island),
following the same pattern as the existing Great Nicobar / South Andaman /
Middle Andaman / Shaheed Dweep pages, and integrates it into the Islands
Landing Page.

New page (`frontend/swaraj-dweep/`) covers:
- History (renaming to Swaraj Dweep in 2018, Bengali resettlement, Ritchie's
  Archipelago)
- Beaches (Radhanagar, Elephant Beach, Kalapathar, Govind Nagar/Vijaynagar)
- Coral Reefs (Nemo Reef, Dixon's Pinnacle, reef-safe practices)
- Marine Life (reef fish, turtles, reef sharks, Rajan the swimming elephant)
- Water Sports (scuba diving, snorkelling, sea walking, kayaking)
- Tourism (ferries, infrastructure, best time to visit)
- An interactive Leaflet map with 5 key-location markers
- An image gallery with lightbox
- A rotating "Did You Know?" facts panel

Also adds a Swaraj Dweep card to the Islands Landing Page (`frontend/islands/islands.js`)
and wires it to redirect to the new page, matching the existing sibling islands.

Fixes #674

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Tested locally in browser (served via `python -m http.server` / `npx serve`, not opened via `file://`)
- [x] Tested in both dark and light themes
- [ ] Tested at mobile viewport widths
- [x] Verified no console errors

Also ran the existing test suite (`npm run test:unit`) and `node scripts/pr-health-checker.js`
locally — no new failures introduced.

## Checklist

- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [ ] I have tested responsive layout (if UI change)
- [ ] I have considered accessibility (aria labels, keyboard nav, focus)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Swaraj Dweep (Havelock Island) destination page.
  * Added island information tabs covering history, beaches, marine life, water sports, and tourism.
  * Added an interactive map, image gallery with lightbox navigation, rotating facts, and responsive layout.
  * Added Swaraj Dweep to the island listings with direct navigation to its explorer page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->