### PR TITLE
fix(biosphere): register biosphere grid in SmartEmptyState and fix empty-state display toggles (#838)

### DIFF
--- a/frontend/biosphere-reserves/script.js
+++ b/frontend/biosphere-reserves/script.js
@@ -292,14 +292,12 @@
         // Handle empty state
         if (data.length === 0) {
             grid.innerHTML = '';
-            grid.style.display = 'none';
             emptyState.classList.remove('hidden');
             return;
         }
 
         // Hide empty state and show grid
         emptyState.classList.add('hidden');
-        grid.style.display = 'grid';
 
         // Clear existing grid
         grid.innerHTML = '';

--- a/js-modules/smart-empty-state/smart-empty-state.js
+++ b/js-modules/smart-empty-state/smart-empty-state.js
@@ -5,9 +5,9 @@
 
   const CONFIG = {
     containerSelector:
-      "[data-smart-empty-container], .cards-grid, .heritage-grid, .wildlife-grid, .textile-grid, .water-grid, .instrument-grid, .butterfly-grid, .bazaar-grid, .script-grid, .glossary-grid, .destinations-grid, .festival-grid, .cuisine-grid, .universities-grid, .plants-grid, .wonders-grid, .trees-grid, .unesco-grid",
+      "[data-smart-empty-container], .cards-grid, .heritage-grid, .wildlife-grid, .textile-grid, .water-grid, .instrument-grid, .butterfly-grid, .bazaar-grid, .script-grid, .glossary-grid, .destinations-grid, .festival-grid, .cuisine-grid, .universities-grid, .plants-grid, .wonders-grid, .trees-grid, .unesco-grid, .biosphere-grid",
     itemSelector:
-      "[data-search-item], [data-filter-item], .heritage-card, .wildlife-card, .textile-card, .water-card, .instrument-card, .butterfly-card, .bazaar-card, .script-card, .glossary-card, .destination-card, .festival-card, .cuisine-card, .university-card, .plant-card, .wonder-card, .tree-card, .unesco-card",
+      "[data-search-item], [data-filter-item], .heritage-card, .wildlife-card, .textile-card, .water-card, .instrument-card, .butterfly-card, .bazaar-card, .script-card, .glossary-card, .destination-card, .festival-card, .cuisine-card, .university-card, .plant-card, .wonder-card, .tree-card, .unesco-card, .reserve-card",
     searchSelector:
       "input[type='search'], input[id*='search' i], input[placeholder*='search' i]",
     filterSelector:


### PR DESCRIPTION
# Pull Request

## Description

Fixes filter reset and empty-state toggling in the Biosphere Reserves directory (`frontend/biosphere-reserves/script.js`). Removes inline `display: none` style mutations on the grid container and registers `.biosphere-grid` and `.reserve-card` in `js-modules/smart-empty-state/smart-empty-state.js` for smart suggestions.

Fixes #838

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Tested locally in browser
- [x] Tested in both dark and light themes
- [x] Tested at mobile viewport widths
- [x] Verified no console errors

## Checklist

- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)

## Screenshots (if applicable)

N/A
