### PR TITLE
feat: add Kaziranga National Park Explorer with interactive map, wildlife, and gallery (#810)

### DIFF
--- a/frontend/kaziranga-national-park-explorer/index.html
+++ b/frontend/kaziranga-national-park-explorer/index.html
@@ -1,0 +1,364 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    document.body.classList.add('light-theme');
+                }
+            })();
+        </script>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Explore Kaziranga National Park & Tiger Reserve in Assam — UNESCO World Heritage Site, home to 2,600+ One-Horned Rhinoceroses, Bengal Tigers, Wild Water Buffalo, and 500+ bird species across the Brahmaputra floodplain wetlands."
+        />
+        <title>Kaziranga National Park Explorer | Incredible India</title>
+
+        <!-- Google Fonts -->
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+            rel="stylesheet"
+        />
+
+        <!-- Stylesheets -->
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="kaziranga.css" />
+
+        <!-- Open Graph -->
+        <meta property="og:title" content="Kaziranga National Park Explorer | Incredible India" />
+        <meta
+            property="og:description"
+            content="Interactive guide to Kaziranga National Park in Assam — UNESCO World Heritage Site, sanctuary of the Great Indian One-Horned Rhinoceros, Bengal Tigers, and the rich wetlands of the Brahmaputra floodplain."
+        />
+        <meta property="og:type" content="website" />
+    </head>
+
+    <body class="kaziranga-main">
+        <!-- Site Navbar -->
+        <header class="navbar scrolled" id="navbar">
+            <div class="nav-container">
+                <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </button>
+                <nav class="nav-menu" id="nav-menu">
+                    <a href="../../index.html#home" class="nav-link">Home</a>
+                    <a href="../national-parks-explorer/index.html" class="nav-link">National Parks</a>
+                    <a href="index.html" class="nav-link active" style="color: var(--saffron)"
+                        >Kaziranga Explorer</a
+                    >
+                    <a href="../national-parks-timeline/national-parks-timeline.html" class="nav-link">Timeline</a>
+                    <button
+                        id="theme-toggle"
+                        class="btn-theme-toggle"
+                        aria-label="Toggle Dark/Light Mode"
+                        title="Toggle Light Mode"
+                    >
+                        ☀️
+                    </button>
+                </nav>
+            </div>
+        </header>
+
+        <main>
+            <!-- Hero Section -->
+            <section class="kaziranga-hero">
+                <div class="section-container">
+                    <div class="hero-badges-row">
+                        <span class="hero-pill pill-unesco">🏛️ UNESCO World Heritage Site</span>
+                        <span class="hero-pill pill-rhino">🦏 2,600+ One-Horned Rhinos</span>
+                        <span class="hero-pill pill-wetland">🌾 Brahmaputra Wetlands</span>
+                    </div>
+                    <h1>Kaziranga <span>National Park</span> Explorer</h1>
+                    <p class="hero-subtitle">
+                        Immerse yourself in India's most spectacular wildlife sanctuary — a UNESCO World Heritage Site
+                        on the floodplains of the Brahmaputra. Home to two-thirds of the world's Great Indian
+                        One-Horned Rhinoceroses, dense tiger populations, wild water buffalo herds, and over 500 species
+                        of migratory and resident birds.
+                    </p>
+
+                    <!-- Quick Stats Bar -->
+                    <div id="stats-grid" class="stats-grid">
+                        <!-- Populated by kaziranga.js -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- One-Horned Rhinoceros Spotlight -->
+            <section class="rhino-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Flagship Species</span>
+                        <h2>The Great Indian One-Horned Rhinoceros</h2>
+                        <p class="section-subtitle">
+                            Kaziranga is the last great stronghold of <em>Rhinoceros unicornis</em>. From fewer than 20
+                            individuals in 1908 to over 2,600 today — this is one of the most remarkable conservation
+                            success stories in the world.
+                        </p>
+                    </div>
+
+                    <div class="rhino-spotlight glass-card">
+                        <div>
+                            <h2>🦏 Rhinoceros unicornis</h2>
+                            <p style="color:var(--kaziranga-text-muted-dark); line-height:1.7; margin-bottom:1rem;">
+                                Kaziranga's rhino population is the single largest wild population of the
+                                One-Horned Rhinoceros anywhere on Earth. These gentle giants spend their days grazing
+                                in the tall grasslands and wallowing in muddy beels. Their thick grey hide is folded
+                                into protective plating, and their single horn — made of keratin, like human hair and
+                                nails — can grow up to 57 cm long.
+                            </p>
+                            <div style="font-size:0.9rem; padding:0.9rem; border-radius:10px; background:rgba(22,101,52,0.1); border-left:4px solid var(--monsoon-green); color:#86efac;">
+                                🧬 <strong>Conservation Success:</strong> From the brink of extinction at 12 individuals
+                                in the early 1900s, Kaziranga's rhino population has recovered to over 2,600 —
+                                protected by a dedicated force of 1,800 forest guards and 165 anti-poaching camps.
+                            </div>
+
+                            <!-- Rhino Stats Grid -->
+                            <div id="rhino-stats" class="rhino-stats-grid">
+                                <!-- Populated by kaziranga.js -->
+                            </div>
+                        </div>
+                        <div style="border-radius:14px; overflow:hidden; position:relative; background:#0f172a; height:300px;">
+                            <img
+                                src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/One_horned_Rhino.jpg/800px-One_horned_Rhino.jpg"
+                                alt="Great Indian One-Horned Rhinoceros"
+                                style="width:100%; height:100%; object-fit:cover;"
+                            />
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Wetlands & Floodplain Ecology -->
+            <section class="wetland-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Floodplain Ecosystem</span>
+                        <h2>Wetlands & Brahmaputra Floodplain Ecology</h2>
+                        <p class="section-subtitle">
+                            The annual monsoon floods of the Brahmaputra River shape Kaziranga's dynamic landscape,
+                            creating a mosaic of tall grasslands, wetlands, and forests that support extraordinary
+                            biodiversity.
+                        </p>
+                    </div>
+
+                    <div class="glass-card" style="padding:2rem; max-width:1000px; margin:0 auto;">
+                        <div style="display:grid; grid-template-columns:1fr 1fr; gap:1.5rem;">
+                            <div style="display:flex; flex-direction:column; gap:1rem;">
+                                <div style="font-size:0.9rem; line-height:1.7; color:var(--kaziranga-text-muted-dark);">
+                                    <strong style="color:var(--gold-bright);">🌾 Tall Wet Grasslands</strong>
+                                    <p style="margin-top:0.3rem;">Dominant grass species: <em>Phragmites karka, Saccharum spontaneum</em> — growing 4–6 meters tall. Primary rhino habitat and tiger ambush cover.</p>
+                                    <strong style="color:var(--gold-bright); margin-top:1rem; display:block;">🌱 Short Grasslands</strong>
+                                    <p style="margin-top:0.3rem;"><em>Cynodon dactylon, Imperata cylindrica</em> — 0.5–1 meter. Preferred grazing areas for swamp deer and water buffalo.</p>
+                                    <strong style="color:var(--gold-bright); margin-top:1rem; display:block;">💧 Wetland Beels (Lakes)</strong>
+                                    <p style="margin-top:0.3rem;">Over 100 seasonal and perennial beels dot the park. Critical dry-season refuges for fish spawning, waterfowl congregations, and megafauna drinking water.</p>
+                                </div>
+                            </div>
+                            <div style="display:flex; flex-direction:column; gap:1rem;">
+                                <div style="border-radius:12px; overflow:hidden; background:#0f172a; height:180px;">
+                                    <img
+                                        src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/db/Keoladeo_Ghana_National_Park%2C_Bharatpur%2C_Rajasthan%2C_India.jpg/800px-Keoladeo_Ghana_National_Park%2C_Bharatpur%2C_Rajasthan%2C_India.jpg"
+                                        alt="Kaziranga Wetlands"
+                                        style="width:100%; height:100%; object-fit:cover;"
+                                    />
+                                </div>
+                                <div style="font-size:0.88rem; padding:1rem; border-radius:10px; background:rgba(2,132,199,0.1); border-left:4px solid var(--wetland-blue); color:#7dd3fc;">
+                                    🌊 <strong>Annual Flood Cycle:</strong> The Brahmaputra overflows every monsoon,
+                                    inundating up to 70% of the park. These floods deposit nutrient-rich silt,
+                                    recharge aquifers, and reset the grassland succession — essential for rhino habitat.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Wildlife Section -->
+            <section class="wildlife-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Rich Biodiversity</span>
+                        <h2>Wildlife of Kaziranga</h2>
+                        <p class="section-subtitle">
+                            From the iconic One-Horned Rhino to the Bengal Tiger, Wild Water Buffalo, Swamp Deer,
+                            and the Ganges River Dolphin — Kaziranga protects an extraordinary concentration of
+                            endangered species.
+                        </p>
+                    </div>
+
+                    <div id="wildlife-grid" class="wildlife-grid">
+                        <!-- Populated by kaziranga.js -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Bird Species -->
+            <section class="birds-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Avian Diversity</span>
+                        <h2>Bird Species of Kaziranga</h2>
+                        <p class="section-subtitle">
+                            With over 500 recorded species, Kaziranga is a birdwatcher's paradise — hosting
+                            endangered Greater Adjutant Storks, Bengal Floricans, Spot-billed Pelicans, and
+                            thousands of migratory waterfowl from Central Asia.
+                        </p>
+                    </div>
+
+                    <div id="birds-grid" class="birds-grid">
+                        <!-- Populated by kaziranga.js -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Conservation Timeline -->
+            <section class="conservation-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Conservation Milestones</span>
+                        <h2>Kaziranga Conservation Timeline</h2>
+                        <p class="section-subtitle">
+                            From a hunting reserve in the 1900s to one of the world's most successful rhino
+                            conservation stories — tracing the history of protection that saved the One-Horned
+                            Rhinoceros from extinction.
+                        </p>
+                    </div>
+
+                    <div id="conservation-timeline" class="timeline-container">
+                        <!-- Populated by kaziranga.js -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Safari Options -->
+            <section class="safari-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Experience the Wild</span>
+                        <h2>Safari Options in Kaziranga</h2>
+                        <p class="section-subtitle">
+                            Explore Kaziranga's wilderness through two classic safari experiences — elephant-back
+                            safari for close-range rhino encounters, and jeep safari for covering more ground
+                            across the park's four ranges.
+                        </p>
+                    </div>
+
+                    <div id="safari-grid" class="safari-grid">
+                        <!-- Populated by kaziranga.js -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Interactive SVG Park Map -->
+            <section class="map-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Park Geography</span>
+                        <h2>Interactive Map of Kaziranga National Park</h2>
+                        <p class="section-subtitle">
+                            Click on map hotspot pins to locate Kohora Central Range, Bagori Western Range,
+                            Agoratoli Eastern Range, Burapahar Range, Mihimukh Rhino Grazing Area, and
+                            the Difloo River wetland system.
+                        </p>
+                    </div>
+
+                    <div class="map-card-wrapper glass-card">
+                        <div class="map-svg-container">
+                            <svg class="park-map-svg" viewBox="0 0 1000 600" xmlns="http://www.w3.org/2000/svg">
+                                <rect width="1000" height="600" fill="#0a1f1a" />
+                                <!-- Park Boundary — Brahmaputra Floodplain Shape -->
+                                <path d="M60,200 Q500,80 940,180 L940,520 L60,520 Z" fill="#0f2a22" stroke="rgba(212,168,67,0.3)" stroke-width="2"/>
+                                <!-- Brahmaputra River -->
+                                <path d="M0,80 Q250,180 500,160 T1000,100" fill="none" stroke="#075985" stroke-width="40" opacity="0.5"/>
+                                <path d="M0,80 Q250,180 500,160 T1000,100" fill="none" stroke="#0284c7" stroke-width="20" opacity="0.7"/>
+                                <!-- Difloo River / Inner Stream -->
+                                <path d="M200,250 Q400,320 600,400 T900,450" fill="none" stroke="#0e7490" stroke-width="12" opacity="0.5"/>
+                                <text x="400" y="140" fill="#38bdf8" font-size="14" font-family="Outfit">Brahmaputra River</text>
+                                <text x="700" y="460" fill="#86efac" font-size="13" font-weight="bold" font-family="Outfit">Mihimukh Rhino Zone</text>
+                            </svg>
+
+                            <!-- Pins Layer -->
+                            <div id="map-hotspots-layer">
+                                <!-- Populated by kaziranga.js -->
+                            </div>
+
+                            <!-- Info Popup -->
+                            <div id="map-info-popup" class="map-info-popup hidden">
+                                <!-- Populated by kaziranga.js -->
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Gallery Section -->
+            <section class="gallery-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Visual Journey</span>
+                        <h2>Kaziranga Photo Gallery</h2>
+                        <p class="section-subtitle">
+                            Immerse yourself in photographs of the One-Horned Rhinoceros, elephant safaris,
+                            Bengal Tigers, wild water buffalo herds, and the stunning floodplain landscapes
+                            of Kaziranga. Click any photo for a full-screen view.
+                        </p>
+                    </div>
+
+                    <div id="gallery-grid" class="gallery-grid">
+                        <!-- Populated by kaziranga.js -->
+                    </div>
+                </div>
+            </section>
+        </main>
+
+        <!-- Lightbox Modal -->
+        <div id="lightbox-modal" class="lightbox-modal hidden" role="dialog" aria-modal="true" aria-label="Photo Lightbox">
+            <div class="lightbox-content">
+                <button type="button" id="lightbox-close" class="lightbox-close" aria-label="Close Lightbox">&times;</button>
+                <img id="lightbox-img" class="lightbox-img" src="" alt="Gallery Preview" />
+                <div id="lightbox-caption" class="lightbox-caption"></div>
+            </div>
+        </div>
+
+        <!-- Site Footer -->
+        <footer class="footer" style="margin-top:4rem; border-top:1px solid var(--kaziranga-border-dark);">
+            <div class="footer-container">
+                <div class="footer-brand">
+                    <h3>Incredible India Explorer</h3>
+                    <p>
+                        An interactive digital guide to the geography, food, festivals, wildlife, and cultural heritage of India.
+                    </p>
+                </div>
+                <div class="footer-links">
+                    <h3>Quick Navigation</h3>
+                    <ul>
+                        <li><a href="../../index.html#home">Home</a></li>
+                        <li><a href="../national-parks-explorer/index.html">National Parks Explorer</a></li>
+                        <li><a href="index.html">Kaziranga Explorer</a></li>
+                        <li><a href="../national-parks-timeline/national-parks-timeline.html">Parks Timeline</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-credits footer-credits-center">
+                <p>&copy; 2026 Incredible India Explorer. Kaziranga National Park Explorer.</p>
+            </div>
+        </footer>
+
+        <!-- Core Scripts -->
+        <script src="../../app.js" defer></script>
+        <script src="kaziranga-data.js" defer></script>
+        <script src="kaziranga.js" defer></script>
+        <script type="module" src="../../auth.js"></script>
+    </body>
+</html>

