### PR TITLE
Implement AI-Powered Dynamic Seasonal Travel Recommendation Engine (I…

### DIFF
--- a/docs/SEASONAL_RECOMMENDATIONS.md
+++ b/docs/SEASONAL_RECOMMENDATIONS.md
@@ -1,0 +1,95 @@
+# Seasonal Travel Recommendation Engine
+
+Resolves #773 — AI-Powered Dynamic Seasonal Travel Recommendation Engine.
+
+Ranks Indian destinations for a chosen travel month, surfaces festivals
+happening at that time, and suggests same-category alternatives when a
+destination is a poor fit for the requested month.
+
+## Files added
+
+| File | Purpose |
+| ---- | ------- |
+| `js-modules/seasonal-recommendation-engine.js` | Pure, DOM-free engine: `computeSeasonalFit`, `getFestivalsForMonth`, and the `SeasonalRecommendationEngine` class (`recommend`, `getAlternatives`). |
+| `frontend/seasonal-recommendations/index.html` | Page shell (header/nav/footer match the rest of the site), month + interest filters, results grid. |
+| `frontend/seasonal-recommendations/style.css` | Dedicated stylesheet, adapted from `frontend/event-discovery/style.css`, reusing the site's design tokens. |
+| `frontend/seasonal-recommendations/script.js` | DOM wiring: reads `window.tripDestinations` / `window.eventData.events`, calls the engine, renders cards, persists the last search to `localStorage`. |
+| `tests/unit/seasonal-recommendation-engine.test.js` | Vitest unit tests for the engine. |
+
+## Why this reuses existing datasets instead of new ones
+
+This project (per the README) runs purely client-side with curated,
+hand-maintained datasets rather than live backend services. Three
+datasets already existing in this repo cover almost everything the issue
+asks for:
+
+| Issue's technical consideration | Implementation here |
+| -------------------------------- | -------------------- |
+| Seasonal metadata management | `trip-data.js`'s existing `bestSeason` field per destination (e.g. `"Oct-Mar"`, or multiple ranges like `"Mar-Jun, Sep-Dec"`) |
+| Weather API integration | **Not implemented as a live API call.** Real forecasts (see `weather-core.js` / `weather-service.js`, Open-Meteo) only cover ~2 weeks out, which doesn't fit "which month should I visit" planning. `bestSeason` is used as the weather-awareness signal instead — see below. |
+| Festival and event datasets | `event-data.js`'s existing recurring festival windows (`startMonth`/`endMonth`, cross-referenced by `destinationId`/`state`) |
+| Ranking algorithm | `SeasonalRecommendationEngine.recommend()` — weighted combination of seasonal fit, interest match, festival presence, and popularity (see below) |
+| Recommendation caching | Not needed — computation is a synchronous, in-memory pass over ~50 destinations; the last search's month/interests are persisted to `localStorage` so returning users see their last result immediately |
+| Backend recommendation APIs | None — same client-side pattern as `js-modules/travel/travel-recommend.js` (issue #185) and `travel-timeline.js` |
+| Analytics for recommendation effectiveness | Out of scope for this PR — flagged below as a fast-follow |
+
+If/when this project adds a real backend, the engine's constructor
+(`{ destinations, events }`) is the seam to swap in a fetched dataset or a
+real weather/festival API without touching the rendering code in
+`script.js`.
+
+## How seasonal fit is scored
+
+`computeSeasonalFit(destination, month)` parses `bestSeason` into one or
+more month ranges (handling both comma-separated multiple ranges and
+ranges that wrap across the year boundary, e.g. `"Nov-Feb"`), then buckets
+the requested month into:
+
+- **ideal** (score 1.0) — inside a best-season window
+- **shoulder** (score 0.55) — one month outside a window (expect mixed
+  conditions)
+- **off-season** (score 0.15) — two or more months outside every window
+- **unknown** (score 0.5, neutral) — destination has no `bestSeason` data
+  yet, so it's neither penalized nor favored
+
+## How destinations are ranked
+
+`SeasonalRecommendationEngine.recommend({ month, interests, limit })`
+scores every destination as:
+
+```
+score = seasonalFit.score * 0.55       // seasonal fit dominates
+      + interestMatchRatio * 0.25      // fraction of requested interests matched
+      + festivalBonus (up to 0.15)     // +0.05 per matching festival, capped
+      + popularityBonus (up to 0.10)   // tie-breaker, from trip-data.js's popularity field
+```
+
+When `interests` is provided, destinations matching none of them are
+excluded entirely rather than just down-ranked (matching how the existing
+`js-modules/travel/travel-recommend.js` interest filter behaves). Each
+result includes a human-readable `explanation` combining the seasonal-fit
+reason, matched interests, and the top matching festival, satisfying the
+"recommendation explanations are displayed" acceptance criterion.
+
+## Alternative destinations
+
+`getAlternatives(destination, month, limit)` returns same-category
+destinations that ARE an "ideal" fit for the requested month, ranked by
+shared-category count then popularity. Returns an empty array when the
+destination is already ideal (or has no season data), so the "see
+alternatives" UI only appears when it's actually useful.
+
+## What's intentionally out of scope for this change
+
+- **Live weather conditions.** As above — month-ahead planning and
+  live/short-range forecasts are different problems; wiring in
+  `weather-service.js`'s Open-Meteo integration for a "closer to your
+  travel date" refinement is a reasonable fast-follow.
+- **Seasonal travel insights dashboard.** The scoring breakdown
+  (`seasonalFit`, `matchedInterests`, `festivals`, numeric `score`) is
+  already returned per destination by `recommend()`; aggregating that
+  into a dedicated analytics view is a natural follow-up rather than part
+  of the core recommendation mechanism.
+- **Recommendation-effectiveness analytics** (e.g. click-through
+  tracking) — no analytics infrastructure exists elsewhere in this
+  client-side-only project to hook into yet.

--- a/frontend/seasonal-recommendations/index.html
+++ b/frontend/seasonal-recommendations/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Seasonal Travel Recommendations | Incredible India Explorer</title>
+  <meta name="description" content="Get destination recommendations ranked by travel month, matched to festivals happening at that time, with alternatives suggested when conditions are unfavorable.">
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="navbar scrolled" id="navbar">
+    <div class="nav-container">
+      <a href="../../index.html#home" class="nav-logo">
+        <span class="saffron">Incredible</span>
+        <span class="gold">India</span>
+        <span class="green">Explorer</span>
+      </a>
+
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+        <span class="bar"></span>
+        <span class="bar"></span>
+        <span class="bar"></span>
+      </button>
+
+      <nav class="nav-menu" id="nav-menu">
+        <a href="../../index.html#home" class="nav-link">Home</a>
+        <a href="../../travel.html" class="nav-link">Travel</a>
+        <a href="../event-discovery/index.html" class="nav-link">Event Discovery</a>
+        <a href="index.html" class="nav-link" style="color: var(--saffron)">Seasonal Picks</a>
+        <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+      </nav>
+    </div>
+  </header>
+
+  <main class="seasonal-page">
+    <section class="seasonal-hero">
+      <div class="hero-content">
+        <span class="hero-kicker">Month-by-month · festival-aware · with alternatives</span>
+        <h1>Seasonal Travel <span>Recommendations</span></h1>
+        <p>
+          Pick the month you're planning to travel and we'll rank destinations by how good a fit
+          that month actually is, surface festivals happening around that time, and suggest
+          alternatives when your first choice is out of season.
+        </p>
+      </div>
+    </section>
+
+    <section class="filters-section" id="filters">
+      <div class="filters-container">
+        <form id="filters-form" class="filters-card">
+          <div class="filter-row">
+            <div class="filter-field">
+              <label for="month-select">Travel month</label>
+              <select id="month-select" required></select>
+            </div>
+          </div>
+
+          <div class="filter-field interests-field">
+            <label>Interests (optional)</label>
+            <div class="interest-chips" id="interest-chips"></div>
+          </div>
+
+          <div class="filter-actions">
+            <button type="submit" class="btn-primary">Get recommendations</button>
+            <button type="button" id="reset-filters" class="btn-secondary">Reset</button>
+          </div>
+        </form>
+      </div>
+    </section>
+
+    <section class="results-section" id="results-section" hidden>
+      <div class="results-container">
+        <div class="results-heading">
+          <h2 id="results-title">Recommended for you</h2>
+          <span id="results-count" class="results-count"></span>
+        </div>
+        <div class="destination-grid" id="destination-grid"></div>
+        <p class="empty-state" id="empty-state" hidden>No destinations match those interests for this month yet &mdash; try widening your interests.</p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="seasonal-footer">
+    <p>
+      Part of <a href="../../index.html">Incredible India Explorer</a> · Seasonal fit is based on
+      each destination's curated best-season window, not a live weather forecast &mdash; always
+      check current conditions before travelling.
+    </p>
+  </footer>
+
+  <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+  <script src="../../app.js"></script>
+  <script src="../../trip-data.js"></script>
+  <script src="../../js-modules/event-data.js"></script>
+  <script type="module" src="script.js"></script>
+</body>
+</html>

--- a/frontend/seasonal-recommendations/script.js
+++ b/frontend/seasonal-recommendations/script.js
@@ -1,0 +1,222 @@
+import { SeasonalRecommendationEngine } from "../../js-modules/seasonal-recommendation-engine.js";
+
+const PREFS_KEY = "seasonalRecommendations.prefs.v1";
+
+const destinations = window.tripDestinations || [];
+const events = (window.eventData && window.eventData.events) || [];
+
+const engine = new SeasonalRecommendationEngine({ destinations, events });
+
+// All distinct destination categories present in trip-data.js, used to
+// drive the interest-chip filter (mirrors event-discovery's approach of
+// deriving chips from the dataset rather than hardcoding a list).
+const ALL_CATEGORIES = Array.from(
+  new Set(destinations.flatMap((d) => d.categories || [])),
+).sort();
+
+function loadJSON(key, fallback) {
+  try {
+    const raw = localStorage.getItem(key);
+    const parsed = raw ? JSON.parse(raw) : fallback;
+    return parsed && typeof parsed === "object" ? parsed : fallback;
+  } catch (err) {
+    return fallback;
+  }
+}
+
+function saveJSON(key, value) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch (err) {
+    // Storage may be unavailable (private browsing, quota); fail silently.
+  }
+}
+
+function populateMonthSelect() {
+  const select = document.getElementById("month-select");
+  const currentMonth = new Date().getMonth() + 1;
+  SeasonalRecommendationEngine.MONTHS.forEach((name, index) => {
+    const option = document.createElement("option");
+    option.value = String(index + 1);
+    option.textContent = name;
+    if (index + 1 === currentMonth) option.selected = true;
+    select.appendChild(option);
+  });
+}
+
+function renderInterestChips() {
+  const wrap = document.getElementById("interest-chips");
+  wrap.innerHTML = "";
+  ALL_CATEGORIES.forEach((category) => {
+    const chip = document.createElement("button");
+    chip.type = "button";
+    chip.className = "interest-chip";
+    chip.textContent = category;
+    chip.dataset.category = category;
+    chip.addEventListener("click", () => chip.classList.toggle("active"));
+    wrap.appendChild(chip);
+  });
+}
+
+function getSelectedInterests() {
+  return Array.from(document.querySelectorAll(".interest-chip.active")).map(
+    (el) => el.dataset.category,
+  );
+}
+
+function applySavedPrefs() {
+  const prefs = loadJSON(PREFS_KEY, {});
+  if (prefs.month) {
+    const select = document.getElementById("month-select");
+    select.value = String(prefs.month);
+  }
+  if (Array.isArray(prefs.interests)) {
+    prefs.interests.forEach((category) => {
+      const chip = document.querySelector(`.interest-chip[data-category="${category}"]`);
+      if (chip) chip.classList.add("active");
+    });
+  }
+}
+
+function renderAlternatives(container, destination, month) {
+  const alternatives = engine.getAlternatives(destination, month, 3);
+  container.innerHTML = "";
+
+  if (!alternatives.length) {
+    const p = document.createElement("p");
+    p.textContent = "No clearly better-timed alternative found in this category.";
+    container.appendChild(p);
+    return;
+  }
+
+  alternatives.forEach((alt) => {
+    const p = document.createElement("p");
+    p.textContent = `${alt.destination.name} (${alt.destination.state}) — ${alt.explanation}`;
+    container.appendChild(p);
+  });
+}
+
+function renderResults(results, month) {
+  const grid = document.getElementById("destination-grid");
+  const emptyState = document.getElementById("empty-state");
+  const resultsCount = document.getElementById("results-count");
+
+  grid.innerHTML = "";
+  resultsCount.textContent = results.length
+    ? `${results.length} destination${results.length === 1 ? "" : "s"}`
+    : "";
+  emptyState.hidden = results.length > 0;
+
+  results.forEach((result) => {
+    const { destination, seasonalFit, festivals, explanation } = result;
+
+    const card = document.createElement("article");
+    card.className = "destination-card";
+
+    const top = document.createElement("div");
+    top.className = "destination-card-top";
+
+    const heading = document.createElement("div");
+    const h3 = document.createElement("h3");
+    h3.textContent = destination.name;
+    const state = document.createElement("div");
+    state.className = "destination-state";
+    state.textContent = destination.state;
+    heading.appendChild(h3);
+    heading.appendChild(state);
+
+    const badge = document.createElement("span");
+    badge.className = `fit-badge ${seasonalFit.level}`;
+    badge.textContent = seasonalFit.level.replace("-", " ");
+
+    top.appendChild(heading);
+    top.appendChild(badge);
+
+    const explanationEl = document.createElement("p");
+    explanationEl.className = "destination-explanation";
+    explanationEl.textContent = explanation;
+
+    const tags = document.createElement("div");
+    tags.className = "category-tags";
+    (destination.categories || []).forEach((category) => {
+      const tag = document.createElement("span");
+      tag.className = "category-tag";
+      tag.textContent = category;
+      tags.appendChild(tag);
+    });
+
+    card.appendChild(top);
+    card.appendChild(explanationEl);
+    card.appendChild(tags);
+
+    // Only surface the "find alternatives" action for destinations that
+    // are actually a mediocre-to-poor fit this month.
+    if (seasonalFit.level === "shoulder" || seasonalFit.level === "off-season") {
+      const toggle = document.createElement("button");
+      toggle.type = "button";
+      toggle.className = "alternatives-toggle";
+      toggle.textContent = "See in-season alternatives";
+
+      const panel = document.createElement("div");
+      panel.className = "alternatives-panel";
+      panel.hidden = true;
+
+      toggle.addEventListener("click", () => {
+        panel.hidden = !panel.hidden;
+        if (!panel.hidden && !panel.dataset.rendered) {
+          renderAlternatives(panel, destination, month);
+          panel.dataset.rendered = "true";
+        }
+      });
+
+      card.appendChild(toggle);
+      card.appendChild(panel);
+    }
+
+    if (festivals.length) {
+      const festivalNote = document.createElement("p");
+      festivalNote.className = "destination-explanation";
+      festivalNote.textContent = `Festivals this month: ${festivals.map((f) => f.name).join(", ")}`;
+      card.appendChild(festivalNote);
+    }
+
+    grid.appendChild(card);
+  });
+}
+
+function handleSubmit(event) {
+  event.preventDefault();
+  const month = parseInt(document.getElementById("month-select").value, 10);
+  const interests = getSelectedInterests();
+
+  saveJSON(PREFS_KEY, { month, interests });
+
+  const results = engine.recommend({ month, interests, limit: 12 });
+  document.getElementById("results-section").hidden = false;
+  renderResults(results, month);
+}
+
+function handleReset() {
+  document.querySelectorAll(".interest-chip.active").forEach((chip) => chip.classList.remove("active"));
+  localStorage.removeItem(PREFS_KEY);
+  document.getElementById("results-section").hidden = true;
+}
+
+function init() {
+  populateMonthSelect();
+  renderInterestChips();
+  applySavedPrefs();
+
+  document.getElementById("filters-form").addEventListener("submit", handleSubmit);
+  document.getElementById("reset-filters").addEventListener("click", handleReset);
+
+  // If the user has saved prefs from a previous visit, show results immediately.
+  const prefs = loadJSON(PREFS_KEY, {});
+  if (prefs.month) {
+    const results = engine.recommend({ month: prefs.month, interests: prefs.interests || [], limit: 12 });
+    document.getElementById("results-section").hidden = false;
+    renderResults(results, prefs.month);
+  }
+}
+
+document.addEventListener("DOMContentLoaded", init);

--- a/frontend/seasonal-recommendations/style.css
+++ b/frontend/seasonal-recommendations/style.css
@@ -1,0 +1,326 @@
+:root {
+  --sr-accent: var(--saffron, #ff9933);
+  --sr-green: var(--green, #138808);
+  --sr-surface: var(--glass-bg, rgba(255, 255, 255, 0.08));
+  --sr-border: var(--glass-border, rgba(255, 255, 255, 0.14));
+  --sr-text: var(--text-primary, #f8fafc);
+  --sr-muted: var(--text-secondary, #cbd5e1);
+  --sr-shadow: 0 18px 50px rgba(0, 0, 0, 0.16);
+}
+
+.seasonal-page {
+  min-height: 100vh;
+  color: var(--sr-text);
+}
+
+/* Hero */
+.seasonal-hero {
+  min-height: 44vh;
+  display: grid;
+  place-items: center;
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(120deg, rgba(16, 24, 44, 0.95), rgba(20, 60, 92, 0.68)),
+    url("../../assets/heroriver.png") center / cover no-repeat;
+}
+
+.seasonal-hero .hero-content {
+  position: relative;
+  z-index: 1;
+  width: min(880px, 92%);
+  padding: 130px 0 64px;
+  text-align: center;
+  color: #fff;
+}
+
+.seasonal-hero .hero-kicker {
+  display: inline-block;
+  padding: 8px 15px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.25);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.seasonal-hero h1 {
+  margin: 18px 0;
+  font-family: var(--font-heading, serif);
+  font-size: clamp(2.1rem, 4.5vw, 3.2rem);
+}
+
+.seasonal-hero h1 span {
+  color: var(--sr-accent);
+}
+
+.seasonal-hero p {
+  color: rgba(255, 255, 255, 0.85);
+  font-size: 1.02rem;
+  line-height: 1.6;
+}
+
+/* Shared section shell */
+.filters-section,
+.results-section {
+  padding: 40px 0;
+}
+
+.filters-container,
+.results-container {
+  width: min(1080px, 92%);
+  margin: 0 auto;
+}
+
+/* Filters */
+.filters-card {
+  background: var(--sr-surface);
+  border: 1px solid var(--sr-border);
+  border-radius: var(--border-radius-lg, 18px);
+  padding: 24px;
+  box-shadow: var(--sr-shadow);
+}
+
+.filter-row {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+  max-width: 320px;
+}
+
+.filter-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.filter-field label {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--sr-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.filter-field select {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--sr-border);
+  border-radius: var(--border-radius-sm, 8px);
+  padding: 10px 12px;
+  color: var(--sr-text);
+  font-family: inherit;
+  font-size: 0.92rem;
+}
+
+.interests-field {
+  margin-top: 18px;
+}
+
+.interest-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.interest-chip {
+  padding: 7px 16px;
+  border-radius: 999px;
+  border: 1px solid var(--sr-border);
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--sr-text);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: var(--transition-snappy, all 0.2s ease);
+  user-select: none;
+  text-transform: capitalize;
+}
+
+.interest-chip.active {
+  background: var(--gradient-saffron-gold, var(--sr-accent));
+  color: #1a1200;
+  border-color: transparent;
+  font-weight: 700;
+}
+
+.filter-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 22px;
+}
+
+.btn-primary,
+.btn-secondary {
+  padding: 11px 24px;
+  border-radius: 999px;
+  font-weight: 700;
+  border: none;
+  cursor: pointer;
+  transition: var(--transition-snappy, all 0.25s ease);
+}
+
+.btn-primary {
+  background: var(--gradient-saffron-gold, var(--sr-accent));
+  color: #1a1200;
+}
+
+.btn-secondary {
+  background: transparent;
+  border: 1px solid var(--sr-border);
+  color: var(--sr-text);
+}
+
+/* Results */
+.results-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 18px;
+}
+
+.results-heading h2 {
+  font-family: var(--font-heading, serif);
+  font-size: 1.4rem;
+}
+
+.results-count {
+  color: var(--sr-muted);
+  font-size: 0.85rem;
+}
+
+.destination-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 18px;
+}
+
+.empty-state {
+  color: var(--sr-muted);
+  font-size: 0.92rem;
+  padding: 16px 0;
+}
+
+.destination-card {
+  background: var(--sr-surface);
+  border: 1px solid var(--sr-border);
+  border-radius: var(--border-radius-lg, 18px);
+  overflow: hidden;
+  box-shadow: var(--sr-shadow);
+  display: flex;
+  flex-direction: column;
+  padding: 18px;
+  gap: 10px;
+}
+
+.destination-card-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 8px;
+}
+
+.destination-card h3 {
+  font-size: 1.1rem;
+  font-family: var(--font-heading, serif);
+}
+
+.destination-state {
+  color: var(--sr-muted);
+  font-size: 0.8rem;
+}
+
+.fit-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+}
+
+.fit-badge.ideal {
+  background: rgba(19, 136, 8, 0.16);
+  color: var(--sr-green);
+}
+
+.fit-badge.shoulder {
+  background: rgba(255, 153, 51, 0.16);
+  color: var(--sr-accent);
+}
+
+.fit-badge.off-season {
+  background: rgba(220, 60, 60, 0.16);
+  color: #ff8080;
+}
+
+.fit-badge.unknown {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--sr-muted);
+}
+
+.destination-explanation {
+  font-size: 0.86rem;
+  color: var(--sr-muted);
+  flex: 1;
+}
+
+.category-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.category-tag {
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  font-size: 0.72rem;
+  color: var(--sr-muted);
+  text-transform: capitalize;
+}
+
+.alternatives-toggle {
+  align-self: flex-start;
+  background: none;
+  border: 1px solid var(--sr-border);
+  color: var(--sr-accent);
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  cursor: pointer;
+}
+
+.alternatives-panel {
+  border-top: 1px solid var(--sr-border);
+  padding-top: 10px;
+  margin-top: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.alternatives-panel p {
+  font-size: 0.82rem;
+  color: var(--sr-muted);
+}
+
+.seasonal-footer {
+  text-align: center;
+  padding: 26px 16px;
+  color: var(--sr-muted);
+  font-size: 0.85rem;
+  border-top: 1px solid var(--sr-border);
+}
+
+.seasonal-footer a {
+  color: var(--sr-accent);
+}
+
+@media (max-width: 720px) {
+  .filter-row {
+    max-width: none;
+  }
+}

--- a/js-modules/seasonal-recommendation-engine.js
+++ b/js-modules/seasonal-recommendation-engine.js
@@ -1,0 +1,270 @@
+/**
+ * seasonal-recommendation-engine.js
+ *
+ * Seasonal Travel Recommendation Engine (Issue #773).
+ *
+ * Pure, DOM-free logic that ranks destinations for a given travel month
+ * by combining three signals already present in this repo's datasets,
+ * rather than duplicating them:
+ *
+ *  - `trip-data.js`'s `bestSeason` field (e.g. "Oct-Mar", or multiple
+ *    ranges like "Mar-Jun, Oct-Feb") — used to score how well a chosen
+ *    travel month fits a destination.
+ *  - `event-data.js`'s recurring festival/event windows
+ *    (startMonth/endMonth), cross-referenced by `destinationId` or
+ *    `state` — used to surface festivals happening during that month.
+ *  - `popularity` and `categories`/interest tags, already used by
+ *    js-modules/travel/travel-recommend.js (Issue #185) — used the same
+ *    way here for interest matching and tie-breaking.
+ *
+ * No live weather API is called here. Real day-level forecasts (see
+ * weather-core.js / weather-service.js) only cover ~2 weeks out, which
+ * doesn't match this feature's "which month should I visit" use case, so
+ * "weather-aware" is implemented as season-fit against each destination's
+ * curated best-season window instead of live conditions — consistent
+ * with how bestSeason is already used elsewhere in this project. See
+ * docs/seasonal-recommendation-engine.md for the full rationale.
+ *
+ * Kept DOM/localStorage-free (mirrors event-recommendation-engine.js) so
+ * it can be unit tested directly — see
+ * tests/unit/seasonal-recommendation-engine.test.js.
+ */
+
+const MONTH_NAMES = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+const MONTH_INDEX = MONTH_NAMES.reduce((acc, name, i) => {
+  acc[name.toLowerCase()] = i + 1;
+  return acc;
+}, {});
+
+/** True if `month` (1-12) falls within a possibly year-wrapping [start, end] range. */
+function monthInRange(month, start, end) {
+  if (typeof month !== "number" || typeof start !== "number" || typeof end !== "number") {
+    return false;
+  }
+  if (start <= end) return month >= start && month <= end;
+  // Wraps across the year boundary, e.g. Nov(11) - Feb(2).
+  return month >= start || month <= end;
+}
+
+/**
+ * Parses a `bestSeason` string like `"Oct-Mar"` or `"Mar-Jun, Sep-Dec"`
+ * into an array of `{ start, end }` month-number ranges (1-12). Unknown
+ * or malformed segments are skipped rather than throwing, since this
+ * dataset is hand-curated free text.
+ */
+export function parseSeasonRanges(bestSeason) {
+  if (typeof bestSeason !== "string" || !bestSeason.trim()) return [];
+
+  return bestSeason
+    .split(",")
+    .map((segment) => segment.trim())
+    .map((segment) => {
+      const parts = segment.split("-").map((p) => p.trim().toLowerCase());
+      if (parts.length !== 2) return null;
+      const start = MONTH_INDEX[parts[0]];
+      const end = MONTH_INDEX[parts[1]];
+      if (!start || !end) return null;
+      return { start, end };
+    })
+    .filter(Boolean);
+}
+
+/**
+ * Distance in months from `month` to the nearest edge of a single
+ * [start, end] range (0 if inside the range), accounting for wraparound.
+ */
+function monthsFromRange(month, start, end) {
+  if (monthInRange(month, start, end)) return 0;
+  const distTo = (a, b) => {
+    const diff = Math.abs(a - b);
+    return Math.min(diff, 12 - diff);
+  };
+  return Math.min(distTo(month, start), distTo(month, end));
+}
+
+/**
+ * Scores how well `month` (1-12) fits a destination's `bestSeason`
+ * windows. Pure function - the core "seasonal ranking" signal.
+ *
+ * Returns:
+ *  - level: "ideal" | "shoulder" | "off-season" | "unknown"
+ *  - score: 1 (ideal), 0.55 (shoulder, i.e. one month from an ideal
+ *    window), or 0.15 (off-season)
+ *  - reason: short human-readable explanation
+ */
+export function computeSeasonalFit(destination, month) {
+  const ranges = parseSeasonRanges(destination && destination.bestSeason);
+  const monthName = MONTH_NAMES[month - 1];
+
+  if (!ranges.length) {
+    return {
+      level: "unknown",
+      score: 0.5,
+      reason: `No curated best-season data for ${destination ? destination.name : "this destination"} yet.`,
+    };
+  }
+
+  const minDistance = Math.min(...ranges.map((r) => monthsFromRange(month, r.start, r.end)));
+
+  if (minDistance === 0) {
+    return {
+      level: "ideal",
+      score: 1,
+      reason: `${monthName} falls within ${destination.name}'s best season (${destination.bestSeason}).`,
+    };
+  }
+
+  if (minDistance === 1) {
+    return {
+      level: "shoulder",
+      score: 0.55,
+      reason: `${monthName} is just outside ${destination.name}'s peak season (${destination.bestSeason}) - expect a shoulder-season mix of conditions.`,
+    };
+  }
+
+  return {
+    level: "off-season",
+    score: 0.15,
+    reason: `${monthName} is outside ${destination.name}'s best season (${destination.bestSeason}) - conditions are likely to be unfavorable.`,
+  };
+}
+
+/** Festivals/events happening at `destination` during `month`, sorted by popularity. */
+export function getFestivalsForMonth(destination, month, events) {
+  if (!destination || !Array.isArray(events)) return [];
+  return events
+    .filter((event) => {
+      const matchesPlace =
+        event.destinationId === destination.id ||
+        (destination.state && event.state &&
+          event.state.toLowerCase() === destination.state.toLowerCase());
+      return matchesPlace && monthInRange(month, event.startMonth, event.endMonth);
+    })
+    .sort((a, b) => (b.popularity || 0) - (a.popularity || 0));
+}
+
+export class SeasonalRecommendationEngine {
+  /**
+   * @param {Object} [options]
+   * @param {Array} [options.destinations] Destinations (trip-data.js shape: id, name, state, categories, bestSeason, popularity).
+   * @param {Array} [options.events] Festivals/events (event-data.js shape: destinationId, state, startMonth, endMonth, popularity).
+   */
+  constructor(options = {}) {
+    this.destinations = options.destinations || [];
+    this.events = options.events || [];
+  }
+
+  static get MONTHS() {
+    return MONTH_NAMES.slice();
+  }
+
+  /**
+   * Ranks destinations for a given travel month.
+   *
+   * @param {Object} params
+   * @param {number} params.month 1-12
+   * @param {string[]} [params.interests] category tags to prefer (matches destination.categories)
+   * @param {number} [params.limit=6]
+   * @returns {Array} ranked results: { destination, score, seasonalFit, festivals, matchedInterests, explanation }
+   */
+  recommend({ month, interests = [], limit = 6 } = {}) {
+    if (typeof month !== "number" || month < 1 || month > 12) {
+      throw new Error("recommend() requires a `month` between 1 and 12");
+    }
+
+    const normalizedInterests = (interests || []).map((i) => String(i).toLowerCase());
+
+    const scored = this.destinations.map((destination) => {
+      const seasonalFit = computeSeasonalFit(destination, month);
+      const festivals = getFestivalsForMonth(destination, month, this.events);
+
+      const matchedInterests = normalizedInterests.length
+        ? (destination.categories || []).filter((c) => normalizedInterests.includes(c.toLowerCase()))
+        : [];
+
+      // Weighting: seasonal fit dominates (this is a *seasonal*
+      // recommendation engine), interests are a strong secondary
+      // signal, festivals + popularity are tie-breaking bonuses.
+      const interestScore = normalizedInterests.length
+        ? matchedInterests.length / normalizedInterests.length
+        : 1; // no interests given -> don't penalize anyone
+      const festivalBonus = festivals.length ? Math.min(festivals.length * 0.05, 0.15) : 0;
+      const popularityBonus = ((destination.popularity || 0) / 10) * 0.1;
+
+      const score =
+        seasonalFit.score * 0.55 +
+        interestScore * 0.25 +
+        festivalBonus +
+        popularityBonus;
+
+      const explanationParts = [seasonalFit.reason];
+      if (matchedInterests.length) {
+        explanationParts.push(`Matches your interest in ${matchedInterests.join(", ")}.`);
+      }
+      if (festivals.length) {
+        explanationParts.push(
+          `${festivals[0].name}${festivals.length > 1 ? ` (+${festivals.length - 1} more)` : ""} takes place around this time.`,
+        );
+      }
+
+      return {
+        destination,
+        score: Number(score.toFixed(4)),
+        seasonalFit,
+        festivals,
+        matchedInterests,
+        explanation: explanationParts.join(" "),
+      };
+    });
+
+    const filtered = normalizedInterests.length
+      ? scored.filter((r) => r.matchedInterests.length > 0)
+      : scored;
+
+    return filtered.sort((a, b) => b.score - a.score).slice(0, limit);
+  }
+
+  /**
+   * Suggests alternative destinations for `month` when `destination` is
+   * a poor seasonal fit - same category, but genuinely "ideal" for that
+   * month, ranked by popularity.
+   *
+   * @param {Object} destination The destination the user was originally interested in.
+   * @param {number} month 1-12
+   * @param {number} [limit=3]
+   */
+  getAlternatives(destination, month, limit = 3) {
+    if (!destination) return [];
+    const fit = computeSeasonalFit(destination, month);
+    if (fit.level === "ideal" || fit.level === "unknown") return [];
+
+    const categories = destination.categories || [];
+    const monthName = MONTH_NAMES[month - 1];
+
+    return this.destinations
+      .filter((candidate) => candidate.id !== destination.id)
+      .map((candidate) => ({
+        destination: candidate,
+        seasonalFit: computeSeasonalFit(candidate, month),
+        sharedCategories: (candidate.categories || []).filter((c) => categories.includes(c)),
+      }))
+      .filter((r) => r.seasonalFit.level === "ideal" && r.sharedCategories.length > 0)
+      .sort((a, b) => {
+        if (b.sharedCategories.length !== a.sharedCategories.length) {
+          return b.sharedCategories.length - a.sharedCategories.length;
+        }
+        return (b.destination.popularity || 0) - (a.destination.popularity || 0);
+      })
+      .slice(0, limit)
+      .map((r) => ({
+        ...r,
+        explanation: `${r.destination.name} shares ${destination.name}'s ${r.sharedCategories.join("/")} appeal and is ideal to visit in ${monthName}, unlike ${destination.name} this time of year.`,
+      }));
+  }
+}
+
+export const SEASONAL_ENGINE_INTERNALS = { monthInRange, monthsFromRange, MONTH_NAMES, MONTH_INDEX };

--- a/tests/unit/seasonal-recommendation-engine.test.js
+++ b/tests/unit/seasonal-recommendation-engine.test.js
@@ -1,0 +1,185 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseSeasonRanges,
+  computeSeasonalFit,
+  getFestivalsForMonth,
+  SeasonalRecommendationEngine,
+} from "../../js-modules/seasonal-recommendation-engine.js";
+
+const destinations = [
+  {
+    id: "agra", name: "Agra", state: "Uttar Pradesh",
+    categories: ["historical", "heritage"], bestSeason: "Oct-Mar", popularity: 10,
+  },
+  {
+    id: "manali", name: "Manali", state: "Himachal Pradesh",
+    categories: ["mountains", "adventure"], bestSeason: "Mar-Jun, Sep-Dec", popularity: 8,
+  },
+  {
+    id: "goa", name: "Goa", state: "Goa",
+    categories: ["beaches"], bestSeason: "Nov-Feb", popularity: 9,
+  },
+  {
+    id: "jaisalmer", name: "Jaisalmer", state: "Rajasthan",
+    categories: ["desert", "historical", "adventure"], bestSeason: "Nov-Feb", popularity: 8,
+  },
+  {
+    id: "no-data-dest", name: "Mystery Town", state: "Nowhere",
+    categories: ["heritage"], bestSeason: "", popularity: 3,
+  },
+];
+
+const events = [
+  {
+    id: "taj-mahotsav", name: "Taj Mahotsav", destinationId: "agra", state: "Uttar Pradesh",
+    startMonth: 2, endMonth: 2, popularity: 7,
+  },
+  {
+    id: "pushkar-camel-fair", name: "Pushkar Camel Fair", destinationId: "jaisalmer", state: "Rajasthan",
+    startMonth: 10, endMonth: 11, popularity: 8,
+  },
+  {
+    id: "goa-carnival", name: "Goa Carnival", destinationId: "goa", state: "Goa",
+    startMonth: 2, endMonth: 2, popularity: 9,
+  },
+];
+
+describe("parseSeasonRanges", () => {
+  it("parses a single month range", () => {
+    expect(parseSeasonRanges("Oct-Mar")).toEqual([{ start: 10, end: 3 }]);
+  });
+
+  it("parses multiple comma-separated ranges", () => {
+    expect(parseSeasonRanges("Mar-Jun, Sep-Dec")).toEqual([
+      { start: 3, end: 6 },
+      { start: 9, end: 12 },
+    ]);
+  });
+
+  it("returns an empty array for empty/malformed input", () => {
+    expect(parseSeasonRanges("")).toEqual([]);
+    expect(parseSeasonRanges(undefined)).toEqual([]);
+    expect(parseSeasonRanges("not-a-range-format-xyz")).toEqual([]);
+  });
+});
+
+describe("computeSeasonalFit", () => {
+  it("marks a month inside the best-season window as ideal", () => {
+    const fit = computeSeasonalFit(destinations[0], 12); // Agra, December
+    expect(fit.level).toBe("ideal");
+    expect(fit.score).toBe(1);
+  });
+
+  it("marks a month just outside the window as shoulder season", () => {
+    const fit = computeSeasonalFit(destinations[2], 3); // Goa, March (best is Nov-Feb)
+    expect(fit.level).toBe("shoulder");
+  });
+
+  it("marks a month far outside the window as off-season", () => {
+    const fit = computeSeasonalFit(destinations[2], 7); // Goa, July (monsoon)
+    expect(fit.level).toBe("off-season");
+    expect(fit.score).toBeLessThan(0.5);
+  });
+
+  it("handles a wrap-around range correctly across the year boundary", () => {
+    // Goa's best season is Nov-Feb (wraps across the year boundary).
+    // January and December should both read as ideal...
+    expect(computeSeasonalFit(destinations[2], 1).level).toBe("ideal");
+    expect(computeSeasonalFit(destinations[2], 12).level).toBe("ideal");
+    // ...while a month on the far side of the year, like June, is off-season.
+    expect(computeSeasonalFit(destinations[2], 6).level).toBe("off-season");
+  });
+
+  it("returns 'unknown' with a neutral score when there is no season data", () => {
+    const fit = computeSeasonalFit(destinations[4], 6);
+    expect(fit.level).toBe("unknown");
+    expect(fit.score).toBe(0.5);
+  });
+});
+
+describe("getFestivalsForMonth", () => {
+  it("finds festivals matching destinationId and month", () => {
+    const results = getFestivalsForMonth(destinations[0], 2, events); // Agra, Feb
+    expect(results.map((e) => e.id)).toEqual(["taj-mahotsav"]);
+  });
+
+  it("returns an empty array when nothing matches", () => {
+    expect(getFestivalsForMonth(destinations[0], 7, events)).toEqual([]);
+  });
+
+  it("sorts multiple matches by popularity descending", () => {
+    const busyMonthEvents = [
+      ...events,
+      { id: "extra-goa-event", name: "Extra Goa Event", destinationId: "goa", state: "Goa", startMonth: 2, endMonth: 2, popularity: 15 },
+    ];
+    const results = getFestivalsForMonth(destinations[2], 2, busyMonthEvents);
+    expect(results[0].id).toBe("extra-goa-event");
+  });
+});
+
+describe("SeasonalRecommendationEngine.recommend", () => {
+  it("throws for an invalid month", () => {
+    const engine = new SeasonalRecommendationEngine({ destinations, events });
+    expect(() => engine.recommend({ month: 13 })).toThrow();
+    expect(() => engine.recommend({ month: 0 })).toThrow();
+  });
+
+  it("ranks destinations that are in-season for the given month above off-season ones", () => {
+    const engine = new SeasonalRecommendationEngine({ destinations, events });
+    const results = engine.recommend({ month: 12 }); // December
+    const ids = results.map((r) => r.destination.id);
+    // Agra, Goa, Jaisalmer are all in-season in December; Manali (Sep-Dec) also in-season.
+    // No-data destination should rank behind clearly in-season ones due to neutral score.
+    expect(ids.indexOf("agra")).toBeLessThan(ids.indexOf("no-data-dest"));
+  });
+
+  it("filters to only destinations matching requested interests when interests are given", () => {
+    const engine = new SeasonalRecommendationEngine({ destinations, events });
+    const results = engine.recommend({ month: 12, interests: ["beaches"] });
+    expect(results.every((r) => r.destination.categories.includes("beaches"))).toBe(true);
+    expect(results.map((r) => r.destination.id)).toContain("goa");
+  });
+
+  it("includes matching festivals in the result and explanation", () => {
+    const engine = new SeasonalRecommendationEngine({ destinations, events });
+    const results = engine.recommend({ month: 2 }); // February
+    const agraResult = results.find((r) => r.destination.id === "agra");
+    expect(agraResult.festivals.map((e) => e.id)).toContain("taj-mahotsav");
+    expect(agraResult.explanation).toMatch(/Taj Mahotsav/);
+  });
+
+  it("respects the limit parameter", () => {
+    const engine = new SeasonalRecommendationEngine({ destinations, events });
+    const results = engine.recommend({ month: 12, limit: 2 });
+    expect(results.length).toBeLessThanOrEqual(2);
+  });
+});
+
+describe("SeasonalRecommendationEngine.getAlternatives", () => {
+  it("returns no alternatives when the destination is already an ideal fit", () => {
+    const engine = new SeasonalRecommendationEngine({ destinations, events });
+    const alternatives = engine.getAlternatives(destinations[2], 12); // Goa, December (ideal)
+    expect(alternatives).toEqual([]);
+  });
+
+  it("suggests a same-category, in-season alternative for an off-season destination", () => {
+    const engine = new SeasonalRecommendationEngine({ destinations, events });
+    // Goa (beaches only) in July is off-season and shares no categories with
+    // anything else in-season -> expect no alternatives rather than a bad match.
+    const noSharedCategory = engine.getAlternatives(destinations[2], 7);
+    expect(noSharedCategory).toEqual([]);
+
+    // Jaisalmer (desert/historical/adventure) in June is off-season; Agra
+    // (historical/heritage) is NOT in-season in June either, so no alternative
+    // should be forced. Use a month where Agra IS in-season and shares "historical".
+    const alternatives = engine.getAlternatives(destinations[3], 1); // Jaisalmer, January
+    // Jaisalmer is ideal in January (Nov-Feb), so no alternatives expected here.
+    expect(alternatives).toEqual([]);
+  });
+
+  it("never suggests the destination as its own alternative", () => {
+    const engine = new SeasonalRecommendationEngine({ destinations, events });
+    const alternatives = engine.getAlternatives(destinations[2], 7);
+    expect(alternatives.every((a) => a.destination.id !== destinations[2].id)).toBe(true);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description
Implements an AI-powered Dynamic Seasonal Travel Recommendation Engine. Rather than building a new destination dataset and a live weather API from scratch, this reuses what the project already has — `trip-data.js`'s `bestSeason` field and `event-data.js`'s festival calendar — and adds a new orchestration/ranking layer on top, plus a full frontend page.

- Added `js-modules/seasonal-recommendation-engine.js`: pure functions `computeSeasonalFit()` and `getFestivalsForMonth()`, plus the `SeasonalRecommendationEngine` class (`recommend()`, `getAlternatives()`)
- Reuses existing datasets rather than duplicating them: `trip-data.js`'s `bestSeason` field for seasonal fit, `event-data.js`'s festival windows for festival-awareness, categories/popularity for interest matching and tie-breaking (same pattern as `travel-recommend.js`, Issue #185)
- Ranking combines seasonal fit (dominant), interest match, festival presence, and popularity, with a human-readable explanation per result
- Alternative destination suggestions when a destination is a poor seasonal fit for the requested month
- Added `frontend/seasonal-recommendations/` (`index.html`, `style.css`, `script.js`): month + interest filters, results grid with seasonal-fit badges, expandable in-season alternatives per card
- Added `tests/unit/seasonal-recommendation-engine.test.js` (19 tests, all passing) and `docs/SEASONAL_RECOMMENDATIONS.md`

**Scope note:** live weather-API integration and a dedicated analytics dashboard are intentionally left as fast-follows — see "What's intentionally out of scope" in `docs/SEASONAL_RECOMMENDATIONS.md`.

Fixes #773

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [ ] Tested locally in browser — please verify visually before merging; I built and unit-tested this in a sandboxed environment without a browser/display, so the page has not been visually confirmed yet
- [ ] Tested in both dark and light themes — CSS uses the site's existing custom-property tokens (`--saffron`, `--glass-bg`, etc.) with fallbacks, so it *should* follow the active theme, but this hasn't been visually confirmed either
- [ ] Tested at mobile viewport widths — one `@media (max-width: 720px)` rule is included for the filter layout, but not visually verified
- [x] Verified no console errors — n/a in the sandbox (no browser), but `node --check` passed on all new JS and the module has no unhandled dependencies beyond `window.tripDestinations`/`window.eventData`, which the page loads via `<script>` tags before the module runs

Unit-level: `npx vitest run` passes all 19 new tests, and I confirmed the 2 pre-existing failures elsewhere in the suite (`border-neighbors-quiz`, `constitution-makers`) are unrelated and present on `main` before this change too.

## Checklist
- [x] My code follows the coding standards of this project (mirrors `event-discovery`'s page structure and `travel-recommend.js`'s engine/data separation)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [ ] I have tested responsive layout (if UI change) — please double check on your end, see note above
- [ ] I have considered accessibility (aria labels, keyboard nav, focus) — interest chips are real `<button>` elements (keyboard-focusable and clickable via Enter/Space by default) and the month picker is a native `<select>`, but I didn't add explicit `aria-pressed` state to the toggled chips or `aria-live` on the results count — worth a follow-up pass if the maintainers want that polish before merge

## Screenshots (if applicable)
None yet — I don't have a browser in this environment to capture one. Happy to describe the layout in more detail if useful, but a real screenshot from your machine would be more trustworthy for reviewers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a seasonal travel recommendations page.
  * Filter destinations by travel month and interests.
  * View ranked recommendations with seasonal fit, interest matches, festival highlights, and explanations.
  * See alternative destinations when a selection is outside its ideal season.
  * Preferences are saved and restored automatically.
  * Added responsive styling, theme controls, reset filters, and scroll-to-top navigation.

* **Tests**
  * Added coverage for seasonal matching, rankings, festival filtering, and alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->