### PR TITLE
feat: Add North Sentinel Island educational page and landing page card

### DIFF
--- a/frontend/islands/islands.js
+++ b/frontend/islands/islands.js
@@ -91,6 +91,20 @@ const ISLANDS_DATA = [
     image: "../../assets/travel_beaches.png"
   },
   {
+    id: "north-sentinel-island",
+    name: "North Sentinel Island",
+    group: "Andaman & Nicobar",
+    location: "Andaman Islands, Bay of Bengal",
+    state: "Union Territory",
+    lat: 11.5533,
+    lng: 92.2367,
+    islandCount: "1 island",
+    tagline: "A protected, off-limits home to the Sentinelese people",
+    description: "North Sentinel Island is home to the Sentinelese, one of the world's last uncontacted tribes. Entry is strictly prohibited by Indian law to protect the tribe's health, safety and way of life.",
+    highlights: ["Home to the uncontacted Sentinelese tribe", "Protected under the Protection of Aboriginal Tribes Regulation, 1956", "Off-limits — no tourism or unauthorised entry permitted", "Part of the Andaman & Nicobar tribal reserve system"],
+    image: "../../assets/travel_hidden.png"
+  },
+  {
     id: "lakshadweep",
     name: "Lakshadweep Islands",
     group: "Lakshadweep",
@@ -314,13 +328,14 @@ function openModal(islandId) {
   const island = ISLANDS_DATA.find((i) => i.id === islandId);
   if (!island) return;
 
-  if (island.id === "great-nicobar" || island.id === "south-andaman" || island.id === "middle-andaman" || island.id === "shaheed-dweep" || island.id === "swaraj-dweep") {
+  if (island.id === "great-nicobar" || island.id === "south-andaman" || island.id === "middle-andaman" || island.id === "shaheed-dweep" || island.id === "swaraj-dweep" || island.id === "north-sentinel-island") {
     const pageMap = {
       "great-nicobar": "../great-nicobar/great-nicobar.html",
       "south-andaman": "../south-andaman/south-andaman.html",
       "middle-andaman": "../middle-andaman/middle-andaman.html",
       "shaheed-dweep": "../shaheed-dweep/shaheed-dweep.html",
-      "swaraj-dweep": "../swaraj-dweep/swaraj-dweep.html"
+      "swaraj-dweep": "../swaraj-dweep/swaraj-dweep.html",
+      "north-sentinel-island": "../north-sentinel-island/north-sentinel-island.html"
     };
     window.location.href = pageMap[island.id];
     return;

--- a/frontend/north-sentinel-island/north-sentinel-island.css
+++ b/frontend/north-sentinel-island/north-sentinel-island.css
@@ -1,0 +1,327 @@
+/* ============================================================
+   North Sentinel Island — north-sentinel-island.css
+   Uses the shared design tokens defined in ../../styles.css
+   ============================================================ */
+
+.sentinel-page {
+  padding-top: var(--navbar-height);
+  overflow-x: hidden;
+}
+
+.sentinel-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* ---------- Hero ---------- */
+.sentinel-hero {
+  position: relative;
+  padding: 90px 24px 70px;
+  text-align: center;
+  background:
+    linear-gradient(180deg, rgba(4, 23, 42, 0.55) 0%, rgba(4, 23, 42, 0.92) 100%),
+    url("../../assets/travel_hidden.png") center/cover no-repeat;
+}
+
+.sentinel-hero-content {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.sentinel-hero-kicker {
+  display: inline-block;
+  padding: 6px 16px;
+  border-radius: 999px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  color: var(--primary-saffron);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-bottom: 20px;
+}
+
+.sentinel-hero h1 {
+  font-family: var(--font-heading);
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  line-height: 1.15;
+  margin-bottom: 18px;
+  color: var(--text-light);
+}
+
+.sentinel-hero h1 span {
+  background: var(--gradient-saffron-gold);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.sentinel-hero p {
+  color: var(--text-secondary);
+  font-size: 1.08rem;
+  line-height: 1.7;
+  margin-bottom: 36px;
+}
+
+.sentinel-hero-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+
+.sentinel-stat-box {
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 18px 12px;
+  transition: var(--transition-snappy);
+}
+
+.sentinel-stat-box:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-glow);
+}
+
+.sentinel-stat-box strong {
+  display: block;
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--primary-saffron);
+}
+
+.sentinel-stat-box span {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+/* ---------- Legal / Ethical Notice ---------- */
+.sentinel-notice-section {
+  padding: 0 0 20px;
+}
+
+.sentinel-notice {
+  max-width: 1000px;
+  margin: -30px auto 0;
+  display: flex;
+  gap: 18px;
+  align-items: flex-start;
+  background: rgba(220, 38, 38, 0.08);
+  border: 1px solid rgba(220, 38, 38, 0.4);
+  border-radius: var(--border-radius-lg);
+  padding: 24px 28px;
+}
+
+.sentinel-notice-icon {
+  font-size: 1.8rem;
+  line-height: 1;
+}
+
+.sentinel-notice-text h3 {
+  font-family: var(--font-heading);
+  color: var(--text-light);
+  font-size: 1.1rem;
+  margin-bottom: 8px;
+}
+
+.sentinel-notice-text p {
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+  line-height: 1.7;
+  margin: 0;
+}
+
+/* ---------- Section heading ---------- */
+.sentinel-section {
+  padding: 70px 0;
+}
+
+.sentinel-section-heading {
+  text-align: center;
+  max-width: 680px;
+  margin: 0 auto 44px;
+}
+
+.sentinel-section-badge {
+  display: inline-block;
+  color: var(--primary-gold);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+
+.sentinel-section-heading h2 {
+  font-family: var(--font-heading);
+  font-size: clamp(1.7rem, 3.5vw, 2.4rem);
+  color: var(--text-light);
+  margin-bottom: 14px;
+}
+
+.sentinel-section-heading p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+/* ---------- Tabs ---------- */
+.sentinel-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  margin-bottom: 32px;
+}
+
+.sentinel-tab-btn {
+  padding: 10px 20px;
+  border-radius: 999px;
+  border: 1px solid var(--glass-border);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: var(--transition-snappy);
+}
+
+.sentinel-tab-btn:hover {
+  border-color: var(--primary-saffron);
+  color: var(--text-light);
+}
+
+.sentinel-tab-btn.active {
+  background: var(--gradient-saffron-gold);
+  color: #1a1200;
+  border-color: transparent;
+  font-weight: 600;
+}
+
+.sentinel-tab-panel {
+  display: none;
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 32px;
+  animation: sentinel-fade-in 0.3s ease;
+}
+
+.sentinel-tab-panel.active {
+  display: block;
+}
+
+@keyframes sentinel-fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.sentinel-tab-panel h3 {
+  font-family: var(--font-heading);
+  color: var(--primary-gold);
+  margin-bottom: 14px;
+  font-size: 1.3rem;
+}
+
+.sentinel-tab-panel p {
+  color: var(--text-secondary);
+  line-height: 1.8;
+  margin-bottom: 14px;
+}
+
+.sentinel-tab-panel ul {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.sentinel-tab-panel ul li {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  padding-left: 24px;
+  position: relative;
+  line-height: 1.6;
+}
+
+.sentinel-tab-panel ul li::before {
+  content: "🌴";
+  position: absolute;
+  left: 0;
+}
+
+/* ---------- Did You Know ---------- */
+.sentinel-fact-panel {
+  max-width: 760px;
+  margin: 0 auto;
+  background: var(--gradient-card-border);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 40px 36px;
+  text-align: center;
+}
+
+.sentinel-fact-icon {
+  font-size: 2.2rem;
+  margin-bottom: 14px;
+}
+
+#sentinel-fact-text {
+  font-family: var(--font-heading);
+  font-size: 1.15rem;
+  color: var(--text-light);
+  line-height: 1.6;
+  transition: opacity 0.2s ease;
+  min-height: 84px;
+}
+
+.sentinel-fact-dots {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.sentinel-fact-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+  background: var(--glass-border);
+  cursor: pointer;
+  transition: var(--transition-snappy);
+}
+
+.sentinel-fact-dot.active {
+  background: var(--primary-saffron);
+  width: 22px;
+  border-radius: 4px;
+}
+
+/* ---------- Back to Islands link ---------- */
+.sentinel-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--primary-saffron);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 14px;
+}
+
+.sentinel-back-link:hover {
+  text-decoration: underline;
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 768px) {
+  .sentinel-hero-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .sentinel-notice {
+    flex-direction: column;
+    margin-top: 0;
+  }
+}

--- a/frontend/north-sentinel-island/north-sentinel-island.html
+++ b/frontend/north-sentinel-island/north-sentinel-island.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="An educational, respectful look at North Sentinel Island — home to the uncontacted Sentinelese people. Geography, conservation status, history and wildlife. Entry is prohibited by law; this page does not promote tourism.">
+    <title>North Sentinel Island | Incredible India</title>
+    <link rel="icon" href="data:,">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="north-sentinel-island.css">
+
+    <!-- Open Graph / Social Media Tags -->
+    <meta property="og:title" content="North Sentinel Island | Incredible India Explorer">
+    <meta property="og:description" content="An educational look at North Sentinel Island's geography, the Sentinelese tribe, conservation status and history. Entry is legally prohibited; this page does not promote tourism.">
+    <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/assets/travel_hidden.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/north-sentinel-island/north-sentinel-island.html">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Incredible India Explorer">
+    <meta property="og:locale" content="en_IN">
+
+    <!-- Twitter Card Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="North Sentinel Island | Incredible India Explorer">
+    <meta name="twitter:description" content="Geography, the Sentinelese tribe, conservation status and history of North Sentinel Island — educational content only.">
+    <meta name="twitter:image" content="https://incredibleindiaexplorer.gov.in/assets/travel_hidden.png">
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/north-sentinel-island/north-sentinel-island.html">
+</head>
+
+<body class="sentinel-body">
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html#home" class="nav-link" id="link-home">Home</a>
+                <a href="../../index.html#map" class="nav-link" id="link-map">Interactive Map</a>
+                <a href="../islands/islands.html" class="nav-link">Islands</a>
+                <a href="north-sentinel-island.html" class="nav-link active" style="color: var(--saffron)">North Sentinel Island</a>
+
+                <div class="nav-dropdown">
+                    <button class="nav-link dropdown-toggle" id="link-explore-more">
+                        Explore More ▾
+                    </button>
+                    <div class="dropdown-menu">
+                        <a href="../travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                        <a href="../wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                        <a href="../coastal-india/coastal-india.html" class="dropdown-item">Coastal India</a>
+                        <a href="../heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    </div>
+                </div>
+
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
+                    ☀️
+                </button>
+                <a href="../../login.html" class="nav-link" id="link-login">Login</a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="sentinel-page">
+        <!-- Hero -->
+        <section class="sentinel-hero">
+            <div class="sentinel-hero-content">
+                <a href="../islands/islands.html" class="sentinel-back-link">← Back to Islands of India</a>
+                <span class="sentinel-hero-kicker">⚠️ Restricted &amp; Protected Territory</span>
+                <h1>North <span>Sentinel Island</span></h1>
+                <p>Home to the Sentinelese — one of the world's last uncontacted peoples. This page is provided for educational purposes only. Entry to the island is strictly prohibited by Indian law, to protect the tribe's health, safety and way of life.</p>
+
+                <div class="sentinel-hero-stats">
+                    <div class="sentinel-stat-box">
+                        <strong>~59.67 km²</strong>
+                        <span>Island Area</span>
+                    </div>
+                    <div class="sentinel-stat-box">
+                        <strong>1956</strong>
+                        <span>Protected Since (Regulation)</span>
+                    </div>
+                    <div class="sentinel-stat-box">
+                        <strong>5 nm</strong>
+                        <span>Enforced Exclusion Zone</span>
+                    </div>
+                    <div class="sentinel-stat-box">
+                        <strong>~150</strong>
+                        <span>Estimated Sentinelese Population</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Legal / Ethical Notice -->
+        <section class="sentinel-notice-section">
+            <div class="sentinel-container">
+                <div class="sentinel-notice">
+                    <div class="sentinel-notice-icon">🚫</div>
+                    <div class="sentinel-notice-text">
+                        <h3>Access is prohibited by law</h3>
+                        <p>Under the Protection of Aboriginal Tribes Regulation, 1956, and Indian Navy-enforced exclusion rules, travel to North Sentinel Island — and photographing or approaching its residents — is illegal. This is a firsthand-contact restriction designed to protect the Sentinelese from disease and harm, and to respect their choice to remain isolated. This page contains no travel information and does not encourage visiting the island.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Tabbed info -->
+        <section class="sentinel-section" id="sentinel-explore">
+            <div class="sentinel-container">
+                <div class="sentinel-section-heading">
+                    <span class="sentinel-section-badge">Learn More</span>
+                    <h2>Geography, People &amp; Conservation</h2>
+                    <p>Select a tab to learn more about the island.</p>
+                </div>
+
+                <div class="sentinel-tabs" role="tablist">
+                    <button type="button" class="sentinel-tab-btn active" data-tab="geography">Geography</button>
+                    <button type="button" class="sentinel-tab-btn" data-tab="tribe">Sentinelese Tribe</button>
+                    <button type="button" class="sentinel-tab-btn" data-tab="conservation">Conservation &amp; Protected Area</button>
+                    <button type="button" class="sentinel-tab-btn" data-tab="history">History</button>
+                    <button type="button" class="sentinel-tab-btn" data-tab="wildlife">Wildlife</button>
+                </div>
+
+                <div class="sentinel-tab-panel active" id="tab-geography">
+                    <h3>🗺️ Geography</h3>
+                    <p>North Sentinel Island is a small, roughly triangular island covering approximately 59.67 sq. km, part of the Andaman Islands in the Bay of Bengal. It lies about 36 km west of Port Blair, the capital of the Andaman &amp; Nicobar Islands.</p>
+                    <p>The island is ringed by coral reefs that make its coastline difficult to approach by boat, with a narrow fringe of sandy beach giving way to dense tropical forest that covers most of the interior. There is no natural harbour, which has historically limited outside contact.</p>
+                </div>
+
+                <div class="sentinel-tab-panel" id="tab-tribe">
+                    <h3>🧑‍🤝‍🧑 The Sentinelese Tribe</h3>
+                    <p>The Sentinelese are believed to be descendants of some of the earliest human populations to migrate out of Africa, having lived in isolation on the island for an estimated 30,000–55,000 years. Their population is thought to number roughly 50 to 200 individuals, though exact figures are unknown since no census or survey has ever been conducted at close range.</p>
+                    <p>Very little is known about their language, customs or social structure, as it remains linguistically and culturally distinct from other Andamanese groups. They are known to sustain themselves through hunting, fishing and foraging, and have consistently resisted contact with outsiders — a choice that Indian policy has, since the late 1990s, chosen to respect rather than override.</p>
+                </div>
+
+                <div class="sentinel-tab-panel" id="tab-conservation">
+                    <h3>🛡️ Conservation &amp; Protected Area</h3>
+                    <p>North Sentinel Island falls under the Andaman &amp; Nicobar tribal reserve system and is protected under the Protection of Aboriginal Tribes Regulation, 1956, which makes it illegal to visit, photograph or attempt contact with the island's inhabitants.</p>
+                    <ul>
+                        <li>The Indian Navy patrols and enforces a several-nautical-mile exclusion zone around the island</li>
+                        <li>India's "eyes-on, hands-off" policy, adopted in the late 1990s, ended earlier attempts at direct contact</li>
+                        <li>The restriction protects the Sentinelese from infectious diseases to which they have no immunity</li>
+                        <li>The policy also protects their right to self-determination and continued isolation</li>
+                    </ul>
+                </div>
+
+                <div class="sentinel-tab-panel" id="tab-history">
+                    <h3>📜 History</h3>
+                    <p>Outside knowledge of North Sentinel Island dates back to colonial-era surveys, including a 19th-century expedition led by British naval officer Maurice Vidal Portman, which involved a brief and forced encounter that ended in tragedy for several islanders taken away by the visitors. This early contact reinforced the community's wariness of outsiders.</p>
+                    <p>Sporadic contact attempts continued through the 20th century, including some in the 1970s–1990s that occasionally saw gifts exchanged from a safe distance. India formally ended these outreach attempts by the late 1990s in favour of a strict no-contact policy. The island survived the 2004 Indian Ocean tsunami with the Sentinelese reportedly having moved to higher ground beforehand, drawing on traditional ecological knowledge. Fatal encounters involving outsiders who breached the exclusion zone in 2006 and 2018 further underscored why the restricted-access policy remains in force today.</p>
+                </div>
+
+                <div class="sentinel-tab-panel" id="tab-wildlife">
+                    <h3>🌿 Wildlife</h3>
+                    <p>Because the island's interior has never been surveyed by outside researchers, detailed wildlife data is limited. What is known comes largely from offshore observation and comparison with similar Andaman ecosystems.</p>
+                    <ul>
+                        <li>Dense tropical evergreen forest covering most of the island's interior</li>
+                        <li>Surrounding coral reefs supporting diverse reef fish and marine invertebrates</li>
+                        <li>Coastal and forest bird species typical of the Andaman Islands</li>
+                        <li>Native fauna such as the Andaman wild pig, believed to be part of the traditional Sentinelese diet</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <!-- Interesting Facts -->
+        <section class="sentinel-section">
+            <div class="sentinel-container">
+                <div class="sentinel-section-heading">
+                    <span class="sentinel-section-badge">Did You Know?</span>
+                    <h2>Interesting Facts</h2>
+                </div>
+                <div class="sentinel-fact-panel">
+                    <div class="sentinel-fact-icon">💡</div>
+                    <p id="sentinel-fact-text">Loading fact...</p>
+                    <div class="sentinel-fact-dots" id="sentinel-fact-dots"></div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <!-- Footer -->
+    <footer class="site-footer">
+        <div class="footer-container">
+            <div class="footer-brand">
+                <a href="../../index.html#home" class="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <p>Preserving and celebrating India's rich island territories, coastlines and culture.</p>
+            </div>
+            <div class="footer-links">
+                <h4>Quick Links</h4>
+                <a href="../../index.html#home">Home</a>
+                <a href="../islands/islands.html">Islands of India</a>
+                <a href="../wildlife/wildlife.html">Nature & Wildlife</a>
+                <a href="north-sentinel-island.html">North Sentinel Island</a>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2026 Incredible India Explorer. Open Source Cultural Heritage Initiative.</p>
+        </div>
+    </footer>
+
+    <script type="module" src="north-sentinel-island.js"></script>
+    <script src="../../pages-common.js"></script>
+</body>
+</html>

--- a/frontend/north-sentinel-island/north-sentinel-island.js
+++ b/frontend/north-sentinel-island/north-sentinel-island.js
@@ -1,0 +1,76 @@
+/* ============================================================
+   North Sentinel Island — north-sentinel-island.js
+   Handles: tab navigation and the rotating "Did You Know?"
+   facts panel. No map or gallery — see PR notes for why.
+   ============================================================ */
+
+// ---------- 1. INTERESTING FACTS ----------
+const SENTINEL_FACTS = [
+  "The Sentinelese are believed to have lived in isolation on North Sentinel Island for tens of thousands of years, possibly since the first human migrations out of Africa.",
+  "North Sentinel Island covers only about 59.67 sq. km, roughly the size of a small town, yet has remained almost entirely unexplored by outsiders.",
+  "Surrounding coral reefs make the island's coastline treacherous to approach by boat, which has helped keep it isolated for centuries.",
+  "The Sentinelese reportedly moved to higher ground before the 2004 Indian Ocean tsunami struck, an example of traditional ecological knowledge passed down without any written record.",
+  "India has enforced a strict 'eyes-on, hands-off' no-contact policy toward the island since the late 1990s.",
+  "The Protection of Aboriginal Tribes Regulation, 1956 makes it illegal to travel to North Sentinel Island or attempt contact with its residents.",
+  "No outside census has ever been conducted on the island; population estimates of roughly 50 to 200 people come from aerial and offshore observation only."
+];
+
+// ---------- 2. STATE ----------
+let factIndex = 0;
+
+// ---------- 3. DOM READY ----------
+document.addEventListener("DOMContentLoaded", () => {
+  initTabs();
+  initFactsRotator();
+});
+
+// ---------- 4. TAB NAVIGATION ----------
+function initTabs() {
+  const tabButtons = document.querySelectorAll(".sentinel-tab-btn");
+  const tabPanels = document.querySelectorAll(".sentinel-tab-panel");
+
+  tabButtons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const target = btn.getAttribute("data-tab");
+
+      tabButtons.forEach((b) => b.classList.remove("active"));
+      btn.classList.add("active");
+
+      tabPanels.forEach((panel) => {
+        panel.classList.toggle("active", panel.id === "tab-" + target);
+      });
+    });
+  });
+}
+
+// ---------- 5. FACTS ROTATOR ----------
+function initFactsRotator() {
+  const factEl = document.getElementById("sentinel-fact-text");
+  const dotsWrap = document.getElementById("sentinel-fact-dots");
+  if (!factEl) return;
+
+  if (dotsWrap) {
+    SENTINEL_FACTS.forEach((_, i) => {
+      const dot = document.createElement("button");
+      dot.className = "sentinel-fact-dot" + (i === 0 ? " active" : "");
+      dot.setAttribute("aria-label", "Show fact " + (i + 1));
+      dot.addEventListener("click", () => showFact(i));
+      dotsWrap.appendChild(dot);
+    });
+  }
+
+  function showFact(i) {
+    factIndex = i;
+    factEl.style.opacity = "0";
+    setTimeout(() => {
+      factEl.textContent = SENTINEL_FACTS[factIndex];
+      factEl.style.opacity = "1";
+    }, 200);
+    if (dotsWrap) {
+      [...dotsWrap.children].forEach((dot, di) => dot.classList.toggle("active", di === factIndex));
+    }
+  }
+
+  showFact(0);
+  setInterval(() => showFact((factIndex + 1) % SENTINEL_FACTS.length), 6000);
+}