--- a/frontend/kaziranga-national-park-explorer/kaziranga-data.js
+++ b/frontend/kaziranga-national-park-explorer/kaziranga-data.js
@@ -1,0 +1,368 @@
+/**
+ * Kaziranga National Park Explorer — Data Module
+ * Comprehensive dataset covering One-Horned Rhinoceros, UNESCO World Heritage,
+ * wetlands ecosystem, wildlife, bird species, conservation, safari, gallery, and map.
+ */
+
+const KAZIRANGA_INFO = {
+    id: "kaziranga",
+    name: "Kaziranga National Park",
+    aka: "Kaziranga Tiger Reserve",
+    location: "Golaghat & Nagaon Districts, Assam, India",
+    state: "Assam",
+    coordinates: { lat: 26.64, lng: 93.42 },
+    area: "858 km² (Core: 430 km², Buffer: 428 km²)",
+    establishedYear: 1974,
+    tigerReserveYear: 2006,
+    unescoYear: 1985,
+    unescoCriteria: "Criteria (ix), (x) — Outstanding example of ongoing ecological processes and superlative natural phenomena",
+    etymology: "Named after the 'Kaziranga' village. 'Kazi' means 'goat' in Karbi language and 'Ranga' means 'red' — referring to red goats once found in the region.",
+    climate: "Tropical Monsoon with annual rainfall exceeding 2,200 mm",
+    bestTime: "November to April (Park closed May–October due to monsoon)",
+    entryFees: "₹650 (Indian Nationals), ₹2,500 (Foreigners), Elephant Safari: ₹1,200/person, Jeep Safari: ₹3,000/vehicle",
+    nearestTransport: {
+        railway: "Furkating Junction (50 km) / Jorhat Railway Station (96 km)",
+        airport: "Jorhat Airport (97 km) / Guwahati International Airport (217 km)",
+        gatewayTown: "Kohora (Central Range entry point)"
+    },
+    quickStats: [
+        { label: "One-Horned Rhinos", value: "2,600+", icon: "🦏" },
+        { label: "UNESCO Inscribed", value: "1985", icon: "🏛️" },
+        { label: "Tiger Reserve", value: "Since 2006", icon: "🐅" },
+        { label: "Wetland Area", value: "858 km²", icon: "🌾" },
+        { label: "Bird Species", value: "500+", icon: "🦅" },
+        { label: "Wildlife Density", value: "India's Finest", icon: "🐘" }
+    ]
+};
+
+const RHINO_INFO = {
+    title: "The Great Indian One-Horned Rhinoceros",
+    scientificName: "Rhinoceros unicornis",
+    conservationStatus: "Vulnerable (IUCN Red List)",
+    populationGlobal: "~4,000 (two-thirds live in Kaziranga)",
+    weight: "1,800 – 2,700 kg (Male) | 1,600 – 2,000 kg (Female)",
+    lifespan: "35–45 years in wild",
+    description: "Kaziranga is home to the world's largest population of the Great Indian One-Horned Rhinoceros. The rhino is distinguished by its single black horn (25–57 cm), thick grey-brown skin folded into shield-like plates, and a prehensile upper lip adapted for grazing. A true prehistoric survivor, it has roamed the Brahmaputra floodplains for millennia.",
+    behavior: "Primarily solitary grazers, most active during early morning and late afternoon. They are excellent swimmers and can travel long distances in water. Rhinos maintain wallowing holes to cool off and coat their skin with mud as natural sunscreen and insect repellent.",
+    significance: "Kaziranga's rhino conservation is one of the world's greatest success stories — from fewer than 20 individuals in the early 1900s to over 2,600 today. Dedicated anti-poaching patrols, intelligence-led operations, and community engagement have brought the population back from the brink.",
+    hornUseAndPoaching: "Rhino horn is composed of keratin (same as human hair and nails). Despite having no proven medicinal value, it is prized in illegal wildlife trade for traditional East Asian medicine, driving persistent poaching threats."
+};
+
+const RHINO_BODY_PARTS = [
+    { label: "Horn Length", value: "25–57 cm, single horn", icon: "🦏" },
+    { label: "Shoulder Height", value: "1.7–2.0 meters", icon: "📏" },
+    { label: "Body Length", value: "3.0–3.8 meters", icon: "📐" },
+    { label: "Top Speed", value: "55 km/h (charge)", icon: "⚡" },
+    { label: "Daily Grazing", value: "50–100 kg grass", icon: "🌿" },
+    { label: "Skin Thickness", value: "1.5–2.5 cm", icon: "🛡️" }
+];
+
+const WILDLIFE = [
+    {
+        id: "wild-one-horned-rhino",
+        name: "One-Horned Rhinoceros",
+        scientificName: "Rhinoceros unicornis",
+        status: "Vulnerable",
+        icon: "🦏",
+        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/One_horned_Rhino.jpg/800px-One_horned_Rhino.jpg",
+        description: "The iconic megaherbivore of Kaziranga. Over 2,600 rhinos roam the tall grasslands and wetlands of the park, making it the single most important rhino conservation area in the world."
+    },
+    {
+        id: "wild-elephant",
+        name: "Asian Elephant",
+        scientificName: "Elephas maximus",
+        status: "Endangered",
+        icon: "🐘",
+        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Elephant_safari_in_Kaziranga.jpg/800px-Elephant_safari_in_Kaziranga.jpg",
+        description: "Kaziranga supports a large population of wild Asian elephants. They migrate across the Brahmaputra floodplains and are frequently spotted during elephant-back safaris along the park's open meadows."
+    },
+    {
+        id: "wild-water-buffalo",
+        name: "Wild Water Buffalo",
+        scientificName: "Bubalus arnee",
+        status: "Endangered",
+        icon: "🐃",
+        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Wild_Buffalo_Kaziranga.jpg/800px-Wild_Buffalo_Kaziranga.jpg",
+        description: "The wild ancestor of domestic water buffalo. Kaziranga protects one of the largest surviving populations of this endangered species, distinguished by its massive crescent-shaped horns."
+    },
+    {
+        id: "wild-swamp-deer",
+        name: "Swamp Deer (Barasingha)",
+        scientificName: "Rucervus duvaucelii",
+        status: "Endangered",
+        icon: "🦌",
+        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Swamp_Deer_Barasingha.jpg/800px-Swamp_Deer_Barasingha.jpg",
+        description: "Kaziranga hosts a thriving population of Barasingha, the swamp deer known for its impressive multi-tined antlers. They graze in large herds across marshy grasslands."
+    },
+    {
+        id: "wild-tiger",
+        name: "Bengal Tiger",
+        scientificName: "Panthera tigris tigris",
+        status: "Endangered",
+        icon: "🐅",
+        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fe/Royal_Bengal_Tiger_at_Nandankanan.jpg/800px-Royal_Bengal_Tiger_at_Nandankanan.jpg",
+        description: "Kaziranga was declared a Tiger Reserve in 2006 and now boasts one of the highest tiger densities in India. The tall grasslands provide perfect ambush cover for hunting."
+    },
+    {
+        id: "wild-dolphin",
+        name: "Ganges River Dolphin",
+        scientificName: "Platanista gangetica",
+        status: "Endangered",
+        icon: "🐬",
+        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6b/Ganges_Dolphin.jpg/800px-Ganges_Dolphin.jpg",
+        description: "The Brahmaputra river system bordering Kaziranga is home to the blind Ganges River Dolphin, a freshwater cetacean that navigates murky waters using echolocation."
+    }
+];
+
+const BIRD_SPECIES = [
+    {
+        id: "bird-greater-adjutant",
+        name: "Greater Adjutant Stork",
+        scientificName: "Leptoptilos dubius",
+        status: "Endangered",
+        icon: "🦩",
+        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Greater_Adjutant_Stork_Kaziranga.jpg/800px-Greater_Adjutant_Stork_Kaziranga.jpg",
+        description: "One of the world's rarest storks, Kaziranga hosts one of its last breeding strongholds. These giant scavengers nest high in the park's ancient trees."
+    },
+    {
+        id: "bird-spotbill-pelican",
+        name: "Spot-billed Pelican",
+        scientificName: "Pelecanus philippensis",
+        status: "Near Threatened",
+        icon: "🦆",
+        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/0/07/Spot-billed_Pelican_Keoladeo.jpg/800px-Spot-billed_Pelican_Keoladeo.jpg",
+        description: "Large waterbird with a distinctive spotted bill and expandable throat pouch. They breed in large colonies in Kaziranga's wetland trees."
+    },
+    {
+        id: "bird-bengal-florican",
+        name: "Bengal Florican",
+        scientificName: "Houbaropsis bengalensis",
+        status: "Critically Endangered",
+        icon: "🐦",
+        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/Bengal_Florican_male.jpg/800px-Bengal_Florican_male.jpg",
+        description: "One of the rarest bustards in the world. Kaziranga's short grasslands provide critical breeding habitat for this critically endangered species, known for the male's spectacular courtship leap display."
+    },
+    {
+        id: "bird-wild-duck",
+        name: "Lesser Whistling Duck",
+        scientificName: "Dendrocygna javanica",
+        status: "Least Concern",
+        icon: "🦆",
+        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/8/83/Lesser_Whistling_Duck_Kaziranga.jpg/800px-Lesser_Whistling_Duck_Kaziranga.jpg",
+        description: "Abundant winter visitor forming large flocks on Kaziranga's beels (wetland lakes). Named for its clear three-note whistling call."
+    },
+    {
+        id: "bird-fishing-eagle",
+        name: "Grey-headed Fish Eagle",
+        scientificName: "Haliaeetus ichthyaetus",
+        status: "Near Threatened",
+        icon: "🦅",
+        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Crested_Serpent_Eagle_Keoladeo.jpg/800px-Crested_Serpent_Eagle_Keoladeo.jpg",
+        description: "A powerful raptor that hunts fish in Kaziranga's wetlands. Easily identified by its grey head, yellow talons, and piercing call."
+    },
+    {
+        id: "bird-hornbill",
+        name: "Oriental Pied Hornbill",
+        scientificName: "Anthracoceros albirostris",
+        status: "Least Concern",
+        icon: "🐦",
+        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/1/1d/Oriental_Pied_Hornbill_Kaziranga.jpg/800px-Oriental_Pied_Hornbill_Kaziranga.jpg",
+        description: "A charismatic hornbill with a striking yellow and white casque. Its loud cackling calls echo through the forest canopy as it feeds on figs and berries."
+    }
+];
+
+const WETLAND_ECOLOGY = {
+    overview: "Kaziranga's landscape is a dynamic mosaic shaped by the annual monsoon floods of the Brahmaputra River. The park comprises tall elephant grass meadows, tropical wet evergreen forests, riparian woodlands, and numerous shallow wetland lakes ('beels') that support an extraordinary density of aquatic life.",
+    floodCycle: "The Brahmaputra overflows its banks every monsoon (June–September), inundating up to 70% of the park. These annual floods deposit nutrient-rich silt, recharge groundwater, and reset the grassland succession cycle — essential for maintaining the open grazing habitat that rhinos and herbivores depend on.",
+    grasslandEcology: [
+        { type: "Tall Wet Grasslands", species: "Phragmites karka, Saccharum spontaneum, Arundo donax", height: "4–6 meters", role: "Primary rhino habitat and tiger ambush cover" },
+        { type: "Short Grasslands", species: "Cynodon dactylon, Imperata cylindrica", height: "0.5–1 meter", role: "Preferred grazing areas for swamp deer and water buffalo" },
+        { type: "Swamp/Marsh", species: "Hydrilla, Vallisneria, Nymphaea (water lilies)", depth: "0.5–2 meters", role: "Rhino wallowing, waterfowl feeding, fish breeding" }
+    ],
+    beels: "Over 100 seasonal and perennial beels dot the Kaziranga landscape. These wetlands are critical dry-season refuges for aquatic flora and fauna, supporting fish spawning, waterfowl congregations, and providing drinking water for the park's megafauna."
+};
+
+const CONSERVATION_HISTORY = [
+    {
+        year: "1905",
+        title: "Initial Protection",
+        description: "The area around Kaziranga was declared a Reserved Forest by the British administration, recognizing its importance as a rhino habitat."
+    },
+    {
+        year: "1908",
+        title: "Kaziranga Proposed Reserve Forest",
+        description: "Mary Victoria Leiter Curzon, wife of Viceroy Lord Curzon, persuaded her husband to act on rhino protection after visiting the area. The reserve was expanded."
+    },
+    {
+        year: "1916",
+        title: "Kaziranga Game Sanctuary",
+        description: "Declared a Game Sanctuary to protect the rapidly dwindling rhino population, which had fallen to below 20 individuals."
+    },
+    {
+        year: "1950",
+        title: "Kaziranga Wildlife Sanctuary",
+        description: "After independence, the sanctuary was re-notified under the Assam Wildlife Protection Act with enhanced legal protection."
+    },
+    {
+        year: "1974",
+        title: "Kaziranga National Park",
+        description: "Upgraded to National Park status on February 11, 1974, under the Wildlife Protection Act of 1972."
+    },
+    {
+        year: "1985",
+        title: "UNESCO World Heritage Site",
+        description: "Inscribed on the UNESCO World Heritage List for its unique natural habitat and exceptional biodiversity, meeting Criteria (ix) and (x)."
+    },
+    {
+        year: "2006",
+        title: "Kaziranga Tiger Reserve",
+        description: "Declared a Tiger Reserve under Project Tiger, recognizing the park's importance as a source population for Bengal Tigers in the Northeast."
+    },
+    {
+        year: "2018–Present",
+        title: "Rhino Population Crosses 2,600",
+        description: "The annual census confirms Kaziranga's rhino population at 2,613. Eight anti-poaching camps and drone surveillance maintain the highest level of protection."
+    }
+];
+
+const SAFARI_OPTIONS = [
+    {
+        id: "safari-elephant",
+        title: "Elephant-back Safari",
+        duration: "1.0–1.5 hours",
+        timing: "5:30 AM & 6:30 AM (Seasonal)",
+        cost: "₹1,200 per person",
+        capacity: "4 persons per elephant",
+        zones: "Central (Kohora), Western (Bagori), Eastern (Agoratoli)",
+        highlights: [
+            "Best chance for close-range rhino sightings",
+            "Guided by trained mahouts with decades of experience",
+            "Access to interior grassland areas inaccessible by jeep",
+            "Spectacular sunrise views over the Brahmaputra floodplain"
+        ],
+        description: "The classic Kaziranga experience. Riding atop a trained elephant, you traverse the tall golden grasslands at dawn. The elevated vantage point allows for extraordinary close encounters with rhinos, elephants, and swamp deer in their natural habitat."
+    },
+    {
+        id: "safari-jeep",
+        title: "Jeep Safari (Gypsy)",
+        duration: "2.0–3.0 hours",
+        timing: "7:00 AM & 1:00 PM (Two shifts)",
+        cost: "₹3,000 per vehicle (up to 6 persons)",
+        capacity: "6 persons per jeep",
+        zones: "Central (Kohora), Western (Bagori), Eastern (Agoratoli), Burapahar",
+        highlights: [
+            "Covers longer distances and more terrain types",
+            "Better for birdwatching and tiger tracking",
+            "Can visit all four ranges over multiple safaris",
+            "More frequent sightings of Bengal Florican and Crested Serpent Eagle"
+        ],
+        description: "An open-topped Gypsy jeep safari takes you through Kaziranga's diverse terrain — from open grasslands to dense forests. Ideal for wildlife photographers and those seeking to maximize species sightings across the park's four ranges."
+    }
+];
+
+const MAP_HOTSPOTS = [
+    {
+        id: "spot-kohora",
+        name: "Kohora Central Range Entry",
+        category: "gate",
+        x: 35,
+        y: 30,
+        description: "Main tourist entry point with Kaziranga Museum, interpretation center, and the famous Mihimukh elephant safari starting point."
+    },
+    {
+        id: "spot-bagori",
+        name: "Bagori Western Range",
+        category: "gate",
+        x: 15,
+        y: 38,
+        description: "Western entrance offering excellent rhino sightings in open meadows. The Bagori range is known for its high density of one-horned rhinos."
+    },
+    {
+        id: "spot-agaratoli",
+        name: "Agoratoli Eastern Range",
+        category: "gate",
+        x: 72,
+        y: 28,
+        description: "Eastern entry point near the Brahmaputra riverbank. Known for tiger sightings and large waterbird congregations on the floodplain beels."
+    },
+    {
+        id: "spot-burapahar",
+        name: "Burapahar Range & Ghorakati",
+        category: "gate",
+        x: 22,
+        y: 62,
+        description: "Southern hilly range with mixed deciduous forest. The only range with significant elevation, offering panoramic views of the floodplain."
+    },
+    {
+        id: "spot-mihimukh",
+        name: "Mihimukh Rhino Grazing Area",
+        category: "wildlife",
+        x: 42,
+        y: 35,
+        description: "Classic rhino viewing area in the central range. Open short grasslands where rhinos, swamp deer, and wild buffalo graze together."
+    },
+    {
+        id: "spot-difloo",
+        name: "Difloo River & Wetland Beels",
+        category: "water",
+        x: 55,
+        y: 42,
+        description: "Major wetland system with interconnected beels. Prime waterfowl habitat during winter and the best area for spotting the Ganges River Dolphin."
+    },
+    {
+        id: "spot-panther",
+        name: "Panbari Reserve Forest (Tiger Zone)",
+        category: "tiger",
+        x: 30,
+        y: 55,
+        description: "Southern forest corridor connecting Kaziranga to the Karbi Anglong hills. Crucial tiger dispersal route and prime leopard habitat."
+    }
+];
+
+const GALLERY_IMAGES = [
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/One_horned_Rhino.jpg/800px-One_horned_Rhino.jpg",
+        title: "Great Indian One-Horned Rhinoceros",
+        caption: "A majestic one-horned rhino grazing in the tall grasslands of Kaziranga's central range at dawn."
+    },
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Elephant_safari_in_Kaziranga.jpg/800px-Elephant_safari_in_Kaziranga.jpg",
+        title: "Elephant Safari at Sunrise",
+        caption: "Tourists on elephant-back safari crossing the golden floodplain with rhinos in the distance."
+    },
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/0/01/Wild_Buffalo_Kaziranga.jpg/800px-Wild_Buffalo_Kaziranga.jpg",
+        title: "Wild Water Buffalo Herd",
+        caption: "An endangered Wild Water Buffalo wallowing in a shallow wetland beel during summer."
+    },
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fe/Royal_Bengal_Tiger_at_Nandankanan.jpg/800px-Royal_Bengal_Tiger_at_Nandankanan.jpg",
+        title: "Bengal Tiger in Tall Grass",
+        caption: "A Bengal Tiger stalks through the tall elephant grass, Kaziranga's apex predator."
+    },
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Swamp_Deer_Barasingha.jpg/800px-Swamp_Deer_Barasingha.jpg",
+        title: "Swamp Deer (Barasingha) Herd",
+        caption: "A herd of Barasingha grazing in the short grasslands of the Bagori range."
+    },
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Greater_Adjutant_Stork_Kaziranga.jpg/800px-Greater_Adjutant_Stork_Kaziranga.jpg",
+        title: "Greater Adjutant Stork Colony",
+        caption: "Endangered Greater Adjutant Storks nesting high in the ancient trees of Kaziranga."
+    }
+];
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        KAZIRANGA_INFO,
+        RHINO_INFO,
+        RHINO_BODY_PARTS,
+        WILDLIFE,
+        BIRD_SPECIES,
+        WETLAND_ECOLOGY,
+        CONSERVATION_HISTORY,
+        SAFARI_OPTIONS,
+        MAP_HOTSPOTS,
+        GALLERY_IMAGES
+    };
+}

