### PR TITLE
Refactor: Centralize configuration constants across js-modules

### DIFF
--- a/app.js
+++ b/app.js
@@ -59,10 +59,10 @@ window.setupFocusTrap = function(modalElement) {
     const previousActiveElement = document.activeElement;
     
     if (focusableElements.length > 0) {
-        setTimeout(() => focusableElements[0].focus(), 50);
+        setTimeout(() => focusableElements[0].focus(), AppConfig.FOCUS_TRAP_DELAY);
     } else {
         modalElement.setAttribute('tabindex', '-1');
-        setTimeout(() => modalElement.focus(), 50);
+        setTimeout(() => modalElement.focus(), AppConfig.FOCUS_TRAP_DELAY);
     }
     
     const keydownHandler = function(e) {
@@ -92,7 +92,7 @@ window.setupFocusTrap = function(modalElement) {
         deactivate: function() {
             modalElement.removeEventListener('keydown', keydownHandler);
             if (previousActiveElement && typeof previousActiveElement.focus === 'function') {
-                setTimeout(() => previousActiveElement.focus(), 50);
+                setTimeout(() => previousActiveElement.focus(), AppConfig.FOCUS_TRAP_DELAY);
             }
         }
     };
@@ -242,57 +242,59 @@ function initNavigation() {
         }
     });
 
