### PR TITLE
feat: Add History of Indian Education module (Gurukul to NEP 2020)

### DIFF
--- a/history/battles/index.html
+++ b/history/battles/index.html
@@ -51,13 +51,13 @@
                         <a class="dropdown-item" href="../governance/cabinet-ministries/index.html">Cabinet Ministries</a>
                         <a class="dropdown-item" href="../defence/armed-forces/index.html">Armed Forces Hub</a>
                         <a class="dropdown-item" href="../science/isro-explorer/index.html">ISRO Explorer</a>
-                        <a class="dropdown-item" href="index.html" style="color: var(--saffron)">Historic Battles</a>
-                    </div>
+<a class="dropdown-item" href="../history/battles/index.html">Historic Battles</a>
+                        <a class="dropdown-item" href="../history/education/index.html">History of Indian Education</a>
+                        <a class="dropdown-item" href="index.html" style="color: var(--saffron)">Historic Battles</a>                    </div>
                 </div>
                 <div class="nav-right">
                     <button class="theme-toggle" id="theme-toggle" aria-label="Toggle Theme">
-                        <svg class="sun-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line></svg>
-                        <svg class="moon-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display: none;"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
+                        <svg class="sun-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="5.64" x2("M21 1２.79A9 9 0 １ １ １１.２１ ３ ７ ７ 0 0 0 ２１ １２.７９z"></path></svg>
                     </button>
                 </div>
             </nav>

--- a/history/dynasties/index.html
+++ b/history/dynasties/index.html
@@ -51,9 +51,9 @@
                         <a class="dropdown-item" href="../governance/cabinet-ministries/index.html">Cabinet Ministries</a>
                         <a class="dropdown-item" href="../defence/armed-forces/index.html">Armed Forces Hub</a>
                         <a class="dropdown-item" href="../science/isro-explorer/index.html">ISRO Explorer</a>
-                        <a class="dropdown-item" href="../history/battles/index.html">Historic Battles</a>
-                        <a class="dropdown-item" href="index.html" style="color: var(--saffron)">Indian Dynasties</a>
-                    </div>
+<a class="dropdown-item" href="../history/battles/index.html">Historic Battles</a>
+                        <a class="dropdown-item" href="../history/education/index.html">History of Indian Education</a>
+                        <a class="dropdown-item" href="index.html" style="color: var(--saffron)">Indian Dynasties</a>                    </div>
                 </div>
                 <div class="nav-right">
                     <button class="theme-toggle" id="theme-toggle" aria-label="Toggle Theme">

--- a/history/education/components/ComparisonPanel.js
+++ b/history/education/components/ComparisonPanel.js
@@ -1,0 +1,27 @@
+export function ComparisonPanel(timeline) {
+  const rows = timeline
+    .map(
+      (entry) => `<tr>
+        <td class="comparison-year">${entry.year}</td>
+        <td class="comparison-then">${entry.then}</td>
+        <td class="comparison-now">${entry.now}</td>
+      </tr>`
+    )
+    .join("");
+
+  return `<div class="comparison-panel">
+    <h3>Then vs. Now, at a Glance</h3>
+    <div class="comparison-table-wrap">
+      <table class="comparison-table">
+        <thead>
+          <tr>
+            <th>Period</th>
+            <th>Historical System</th>
+            <th>Modern Equivalent</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </div>
+  </div>`;
+}

--- a/history/education/components/EraCard.js
+++ b/history/education/components/EraCard.js
@@ -1,0 +1,31 @@
+export function EraCard(era, isSelected = false) {
+  return `<div class="era-card ${isSelected ? "selected" : ""}" data-id="${era.id}">
+    <div class="era-card-image">
+      <img src="${era.image}" alt="${era.name}" loading="lazy" />
+      <div class="era-card-overlay" style="border-left-color: ${era.color}">
+        <span class="era-period">${era.period}</span>
+      </div>
+    </div>
+    <div class="era-card-body">
+      <h3 class="era-card-name">${era.name}</h3>
+      <p class="era-card-summary">${era.summary}</p>
+      <button class="era-card-btn" data-id="${era.id}">
+        Learn more <span class="arrow">→</span>
+      </button>
+    </div>
+  </div>`;
+}
+
+export function EraDetail(era) {
+  const facts = era.keyFacts.map((fact) => `<li>${fact}</li>`).join("");
+
+  return `<div class="era-detail" style="border-top-color: ${era.color}">
+    <div class="era-detail-header">
+      <h2>${era.name}</h2>
+      <span class="era-detail-period">${era.period}</span>
+    </div>
+    <p class="era-detail-summary">${era.summary}</p>
+    <h4>Key Facts</h4>
+    <ul class="era-detail-facts">${facts}</ul>
+  </div>`;
+}