--- a/frontend/kaziranga-national-park-explorer/kaziranga.css
+++ b/frontend/kaziranga-national-park-explorer/kaziranga.css
@@ -1,0 +1,645 @@
+/* ==========================================================================
+   Kaziranga National Park Explorer — Styling
+   Rhino gold & monsoon green dark/light theme design system
+   ========================================================================== */
+
+:root {
+    --kaziranga-bg-dark: #0a1f1a;
+    --kaziranga-card-bg-dark: rgba(10, 35, 28, 0.82);
+    --kaziranga-text-primary-dark: #f8fafc;
+    --kaziranga-text-muted-dark: #94a3b8;
+    --kaziranga-border-dark: rgba(255, 255, 255, 0.1);
+
+    /* Palette Accent Tokens */
+    --rhino-gold: #d4a843;
+    --monsoon-green: #166534;
+    --wetland-blue: #0284c7;
+    --grassland-amber: #d97706;
+    --sunrise-orange: #ea580c;
+    --gold-bright: #fbbf24;
+    --card-shadow: 0 10px 30px -5px rgba(0, 0, 0, 0.55);
+
+    /* Fonts */
+    --font-heading: 'Playfair Display', Georgia, serif;
+    --font-body: 'Outfit', 'Inter', system-ui, sans-serif;
+}
+
+body.light-theme {
+    --kaziranga-bg-dark: #fefce8;
+    --kaziranga-card-bg-dark: rgba(255, 255, 255, 0.88);
+    --kaziranga-text-primary-dark: #422006;
+    --kaziranga-text-muted-dark: #334155;
+    --kaziranga-border-dark: rgba(212, 168, 67, 0.2);
+    --card-shadow: 0 10px 25px -5px rgba(212, 168, 67, 0.12);
+}
+
+.kaziranga-main {
+    background-color: var(--kaziranga-bg-dark);
+    color: var(--kaziranga-text-primary-dark);
+    font-family: var(--font-body);
+    min-height: 100vh;
+    overflow-x: hidden;
+}
+
+.section-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+}
+
+/* Glassmorphism Card Utility */
+.glass-card {
+    background: var(--kaziranga-card-bg-dark);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid var(--kaziranga-border-dark);
+    border-radius: 16px;
+    box-shadow: var(--card-shadow);
+    transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+.glass-card:hover {
+    border-color: rgba(212, 168, 67, 0.4);
+}
+
+/* Hero Section */
+.kaziranga-hero {
+    position: relative;
+    padding: 8rem 1.5rem 5rem;
+    text-align: center;
+    background: linear-gradient(180deg, rgba(10, 31, 26, 0.82) 0%, rgba(10, 31, 26, 0.96) 100%),
+                url("https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Elephant_safari_in_Kaziranga.jpg/1280px-Elephant_safari_in_Kaziranga.jpg") center/cover no-repeat;
+    overflow: hidden;
+}
+
+.hero-badges-row {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+}
+
+.hero-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.4rem 1rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+}
+
+.pill-unesco {
+    background: rgba(212, 168, 67, 0.2);
+    color: #fbbf24;
+    border: 1px solid rgba(212, 168, 67, 0.4);
+}
+
+.pill-rhino {
+    background: rgba(22, 101, 52, 0.2);
+    color: #4ade80;
+    border: 1px solid rgba(22, 101, 52, 0.4);
+}
+
+.pill-wetland {
+    background: rgba(2, 132, 199, 0.2);
+    color: #38bdf8;
+    border: 1px solid rgba(2, 132, 199, 0.4);
+}
+
+.kaziranga-hero h1 {
+    font-family: var(--font-heading);
+    font-size: clamp(2.5rem, 5vw, 4.2rem);
+    font-weight: 700;
+    line-height: 1.15;
+    margin-bottom: 1rem;
+    color: #ffffff;
+}
+
+.kaziranga-hero h1 span {
+    color: var(--rhino-gold);
+    background: linear-gradient(135deg, #d4a843 0%, #fbbf24 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.hero-subtitle {
+    max-width: 780px;
+    margin: 0 auto 2.5rem;
+    font-size: 1.15rem;
+    line-height: 1.7;
+    color: #cbd5e1;
+}
+
+/* Quick Stats Bar */
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.stat-card {
+    padding: 1.2rem;
+    text-align: center;
+}
+
+.stat-icon {
+    font-size: 1.8rem;
+    margin-bottom: 0.3rem;
+}
+
+.stat-value {
+    font-size: 1.8rem;
+    font-weight: 800;
+    color: var(--gold-bright);
+    display: block;
+}
+
+.stat-label {
+    font-size: 0.85rem;
+    color: var(--kaziranga-text-muted-dark);
+}
+
+/* Section Header Component */
+.section-header {
+    text-align: center;
+    margin-bottom: 3rem;
+}
+
+.section-badge {
+    display: inline-block;
+    padding: 0.3rem 0.8rem;
+    background: rgba(212, 168, 67, 0.15);
+    color: #fbbf24;
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin-bottom: 0.6rem;
+}
+
+.section-header h2 {
+    font-family: var(--font-heading);
+    font-size: clamp(2rem, 3.5vw, 2.8rem);
+    margin-bottom: 0.8rem;
+}
+
+.section-subtitle {
+    max-width: 680px;
+    margin: 0 auto;
+    color: var(--kaziranga-text-muted-dark);
+    font-size: 1.05rem;
+    line-height: 1.6;
+}
+
+/* Sections Base */
+.rhino-section,
+.wetland-section,
+.wildlife-section,
+.birds-section,
+.conservation-section,
+.safari-section,
+.gallery-section,
+.map-section,
+.history-section {
+    padding: 5rem 0;
+}
+
+.rhino-section {
+    background: rgba(22, 101, 52, 0.03);
+}
+
+.wetland-section {
+    background: rgba(2, 132, 199, 0.02);
+}
+
+.wildlife-section {
+    background: rgba(212, 168, 67, 0.02);
+}
+
+.birds-section {
+    background: rgba(22, 101, 52, 0.03);
+}
+
+.conservation-section {
+    background: rgba(212, 168, 67, 0.02);
+}
+
+.safari-section {
+    background: rgba(10, 31, 26, 0.5);
+}
+
+.map-section {
+    background: rgba(2, 132, 199, 0.02);
+}
+
+/* Rhino Spotlight Card */
+.rhino-spotlight {
+    display: grid;
+    grid-template-columns: 1.2fr 0.8fr;
+    gap: 2rem;
+    align-items: center;
+    padding: 2.5rem;
+    max-width: 1100px;
+    margin: 0 auto;
+}
+
+.rhino-spotlight h2 {
+    font-family: var(--font-heading);
+    font-size: clamp(1.8rem, 3vw, 2.5rem);
+    color: var(--gold-bright);
+    margin-bottom: 1rem;
+}
+
+.rhino-stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.8rem;
+    margin: 1.5rem 0;
+}
+
+.rhino-stat-item {
+    background: rgba(212, 168, 67, 0.08);
+    padding: 0.8rem;
+    border-radius: 10px;
+    text-align: center;
+    border: 1px solid rgba(212, 168, 67, 0.12);
+}
+
+.rhino-stat-item .stat-emoji {
+    font-size: 1.4rem;
+    display: block;
+}
+
+.rhino-stat-item .stat-val {
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: var(--gold-bright);
+    display: block;
+    margin-top: 0.2rem;
+}
+
+.rhino-stat-item .stat-lbl {
+    font-size: 0.75rem;
+    color: var(--kaziranga-text-muted-dark);
+}
+
+/* Wildlife Grid */
+.wildlife-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 1.5rem;
+}
+
+/* Bird Grid */
+.birds-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 1.5rem;
+}
+
+/* Safari Cards */
+.safari-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
+    gap: 2rem;
+}
+
+.safari-card-body {
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    flex-grow: 1;
+}
+
+.safari-detail-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5rem 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    font-size: 0.9rem;
+}
+
+.safari-detail-label {
+    color: var(--kaziranga-text-muted-dark);
+}
+
+.safari-detail-value {
+    font-weight: 600;
+    color: var(--gold-bright);
+}
+
+.safari-highlights {
+    list-style: none;
+    padding: 0;
+    margin-top: 1rem;
+}
+
+.safari-highlights li {
+    padding: 0.3rem 0;
+    font-size: 0.9rem;
+    color: var(--kaziranga-text-muted-dark);
+    display: flex;
+    gap: 0.5rem;
+    align-items: flex-start;
+}
+
+/* Conservation Timeline */
+.timeline-container {
+    position: relative;
+    max-width: 800px;
+    margin: 0 auto;
+    padding-left: 2rem;
+}
+
+.timeline-container::before {
+    content: '';
+    position: absolute;
+    left: 8px;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: rgba(212, 168, 67, 0.3);
+}
+
+.timeline-item {
+    position: relative;
+    margin-bottom: 2rem;
+    padding-left: 2rem;
+}
+
+.timeline-dot {
+    position: absolute;
+    left: -1.6rem;
+    top: 0.8rem;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--monsoon-green);
+    border: 3px solid var(--rhino-gold);
+    z-index: 1;
+}
+
+.timeline-card {
+    padding: 1.2rem 1.5rem;
+}
+
+/* Interactive Map */
+.map-card-wrapper {
+    padding: 1.5rem;
+}
+
+.map-svg-container {
+    position: relative;
+    width: 100%;
+    max-width: 800px;
+    margin: 0 auto;
+    border-radius: 14px;
+    overflow: hidden;
+}
+
+.park-map-svg {
+    width: 100%;
+    display: block;
+}
+
+.map-hotspot-pin {
+    position: absolute;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    border: 2px solid var(--rhino-gold);
+    background: rgba(10, 31, 26, 0.85);
+    font-size: 1.2rem;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transform: translate(-50%, -50%);
+}
+
+.map-hotspot-pin:hover {
+    transform: translate(-50%, -50%) scale(1.3);
+    box-shadow: 0 0 20px rgba(212, 168, 67, 0.6);
+    z-index: 10;
+}
+
+.map-info-popup {
+    position: absolute;
+    bottom: 1.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(10, 31, 26, 0.95);
+    border: 1px solid var(--rhino-gold);
+    border-radius: 12px;
+    padding: 1rem 1.5rem;
+    max-width: 340px;
+    text-align: center;
+    z-index: 20;
+    backdrop-filter: blur(8px);
+}
+
+.map-info-popup h4 {
+    color: var(--gold-bright);
+    margin-bottom: 0.3rem;
+    font-size: 1rem;
+}
+
+.map-info-popup p {
+    color: var(--kaziranga-text-muted-dark);
+    font-size: 0.85rem;
+    line-height: 1.4;
+}
+
+/* Gallery */
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 1.5rem;
+}
+
+.gallery-item {
+    position: relative;
+    border-radius: 14px;
+    overflow: hidden;
+    cursor: pointer;
+    height: 240px;
+    background: #0f172a;
+}
+
+.gallery-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.4s ease;
+}
+
+.gallery-item:hover .gallery-img {
+    transform: scale(1.08);
+}
+
+.gallery-overlay {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: 1.2rem;
+    background: linear-gradient(transparent, rgba(0, 0, 0, 0.85));
+    pointer-events: none;
+}
+
+.gallery-overlay h4 {
+    color: #fff;
+    margin-bottom: 0.2rem;
+    font-size: 1rem;
+}
+
+.gallery-overlay p {
+    color: #cbd5e1;
+    font-size: 0.82rem;
+}
+
+/* Lightbox Modal */
+.lightbox-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.92);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    padding: 2rem;
+}
+
+.lightbox-content {
+    position: relative;
+    max-width: 900px;
+    max-height: 85vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.lightbox-close {
+    position: absolute;
+    top: -2.5rem;
+    right: -0.5rem;
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 2rem;
+    cursor: pointer;
+    padding: 0.25rem 0.5rem;
+    line-height: 1;
+}
+
+.lightbox-img {
+    max-width: 100%;
+    max-height: 70vh;
+    border-radius: 12px;
+    object-fit: contain;
+}
+
+.lightbox-caption {
+    margin-top: 1rem;
+    color: #cbd5e1;
+    text-align: center;
+    font-size: 0.95rem;
+    max-width: 600px;
+}
+
+/* Hidden Utility */
+.hidden {
+    display: none !important;
+}
+
+/* Footer */
+.footer {
+    padding: 3rem 1.5rem 1.5rem;
+    background: rgba(10, 31, 26, 0.8);
+}
+
+.footer-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 3rem;
+}
+
+.footer-brand h3 {
+    font-family: var(--font-heading);
+    color: var(--rhino-gold);
+    margin-bottom: 0.5rem;
+}
+
+.footer-brand p {
+    color: var(--kaziranga-text-muted-dark);
+    font-size: 0.9rem;
+}
+
+.footer-links h3 {
+    color: var(--rhino-gold);
+    margin-bottom: 0.5rem;
+    font-size: 1rem;
+}
+
+.footer-links ul {
+    list-style: none;
+    padding: 0;
+}
+
+.footer-links li {
+    margin-bottom: 0.3rem;
+}
+
+.footer-links a {
+    color: var(--kaziranga-text-muted-dark);
+    text-decoration: none;
+    font-size: 0.9rem;
+    transition: color 0.2s;
+}
+
+.footer-links a:hover {
+    color: var(--gold-bright);
+}
+
+.footer-credits-center {
+    text-align: center;
+    padding-top: 2rem;
+    margin-top: 2rem;
+    border-top: 1px solid var(--kaziranga-border-dark);
+    color: var(--kaziranga-text-muted-dark);
+    font-size: 0.85rem;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .rhino-spotlight {
+        grid-template-columns: 1fr;
+    }
+
+    .safari-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .footer-container {
+        grid-template-columns: 1fr;
+        gap: 1.5rem;
+    }
+
+    .stats-grid {
+        grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    }
+}

