### PR TITLE
Add Trisul I Mountain Page

### DIFF
--- a/frontend/mountains/script.js
+++ b/frontend/mountains/script.js
@@ -151,8 +151,8 @@ document.addEventListener("DOMContentLoaded", () => {
       tags: ["restricted-access"]
     },
     {
-      id: "trisul",
-      name: "Trisul",
+      id: "trisul-i",
+      name: "Trisul I",
       height: 7120,
       heightDisplay: "7,120 m",
       range: "Himalayas",
@@ -162,10 +162,10 @@ document.addEventListener("DOMContentLoaded", () => {
       difficulty: "Hard",
       image: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6f/Time_lapse_shot_of_Trishul_peak.jpg/960px-Time_lapse_shot_of_Trishul_peak.jpg",
       firstAscent: "1907",
-      description: "A group of three peaks whose name refers to Lord Shiva's trident. The first 7,000 m peak ever to be climbed, in 1907.",
+      description: "The highest of the three Trisul peaks, named after Lord Shiva's trident. The first 7,000 m peak ever to be climbed, in 1907.",
       fact: "Trisul was the first mountain over 7,000 metres to be climbed, by T.G. Longstaff's expedition in 1907.",
-      link: "https://en.wikipedia.org/wiki/Trisul",
-      linkLabel: "Explore More",
+      link: "../trisul-i/trisul-i.html",
+      linkLabel: "Explore Peak",
       tags: ["first-7000er"]
     },
     {

--- a/frontend/trisul-i/trisul-i.css
+++ b/frontend/trisul-i/trisul-i.css
@@ -1,0 +1,547 @@
+.trisul-i-page {
+  padding-top: var(--navbar-height);
+  overflow-x: hidden;
+}
+
+.trisul-i-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.trisul-i-hero {
+  position: relative;
+  padding: 90px 24px 70px;
+  text-align: center;
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.6) 0%, rgba(15, 23, 42, 0.95) 100%),
+    url("../../assets/travel_mountains.png") center/cover no-repeat;
+}
+
+.trisul-i-hero-content {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.trisul-i-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--primary-saffron);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 14px;
+  transition: var(--transition-snappy);
+}
+
+.trisul-i-back-link:hover {
+  text-decoration: underline;
+  transform: translateX(-3px);
+}
+
+.trisul-i-hero-kicker {
+  display: inline-block;
+  padding: 6px 16px;
+  border-radius: 999px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  color: var(--primary-saffron);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-bottom: 20px;
+}
+
+.trisul-i-hero h1 {
+  font-family: var(--font-heading);
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  line-height: 1.15;
+  margin-bottom: 18px;
+  color: var(--text-light);
+}
+
+.trisul-i-hero h1 span {
+  background: var(--gradient-saffron-gold);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.trisul-i-hero p {
+  color: var(--text-secondary);
+  font-size: 1.08rem;
+  line-height: 1.7;
+  margin-bottom: 36px;
+}
+
+.trisul-i-hero-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+
+.trisul-i-stat-box {
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 18px 12px;
+  transition: var(--transition-snappy);
+}
+
+.trisul-i-stat-box:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-glow);
+}
+
+.trisul-i-stat-box strong {
+  display: block;
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--primary-saffron);
+}
+
+.trisul-i-stat-box span {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.trisul-i-section {
+  padding: 70px 0;
+}
+
+.trisul-i-section:nth-of-type(even) {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.trisul-i-section-heading {
+  text-align: center;
+  max-width: 680px;
+  margin: 0 auto 44px;
+}
+
+.trisul-i-section-badge {
+  display: inline-block;
+  color: var(--primary-gold);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+
+.trisul-i-section-heading h2 {
+  font-family: var(--font-heading);
+  font-size: clamp(1.7rem, 3.5vw, 2.4rem);
+  color: var(--text-light);
+  margin-bottom: 14px;
+}
+
+.trisul-i-section-heading p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+.trisul-i-overview-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 36px;
+  align-items: start;
+}
+
+.trisul-i-overview-text h3 {
+  font-family: var(--font-heading);
+  color: var(--primary-gold);
+  margin-bottom: 16px;
+  font-size: 1.4rem;
+}
+
+.trisul-i-overview-text p {
+  color: var(--text-secondary);
+  line-height: 1.8;
+  margin-bottom: 16px;
+}
+
+.trisul-i-overview-spec-card {
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 24px 28px;
+  box-shadow: var(--shadow-soft);
+}
+
+.trisul-i-overview-spec-card h3 {
+  font-family: var(--font-heading);
+  color: var(--primary-gold);
+  margin-bottom: 18px;
+  font-size: 1.2rem;
+  border-bottom: 1px dashed var(--glass-border);
+  padding-bottom: 10px;
+}
+
+.spec-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.spec-list li {
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  font-size: 0.95rem;
+}
+
+.spec-list li:last-child {
+  border-bottom: none;
+}
+
+.spec-list li strong {
+  color: var(--text-muted);
+}
+
+.spec-list li {
+  color: var(--text-light);
+}
+
+/* ---------- Trekking Information Section ---------- */
+.trisul-i-trekking-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+
+.trisul-i-trek-card {
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 28px 24px;
+  transition: var(--transition-snappy);
+}
+
+.trisul-i-trek-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-glow);
+  border-color: var(--primary-saffron);
+}
+
+.trisul-i-trek-icon {
+  font-size: 2rem;
+  margin-bottom: 14px;
+}
+
+.trisul-i-trek-card h3 {
+  font-family: var(--font-heading);
+  color: var(--primary-gold);
+  font-size: 1.15rem;
+  margin-bottom: 12px;
+}
+
+.trisul-i-trek-card p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+  font-size: 0.92rem;
+}
+
+@media (max-width: 900px) {
+  .trisul-i-trekking-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .trisul-i-trekking-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.trisul-i-fact-panel {
+  max-width: 760px;
+  margin: 0 auto;
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 40px 36px;
+  text-align: center;
+  box-shadow: var(--shadow-soft);
+}
+
+.trisul-i-fact-icon {
+  font-size: 2.2rem;
+  margin-bottom: 14px;
+}
+
+#trisul-i-fact-text {
+  font-family: var(--font-heading);
+  font-size: 1.15rem;
+  color: var(--text-light);
+  line-height: 1.6;
+  transition: opacity 0.2s ease;
+  min-height: 84px;
+}
+
+.trisul-i-fact-dots {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.trisul-i-fact-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+  background: var(--glass-border);
+  cursor: pointer;
+  transition: var(--transition-snappy);
+}
+
+.trisul-i-fact-dot.active {
+  background: var(--primary-saffron);
+  width: 22px;
+  border-radius: 4px;
+}
+
+.trisul-i-map-wrap {
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow-soft);
+}
+
+#trisul-i-map {
+  height: 440px;
+  width: 100%;
+  background: var(--bg-dark-deep);
+}
+
+.leaflet-popup-content-wrapper {
+  background: var(--bg-dark-modal, #0f172a) !important;
+  color: var(--text-light) !important;
+  border: 1px solid var(--glass-border) !important;
+  border-radius: 8px !important;
+  font-family: var(--font-body), sans-serif !important;
+}
+
+.leaflet-popup-tip {
+  background: var(--bg-dark-modal, #0f172a) !important;
+}
+
+.trisul-i-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 18px;
+}
+
+.trisul-i-gallery-item {
+  margin: 0;
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+  cursor: pointer;
+  border: 1px solid var(--glass-border);
+  transition: var(--transition-snappy);
+  position: relative;
+}
+
+.trisul-i-gallery-item:hover {
+  transform: translateY(-4px);
+  border-color: var(--primary-saffron);
+  box-shadow: var(--shadow-glow);
+}
+
+.trisul-i-gallery-item img {
+  width: 100%;
+  height: 190px;
+  object-fit: cover;
+  display: block;
+}
+
+.trisul-i-gallery-item figcaption {
+  padding: 10px 14px;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  background: var(--bg-dark-card);
+  border-top: 1px solid var(--glass-border);
+}
+
+.trisul-i-faq-container {
+  max-width: 800px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.trisul-i-faq-item {
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-sm);
+  overflow: hidden;
+  transition: var(--transition-snappy);
+}
+
+.trisul-i-faq-question {
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 20px 24px;
+  text-align: left;
+  font-family: var(--font-body);
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text-light);
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  transition: var(--transition-snappy);
+}
+
+.trisul-i-faq-question:hover {
+  color: var(--primary-saffron);
+}
+
+.trisul-i-faq-question::after {
+  content: "▼";
+  font-size: 0.8rem;
+  transition: transform 0.25s ease;
+  color: var(--text-muted);
+}
+
+.trisul-i-faq-item.active {
+  border-color: var(--primary-saffron);
+  box-shadow: var(--shadow-glow);
+}
+
+.trisul-i-faq-item.active .trisul-i-faq-question::after {
+  transform: rotate(-180deg);
+  color: var(--primary-saffron);
+}
+
+.trisul-i-faq-answer {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s cubic-bezier(0, 1, 0, 1), padding 0.3s ease;
+  padding: 0 24px;
+}
+
+.trisul-i-faq-item.active .trisul-i-faq-answer {
+  max-height: 500px;
+  padding-bottom: 20px;
+}
+
+.trisul-i-faq-answer p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+  font-size: 0.95rem;
+}
+
+.trisul-i-lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(10, 18, 30, 0.92);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  padding: 24px;
+  backdrop-filter: blur(8px);
+}
+
+.trisul-i-lightbox-overlay[hidden] {
+  display: none;
+}
+
+.trisul-i-lightbox-content {
+  max-width: 800px;
+  width: 100%;
+  text-align: center;
+  position: relative;
+}
+
+.trisul-i-lightbox-content img {
+  width: 100%;
+  max-height: 65vh;
+  object-fit: contain;
+  border-radius: var(--border-radius-lg);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow-soft);
+}
+
+.trisul-i-lightbox-caption {
+  color: var(--text-light);
+  margin-top: 14px;
+  font-size: 0.95rem;
+}
+
+.trisul-i-lightbox-close {
+  position: absolute;
+  top: -44px;
+  right: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-light);
+  font-size: 1.4rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: var(--transition-snappy);
+}
+
+.trisul-i-lightbox-close:hover {
+  background: rgba(255, 255, 255, 0.2);
+  color: var(--primary-saffron);
+}
+
+.trisul-i-lightbox-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-light);
+  font-size: 1.3rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: var(--transition-snappy);
+}
+
+.trisul-i-lightbox-nav:hover {
+  background: rgba(255, 255, 255, 0.2);
+  color: var(--primary-saffron);
+}
+
+.trisul-i-lightbox-nav.prev { left: -20px; }
+.trisul-i-lightbox-nav.next { right: -20px; }
+
+@media (max-width: 900px) {
+  .trisul-i-overview-grid {
+    grid-template-columns: 1fr;
+    gap: 28px;
+  }
+}
+
+@media (max-width: 768px) {
+  .trisul-i-hero-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  #trisul-i-map {
+    height: 320px;
+  }
+
+  .trisul-i-lightbox-nav.prev { left: 4px; }
+  .trisul-i-lightbox-nav.next { right: 4px; }
+}