--- a/history/education/components/TabNav.js
+++ b/history/education/components/TabNav.js
@@ -1,0 +1,18 @@
+export function TabNav(tabs, activeTab) {
+  const tabsHtml = tabs
+    .map((tab) => {
+      const isActive = tab.id === activeTab;
+      return `<button class="education-tab-btn ${isActive ? "active" : ""}"
+        data-tab="${tab.id}"
+        role="tab"
+        aria-selected="${isActive}"
+        tabindex="${isActive ? 0 : -1}">
+        ${tab.label}
+      </button>`;
+    })
+    .join("");
+
+  return `<div class="education-tab-nav" role="tablist">
+    <div class="tab-scroll">${tabsHtml}</div>
+  </div>`;
+}

--- a/history/education/components/TimelineItem.js
+++ b/history/education/components/TimelineItem.js
@@ -1,0 +1,13 @@
+export function TimelineItem(entry, era) {
+  const color = era ? era.color : "#FF6B35";
+
+  return `<div class="timeline-item" data-era-id="${entry.eraId}" style="--item-color: ${color}">
+    <div class="timeline-dot" style="background: ${color}"></div>
+    <div class="timeline-content">
+      <span class="timeline-year">${entry.year}</span>
+      <h4 class="timeline-title">${era ? era.name : entry.eraId}</h4>
+      <p class="timeline-then"><strong>Then:</strong> ${entry.then}</p>
+      <p class="timeline-now"><strong>Today's equivalent:</strong> ${entry.now}</p>
+    </div>
+  </div>`;
+}