--- a/frontend/kaziranga-national-park-explorer/kaziranga.js
+++ b/frontend/kaziranga-national-park-explorer/kaziranga.js
@@ -1,0 +1,246 @@
+/**
+ * Kaziranga National Park Explorer — Interactive Logic
+ */
+
+(function () {
+    'use strict';
+
+    document.addEventListener('DOMContentLoaded', function () {
+        initTheme();
+        renderQuickStats();
+        renderRhinoBodyParts();
+        renderWildlife();
+        renderBirdSpecies();
+        renderSafariOptions();
+        renderConservationTimeline();
+        renderInteractiveMap();
+        renderGalleryGrid();
+        bindEvents();
+    });
+
+    function initTheme() {
+        var savedTheme = localStorage.getItem('theme') || 'dark';
+        if (savedTheme === 'light') {
+            document.body.classList.add('light-theme');
+        }
+    }
+
+    function bindEvents() {
+        var themeBtn = document.getElementById('theme-toggle');
+        if (themeBtn) {
+            themeBtn.addEventListener('click', function () {
+                document.body.classList.toggle('light-theme');
+                var isLight = document.body.classList.contains('light-theme');
+                localStorage.setItem('theme', isLight ? 'light' : 'dark');
+            });
+        }
+
+        var lbClose = document.getElementById('lightbox-close');
+        if (lbClose) lbClose.addEventListener('click', closeLightbox);
+
+        var lbModal = document.getElementById('lightbox-modal');
+        if (lbModal) {
+            lbModal.addEventListener('click', function (e) {
+                if (e.target === lbModal) closeLightbox();
+            });
+        }
+
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape') closeLightbox();
+        });
+    }
+
+    function renderQuickStats() {
+        var container = document.getElementById('stats-grid');
+        if (!container || typeof KAZIRANGA_INFO === 'undefined') return;
+
+        var html = '';
+        KAZIRANGA_INFO.quickStats.forEach(function (st) {
+            html +=
+                '<div class="stat-card glass-card">' +
+                '<div class="stat-icon">' + st.icon + '</div>' +
+                '<span class="stat-value">' + st.value + '</span>' +
+                '<span class="stat-label">' + st.label + '</span>' +
+                '</div>';
+        });
+        container.innerHTML = html;
+    }
+
+    function renderRhinoBodyParts() {
+        var container = document.getElementById('rhino-stats');
+        if (!container || typeof RHINO_BODY_PARTS === 'undefined') return;
+
+        var html = '';
+        RHINO_BODY_PARTS.forEach(function (part) {
+            html +=
+                '<div class="rhino-stat-item">' +
+                '<span class="stat-emoji">' + part.icon + '</span>' +
+                '<span class="stat-val">' + part.value + '</span>' +
+                '<span class="stat-lbl">' + part.label + '</span>' +
+                '</div>';
+        });
+        container.innerHTML = html;
+    }
+
+    function renderWildlife() {
+        var container = document.getElementById('wildlife-grid');
+        if (!container || typeof WILDLIFE === 'undefined') return;
+
+        var html = '';
+        WILDLIFE.forEach(function (w) {
+            html +=
+                '<div class="glass-card" style="overflow:hidden; display:flex; flex-direction:column;">' +
+                '<div style="height:190px; position:relative; overflow:hidden; background:#0f172a;">' +
+                '<img src="' + w.image + '" alt="' + w.name + '" style="width:100%; height:100%; object-fit:cover;" loading="lazy" onerror="this.src=\'https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Elephant_safari_in_Kaziranga.jpg/800px-Elephant_safari_in_Kaziranga.jpg\'">' +
+                '<span style="position:absolute; top:0.8rem; right:0.8rem; padding:0.3rem 0.7rem; border-radius:999px; font-size:0.75rem; font-weight:700; background:rgba(220,38,38,0.9); color:#fff;">' + w.status + '</span>' +
+                '</div>' +
+                '<div style="padding:1.5rem; display:flex; flex-direction:column; flex-grow:1;">' +
+                '<h3 style="font-family:var(--font-heading); font-size:1.3rem; margin-bottom:0.2rem;">' + w.name + '</h3>' +
+                '<div style="font-style:italic; font-size:0.85rem; color:var(--gold-bright); margin-bottom:0.8rem;">' + w.scientificName + '</div>' +
+                '<p style="font-size:0.9rem; color:var(--kaziranga-text-muted-dark); line-height:1.55;">' + w.description + '</p>' +
+                '</div>' +
+                '</div>';
+        });
+        container.innerHTML = html;
+    }
+
+    function renderBirdSpecies() {
+        var container = document.getElementById('birds-grid');
+        if (!container || typeof BIRD_SPECIES === 'undefined') return;
+
+        var html = '';
+        BIRD_SPECIES.forEach(function (b) {
+            html +=
+                '<div class="glass-card" style="overflow:hidden; display:flex; flex-direction:column;">' +
+                '<div style="height:170px; position:relative; overflow:hidden; background:#0f172a;">' +
+                '<img src="' + b.image + '" alt="' + b.name + '" style="width:100%; height:100%; object-fit:cover;" loading="lazy" onerror="this.style.display=\'none\'">' +
+                '<span style="position:absolute; top:0.8rem; right:0.8rem; padding:0.3rem 0.7rem; border-radius:999px; font-size:0.75rem; font-weight:700; background:rgba(220,38,38,0.9); color:#fff;">' + b.status + '</span>' +
+                '</div>' +
+                '<div style="padding:1.5rem; display:flex; flex-direction:column; flex-grow:1;">' +
+                '<h3 style="font-family:var(--font-heading); font-size:1.2rem; margin-bottom:0.2rem;">' + b.icon + ' ' + b.name + '</h3>' +
+                '<div style="font-style:italic; font-size:0.82rem; color:var(--gold-bright); margin-bottom:0.8rem;">' + b.scientificName + '</div>' +
+                '<p style="font-size:0.88rem; color:var(--kaziranga-text-muted-dark); line-height:1.5;">' + b.description + '</p>' +
+                '</div>' +
+                '</div>';
+        });
+        container.innerHTML = html;
+    }
+
+    function renderSafariOptions() {
+        var container = document.getElementById('safari-grid');
+        if (!container || typeof SAFARI_OPTIONS === 'undefined') return;
+
+        var html = '';
+        SAFARI_OPTIONS.forEach(function (s) {
+            var highlightsHtml = '';
+            s.highlights.forEach(function (h) {
+                highlightsHtml += '<li>✨ <span>' + h + '</span></li>';
+            });
+
+            html +=
+                '<div class="glass-card" style="overflow:hidden; display:flex; flex-direction:column;">' +
+                '<div style="padding:1.5rem 1.5rem 0.5rem;">' +
+                '<h3 style="font-family:var(--font-heading); font-size:1.4rem; color:var(--gold-bright); margin-bottom:0.3rem;">' + s.title + '</h3>' +
+                '<p style="font-size:0.9rem; color:var(--kaziranga-text-muted-dark); line-height:1.5;">' + s.description + '</p>' +
+                '</div>' +
+                '<div class="safari-card-body">' +
+                '<div class="safari-detail-row"><span class="safari-detail-label">⏱ Duration</span><span class="safari-detail-value">' + s.duration + '</span></div>' +
+                '<div class="safari-detail-row"><span class="safari-detail-label">🕐 Timings</span><span class="safari-detail-value">' + s.timing + '</span></div>' +
+                '<div class="safari-detail-row"><span class="safari-detail-label">💰 Cost</span><span class="safari-detail-value">' + s.cost + '</span></div>' +
+                '<div class="safari-detail-row"><span class="safari-detail-label">👥 Capacity</span><span class="safari-detail-value">' + s.capacity + '</span></div>' +
+                '<div class="safari-detail-row" style="flex-wrap:wrap;"><span class="safari-detail-label">📍 Zones</span><span class="safari-detail-value" style="text-align:right; max-width:60%;">' + s.zones + '</span></div>' +
+                '<ul class="safari-highlights">' + highlightsHtml + '</ul>' +
+                '</div>' +
+                '</div>';
+        });
+        container.innerHTML = html;
+    }
+
+    function renderConservationTimeline() {
+        var container = document.getElementById('conservation-timeline');
+        if (!container || typeof CONSERVATION_HISTORY === 'undefined') return;
+
+        var html = '';
+        CONSERVATION_HISTORY.forEach(function (item) {
+            html +=
+                '<div class="timeline-item">' +
+                '<div class="timeline-dot"></div>' +
+                '<div class="timeline-card glass-card">' +
+                '<div style="font-weight:800; font-size:1.2rem; color:var(--gold-bright); margin-bottom:0.4rem;">' + item.year + '</div>' +
+                '<h4>' + item.title + '</h4>' +
+                '<p style="font-size:0.92rem; color:var(--kaziranga-text-muted-dark); line-height:1.6;">' + item.description + '</p>' +
+                '</div>' +
+                '</div>';
+        });
+        container.innerHTML = html;
+    }
+
+    function renderInteractiveMap() {
+        var container = document.getElementById('map-hotspots-layer');
+        var infoPopup = document.getElementById('map-info-popup');
+        if (!container || typeof MAP_HOTSPOTS === 'undefined') return;
+
+        var html = '';
+        MAP_HOTSPOTS.forEach(function (spot) {
+            var icon = spot.category === 'gate' ? '🚪' : spot.category === 'wildlife' ? '🦏' : spot.category === 'water' ? '💧' : spot.category === 'tiger' ? '🐅' : '📍';
+            html +=
+                '<button type="button" class="map-hotspot-pin" style="left:' + spot.x + '%; top:' + spot.y + '%;" data-spot-id="' + spot.id + '" aria-label="' + spot.name + '">' +
+                icon +
+                '</button>';
+        });
+        container.innerHTML = html;
+
+        container.querySelectorAll('.map-hotspot-pin').forEach(function (pin) {
+            pin.addEventListener('click', function () {
+                var spot = MAP_HOTSPOTS.find(function (s) { return s.id === pin.dataset.spot-id; });
+                if (spot && infoPopup) {
+                    infoPopup.innerHTML =
+                        '<h4>' + spot.name + '</h4>' +
+                        '<p>' + spot.description + '</p>';
+                    infoPopup.classList.remove('hidden');
+                }
+            });
+        });
+    }
+
+    function renderGalleryGrid() {
+        var container = document.getElementById('gallery-grid');
+        if (!container || typeof GALLERY_IMAGES === 'undefined') return;
+
+        var html = '';
+        GALLERY_IMAGES.forEach(function (img, idx) {
+            html +=
+                '<div class="gallery-item" data-idx="' + idx + '">' +
+                '<img class="gallery-img" src="' + img.url + '" alt="' + img.title + '" loading="lazy">' +
+                '<div class="gallery-overlay">' +
+                '<h4 style="color:#fff;">' + img.title + '</h4>' +
+                '<p style="color:#cbd5e1; font-size:0.82rem;">' + img.caption + '</p>' +
+                '</div>' +
+                '</div>';
+        });
+        container.innerHTML = html;
+
+        container.querySelectorAll('.gallery-item').forEach(function (item) {
+            item.addEventListener('click', function () {
+                openLightbox(parseInt(item.dataset.idx, 10));
+            });
+        });
+    }
+
+    function openLightbox(idx) {
+        if (typeof GALLERY_IMAGES === 'undefined' || !GALLERY_IMAGES[idx]) return;
+        var modal = document.getElementById('lightbox-modal');
+        var imgEl = document.getElementById('lightbox-img');
+        var capEl = document.getElementById('lightbox-caption');
+        if (!modal || !imgEl || !capEl) return;
+
+        imgEl.src = GALLERY_IMAGES[idx].url;
+        capEl.textContent = GALLERY_IMAGES[idx].title + ' — ' + GALLERY_IMAGES[idx].caption;
+        modal.classList.remove('hidden');
+    }
+
+    function closeLightbox() {
+        var modal = document.getElementById('lightbox-modal');
+        if (modal) modal.classList.add('hidden');
+    }
+})();