--- a/frontend/trisul-i/trisul-i.html
+++ b/frontend/trisul-i/trisul-i.html
@@ -1,0 +1,291 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Explore Trisul I Mountain, a 7,120 m high peak in the Garhwal Himalayas of Uttarakhand. Discover facts, map locations, image gallery, and climb details.">
+    <title>Trisul I Mountain Explorer | Incredible India</title>
+    <link rel="icon" href="data:,">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap" rel="stylesheet">
+
+    <!-- Leaflet CSS for Map -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="trisul-i.css">
+
+    <!-- Open Graph / Social Media Tags -->
+    <meta property="og:title" content="Trisul I Mountain Explorer | Incredible India Explorer">
+    <meta property="og:description" content="Explore Trisul I Mountain, a 7,120 m high peak in the Garhwal Himalayas of Uttarakhand. Discover facts, map locations, image gallery, and climb details.">
+    <meta property="og:image" content="https://upload.wikimedia.org/wikipedia/commons/thumb/6/6f/Time_lapse_shot_of_Trishul_peak.jpg/960px-Time_lapse_shot_of_Trishul_peak.jpg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/trisul-i/trisul-i.html">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Incredible India Explorer">
+    <meta property="og:locale" content="en_IN">
+
+    <!-- Twitter Card Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Trisul I Mountain Explorer | Incredible India Explorer">
+    <meta name="twitter:description" content="Explore Trisul I Mountain, a 7,120 m high peak in the Garhwal Himalayas of Uttarakhand. Discover facts, map locations, image gallery, and climb details.">
+    <meta name="twitter:image" content="https://upload.wikimedia.org/wikipedia/commons/thumb/6/6f/Time_lapse_shot_of_Trishul_peak.jpg/960px-Time_lapse_shot_of_Trishul_peak.jpg">
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/trisul-i/trisul-i.html">
+</head>
+
+<body class="trisul-i-body-wrapper">
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html#home" class="nav-link" id="link-home">Home</a>
+                <a href="../../index.html#map" class="nav-link" id="link-map">Interactive Map</a>
+                <a href="../travel/travel.html" class="nav-link" id="link-travel">Travel</a>
+                <a href="trisul-i.html" class="nav-link active" style="color: var(--saffron)">Trisul I</a>
+
+                <div class="nav-dropdown">
+                    <button class="nav-link dropdown-toggle" id="link-explore-more">
+                        Explore More ▾
+                    </button>
+                    <div class="dropdown-menu">
+                        <a href="../travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                        <a href="../wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                        <a href="../coastal-india/coastal-india.html" class="dropdown-item">Coastal India</a>
+                        <a href="../heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    </div>
+                </div>
+
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
+                    ☀️
+                </button>
+                <a href="../../login.html" class="nav-link" id="link-login">Login</a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="trisul-i-page" id="app-root">
+        <!-- Hero Section -->
+        <section class="trisul-i-hero">
+            <div class="trisul-i-hero-content">
+                <a href="../mountains/index.html" class="trisul-i-back-link">← Back to Mountains Explorer</a>
+                <span class="trisul-i-hero-kicker">🏔️ Garhwal Himalayas</span>
+                <h1>Trisul I <span>Explorer</span></h1>
+                <p>Standing majestically at 7,120 meters, Trisul I is the highest of the three iconic peaks named after Lord Shiva's trident. It holds a legendary place in mountaineering history as the first 7,000-meter peak ever to be climbed, marking a golden milestone in Himalayan exploration.</p>
+
+                <div class="trisul-i-hero-stats">
+                    <div class="trisul-i-stat-box">
+                        <strong>7,120 m</strong>
+                        <span>Peak Elevation</span>
+                    </div>
+                    <div class="trisul-i-stat-box">
+                        <strong>Uttarakhand</strong>
+                        <span>State Location</span>
+                    </div>
+                    <div class="trisul-i-stat-box">
+                        <strong>Garhwal Himalayas</strong>
+                        <span>Mountain Range</span>
+                    </div>
+                    <div class="trisul-i-stat-box">
+                        <strong>First 7,000er</strong>
+                        <span>Climbing Milestone</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Overview Section -->
+        <section class="trisul-i-section" id="trisul-i-overview">
+            <div class="trisul-i-container">
+                <div class="trisul-i-section-heading">
+                    <span class="trisul-i-section-badge">Peak Profile</span>
+                    <h2>Geography, History &amp; Significance</h2>
+                </div>
+                
+                <div class="trisul-i-overview-grid">
+                    <div class="trisul-i-overview-text">
+                        <h3>The Trident of Shiva</h3>
+                        <p>Trisul I is the highest of the three Trisul massif peaks in the Kumaon region of the Garhwal Himalayas, Uttarakhand. The three peaks — Trisul I (7,120 m), Trisul II (6,690 m), and Trisul III (6,008 m) — form a striking silhouette resembling Lord Shiva's trident, after which they are named.</p>
+                        <p>The mountain is located in the Nanda Devi Biosphere Reserve, surrounded by pristine alpine meadows and glaciers. Its prominence and relatively accessible route made it a target for early Himalayan mountaineering, leading to its historic first ascent in 1907.</p>
+                        <p>Today, Trisul I remains a sought destination for experienced trekkers and climbers. The standard route approaches via the Pindari Glacier and offers breathtaking views of the surrounding Kumaon peaks, including Nanda Devi, Nanda Kot, and Panchachuli.</p>
+                    </div>
+                    <div class="trisul-i-overview-spec-card">
+                        <h3>Technical Specifications</h3>
+                        <ul class="spec-list">
+                            <li><strong>Elevation:</strong> 7,120 m (23,360 ft)</li>
+                            <li><strong>Prominence:</strong> 1,586 m (5,203 ft)</li>
+                            <li><strong>Coordinates:</strong> 30°18'44"N 79°46'35"E</li>
+                            <li><strong>Climbing Difficulty:</strong> Hard / Technical</li>
+                            <li><strong>First Ascent:</strong> June 12, 1907</li>
+                            <li><strong>Expedition Team:</strong> T.G. Longstaff &amp; Party</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Trekking Information Section -->
+        <section class="trisul-i-section" id="trisul-i-trekking-section">
+            <div class="trisul-i-container">
+                <div class="trisul-i-section-heading">
+                    <span class="trisul-i-section-badge">Trekking Information</span>
+                    <h2>Plan Your Trisul Expedition</h2>
+                    <p>Essential details for trekkers and mountaineers planning to explore the Trisul massif region.</p>
+                </div>
+                <div class="trisul-i-trekking-grid">
+                    <div class="trisul-i-trek-card">
+                        <div class="trisul-i-trek-icon">🗓️</div>
+                        <h3>Best Season</h3>
+                        <p>May to June and September to October. The post-monsoon months offer clear skies and stable weather, while pre-monsoon provides moderate temperatures.</p>
+                    </div>
+                    <div class="trisul-i-trek-card">
+                        <div class="trisul-i-trek-icon">🥾</div>
+                        <h3>Trek Difficulty</h3>
+                        <p>Moderate to Difficult. The trek involves high-altitude hiking above 4,000 m with steep moraine sections. Prior Himalayan trekking experience is recommended.</p>
+                    </div>
+                    <div class="trisul-i-trek-card">
+                        <div class="trisul-i-trek-icon">⏱️</div>
+                        <h3>Duration</h3>
+                        <p>The Pindari Glacier trek typically takes 7–10 days round trip from Munsiyari, covering a distance of approximately 90 km with gradual altitude gain.</p>
+                    </div>
+                    <div class="trisul-i-trek-card">
+                        <div class="trisul-i-trek-icon">🏕️</div>
+                        <h3>Base Camp</h3>
+                        <p>Munsiyari (2,200 m) serves as the gateway. The trek proceeds through Khati village, Dwali, and Phurkia before reaching the Pindari Glacier snout.</p>
+                    </div>
+                    <div class="trisul-i-trek-card">
+                        <div class="trisul-i-trek-icon">📋</div>
+                        <h3>Permits</h3>
+                        <p>Trekking permits are required from the Forest Department in Munsiyari. The area falls within the Nanda Devi Biosphere Reserve, and entry fees apply.</p>
+                    </div>
+                    <div class="trisul-i-trek-card">
+                        <div class="trisul-i-trek-icon">🏔️</div>
+                        <h3>Key Highlights</h3>
+                        <p>Panoramic views of Trisul I, Nanda Devi, Nanda Kot, and Panchachuli peaks. The trek passes through dense rhododendron forests and alpine meadows.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Facts Section -->
+        <section class="trisul-i-section" id="trisul-i-facts-section">
+            <div class="trisul-i-container">
+                <div class="trisul-i-section-heading">
+                    <span class="trisul-i-section-badge">Did You Know?</span>
+                    <h2>Interesting Facts</h2>
+                </div>
+                <div class="trisul-i-fact-panel">
+                    <div class="trisul-i-fact-icon">💡</div>
+                    <p id="trisul-i-fact-text" aria-live="polite">Loading fact...</p>
+                    <div class="trisul-i-fact-dots" id="trisul-i-fact-dots"></div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Interactive Map Section -->
+        <section class="trisul-i-section" id="trisul-i-map-section">
+            <div class="trisul-i-container">
+                <div class="trisul-i-section-heading">
+                    <span class="trisul-i-section-badge">Interactive Map</span>
+                    <h2>Key Locations Around Trisul I</h2>
+                    <p>Click on any marker to learn about that geographic landmark.</p>
+                </div>
+                <div class="trisul-i-map-wrap">
+                    <div id="trisul-i-map" aria-label="Interactive Leaflet Map showing Trisul I and surrounding landmarks"></div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Image Gallery Section -->
+        <section class="trisul-i-section" id="trisul-i-gallery-section">
+            <div class="trisul-i-container">
+                <div class="trisul-i-section-heading">
+                    <span class="trisul-i-section-badge">Image Gallery</span>
+                    <h2>Views of the Massif &amp; Kumaon Range</h2>
+                    <p>Explore the stunning peaks and valleys of Uttarakhand. Click an image to view it larger.</p>
+                </div>
+                <div id="trisul-i-gallery-grid" class="trisul-i-gallery-grid"></div>
+            </div>
+        </section>
+
+        <!-- FAQs Section -->
+        <section class="trisul-i-section" id="trisul-i-faq-section">
+            <div class="trisul-i-container">
+                <div class="trisul-i-section-heading">
+                    <span class="trisul-i-section-badge">FAQ</span>
+                    <h2>Frequently Asked Questions</h2>
+                </div>
+                <div class="trisul-i-faq-container" id="trisul-i-faq-accordion">
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <!-- Lightbox Modal -->
+    <div class="trisul-i-lightbox-overlay" id="trisul-i-lightbox" hidden role="dialog" aria-modal="true" aria-label="Image Lightbox">
+        <div class="trisul-i-lightbox-content">
+            <button class="trisul-i-lightbox-close" data-close-lightbox="true" aria-label="Close Lightbox">&times;</button>
+            <button class="trisul-i-lightbox-nav prev" id="trisul-i-lightbox-prev" aria-label="Previous image">‹</button>
+            <img id="trisul-i-lightbox-image" src="" alt="">
+            <button class="trisul-i-lightbox-nav next" id="trisul-i-lightbox-next" aria-label="Next image">›</button>
+            <p class="trisul-i-lightbox-caption" id="trisul-i-lightbox-caption"></p>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <footer class="site-footer">
+        <div class="footer-container">
+            <div class="footer-brand">
+                <a href="../../index.html#home" class="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <p>Highlighting and documenting India's magnificent geography, mountains, and cultural heritage.</p>
+            </div>
+            <div class="footer-links">
+                <h4>Quick Links</h4>
+                <a href="../../index.html#home">Home</a>
+                <a href="../mountains/index.html">Mountains Explorer</a>
+                <a href="../travel/travel.html">Travel &amp; Destinations</a>
+                <a href="trisul-i.html">Trisul I Explorer</a>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2026 Incredible India Explorer. Developed with Vanilla Web Tech.</p>
+        </div>
+    </footer>
+
+    <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+
+    <!-- Leaflet JS for Map -->
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+    
+    <!-- Local Javascript Module -->
+    <script type="module" src="trisul-i.js"></script>
+    <script src="../../pages-common.js"></script>
+</body>
+</html>