--- a/history/education/data.js
+++ b/history/education/data.js
@@ -1,0 +1,179 @@
+export const educationTabs = [
+  { id: "cover", label: "Cover" },
+  { id: "eras", label: "Eras" },
+  { id: "timeline", label: "Timeline" },
+];
+
+export const educationEras = [
+  {
+    id: "gurukul",
+    name: "Gurukul System",
+    period: "c. 1500 BCE – 500 CE",
+    image: "assets/education/gurukul.jpg",
+    summary:
+      "Students lived with their guru (teacher) in a residential setting, learning the Vedas, philosophy, ethics, and practical life skills through oral instruction.",
+    keyFacts: [
+      "Education was oral — students memorized verses through repetition",
+      "Students lived with the guru's family, regardless of their own social status",
+      "Curriculum included Vedic scriptures, grammar, mathematics, and archery",
+      "No fees were charged; students offered 'guru dakshina' after completing studies",
+    ],
+    color: "#FF6B35",
+  },
+  {
+    id: "takshashila",
+    name: "Takshashila",
+    period: "c. 6th century BCE – 5th century CE",
+    image: "assets/education/takshashila.jpg",
+    summary:
+      "One of the earliest known centers of higher learning in the world, located in present-day Pakistan. It attracted students from across Asia to study a wide range of subjects.",
+    keyFacts: [
+      "Taught over 60 subjects, including medicine, law, warfare, and astronomy",
+      "Students typically began studies around age 16 after basic education elsewhere",
+      "Renowned alumni are traditionally associated with figures like Chanakya",
+      "Functioned more as a cluster of individual teachers than a single institution",
+    ],
+    color: "#F7931E",
+  },
+  {
+    id: "nalanda",
+    name: "Nalanda University",
+    period: "c. 5th – 12th century CE",
+    image: "assets/education/nalanda.jpg",
+    summary:
+      "A major Buddhist monastic university in present-day Bihar, considered one of the first residential international universities, hosting thousands of students and scholars from across Asia.",
+    keyFacts: [
+      "At its peak, housed an estimated 10,000 students and 2,000 teachers",
+      "Famous library complex, Dharmaganja, held millions of manuscripts",
+      "Attracted scholars from China, Korea, Tibet, and Central Asia",
+      "Declined after invasions in the late 12th century",
+    ],
+    color: "#FDB827",
+  },
+  {
+    id: "medieval",
+    name: "Medieval Education",
+    period: "c. 8th – 18th century CE",
+    image: "assets/education/medieval.jpg",
+    summary:
+      "Education diversified with the growth of maktabs and madrasas alongside traditional gurukuls, and Persian became the language of administration and scholarship in many regions.",
+    keyFacts: [
+      "Maktabs taught basic literacy; madrasas offered advanced religious and secular study",
+      "Persian and Sanskrit coexisted as languages of learning and administration",
+      "Royal courts patronized scholars, poets, and translators",
+      "Regional languages and literature also flourished during this period",
+    ],
+    color: "#2E8B57",
+  },
+  {
+    id: "british-reforms",
+    name: "British Education Reforms",
+    period: "1813 – 1947",
+    image: "assets/education/british-reforms.jpg",
+    summary:
+      "Colonial policy gradually introduced English-medium, Western-style education, reshaping the structure of schooling and higher education across India.",
+    keyFacts: [
+      "Charter Act of 1813 allocated funds for Indian education for the first time",
+      "Macaulay's Minute (1835) established English as the medium of higher instruction",
+      "Wood's Despatch (1854) proposed a structured system of schools and universities",
+      "Education access remained limited, favoring administrative and clerical training",
+    ],
+    color: "#4169E1",
+  },
+  {
+    id: "universities",
+    name: "Modern Universities",
+    period: "1857 onwards",
+    image: "assets/education/universities.jpg",
+    summary:
+      "The universities of Calcutta, Bombay, and Madras were established in 1857, laying the foundation for India's modern higher education system.",
+    keyFacts: [
+      "Calcutta, Bombay, and Madras universities founded in 1857",
+      "Modeled on the University of London's affiliating structure",
+      "Expanded rapidly after independence to serve a growing population",
+      "India now has one of the largest higher education systems in the world",
+    ],
+    color: "#8A2BE2",
+  },
+  {
+    id: "iits",
+    name: "IITs",
+    period: "1951 onwards",
+    image: "assets/education/iits.jpg",
+    summary:
+      "The Indian Institutes of Technology were established to build a national base of engineering and technical talent, starting with IIT Kharagpur in 1951.",
+    keyFacts: [
+      "IIT Kharagpur (1951) was the first of the IITs",
+      "Declared 'Institutes of National Importance' by an act of Parliament",
+      "Selection is through the highly competitive JEE examinations",
+      "Now number 23 institutes across India",
+    ],
+    color: "#DC143C",
+  },
+  {
+    id: "nep2020",
+    name: "NEP 2020",
+    period: "2020 – present",
+    image: "assets/education/nep2020.jpg",
+    summary:
+      "The National Education Policy 2020 replaced the 1986 policy, introducing a new 5+3+3+4 school structure, multidisciplinary higher education, and multiple entry-exit options.",
+    keyFacts: [
+      "Replaces the 10+2 structure with a 5+3+3+4 model",
+      "Promotes mother-tongue or regional language instruction until at least Grade 5",
+      "Introduces multiple entry and exit points in undergraduate programs",
+      "Aims to raise Gross Enrolment Ratio in higher education to 50% by 2035",
+    ],
+    color: "#20B2AA",
+  },
+];
+
+export const educationTimeline = [
+  {
+    year: "c. 1500 BCE",
+    eraId: "gurukul",
+    then: "Gurukul system — oral teaching in the guru's home, focused on the Vedas, ethics, and life skills.",
+    now: "Comparable to a residential mentorship model, closer to boarding schools than modern classrooms.",
+  },
+  {
+    year: "c. 6th century BCE",
+    eraId: "takshashila",
+    then: "Takshashila offers advanced study in 60+ subjects, drawing students from across the region.",
+    now: "Comparable to a multidisciplinary university campus.",
+  },
+  {
+    year: "c. 5th century CE",
+    eraId: "nalanda",
+    then: "Nalanda becomes a residential university hosting thousands of students, including many from abroad.",
+    now: "Comparable to a modern research university with a large international student body.",
+  },
+  {
+    year: "8th–18th century CE",
+    eraId: "medieval",
+    then: "Maktabs and madrasas grow alongside gurukuls; Persian becomes the language of administration.",
+    now: "Comparable to parallel public and faith-based school systems operating side by side.",
+  },
+  {
+    year: "1835",
+    eraId: "british-reforms",
+    then: "Macaulay's Minute establishes English-medium Western education as official policy.",
+    now: "Comparable to a nationwide curriculum and language-of-instruction reform.",
+  },
+  {
+    year: "1857",
+    eraId: "universities",
+    then: "Universities of Calcutta, Bombay, and Madras are established.",
+    now: "Comparable to the founding of a country's first public university system.",
+  },
+  {
+    year: "1951",
+    eraId: "iits",
+    then: "IIT Kharagpur, the first IIT, is established to build technical talent.",
+    now: "Comparable to founding an elite, government-backed engineering institute network.",
+  },
+  {
+    year: "2020",
+    eraId: "nep2020",
+    then: "National Education Policy 2020 replaces the 1986 policy with a new structure and goals.",
+    now: "Comparable to a full curriculum and schooling-structure overhaul.",
+  },
+];