--- a/frontend/national-parks-explorer/data.js
+++ b/frontend/national-parks-explorer/data.js
@@ -45,7 +45,8 @@ const NATIONAL_PARKS = [
         climate: 'Subtropical Monsoon',
         bestTime: 'November to April',
         entryFee: '₹650 (Indian), ₹2500 (Foreign)',
-        image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Elephant_safari_in_Kaziranga.jpg/960px-Elephant_safari_in_Kaziranga.jpg'
+        image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Elephant_safari_in_Kaziranga.jpg/960px-Elephant_safari_in_Kaziranga.jpg',
+        explorerUrl: '../kaziranga-national-park-explorer/index.html'
     },
     {
         id: 'ranthambore',


### PR DESCRIPTION
# Pull Request

## Description

Built a complete **Kaziranga National Park Explorer** interactive page covering all requested features:
- One-Horned Rhinoceros spotlight with conservation success story, body stats, and population data
- UNESCO World Heritage Site designation (1985) with criteria badges
- Wetlands & Brahmaputra floodplain ecology section (grassland types, beels, annual flood cycle)
- Wildlife catalog featuring 6 flagship species (One-Horned Rhino, Asian Elephant, Wild Water Buffalo, Swamp Deer, Bengal Tiger, Ganges River Dolphin)
- Bird species showcase covering 6 endangered/noteworthy species with scientific names
- Conservation history timeline with 8 milestones from 1905 to present
- Safari options comparison (Elephant-back vs Jeep safari) with pricing, timing, capacity, and zones
- Interactive SVG park map with 7 geo-tagged hotspot pins (gates, wildlife areas, wetlands, tiger zone)
- Photo gallery with 6 images and lightbox modal
- Full dark/light theme support following project design tokens

Also added `explorerUrl` to the Kaziranga entry in the National Parks Explorer listing so the "Explore" button appears on the landing page.

Fixes #810

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Tested locally in browser
- [ ] Tested in both dark and light themes
- [ ] Tested at mobile viewport widths
- [x] Verified no console errors

## Checklist

- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [ ] I have tested responsive layout (if UI change)
- [ ] I have considered accessibility (aria labels, keyboard nav, focus)

## Screenshots (if applicable)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated Kaziranga National Park Explorer with park highlights, wildlife and bird species, wetlands ecology, conservation history, safari options, and photo galleries.
  - Added an interactive park map with hotspot details and a full-screen image lightbox.
  - Added dark/light theme switching and responsive layouts for mobile devices.
  - Added navigation from the national parks listing to the Kaziranga explorer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->