-    if (exploreDropdown && !exploreDropdown.querySelector('a[href="frontend/dance/dance.html"]')) {
+    var C = AppConfig;
+
+    if (exploreDropdown && !exploreDropdown.querySelector('a[href="' + C.NAV_PATHS.DANCE + '"]')) {
         const danceLink = document.createElement('a');
-        danceLink.href = 'frontend/dance/dance.html';
+        danceLink.href = C.NAV_PATHS.DANCE;
         danceLink.className = 'dropdown-item';
         danceLink.textContent = 'Dance';
-        if (currentPath.includes('frontend/dance/dance.html')) {
-            danceLink.classList.add('active');
+        if (currentPath.includes(C.NAV_PATHS.DANCE)) {
+            danceLink.classList.add(C.CLASS_ACTIVE);
         }
         exploreDropdown.appendChild(danceLink);
     }
 
-    if (exploreDropdown && !exploreDropdown.querySelector('a[href="frontend/sports/sports.html"]')) {
+    if (exploreDropdown && !exploreDropdown.querySelector('a[href="' + C.NAV_PATHS.SPORTS + '"]')) {
         const sportsLink = document.createElement('a');
-        sportsLink.href = 'frontend/sports/sports.html';
+        sportsLink.href = C.NAV_PATHS.SPORTS;
         sportsLink.className = 'dropdown-item';
         sportsLink.textContent = 'Sports';
-        if (currentPath.includes('frontend/sports/sports.html')) {
-            sportsLink.classList.add('active');
+        if (currentPath.includes(C.NAV_PATHS.SPORTS)) {
+            sportsLink.classList.add(C.CLASS_ACTIVE);
         }
         exploreDropdown.appendChild(sportsLink);
     }
 
-    if (exploreDropdown && !exploreDropdown.querySelector('a[href="frontend/science/science.html"]')) {
+    if (exploreDropdown && !exploreDropdown.querySelector('a[href="' + C.NAV_PATHS.SCIENCE + '"]')) {
         const scienceLink = document.createElement('a');
-        scienceLink.href = 'frontend/science/science.html';
+        scienceLink.href = C.NAV_PATHS.SCIENCE;
         scienceLink.className = 'dropdown-item';
         scienceLink.textContent = 'Science';
-        if (currentPath.includes('frontend/science/science.html')) {
-            scienceLink.classList.add('active');
+        if (currentPath.includes(C.NAV_PATHS.SCIENCE)) {
+            scienceLink.classList.add(C.CLASS_ACTIVE);
         }
         exploreDropdown.appendChild(scienceLink);
     }
 
-    if (exploreDropdown && !exploreDropdown.querySelector('a[href="frontend/music/music.html"]')) {
+    if (exploreDropdown && !exploreDropdown.querySelector('a[href="' + C.NAV_PATHS.MUSIC + '"]')) {
         const musicLink = document.createElement('a');
-        musicLink.href = 'frontend/music/music.html';
+        musicLink.href = C.NAV_PATHS.MUSIC;
         musicLink.className = 'dropdown-item';
         musicLink.textContent = 'Music';
-        if (currentPath.includes('frontend/music/music.html')) {
-            musicLink.classList.add('active');
+        if (currentPath.includes(C.NAV_PATHS.MUSIC)) {
+            musicLink.classList.add(C.CLASS_ACTIVE);
         }
         exploreDropdown.appendChild(musicLink);
     }
 
-    if (exploreDropdown && !exploreDropdown.querySelector('a[href="frontend/literature/literature.html"]')) {
+    if (exploreDropdown && !exploreDropdown.querySelector('a[href="' + C.NAV_PATHS.LITERATURE + '"]')) {
         const literatureLink = document.createElement('a');
-        literatureLink.href = 'frontend/literature/literature.html';
+        literatureLink.href = C.NAV_PATHS.LITERATURE;
         literatureLink.className = 'dropdown-item';
         literatureLink.textContent = 'Literature';
-        if (currentPath.includes('frontend/literature/literature.html')) {
-            literatureLink.classList.add('active');
+        if (currentPath.includes(C.NAV_PATHS.LITERATURE)) {
+            literatureLink.classList.add(C.CLASS_ACTIVE);
         }
         exploreDropdown.appendChild(literatureLink);
     }
@@ -390,20 +392,20 @@ function initThemeToggle() {
         }
     };
 
-    const currentTheme = localStorage.getItem('theme');
-    if (currentTheme === 'light') {
-        document.body.classList.add('light-theme');
+    const currentTheme = localStorage.getItem(AppConfig.THEME_STORAGE_KEY);
+    if (currentTheme === AppConfig.THEME_LIGHT) {
+        document.body.classList.add(AppConfig.THEME_CLASS_LIGHT);
         setThemeIcon(true);
     } else {
         setThemeIcon(false);
     }
 
     themeBtn.addEventListener('click', () => {
-        document.body.classList.toggle('light-theme');
-        const isLightTheme = document.body.classList.contains('light-theme');
+        document.body.classList.toggle(AppConfig.THEME_CLASS_LIGHT);
+        const isLightTheme = document.body.classList.contains(AppConfig.THEME_CLASS_LIGHT);
         setThemeIcon(isLightTheme);
-        const theme = isLightTheme ? 'light' : 'dark';
-        localStorage.setItem('theme', theme);
+        const theme = isLightTheme ? AppConfig.THEME_LIGHT : AppConfig.THEME_DARK;
+        localStorage.setItem(AppConfig.THEME_STORAGE_KEY, theme);
     });
 }
 
@@ -1768,7 +1770,7 @@ function playNavratriSoundscape(sticksElement) {
             synthesizeDandiyaStrike(strength);
             if (sticksElement) {
                 sticksElement.classList.add('beat-pulse');
-                setTimeout(() => sticksElement.classList.remove('beat-pulse'), 150);
+                setTimeout(() => sticksElement.classList.remove('beat-pulse'), AppConfig.BEAT_PULSE_DELAY);
             }
         }
 
@@ -1812,7 +1814,7 @@ function playBihuSoundscape(drumElement) {
             synthesizeDholStrike(strength * 1.1);
             if (drumElement) {
                 drumElement.classList.add('beat-pulse');
-                setTimeout(() => drumElement.classList.remove('beat-pulse'), 150);
+                setTimeout(() => drumElement.classList.remove('beat-pulse'), AppConfig.BEAT_PULSE_DELAY);
             }
         }
 

--- a/index.html
+++ b/index.html
@@ -881,6 +881,7 @@
     <script src="dist/map-data.js" defer></script>
     <script src="chatbot-data.js" defer></script>
     <script src="sw-register.js" defer></script>
+    <script src="js-modules/config.js" defer></script>
     <script src="app.js" defer></script>
     <script type="module" src="firebase-config.js"></script>
     <script type="module" src="auth.js"></script>

--- a/js-modules/config.js
+++ b/js-modules/config.js
@@ -1,0 +1,65 @@
+window.AppConfig = {
+    // Theme
+    THEME_STORAGE_KEY: 'theme',
+    THEME_LIGHT: 'light',
+    THEME_DARK: 'dark',
+    THEME_CLASS_LIGHT: 'light-theme',
+
+    // CSS class constants
+    CLASS_ACTIVE: 'active',
+    CLASS_OPEN: 'open',
+    CLASS_HIDDEN: 'hidden',
+    CLASS_VISIBLE: 'visible',
+    CLASS_IS_VISIBLE: 'is-visible',
+    CLASS_SCROLLED: 'scrolled',
+    CLASS_NO_SCROLL: 'no-scroll',
+    CLASS_DROP_CAP: 'drop-cap',
+    CLASS_REVEAL: 'reveal',
+    CLASS_PLAYING: 'playing',
+    CLASS_BEAT_PULSE: 'beat-pulse',
+    CLASS_DIMMED: 'dimmed',
+    CLASS_DISABLED: 'disabled',
+    CLASS_CORRECT: 'correct',
+    CLASS_WRONG: 'wrong',
+    CLASS_LISTENING: 'listening',
+
+    // Timing (ms)
+    FOCUS_TRAP_DELAY: 50,
+    BEAT_PULSE_DELAY: 150,
+    TOAST_DURATION: 4000,
+    LOADING_OVERLAY_TIMEOUT: 8000,
+    ROUTE_TRANSITION_DURATION: 250,
+    SCROLL_ANIMATION_DURATION: 500,
+    MODAL_SHOW_DELAY: 300,
+
+    // Animation
+    ROTATING_TEXT_INTERVAL: 3500,
+
+    // Navigation
+    NAV_PATHS: {
+        DANCE: 'frontend/dance/dance.html',
+        SPORTS: 'frontend/sports/sports.html',
+        SCIENCE: 'frontend/science/science.html',
+        MUSIC: 'frontend/music/music.html',
+        LITERATURE: 'frontend/literature/literature.html',
+    },
+
+    // Cache
+    CACHE_TTL_SHORT: 15 * 60 * 1000,
+    CACHE_TTL_MEDIUM: 30 * 60 * 1000,
+    CACHE_TTL_LONG: 3 * 60 * 60 * 1000,
+
+    // Limits
+    RECENTLY_VIEWED_MAX: 10,
+    TRANSLATION_CACHE_LIMIT: 500,
+
+    // Routes (pages in command palette)
+    CMD_PALETTE_ROUTES: [
+        'index.html',
+        'monuments.html',
+        'culture.html',
+        'festivals.html',
+        'itinery-generator.html',
+        'india-3d-map.html',
+    ],
+};

--- a/js-modules/navigation.js
+++ b/js-modules/navigation.js
@@ -21,57 +21,59 @@ function initNavigation() {
         }
     });
 
-    if (exploreDropdown && !exploreDropdown.querySelector('a[href="frontend/dance/dance.html"]')) {
+    var C = window.AppConfig;
+
+    if (exploreDropdown && !exploreDropdown.querySelector('a[href="' + C.NAV_PATHS.DANCE + '"]')) {
         const danceLink = document.createElement('a');
-        danceLink.href = 'frontend/dance/dance.html';
+        danceLink.href = C.NAV_PATHS.DANCE;
         danceLink.className = 'dropdown-item';
         danceLink.textContent = 'Dance';
-        if (currentPath.includes('frontend/dance/dance.html')) {
-            danceLink.classList.add('active');
+        if (currentPath.includes(C.NAV_PATHS.DANCE)) {
+            danceLink.classList.add(C.CLASS_ACTIVE);
         }
         exploreDropdown.appendChild(danceLink);
     }
 
-    if (exploreDropdown && !exploreDropdown.querySelector('a[href="frontend/sports/sports.html"]')) {
+    if (exploreDropdown && !exploreDropdown.querySelector('a[href="' + C.NAV_PATHS.SPORTS + '"]')) {
         const sportsLink = document.createElement('a');
-        sportsLink.href = 'frontend/sports/sports.html';
+        sportsLink.href = C.NAV_PATHS.SPORTS;
         sportsLink.className = 'dropdown-item';
         sportsLink.textContent = 'Sports';
-        if (currentPath.includes('frontend/sports/sports.html')) {
-            sportsLink.classList.add('active');
+        if (currentPath.includes(C.NAV_PATHS.SPORTS)) {
+            sportsLink.classList.add(C.CLASS_ACTIVE);
         }
         exploreDropdown.appendChild(sportsLink);
     }
 
-    if (exploreDropdown && !exploreDropdown.querySelector('a[href="frontend/science/science.html"]')) {
+    if (exploreDropdown && !exploreDropdown.querySelector('a[href="' + C.NAV_PATHS.SCIENCE + '"]')) {
         const scienceLink = document.createElement('a');
-        scienceLink.href = 'frontend/science/science.html';
+        scienceLink.href = C.NAV_PATHS.SCIENCE;
         scienceLink.className = 'dropdown-item';
         scienceLink.textContent = 'Science';
-        if (currentPath.includes('frontend/science/science.html')) {
-            scienceLink.classList.add('active');
+        if (currentPath.includes(C.NAV_PATHS.SCIENCE)) {
+            scienceLink.classList.add(C.CLASS_ACTIVE);
         }
         exploreDropdown.appendChild(scienceLink);
     }
 
-    if (exploreDropdown && !exploreDropdown.querySelector('a[href="frontend/music/music.html"]')) {
+    if (exploreDropdown && !exploreDropdown.querySelector('a[href="' + C.NAV_PATHS.MUSIC + '"]')) {
         const musicLink = document.createElement('a');
-        musicLink.href = 'frontend/music/music.html';
+        musicLink.href = C.NAV_PATHS.MUSIC;
         musicLink.className = 'dropdown-item';
         musicLink.textContent = 'Music';
-        if (currentPath.includes('frontend/music/music.html')) {
-            musicLink.classList.add('active');
+        if (currentPath.includes(C.NAV_PATHS.MUSIC)) {
+            musicLink.classList.add(C.CLASS_ACTIVE);
         }
         exploreDropdown.appendChild(musicLink);
     }
 
-    if (exploreDropdown && !exploreDropdown.querySelector('a[href="frontend/literature/literature.html"]')) {
+    if (exploreDropdown && !exploreDropdown.querySelector('a[href="' + C.NAV_PATHS.LITERATURE + '"]')) {
         const literatureLink = document.createElement('a');
-        literatureLink.href = 'frontend/literature/literature.html';
+        literatureLink.href = C.NAV_PATHS.LITERATURE;
         literatureLink.className = 'dropdown-item';
         literatureLink.textContent = 'Literature';
-        if (currentPath.includes('frontend/literature/literature.html')) {
-            literatureLink.classList.add('active');
+        if (currentPath.includes(C.NAV_PATHS.LITERATURE)) {
+            literatureLink.classList.add(C.CLASS_ACTIVE);
         }
         exploreDropdown.appendChild(literatureLink);
     }

--- a/js-modules/toast-system.js
+++ b/js-modules/toast-system.js
@@ -2,7 +2,7 @@
     'use strict';
 
     const TOAST_CONTAINER_ID = 'app-toast-container';
-    const DEFAULT_DURATION = 4000;
+    const DEFAULT_DURATION = AppConfig.TOAST_DURATION;
 
     let container = null;
 


### PR DESCRIPTION
## Description
Introduces \AppConfig\ (\js-modules/config.js\) as the single source of truth for configuration constants used across the codebase. Eliminates hardcoded magic values spread across multiple files.

## New file: \js-modules/config.js\
| Category | Constants |
|---|---|
| Theme | \THEME_STORAGE_KEY\, \THEME_LIGHT\, \THEME_DARK\, \THEME_CLASS_LIGHT\ |
| CSS classes | \CLASS_ACTIVE\, \CLASS_OPEN\, \CLASS_VISIBLE\, \CLASS_IS_VISIBLE\, \CLASS_SCROLLED\, \CLASS_NO_SCROLL\, \CLASS_BEAT_PULSE\, etc. |
| Timing | \FOCUS_TRAP_DELAY\ (50ms), \BEAT_PULSE_DELAY\ (150ms), \TOAST_DURATION\ (4000ms), \LOADING_OVERLAY_TIMEOUT\ (8000ms), \ROUTE_TRANSITION_DURATION\ (250ms) |
| Navigation | \NAV_PATHS.DANCE\, \NAV_PATHS.SPORTS\, \NAV_PATHS.SCIENCE\, \NAV_PATHS.MUSIC\, \NAV_PATHS.LITERATURE\ |
| Cache/Limits | \CACHE_TTL_SHORT\, \CACHE_TTL_MEDIUM\, \CACHE_TTL_LONG\, \RECENTLY_VIEWED_MAX\ |

## Reference updates
- \pp.js\: Focus trap delay, theme storage key/values/class, navigation paths, active class, beat-pulse timing
- \
avigation.js\: Navigation paths, active class
- \	oast-system.js\: Default toast duration
- \index.html\: Loads \config.js\ before \pp.js\

Closes #801