--- a/history/education/index.html
+++ b/history/education/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>National Memorials Explorer | Incredible India</title>
+  <title>History of Indian Education | Incredible India</title>
   <script>
     (function () {
       const theme = localStorage.getItem('theme');
@@ -27,9 +27,10 @@
           <button class="nav-link dropdown-toggle">History <span class="arrow">▾</span></button>
           <div class="dropdown-menu">
             <a href="../dynasties/index.html" class="dropdown-item">Dynasties</a>
-<a href="../battles/index.html" class="dropdown-item">Battles</a>
-            <a href="../education/index.html" class="dropdown-item">Education</a>
-            <a href="../memorials/index.html" class="dropdown-item active">Memorials</a>          </div>
+            <a href="../battles/index.html" class="dropdown-item">Battles</a>
+            <a href="../memorials/index.html" class="dropdown-item">Memorials</a>
+            <a href="../education/index.html" class="dropdown-item active">Education</a>
+          </div>
         </div>
         <div class="nav-dropdown">
           <button class="nav-link dropdown-toggle">Science <span class="arrow">▾</span></button>
@@ -55,14 +56,14 @@
     </div>
   </nav>
 
-  <main id="memorials-app">
+  <main id="education-app">
     <div class="page-header"></div>
   </main>
 
   <footer class="footer">
     <div class="footer-content">
       <p>Incredible India Explorer — Celebrating India's Heritage</p>
-      <p>Built with ❤️ for ECSoC '26</p>
+      <p>Built with ❤️</p>
     </div>
   </footer>
 

--- a/history/education/script.js
+++ b/history/education/script.js
@@ -1,0 +1,132 @@
+import { educationEras, educationTabs, educationTimeline } from "./data.js";
+import { TabNav } from "./components/TabNav.js";
+import { EraCard, EraDetail } from "./components/EraCard.js";
+import { TimelineItem } from "./components/TimelineItem.js";
+import { ComparisonPanel } from "./components/ComparisonPanel.js";
+
+document.addEventListener("DOMContentLoaded", () => {
+  const app = document.getElementById("education-app");
+  let activeTab = "cover";
+  let selectedEra = null;
+
+  function renderCover() {
+    return `<div class="education-cover">
+      <h2>From Gurukuls to NEP 2020</h2>
+      <p>
+        India's education story spans more than three thousand years — from
+        oral learning in a guru's home, to the great residential universities
+        of Nalanda and Takshashila, through colonial reform, and into today's
+        network of IITs and universities under the National Education Policy
+        2020.
+      </p>
+      <div class="cover-stats">
+        <div class="cover-stat">
+          <span class="cover-stat-value">${educationEras.length}</span>
+          <span class="cover-stat-label">Eras covered</span>
+        </div>
+        <div class="cover-stat">
+          <span class="cover-stat-value">c. 1500 BCE</span>
+          <span class="cover-stat-label">Earliest era</span>
+        </div>
+        <div class="cover-stat">
+          <span class="cover-stat-value">2020</span>
+          <span class="cover-stat-label">Latest reform</span>
+        </div>
+      </div>
+      <button class="cover-cta" id="explore-eras-btn">Explore the Eras <span class="arrow">→</span></button>
+    </div>`;
+  }
+
+  function renderEras() {
+    const cards = educationEras
+      .map((era) => EraCard(era, selectedEra?.id === era.id))
+      .join("");
+    const detail = selectedEra
+      ? EraDetail(selectedEra)
+      : `<p class="era-detail-placeholder">Select an era above to read more.</p>`;
+
+    return `<div class="eras-grid">${cards}</div>
+      <div class="era-detail-wrap">${detail}</div>`;
+  }
+
+  function renderTimeline() {
+    const items = educationTimeline
+      .map((entry) => {
+        const era = educationEras.find((e) => e.id === entry.eraId);
+        return TimelineItem(entry, era);
+      })
+      .join("");
+
+    return `<div class="education-timeline">${items}</div>
+      ${ComparisonPanel(educationTimeline)}`;
+  }
+
+  function renderContent() {
+    switch (activeTab) {
+      case "cover":
+        return renderCover();
+      case "eras":
+        return renderEras();
+      case "timeline":
+        return renderTimeline();
+      default:
+        return renderCover();
+    }
+  }
+
+  function render() {
+    app.innerHTML = `
+      <div class="education-page">
+        <div class="page-header">
+          <h1>History of Indian Education</h1>
+          <p>From the Gurukul system to NEP 2020 — how India has taught its children across the centuries</p>
+        </div>
+        ${TabNav(educationTabs, activeTab)}
+        <div class="education-content" id="education-content">
+          ${renderContent()}
+        </div>
+      </div>`;
+
+    attachEventListeners();
+  }
+
+  function attachEventListeners() {
+    document.querySelectorAll(".education-tab-btn").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        activeTab = btn.dataset.tab;
+        render();
+      });
+    });
+
+    const exploreBtn = document.getElementById("explore-eras-btn");
+    if (exploreBtn) {
+      exploreBtn.addEventListener("click", () => {
+        activeTab = "eras";
+        render();
+      });
+    }
+
+    document.querySelectorAll(".era-card-btn, .era-card").forEach((el) => {
+      el.addEventListener("click", (e) => {
+        const id = el.dataset.id || e.currentTarget.dataset?.id;
+        if (id) {
+          selectedEra = educationEras.find((era) => era.id === id) || selectedEra;
+          render();
+        }
+      });
+    });
+
+    document.querySelectorAll(".timeline-item").forEach((el) => {
+      el.addEventListener("click", () => {
+        const id = el.dataset.eraId;
+        if (id) {
+          selectedEra = educationEras.find((era) => era.id === id) || selectedEra;
+          activeTab = "eras";
+          render();
+        }
+      });
+    });
+  }
+
+  render();
+});

