### PR TITLE
style(waterfall-explorer): extract inline CSS to dedicated file

### DIFF
--- a/frontend/waterfall-explorer/index.html
+++ b/frontend/waterfall-explorer/index.html
@@ -26,7 +26,7 @@
       <nav class="nav-menu" id="nav-menu">
         <a href="../../index.html#home" class="nav-link">Home</a>
         <a href="../../travel.html" class="nav-link">Travel</a>
-        <a href="index.html" class="nav-link" style="color: var(--saffron)">Waterfall Explorer</a>
+        <a href="index.html" class="nav-link active">Waterfall Explorer</a>
         <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
       </nav>
     </div>

--- a/frontend/waterfall-explorer/style.css
+++ b/frontend/waterfall-explorer/style.css
@@ -9,6 +9,9 @@
   --wf-shadow: 0 18px 50px rgba(0, 0, 0, 0.16);
 }
 
+.nav-menu .nav-link.active {
+  color: var(--wf-accent);
+}
 .waterfall-page {
   min-height: 100vh;
   color: var(--wf-text);


### PR DESCRIPTION
resolves #873 
# Summary
The `waterfall-explorer` module was utilizing inline CSS to highlight the active navigation link, which violated project contribution guidelines around strict HTML, CSS, and JS file separation.

---

# Root Cause
The active link state was hardcoded in `index.html` using a `style="..."` attribute rather than applying a specific CSS class that is handled in the stylesheet.

---

# Solution
Extracted the hardcoded styling to a new `.active` CSS class within `style.css` and applied it to the link inside `index.html`. No inline styles remain.

---

# Files Changed
* `frontend/waterfall-explorer/index.html` - Removed inline `style` attribute and added `.active` class.
* `frontend/waterfall-explorer/style.css` - Added CSS rule for `.nav-menu .nav-link.active`.

---

# Testing
* Build passed
* Lint passed
* Tests passed
* Manual verification completed (styling accurately reflects the saffron color on the active route as intended)

---

# Impact
* Breaking changes: No
* Performance impact: None
* Security impact: None
* Compatibility: Backward compatible

---

# Checklist
* [x] Issue solved
* [x] Build passes
* [x] Tests pass
* [x] Lint passes
* [x] No unrelated changes
* [x] Ready for review


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Waterfall Explorer navigation to use consistent active-link styling.
  * The current page is now highlighted using the theme’s accent color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->