### PR TITLE
fix(waterfall): prevent log card grid overflow with min-width and word-wrap (#811)

### DIFF
--- a/frontend/waterfall-explorer/style.css
+++ b/frontend/waterfall-explorer/style.css
@@ -328,6 +328,9 @@
   border-radius: 18px;
   padding: 12px;
   background: rgba(255, 255, 255, 0.045);
+  min-width: 0;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .log-card.locked {
@@ -336,6 +339,8 @@
 
 .log-card h4 {
   margin: 0 0 6px;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .log-card p {
@@ -343,6 +348,8 @@
   color: var(--wf-muted);
   font-size: 0.84rem;
   line-height: 1.45;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .waterfall-footer {


### PR DESCRIPTION
# Pull Request

## Description

Fixes card grid overflow in the Waterfall Explorer section by adding `min-width: 0` and word-wrap rules (`overflow-wrap: break-word; word-break: break-word;`) to `.log-card` and its heading/paragraph elements in `frontend/waterfall-explorer/style.css`.

Fixes #811

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Tested locally in browser
- [x] Tested in both dark and light themes
- [x] Tested at mobile viewport widths
- [x] Verified no console errors

## Checklist

- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)

## Screenshots (if applicable)

N/A