### PR DESCRIPTION
## What this PR does
Closes #671

- Adds a new educational page for North Sentinel Island covering:
  - Geography
  - The Sentinelese Tribe
  - Conservation & Protected Area status
  - History
  - Wildlife
  - Interesting Facts
- Adds a clear notice that the island is legally off-limits and that
  this page is educational only — no tourism information is included,
  and no photos of the Sentinelese are shown, in line with Indian law
  and respect for the tribe's isolation.
- Adds a North Sentinel Island card to the Islands Landing Page
  (frontend/islands/islands.html), consistent with how other island
  pages (e.g. Great Nicobar, Swaraj Dweep) are integrated.

## Files changed
- frontend/north-sentinel-island/north-sentinel-island.html (new)
- frontend/north-sentinel-island/north-sentinel-island.css (new)
- frontend/north-sentinel-island/north-sentinel-island.js (new)
- frontend/islands/islands.js (edited)

@Eshajha19 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated North Sentinel Island destination page with location details, key statistics, history, wildlife, conservation information, and cultural context.
  * Added interactive tabs for browsing island information.
  * Added rotating “Did You Know?” facts with selectable indicators.
  * Added responsive layouts, visual highlights, ethical notices, and navigation back to the islands listing.
  * Updated island details to open the dedicated North Sentinel Island page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->