--- a/frontend/trisul-i/trisul-i.js
+++ b/frontend/trisul-i/trisul-i.js
@@ -1,0 +1,285 @@
+const TRISUL_I_LOCATIONS = [
+  {
+    name: "Trisul I Peak",
+    lat: 30.3121,
+    lng: 79.7765,
+    description: "The highest of the three Trisul peaks, standing at 7,120 meters. The first 7,000m peak ever climbed."
+  },
+  {
+    name: "Pindari Glacier",
+    lat: 30.27,
+    lng: 79.98,
+    description: "A massive glacier forming the traditional approach route to the Trisul massif from the southeast."
+  },
+  {
+    name: "Kausani",
+    lat: 29.8438,
+    lng: 79.6023,
+    description: "A scenic hill station offering panoramic views of the Trisul peaks and the broader Kumaon Himalayas."
+  },
+  {
+    name: "Nanda Devi Peak",
+    lat: 30.3758,
+    lng: 79.9707,
+    description: "India's second highest peak at 7,816 m, located northeast of Trisul within the Nanda Devi Biosphere Reserve."
+  },
+  {
+    name: "Munsiyari",
+    lat: 30.0736,
+    lng: 80.2398,
+    description: "A hill town serving as the gateway to the Pindari Glacier trek and the eastern Kumaon region."
+  }
+];
+
+const TRISUL_I_GALLERY = [
+  { src: "../../assets/travel_mountains.png", caption: "The majestic Trisul I peak towering over the Kumaon Himalayas." },
+  { src: "../../assets/Manalileh.png", caption: "Alpine trails leading towards the Pindari Glacier approach." },
+  { src: "../../assets/Shimlakaza.png", caption: "Sunrise over the Trisul massif from the eastern ridgeline." },
+  { src: "../../assets/Hemis_Monastery.png", caption: "Scenic valleys and meadows surrounding the Trisul range." }
+];
+
+const TRISUL_I_FACTS = [
+  "Trisul was the first mountain over 7,000 metres ever to be climbed, achieved in 1907 by T.G. Longstaff's expedition.",
+  "The three peaks of Trisul (I, II, III) are named after Lord Shiva's trident, which is a symbol of power and protection.",
+  "Trisul I is located within the Nanda Devi Biosphere Reserve, one of India's most ecologically rich protected areas.",
+  "The first ascent of Trisul I was accomplished by Tom Longstaff, Charles Bruce, and Alpine guide Alexis Brocherel on June 12, 1907.",
+  "The mountain is visible from the famous hill station of Kausani, which Mahatma Gandhi once called the 'Switzerland of India'.",
+  "Trisul I's standard climbing route approaches via the Pindari Glacier, one of the most popular trekking routes in Uttarakhand."
+];
+
+const TRISUL_I_FAQS = [
+  {
+    question: "Where is Trisul I located?",
+    answer: "Trisul I is located in the Kumaon region of the Garhwal Himalayas in Uttarakhand, India, within the Nanda Devi Biosphere Reserve."
+  },
+  {
+    question: "Why is it called Trisul?",
+    answer: "The name 'Trisul' refers to Lord Shiva's trident. The three peaks of the massif are said to resemble the three prongs of a trident."
+  },
+  {
+    question: "What is the elevation of Trisul I?",
+    answer: "Trisul I stands at 7,120 meters (23,360 feet) above sea level, making it the highest of the three Trisul peaks."
+  },
+  {
+    question: "What is the historical significance of Trisul I?",
+    answer: "Trisul I was the first 7,000-meter peak ever to be climbed, marking a historic milestone in Himalayan mountaineering in 1907."
+  },
+  {
+    question: "How can trekkers experience Trisul I?",
+    answer: "The Pindari Glacier trek offers stunning views of Trisul I and is one of the most popular trekking routes in Uttarakhand, suitable for experienced trekkers."
+  }
+];
+
+let map = null;
+let currentGalleryIndex = 0;
+let factIndex = 0;
+let factIntervalId = null;
+
+function init() {
+  initAccordion();
+  initGallery();
+  initFactsRotator();
+  initMap();
+  initLightbox();
+}
+
+if (document.readyState !== "loading") {
+  init();
+} else {
+  document.addEventListener("DOMContentLoaded", init);
+}
+
+if (window.appLifecycle) {
+  window.appLifecycle.registerCleanup(() => {
+    if (factIntervalId) {
+      clearInterval(factIntervalId);
+      factIntervalId = null;
+    }
+  });
+}
+
+function initAccordion() {
+  const container = document.getElementById("trisul-i-faq-accordion");
+  if (!container) return;
+
+  container.innerHTML = "";
+  TRISUL_I_FAQS.forEach((faq, index) => {
+    const item = document.createElement("div");
+    item.className = "trisul-i-faq-item";
+    
+    item.innerHTML = `
+      <button class="trisul-i-faq-question" id="faq-q-${index}" aria-expanded="false" aria-controls="faq-a-${index}">
+        ${faq.question}
+      </button>
+      <div class="trisul-i-faq-answer" id="faq-a-${index}" role="region" aria-labelledby="faq-q-${index}">
+        <p>${faq.answer}</p>
+      </div>
+    `;
+
+    const button = item.querySelector(".trisul-i-faq-question");
+    button.addEventListener("click", () => {
+      const isActive = item.classList.contains("active");
+
+      container.querySelectorAll(".trisul-i-faq-item").forEach((otherItem) => {
+        otherItem.classList.remove("active");
+        otherItem.querySelector(".trisul-i-faq-question").setAttribute("aria-expanded", "false");
+      });
+
+      if (!isActive) {
+        item.classList.add("active");
+        button.setAttribute("aria-expanded", "true");
+      }
+    });
+
+    container.appendChild(item);
+  });
+}
+
+function initGallery() {
+  const grid = document.getElementById("trisul-i-gallery-grid");
+  if (!grid) return;
+
+  grid.innerHTML = "";
+  TRISUL_I_GALLERY.forEach((item, index) => {
+    const figure = document.createElement("figure");
+    figure.className = "trisul-i-gallery-item";
+    figure.setAttribute("tabindex", "0");
+    figure.setAttribute("role", "button");
+    figure.setAttribute("aria-label", `Open image: ${item.caption}`);
+    figure.innerHTML = `
+      <img src="${item.src}" alt="${item.caption}" loading="lazy">
+      <figcaption>${item.caption}</figcaption>
+    `;
+
+    figure.addEventListener("click", () => openLightbox(index));
+    figure.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        openLightbox(index);
+      }
+    });
+
+    grid.appendChild(figure);
+  });
+}
+
+function initLightbox() {
+  const lightbox = document.getElementById("trisul-i-lightbox");
+  if (!lightbox) return;
+
+  document.querySelectorAll("[data-close-lightbox]").forEach((el) => {
+    el.addEventListener("click", closeLightbox);
+  });
+
+  const prevBtn = document.getElementById("trisul-i-lightbox-prev");
+  const nextBtn = document.getElementById("trisul-i-lightbox-next");
+
+  if (prevBtn) prevBtn.addEventListener("click", () => showGalleryImage(currentGalleryIndex - 1));
+  if (nextBtn) nextBtn.addEventListener("click", () => showGalleryImage(currentGalleryIndex + 1));
+
+  document.addEventListener("keydown", (e) => {
+    if (lightbox.hidden) return;
+    if (e.key === "Escape") closeLightbox();
+    if (e.key === "ArrowRight") showGalleryImage(currentGalleryIndex + 1);
+    if (e.key === "ArrowLeft") showGalleryImage(currentGalleryIndex - 1);
+  });
+}
+
+function openLightbox(index) {
+  const lightbox = document.getElementById("trisul-i-lightbox");
+  if (!lightbox) return;
+  lightbox.hidden = false;
+  document.body.style.overflow = "hidden";
+  showGalleryImage(index);
+}
+
+function closeLightbox() {
+  const lightbox = document.getElementById("trisul-i-lightbox");
+  if (!lightbox) return;
+  lightbox.hidden = true;
+  document.body.style.overflow = "";
+}
+
+function showGalleryImage(index) {
+  const total = TRISUL_I_GALLERY.length;
+  currentGalleryIndex = (index + total) % total;
+  const item = TRISUL_I_GALLERY[currentGalleryIndex];
+  
+  const img = document.getElementById("trisul-i-lightbox-image");
+  const caption = document.getElementById("trisul-i-lightbox-caption");
+  
+  if (img) img.src = item.src;
+  if (img) img.alt = item.caption;
+  if (caption) caption.textContent = item.caption;
+}
+
+function initFactsRotator() {
+  const factEl = document.getElementById("trisul-i-fact-text");
+  const dotsWrap = document.getElementById("trisul-i-fact-dots");
+  if (!factEl) return;
+
+  if (dotsWrap) dotsWrap.innerHTML = "";
+  if (factIntervalId) clearInterval(factIntervalId);
+
+  if (dotsWrap) {
+    TRISUL_I_FACTS.forEach((_, i) => {
+      const dot = document.createElement("button");
+      dot.className = "trisul-i-fact-dot" + (i === 0 ? " active" : "");
+      dot.setAttribute("aria-label", "Show fact " + (i + 1));
+      dot.addEventListener("click", () => showFact(i));
+      dotsWrap.appendChild(dot);
+    });
+  }
+
+  function showFact(i) {
+    factIndex = i;
+    factEl.style.opacity = "0";
+    setTimeout(() => {
+      factEl.textContent = TRISUL_I_FACTS[factIndex];
+      factEl.style.opacity = "1";
+    }, 200);
+    if (dotsWrap) {
+      [...dotsWrap.children].forEach((dot, di) => dot.classList.toggle("active", di === factIndex));
+    }
+  }
+
+  showFact(0);
+  factIntervalId = setInterval(() => showFact((factIndex + 1) % TRISUL_I_FACTS.length), 6000);
+}
+
+function initMap() {
+  const mapContainer = document.getElementById("trisul-i-map");
+  if (!mapContainer || typeof L === "undefined") return;
+
+  if (map !== null) {
+    try {
+      map.remove();
+    } catch (e) {
+      console.warn("Failed to remove old map instance", e);
+    }
+    map = null;
+  }
+
+  map = L.map("trisul-i-map", {
+    scrollWheelZoom: false,
+    minZoom: 6,
+  }).setView([30.3121, 79.7765], 10);
+
+  L.tileLayer("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png", {
+    attribution: "&copy; OpenStreetMap contributors &copy; CARTO",
+    maxZoom: 18,
+  }).addTo(map);
+
+  TRISUL_I_LOCATIONS.forEach((loc) => {
+    const isPeak = loc.name.includes("Peak");
+    const marker = L.circleMarker([loc.lat, loc.lng], {
+      radius: isPeak ? 9 : 7,
+      color: isPeak ? "#ff9933" : "#0284c7",
+      fillColor: isPeak ? "#ffb01f" : "#38bdf8",
+      fillOpacity: 0.85,
+      weight: 2,
+    }).addTo(map);
+
+    marker.bindPopup(`<strong>${loc.name}</strong><br>${loc.description}`);
+  });
+}


### PR DESCRIPTION
Created a dedicated page for Trisul I, one of Uttarakhand's iconic Himalayan peaks.

**Implemented:**
- Hero section
- Mountain overview
- Trekking information (6 cards: season, difficulty, duration, base camp, permits, highlights)
- Quick facts rotator (6 facts)
- Interactive Leaflet map with 5 markers
- Image gallery with lightbox
- FAQ accordion (5 Q&As)
- Mountain card on Landing Page with Explore button connected

Closes #731

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Trisul I mountain exploration page.
  * Added responsive sections for peak details, trekking information, facts, gallery, FAQs, and interactive maps.
  * Added image lightbox viewing with captions and navigation controls.
  * Added rotating fact highlights, accordion FAQs, dark mode support, and mobile-friendly layouts.
  * Updated the mountain listing to link directly to the new Trisul I page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->