### PR TITLE
Feature: Add SPA resource cleanup registry to prevent memory leaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -882,6 +882,7 @@
     <script src="chatbot-data.js" defer></script>
     <script src="sw-register.js" defer></script>
     <script src="app.js" defer></script>
+    <script src="js-modules/resource-cleanup.js" defer></script>
     <script type="module" src="firebase-config.js"></script>
     <script type="module" src="auth.js"></script>
     <script src="router.js" defer></script>

--- a/js-modules/resource-cleanup.js
+++ b/js-modules/resource-cleanup.js
@@ -1,0 +1,59 @@
+/**
+ * resource-cleanup.js
+ * Lightweight cleanup registry for SPA route transitions.
+ * Prevents memory leaks by ensuring event listeners, timers, and
+ * other resources are properly disposed when navigating between pages.
+ *
+ * Usage in feature pages:
+ *   ResourceCleanup.register(() => { myModal.close(); });
+ *   ResourceCleanup.addManagedListener(btn, 'click', onClick);
+ *   const id = ResourceCleanup.addManagedTimeout(() => {}, 1000);
+ *
+ * All registered cleanups are automatically executed by the router
+ * (via RouteLifecycleManager.runCleanups()) before each route change.
+ */
+
+window.ResourceCleanup = {
+    runAll() {
+        if (window.appLifecycle && typeof window.appLifecycle.runCleanups === 'function') {
+            window.appLifecycle.runCleanups();
+        }
+    },
+
+    register(cleanupFn) {
+        if (typeof cleanupFn !== 'function') return;
+        if (window.appLifecycle && typeof window.appLifecycle.registerCleanup === 'function') {
+            window.appLifecycle.registerCleanup(cleanupFn);
+        }
+    },
+
+    addManagedListener(element, event, handler, options) {
+        if (!element || !event || typeof handler !== 'function') return;
+        element.addEventListener(event, handler, options);
+        this.register(() => {
+            element.removeEventListener(event, handler, options);
+        });
+    },
+
+    addManagedTimeout(fn, delay) {
+        const id = setTimeout(fn, delay);
+        this.register(() => clearTimeout(id));
+        return id;
+    },
+
+    addManagedInterval(fn, delay) {
+        const id = setInterval(fn, delay);
+        this.register(() => clearInterval(id));
+        return id;
+    },
+
+    addManagedObserver(observer) {
+        if (!observer || typeof observer.disconnect !== 'function') return;
+        this.register(() => observer.disconnect());
+    },
+
+    addManagedAbortController(controller) {
+        if (!controller || typeof controller.abort !== 'function') return;
+        this.register(() => controller.abort());
+    }
+};

--- a/js-modules/sports.js
+++ b/js-modules/sports.js
@@ -215,8 +215,10 @@ function initSportsPage() {
     renderAthletes();
     setActiveFilterButton(activeFilter);
 
+    const cleanup = window.ResourceCleanup;
+
     filterButtons.forEach(btn => {
-        btn.addEventListener('click', () => {
+        cleanup.addManagedListener(btn, 'click', () => {
             activeFilter = btn.getAttribute('data-sports-filter') || 'all';
             setActiveFilterButton(activeFilter);
 
@@ -228,11 +230,11 @@ function initSportsPage() {
         });
     });
 
-    searchInput.addEventListener('input', () => {
+    cleanup.addManagedListener(searchInput, 'input', () => {
         renderAthletes();
     });
 
-    timelineGrid.addEventListener('click', (event) => {
+    cleanup.addManagedListener(timelineGrid, 'click', (event) => {
         const button = event.target.closest('[data-timeline-filter]');
         if (!button) return;
 
@@ -248,12 +250,12 @@ function initSportsPage() {
         sportsSection?.scrollIntoView({ behavior: 'smooth', block: 'start' });
     });
 
-    modalClose.addEventListener('click', closeModal);
-    modal.addEventListener('click', (event) => {
+    cleanup.addManagedListener(modalClose, 'click', closeModal);
+    cleanup.addManagedListener(modal, 'click', (event) => {
         if (event.target === modal) closeModal();
     });
 
-    document.addEventListener('keydown', (event) => {
+    cleanup.addManagedListener(document, 'keydown', (event) => {
         if (!isModalOpen) return;
 
         if (event.key === 'Escape') {


### PR DESCRIPTION
## Description
Introduces a lightweight \ResourceCleanup\ registry API that feature pages use to register cleanup callbacks. All registered cleanups are automatically executed by the existing \RouteLifecycleManager.runCleanups()\ before each route transition, preventing memory leaks from orphaned event listeners and timers.

## Changes

### New file: \js-modules/resource-cleanup.js\
| Method | Purpose |
|---|---|
| \egister(fn)\ | Register a custom cleanup callback |
| \ddManagedListener(el, evt, handler)\ | Add listener + auto-register removal |
| \ddManagedTimeout(fn, delay)\ | Tracked setTimeout |
| \ddManagedInterval(fn, delay)\ | Tracked setInterval |
| \ddManagedObserver(observer)\ | Register IntersectionObserver/MutationObserver disconnect |
| \ddManagedAbortController(controller)\ | Register AbortController abort |

### Modified: \index.html\
- Loads \esource-cleanup.js\ (deferred) before \outer.js\ so the API is available during route initialization

### Reference implementation: \js-modules/sports.js\
- All 6 \ddEventListener\ calls replaced with \ResourceCleanup.addManagedListener(...)\
- Serves as a pattern for the remaining 40+ feature page modules

Closes #802