--- a/history/education/styles.css
+++ b/history/education/styles.css
@@ -1,0 +1,352 @@
+#education-app {
+  min-height: 100vh;
+  padding: 2rem 1.5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.page-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.page-header h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: 2.5rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 0.5rem;
+}
+
+.page-header p {
+  font-size: 1.1rem;
+  color: var(--text-secondary);
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+/* Tab Navigation */
+.education-tab-nav {
+  margin-bottom: 2rem;
+}
+
+.tab-scroll {
+  display: flex;
+  gap: 0.5rem;
+  overflow-x: auto;
+  padding: 0.5rem 0;
+  scrollbar-width: none;
+}
+
+.tab-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.education-tab-btn {
+  flex-shrink: 0;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  font-weight: 500;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  border-bottom: 3px solid transparent;
+}
+
+.education-tab-btn:hover {
+  background: var(--bg-hover, rgba(255, 107, 53, 0.1));
+}
+
+.education-tab-btn.active {
+  color: var(--saffron);
+  border-bottom-color: var(--saffron);
+}
+
+/* Cover */
+.education-cover {
+  text-align: center;
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 1rem 0 2rem;
+}
+
+.education-cover h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.9rem;
+  color: var(--text-primary);
+  margin-bottom: 1rem;
+}
+
+.education-cover p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+  margin-bottom: 2rem;
+}
+
+.cover-stats {
+  display: flex;
+  justify-content: center;
+  gap: 2.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.cover-stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.cover-stat-value {
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: var(--saffron);
+}
+
+.cover-stat-label {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.cover-cta {
+  padding: 0.85rem 2rem;
+  border: none;
+  border-radius: 8px;
+  background: var(--gradient-saffron-gold, var(--saffron));
+  color: #1a1a2e;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.cover-cta:hover {
+  transform: translateY(-2px);
+}
+
+/* Eras grid */
+.eras-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.era-card {
+  background: var(--bg-card);
+  border-radius: 12px;
+  overflow: hidden;
+  cursor: pointer;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.era-card:hover,
+.era-card.selected {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-soft, 0 8px 30px rgba(0, 0, 0, 0.3));
+}
+
+.era-card-image {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+}
+
+.era-card-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.era-card-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  padding: 0.3rem 0.75rem;
+  background: rgba(0, 0, 0, 0.55);
+  border-left: 4px solid;
+}
+
+.era-period {
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.era-card-body {
+  padding: 1.1rem;
+}
+
+.era-card-name {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.15rem;
+  color: var(--text-primary);
+  margin-bottom: 0.5rem;
+}
+
+.era-card-summary {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin-bottom: 0.9rem;
+}
+
+.era-card-btn {
+  background: none;
+  border: none;
+  color: var(--saffron);
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0;
+}
+
+/* Era detail */
+.era-detail-wrap {
+  margin-top: 1rem;
+}
+
+.era-detail {
+  background: var(--bg-card);
+  border-radius: 12px;
+  border-top: 4px solid;
+  padding: 1.5rem;
+}
+
+.era-detail-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.era-detail-header h2 {
+  font-family: 'Playfair Display', serif;
+  color: var(--text-primary);
+}
+
+.era-detail-period {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.era-detail-summary {
+  color: var(--text-secondary);
+  line-height: 1.7;
+  margin-bottom: 1rem;
+}
+
+.era-detail-facts {
+  padding-left: 1.2rem;
+  color: var(--text-secondary);
+  line-height: 1.8;
+}
+
+.era-detail-placeholder {
+  text-align: center;
+  color: var(--text-secondary);
+  padding: 2rem 0;
+}
+
+/* Timeline */
+.education-timeline {
+  position: relative;
+  padding-left: 1.5rem;
+  border-left: 2px solid var(--glass-border, rgba(255, 255, 255, 0.14));
+  margin-bottom: 2.5rem;
+}
+
+.timeline-item {
+  position: relative;
+  padding: 0 0 1.75rem 1.25rem;
+  cursor: pointer;
+}
+
+.timeline-dot {
+  position: absolute;
+  left: -1.94rem;
+  top: 0.3rem;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.timeline-year {
+  font-weight: 700;
+  color: var(--item-color, var(--saffron));
+  font-size: 0.85rem;
+}
+
+.timeline-title {
+  font-family: 'Playfair Display', serif;
+  color: var(--text-primary);
+  margin: 0.25rem 0 0.5rem;
+}
+
+.timeline-then,
+.timeline-now {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin-bottom: 0.25rem;
+}
+
+/* Comparison panel */
+.comparison-panel h3 {
+  font-family: 'Playfair Display', serif;
+  color: var(--text-primary);
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.comparison-table-wrap {
+  overflow-x: auto;
+}
+
+.comparison-table {
+  width: 100%;
+  border-collapse: collapse;
+  background: var(--bg-card);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+.comparison-table th,
+.comparison-table td {
+  padding: 0.85rem 1rem;
+  text-align: left;
+  font-size: 0.88rem;
+  border-bottom: 1px solid var(--glass-border, rgba(255, 255, 255, 0.1));
+}
+
+.comparison-table th {
+  color: var(--saffron);
+  font-weight: 600;
+}
+
+.comparison-table td {
+  color: var(--text-secondary);
+}
+
+.comparison-year {
+  font-weight: 700;
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
+@media (max-width: 640px) {
+  .cover-stats {
+    gap: 1.5rem;
+  }
+
+  .comparison-table th,
+  .comparison-table td {
+    font-size: 0.8rem;
+    padding: 0.6rem 0.7rem;
+  }
+}


### PR DESCRIPTION
## What this PR does
Adds a new "History of Indian Education" section under history/education/,
following the same structure as the existing history/dynasties,
history/battles and history/memorials modules.

New content covers:
- Cover section
- Gurukul system
- Nalanda
- Takshashila
- Medieval education
- British education reforms
- Universities
- IITs
- NEP 2020
- Timeline with comparisons

## Files added
- history/education/index.html
- history/education/styles.css
- history/education/script.js
- history/education/data.js
- history/education/components/TabNav.js
- history/education/components/EraCard.js
- history/education/components/TimelineItem.js
- history/education/components/ComparisonPanel.js

## Files modified
- history/dynasties/index.html (added nav link)
- history/battles/index.html (added nav link)
- history/memorials/index.html (added nav link)

Closes #666

@Eshajha19 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “History of Indian Education” section with an introductory view, education eras, detailed key facts, and an interactive timeline.
  * Added “Then vs. Now” comparisons highlighting historical education systems and modern equivalents.
  * Added responsive layouts and interactive navigation for browsing tabs, eras, and timeline entries.

* **Navigation**
  * Added Education links to relevant History dropdown menus.

* **Style**
  * Updated the theme toggle icon presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->