### PR TITLE
Implement Intelligent Destination Comparison Tool with Personalized R…

### DIFF
--- a/docs/DESTINATION_COMPARISON.md
+++ b/docs/DESTINATION_COMPARISON.md
@@ -1,0 +1,119 @@
+# Destination Comparison Tool
+
+Resolves #863 — Implement Intelligent Destination Comparison Tool with
+Personalized Recommendations.
+
+## What it does
+
+At `frontend/destination-comparison/destination-comparison.html`: pick up
+to four destinations from the existing `trip-data.js` dataset, set how much
+you care about budget / adventure / family-friendliness / accessibility and
+your trip-length limit, and get:
+
+- A side-by-side comparison card per destination (best time to visit,
+  weather, budget/day, ideal duration, adventure level, family
+  friendliness, accessibility, popular attractions, nearby destinations,
+  traveler popularity).
+- A personalized recommendation naming a winner and explaining *why*, in
+  plain language tied to your stated preferences.
+- Export as a downloadable `.txt` report, or save the comparison (by
+  destination selection) to `localStorage` for later.
+
+Everything recalculates live — changing a preference slider, the cost
+tier, or the destination list re-runs the comparison immediately.
+
+## "AI-powered" — what's actually happening
+
+The issue calls for "AI-powered recommendations." This is implemented as
+transparent, deterministic weighted scoring, not a model call — consistent
+with `trip-data.js`'s own description of itself as "rule-based, client-side
+only, no backend," which every feature built on that dataset in this
+project follows. Each compared destination gets a score built from:
+
+- **Budget fit** — cheaper destinations score higher when budget priority
+  is set high, normalized against a configurable daily budget ceiling.
+- **Adventure level, family-friendliness, accessibility** — the
+  destination's derived score (see below) multiplied by how much you said
+  that factor matters (0-5).
+- **Trip-length fit** — a penalty if the destination typically needs more
+  days than your stated limit.
+- **A small popularity tie-breaker** so close scores don't feel arbitrary.
+
+The recommendation explanation is built directly from which of these
+factors actually pushed the winner ahead — every claim in the explanation
+traces back to a specific score component, which is also why this is
+fully unit-testable (`tests/unit/destination-comparison-engine.test.js`)
+without any network call or fixture recording.
+
+## Derived attributes — and their honest limits
+
+`trip-data.js` has `bestSeason`, `costPerDay`, `highlights`, `minDays`/
+`maxDays`, `categories`, and `popularity` for ~96 destinations, but no
+explicit weather, adventure-level, family-friendliness, accessibility, or
+review-based rating fields. Rather than hand-curating a large new dataset
+across all 96 entries (a huge, hard-to-verify lift), these are computed
+with transparent heuristics from the fields that already exist:
+
+| Attribute | Derived from | Range |
+| --------- | ------------- | ----- |
+| Weather | `categories` (desert/mountains/beaches/etc.) | Text description |
+| Adventure level | `categories` (adventure/mountains/desert/wildlife push it up) | 1-5 |
+| Family friendliness | `categories` (historical/heritage/city/spiritual/beaches push up, adventure/desert push down) | 1-5 |
+| Accessibility | `popularity` and `minDays` as a proxy for how well-connected a destination tends to be | 1-5 |
+| Nearby destinations | Haversine distance to every other destination in the dataset, within 200km | Up to 3 |
+| User rating | `popularity` field, relabeled honestly as "traveler popularity" | 1-10 |
+
+These are documented here and in the module's own comments as **editorial
+heuristics, not measured or crowd-sourced data**. If this dataset later
+gains real per-destination weather/accessibility/review data, the derived
+functions in `destination-comparison-engine.js` are the only place that
+would need to change — the comparison and recommendation logic around them
+stays the same.
+
+## Architecture
+
+- `js-modules/destination-comparison-engine.js` — pure logic, no DOM
+  dependency, depends only on the shared `tripDestinations` global from
+  `trip-data.js` (same dependency `js-modules/trip-planner.js` already
+  has). Exposes `window.DestinationComparison`.
+- `frontend/destination-comparison/destination-comparison.html` +
+  `destination-comparison-ui.js` — a standalone page (same pattern as
+  `route-planner.html`/`island-explorer/index.html`: shared `styles.css`,
+  direct `<script>` includes, `DOMContentLoaded` wiring) rather than the
+  SPA router (`js-modules/router-init.js`) that `trip-planner.html` uses.
+  Both patterns already coexist in this codebase; the standalone pattern
+  was chosen here to keep the page self-contained and easy to verify in
+  isolation.
+- `tests/unit/destination-comparison-engine.test.js` — 20 vitest tests,
+  following the exact pattern `tests/unit/trip-planner.test.js` already
+  uses (load `trip-data.js` and the engine source via `readFileSync` +
+  `new Function()`, exercise the resulting global).
+
+## Testing
+
+```bash
+npx vitest run tests/unit/destination-comparison-engine.test.js
+```
+
+Covers: derived-attribute ranges and category sensitivity, nearby-search
+correctness (sorted, radius-bounded, excludes self), the 4-destination cap
+and other input validation, cost-tier sensitivity, live recalculation on
+a changed destination set, preference-driven recommendation correctness
+(budget-only and adventure-only cases produce the expected winner),
+trip-length penalty behavior, graceful handling of an empty comparison,
+export text/JSON completeness, and save/load/delete against `localStorage`.
+
+## Known limitations / future work
+
+- Derived attributes (weather, adventure, family, accessibility) are
+  heuristics from existing categorical data, not verified per-destination
+  data — see the table above.
+- "Nearby destinations" only searches within this project's existing
+  ~96-destination `trip-data.js` list, not all of India.
+- No backend means no real user-review aggregation for the "user ratings"
+  field — it's `trip-data.js`'s existing editorial `popularity` score,
+  relabeled honestly rather than presented as crowd-sourced.
+- Saved comparisons store only the destination-id selection, not a
+  point-in-time snapshot of the comparison output — if `trip-data.js`
+  changes later, a loaded saved comparison reflects current data, not
+  what was on screen when it was saved.

--- a/frontend/destination-comparison/destination-comparison-ui.js
+++ b/frontend/destination-comparison/destination-comparison-ui.js
@@ -1,0 +1,248 @@
+(function () {
+  "use strict";
+
+  const MAX_COMPARE = window.DestinationComparison.MAX_COMPARE;
+  const ALL_DESTINATIONS = (window.tripDestinations || []).slice().sort((a, b) => a.name.localeCompare(b.name));
+
+  let selectedIds = [];
+  let lastComparison = null;
+  let lastRecommendation = null;
+
+  function $(id) {
+    return document.getElementById(id);
+  }
+
+  function setStatus(message, kind) {
+    const el = $("dc-status");
+    el.textContent = message || "";
+    el.className = "dc-status" + (kind ? ` ${kind}` : "");
+  }
+
+  // -------------------------------------------------------------------
+  // Destination picker
+  // -------------------------------------------------------------------
+  function populateDestinationSelect() {
+    const select = $("dc-destination-select");
+    select.innerHTML = ALL_DESTINATIONS
+      .filter((d) => !selectedIds.includes(d.id))
+      .map((d) => `<option value="${d.id}">${d.name}, ${d.state}</option>`)
+      .join("");
+  }
+
+  function renderChips() {
+    const container = $("dc-chips");
+    container.innerHTML = selectedIds
+      .map((id) => {
+        const d = ALL_DESTINATIONS.find((dest) => dest.id === id);
+        return `<span class="dc-chip">${d ? d.name : id} <button type="button" data-remove="${id}" aria-label="Remove ${d ? d.name : id}">✕</button></span>`;
+      })
+      .join("");
+
+    container.querySelectorAll("[data-remove]").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        selectedIds = selectedIds.filter((id) => id !== btn.dataset.remove);
+        renderChips();
+        populateDestinationSelect();
+        invalidateResults();
+      });
+    });
+
+    $("dc-add-btn").disabled = selectedIds.length >= MAX_COMPARE;
+  }
+
+  function handleAddDestination() {
+    const select = $("dc-destination-select");
+    const id = select.value;
+    if (!id || selectedIds.includes(id) || selectedIds.length >= MAX_COMPARE) return;
+    selectedIds.push(id);
+    renderChips();
+    populateDestinationSelect();
+    invalidateResults();
+  }
+
+  // -------------------------------------------------------------------
+  // Preferences
+  // -------------------------------------------------------------------
+  function readPreferences() {
+    return {
+      budgetWeight: Number($("dc-budget-weight").value),
+      adventureWeight: Number($("dc-adventure-weight").value),
+      familyWeight: Number($("dc-family-weight").value),
+      accessibilityWeight: Number($("dc-accessibility-weight").value),
+      maxDays: $("dc-max-days").value ? Number($("dc-max-days").value) : undefined,
+    };
+  }
+
+  function wireRangeDisplay(id) {
+    const input = $(id);
+    const display = $(`${id}-val`);
+    input.addEventListener("input", () => {
+      display.textContent = input.value;
+      // Preferences changed — recompute immediately if a comparison is on screen.
+      if (lastComparison) runComparison({ silent: true });
+    });
+  }
+
+  // -------------------------------------------------------------------
+  // Comparison + recommendation rendering
+  // -------------------------------------------------------------------
+  function invalidateResults() {
+    lastComparison = null;
+    lastRecommendation = null;
+    $("dc-results-panel").hidden = true;
+    $("dc-recommendation-panel").hidden = true;
+  }
+
+  function runComparison(opts) {
+    const silent = opts && opts.silent;
+    if (selectedIds.length === 0) {
+      if (!silent) setStatus("Add at least one destination to compare.", "error");
+      return;
+    }
+
+    const costTier = $("dc-cost-tier").value;
+    try {
+      const comparison = window.DestinationComparison.compareDestinations(selectedIds, ALL_DESTINATIONS, costTier);
+      const recommendation = window.DestinationComparison.getRecommendation(comparison, readPreferences());
+      lastComparison = comparison;
+      lastRecommendation = recommendation;
+      renderRecommendation(recommendation);
+      renderComparison(comparison, recommendation);
+      if (!silent) setStatus(`Compared ${comparison.destinations.length} destination(s).`, "ok");
+    } catch (err) {
+      setStatus(err.message, "error");
+    }
+  }
+
+  function renderRecommendation(recommendation) {
+    const panel = $("dc-recommendation-panel");
+    if (!recommendation.winner) {
+      panel.hidden = true;
+      return;
+    }
+    panel.hidden = false;
+    panel.innerHTML = `
+      <div class="dc-recommendation">
+        <h3>🤖 Recommended for you: ${recommendation.winner.name}</h3>
+        <p>${recommendation.explanation}</p>
+      </div>`;
+  }
+
+  function renderComparison(comparison, recommendation) {
+    const panel = $("dc-results-panel");
+    const grid = $("dc-compare-grid");
+    panel.hidden = false;
+
+    grid.innerHTML = comparison.destinations
+      .map((row) => {
+        const isWinner = recommendation.winner && recommendation.winner.id === row.id;
+        return `
+        <div class="dc-compare-card ${isWinner ? "is-winner" : ""}">
+          ${isWinner ? '<span class="winner-badge">Recommended</span>' : ""}
+          <h4>${row.name}</h4>
+          <div class="state">${row.state}</div>
+          <div class="dc-attr"><span>Best time to visit</span><span>${row.bestTimeToVisit}</span></div>
+          <div class="dc-attr"><span>Weather</span><span>${row.weather}</span></div>
+          <div class="dc-attr"><span>Est. budget/day</span><span>₹${row.estimatedBudgetPerDay.toLocaleString("en-IN")}</span></div>
+          <div class="dc-attr"><span>Ideal duration</span><span>${row.idealTripDuration.minDays}-${row.idealTripDuration.maxDays} days</span></div>
+          <div class="dc-attr"><span>Adventure level</span><span>${"★".repeat(row.adventureLevel)}${"☆".repeat(5 - row.adventureLevel)}</span></div>
+          <div class="dc-attr"><span>Family friendly</span><span>${"★".repeat(row.familyFriendliness)}${"☆".repeat(5 - row.familyFriendliness)}</span></div>
+          <div class="dc-attr"><span>Accessibility</span><span>${"★".repeat(row.accessibility)}${"☆".repeat(5 - row.accessibility)}</span></div>
+          <div class="dc-attr"><span>Traveler popularity</span><span>${row.userRating}/10</span></div>
+          <p class="dc-attractions"><strong>Attractions:</strong> ${row.popularAttractions.join(", ")}</p>
+          ${row.nearbyDestinations.length ? `<p class="dc-nearby">Nearby: ${row.nearbyDestinations.map((n) => `${n.name} (${n.distanceKm.toFixed(0)}km)`).join(", ")}</p>` : ""}
+        </div>`;
+      })
+      .join("");
+  }
+
+  // -------------------------------------------------------------------
+  // Save / Export
+  // -------------------------------------------------------------------
+  function handleSave() {
+    if (selectedIds.length === 0) {
+      setStatus("Add destinations before saving a comparison.", "error");
+      return;
+    }
+    const names = selectedIds.map((id) => (ALL_DESTINATIONS.find((d) => d.id === id) || {}).name || id);
+    window.DestinationComparison.saveComparison(names.join(" vs "), selectedIds);
+    renderSavedComparisons();
+    setStatus("Comparison saved.", "ok");
+  }
+
+  function handleExport() {
+    if (!lastComparison) {
+      setStatus("Run a comparison first, then export.", "error");
+      return;
+    }
+    const text = window.DestinationComparison.exportComparisonText(lastComparison, lastRecommendation);
+    const blob = new Blob([text], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "destination-comparison.txt";
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
+
+  function renderSavedComparisons() {
+    const list = $("dc-saved-list");
+    const saved = window.DestinationComparison.getSavedComparisons();
+    if (!saved.length) {
+      list.innerHTML = '<p class="dc-empty">No saved comparisons yet.</p>';
+      return;
+    }
+    list.innerHTML = saved
+      .slice()
+      .reverse()
+      .map(
+        (entry) => `
+        <div class="dc-saved-item">
+          <span>${entry.name}</span>
+          <span class="actions">
+            <button type="button" data-load="${entry.id}">Load</button>
+            <button type="button" data-delete="${entry.id}">Delete</button>
+          </span>
+        </div>`
+      )
+      .join("");
+
+    list.querySelectorAll("[data-load]").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        const entry = saved.find((s) => s.id === btn.dataset.load);
+        if (!entry) return;
+        selectedIds = entry.ids.filter((id) => ALL_DESTINATIONS.some((d) => d.id === id)).slice(0, MAX_COMPARE);
+        renderChips();
+        populateDestinationSelect();
+        runComparison({});
+      });
+    });
+    list.querySelectorAll("[data-delete]").forEach((btn) => {
+      btn.addEventListener("click", () => {
+        window.DestinationComparison.deleteSavedComparison(btn.dataset.delete);
+        renderSavedComparisons();
+      });
+    });
+  }
+
+  // -------------------------------------------------------------------
+  document.addEventListener("DOMContentLoaded", () => {
+    populateDestinationSelect();
+    renderChips();
+    renderSavedComparisons();
+
+    $("dc-add-btn").addEventListener("click", handleAddDestination);
+    $("dc-compare-btn").addEventListener("click", () => runComparison({}));
+    $("dc-save-btn").addEventListener("click", handleSave);
+    $("dc-export-btn").addEventListener("click", handleExport);
+    $("dc-cost-tier").addEventListener("change", () => {
+      if (lastComparison) runComparison({ silent: true });
+    });
+    $("dc-max-days").addEventListener("input", () => {
+      if (lastComparison) runComparison({ silent: true });
+    });
+    ["dc-budget-weight", "dc-adventure-weight", "dc-family-weight", "dc-accessibility-weight"].forEach(wireRangeDisplay);
+  });
+})();

--- a/frontend/destination-comparison/destination-comparison.html
+++ b/frontend/destination-comparison/destination-comparison.html
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<script>
+  (function () {
+    const theme = localStorage.getItem('theme') || 'dark';
+    if (theme === 'light') document.body.classList.add('light-theme');
+  })();
+</script>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Destination Comparison Tool | Incredible India Explorer</title>
+<meta name="description" content="Compare up to four Indian destinations side by side — budget, weather, attractions, adventure level, and family friendliness — with a personalized recommendation.">
+<link href="https://fonts.googleapis.com" rel="preconnect">
+<link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
+<link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:wght@500;600;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../../styles.css">
+<style>
+  .dc-hero {
+    padding: 120px 0 50px;
+    text-align: center;
+  }
+  .dc-hero h1 { font-family: "Playfair Display", serif; font-size: clamp(2.2rem, 5vw, 3.4rem); margin: 0 0 12px; }
+  .dc-hero p { max-width: 680px; margin: 0 auto; color: var(--text-secondary, #b7b7b7); line-height: 1.7; }
+
+  .dc-container { width: min(1180px, 94%); margin: 0 auto; padding-bottom: 80px; }
+
+  .dc-panel {
+    background: var(--glass-bg, rgba(255,255,255,.05));
+    border: 1px solid var(--glass-border, rgba(255,255,255,.12));
+    border-radius: 16px;
+    padding: 24px;
+    margin-bottom: 24px;
+  }
+  .dc-panel h2 { font-family: "Playfair Display", serif; font-size: 1.4rem; margin: 0 0 16px; }
+
+  /* --- Destination picker --- */
+  .dc-picker-row { display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 14px; }
+  .dc-picker-row select {
+    flex: 1; min-width: 220px; padding: 10px 12px; border-radius: 10px;
+    border: 1px solid var(--glass-border, rgba(255,255,255,.14));
+    background: rgba(255,255,255,.05); color: inherit; font-family: 'Outfit', sans-serif;
+  }
+  .dc-picker-row button {
+    padding: 10px 18px; border-radius: 10px; border: none; cursor: pointer;
+    background: var(--green, #138808); color: #fff; font-weight: 600; font-family: 'Outfit', sans-serif;
+  }
+  .dc-picker-row button:disabled { opacity: .5; cursor: not-allowed; }
+  .dc-chips { display: flex; gap: 8px; flex-wrap: wrap; }
+  .dc-chip {
+    display: inline-flex; align-items: center; gap: 8px;
+    background: rgba(23,184,176,.14); border: 1px solid rgba(23,184,176,.35);
+    padding: 6px 8px 6px 14px; border-radius: 999px; font-size: .88rem;
+  }
+  .dc-chip button {
+    background: none; border: none; color: inherit; cursor: pointer; font-size: 1rem;
+    width: 22px; height: 22px; border-radius: 50%; display: grid; place-items: center;
+  }
+  .dc-chip button:hover { background: rgba(255,255,255,.15); }
+  .dc-hint { font-size: .82rem; color: var(--text-secondary, #b7b7b7); margin-top: 6px; }
+
+  /* --- Preferences --- */
+  .dc-pref-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 18px; }
+  .dc-pref-field label { display: block; font-size: .85rem; margin-bottom: 6px; color: var(--text-secondary, #b7b7b7); }
+  .dc-pref-field input[type="range"] { width: 100%; }
+  .dc-pref-field input[type="number"], .dc-pref-field select {
+    width: 100%; padding: 8px 10px; border-radius: 8px; border: 1px solid var(--glass-border, rgba(255,255,255,.14));
+    background: rgba(255,255,255,.05); color: inherit; font-family: 'Outfit', sans-serif;
+  }
+  .dc-pref-value { font-weight: 600; color: var(--gold); }
+
+  .dc-actions { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 18px; }
+  .dc-actions button {
+    padding: 12px 22px; border-radius: 10px; border: 1px solid var(--glass-border, rgba(255,255,255,.14));
+    background: rgba(255,255,255,.06); color: inherit; font-weight: 600; cursor: pointer; font-family: 'Outfit', sans-serif;
+  }
+  .dc-actions .primary { background: var(--saffron, #ff9933); border-color: transparent; color: #1a1a1a; }
+  .dc-actions button:hover { filter: brightness(1.08); }
+
+  /* --- Recommendation --- */
+  .dc-recommendation {
+    border-radius: 16px; padding: 22px 24px; margin-bottom: 24px;
+    background: linear-gradient(135deg, rgba(255,153,51,.14), rgba(19,136,8,.1));
+    border: 1px solid rgba(255,153,51,.35);
+  }
+  .dc-recommendation h3 { margin: 0 0 8px; font-family: "Playfair Display", serif; font-size: 1.25rem; }
+  .dc-recommendation p { margin: 0; line-height: 1.7; }
+
+  /* --- Comparison cards --- */
+  .dc-compare-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 18px; }
+  .dc-compare-card {
+    background: var(--glass-bg, rgba(255,255,255,.05)); border: 1px solid var(--glass-border, rgba(255,255,255,.12));
+    border-radius: 14px; padding: 18px; position: relative;
+  }
+  .dc-compare-card.is-winner { border-color: var(--saffron, #ff9933); box-shadow: 0 0 0 1px rgba(255,153,51,.3); }
+  .dc-compare-card .winner-badge {
+    position: absolute; top: -10px; right: 14px; background: var(--saffron, #ff9933); color: #1a1a1a;
+    font-size: .72rem; font-weight: 700; padding: 3px 10px; border-radius: 999px;
+  }
+  .dc-compare-card h4 { margin: 0 0 2px; font-family: "Playfair Display", serif; font-size: 1.15rem; }
+  .dc-compare-card .state { font-size: .82rem; color: var(--text-secondary, #b7b7b7); margin-bottom: 12px; }
+  .dc-attr { display: flex; justify-content: space-between; gap: 8px; padding: 6px 0; border-bottom: 1px solid rgba(255,255,255,.06); font-size: .87rem; }
+  .dc-attr:last-of-type { border-bottom: none; }
+  .dc-attr span:first-child { color: var(--text-secondary, #b7b7b7); }
+  .dc-attr span:last-child { text-align: right; font-weight: 600; }
+  .dc-attractions { margin: 10px 0 0; font-size: .85rem; color: var(--text-secondary, #b7b7b7); line-height: 1.6; }
+  .dc-nearby { margin: 8px 0 0; font-size: .8rem; color: var(--text-secondary, #b7b7b7); }
+
+  /* --- Saved comparisons --- */
+  .dc-saved-list { display: flex; flex-direction: column; gap: 8px; }
+  .dc-saved-item {
+    display: flex; justify-content: space-between; align-items: center; gap: 10px;
+    padding: 10px 14px; border-radius: 10px; background: rgba(255,255,255,.04); border: 1px solid var(--glass-border, rgba(255,255,255,.1));
+    font-size: .88rem;
+  }
+  .dc-saved-item .actions { display: flex; gap: 8px; }
+  .dc-saved-item button {
+    background: none; border: 1px solid var(--glass-border, rgba(255,255,255,.16)); color: inherit;
+    border-radius: 8px; padding: 4px 10px; cursor: pointer; font-size: .8rem;
+  }
+  .dc-empty { color: var(--text-secondary, #b7b7b7); font-size: .88rem; font-style: italic; }
+  .dc-status { font-size: .85rem; margin-top: 10px; min-height: 1.2em; }
+  .dc-status.error { color: #ff6b6b; }
+  .dc-status.ok { color: var(--green, #138808); }
+</style>
+</head>
+<body>
+<header class="navbar scrolled" id="navbar">
+  <div class="nav-container">
+    <a href="../../index.html#home" class="nav-logo">
+      <span class="saffron">Incredible</span><span class="gold">India</span><span class="green">Explorer</span>
+    </a>
+    <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+      <span class="bar"></span><span class="bar"></span><span class="bar"></span>
+    </button>
+    <nav class="nav-menu" id="nav-menu">
+      <a href="../../index.html#home" class="nav-link">Home</a>
+      <a href="../trip-planner/trip-planner.html" class="nav-link">Trip Planner</a>
+      <a href="destination-comparison.html" class="nav-link current-link">Compare Destinations</a>
+      <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+    </nav>
+  </div>
+</header>
+
+<main>
+  <section class="dc-hero">
+    <h1>Destination Comparison Tool</h1>
+    <p>Pick up to four destinations, tell us what matters to you, and get a side-by-side comparison with a personalized, explainable recommendation.</p>
+  </section>
+
+  <div class="dc-container">
+
+    <div class="dc-panel">
+      <h2>1. Choose destinations <span style="font-weight:400; font-size:.85rem; color:var(--text-secondary,#b7b7b7);">(up to 4)</span></h2>
+      <div class="dc-picker-row">
+        <select id="dc-destination-select" aria-label="Choose a destination to add"></select>
+        <button type="button" id="dc-add-btn">+ Add</button>
+      </div>
+      <div class="dc-chips" id="dc-chips"></div>
+      <p class="dc-hint">Add at least one destination, then set your preferences below and compare.</p>
+    </div>
+
+    <div class="dc-panel">
+      <h2>2. What matters to you?</h2>
+      <div class="dc-pref-grid">
+        <div class="dc-pref-field">
+          <label for="dc-cost-tier">Travel style</label>
+          <select id="dc-cost-tier">
+            <option value="budget">Budget</option>
+            <option value="mid" selected>Mid-range</option>
+            <option value="luxury">Luxury</option>
+          </select>
+        </div>
+        <div class="dc-pref-field">
+          <label for="dc-max-days">Max trip length (days)</label>
+          <input type="number" id="dc-max-days" min="1" max="30" placeholder="e.g. 5">
+        </div>
+        <div class="dc-pref-field">
+          <label for="dc-budget-weight">Budget priority: <span class="dc-pref-value" id="dc-budget-weight-val">3</span></label>
+          <input type="range" id="dc-budget-weight" min="0" max="5" value="3">
+        </div>
+        <div class="dc-pref-field">
+          <label for="dc-adventure-weight">Adventure priority: <span class="dc-pref-value" id="dc-adventure-weight-val">2</span></label>
+          <input type="range" id="dc-adventure-weight" min="0" max="5" value="2">
+        </div>
+        <div class="dc-pref-field">
+          <label for="dc-family-weight">Family-friendliness priority: <span class="dc-pref-value" id="dc-family-weight-val">2</span></label>
+          <input type="range" id="dc-family-weight" min="0" max="5" value="2">
+        </div>
+        <div class="dc-pref-field">
+          <label for="dc-accessibility-weight">Ease of access priority: <span class="dc-pref-value" id="dc-accessibility-weight-val">2</span></label>
+          <input type="range" id="dc-accessibility-weight" min="0" max="5" value="2">
+        </div>
+      </div>
+
+      <div class="dc-actions">
+        <button type="button" id="dc-compare-btn" class="primary">Compare</button>
+        <button type="button" id="dc-save-btn">💾 Save this comparison</button>
+        <button type="button" id="dc-export-btn">⬇ Export report (.txt)</button>
+      </div>
+      <p class="dc-status" id="dc-status"></p>
+    </div>
+
+    <div id="dc-recommendation-panel" hidden></div>
+
+    <div class="dc-panel" id="dc-results-panel" hidden>
+      <h2>Side-by-side comparison</h2>
+      <div class="dc-compare-grid" id="dc-compare-grid"></div>
+    </div>
+
+    <div class="dc-panel">
+      <h2>Saved comparisons</h2>
+      <div class="dc-saved-list" id="dc-saved-list"></div>
+    </div>
+
+  </div>
+</main>
+
+<footer style="padding: 30px 0; text-align: center; color: var(--text-secondary,#b7b7b7); border-top: 1px solid var(--glass-border, rgba(255,255,255,.1));">
+  <p>Part of <a href="../../index.html" style="color: var(--saffron,#ff9933);">Incredible India Explorer</a></p>
+</footer>
+
+<button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+<script src="../../app.js" defer></script>
+<script src="../../trip-data.js"></script>
+<script src="../../js-modules/destination-comparison-engine.js"></script>
+<script src="destination-comparison-ui.js" defer></script>
+</body>
+</html>

--- a/issue-863-resolution.patch
+++ b/issue-863-resolution.patch
@@ -1,0 +1,1139 @@
+diff --git a/docs/DESTINATION_COMPARISON.md b/docs/DESTINATION_COMPARISON.md
+new file mode 100644
+index 0000000..b4244b7
+--- /dev/null
++++ b/docs/DESTINATION_COMPARISON.md
+@@ -0,0 +1,119 @@
++# Destination Comparison Tool
++
++Resolves #863 — Implement Intelligent Destination Comparison Tool with
++Personalized Recommendations.
++
++## What it does
++
++At `frontend/destination-comparison/destination-comparison.html`: pick up
++to four destinations from the existing `trip-data.js` dataset, set how much
++you care about budget / adventure / family-friendliness / accessibility and
++your trip-length limit, and get:
++
++- A side-by-side comparison card per destination (best time to visit,
++  weather, budget/day, ideal duration, adventure level, family
++  friendliness, accessibility, popular attractions, nearby destinations,
++  traveler popularity).
++- A personalized recommendation naming a winner and explaining *why*, in
++  plain language tied to your stated preferences.
++- Export as a downloadable `.txt` report, or save the comparison (by
++  destination selection) to `localStorage` for later.
++
++Everything recalculates live — changing a preference slider, the cost
++tier, or the destination list re-runs the comparison immediately.
++
++## "AI-powered" — what's actually happening
++
++The issue calls for "AI-powered recommendations." This is implemented as
++transparent, deterministic weighted scoring, not a model call — consistent
++with `trip-data.js`'s own description of itself as "rule-based, client-side
++only, no backend," which every feature built on that dataset in this
++project follows. Each compared destination gets a score built from:
++
++- **Budget fit** — cheaper destinations score higher when budget priority
++  is set high, normalized against a configurable daily budget ceiling.
++- **Adventure level, family-friendliness, accessibility** — the
++  destination's derived score (see below) multiplied by how much you said
++  that factor matters (0-5).
++- **Trip-length fit** — a penalty if the destination typically needs more
++  days than your stated limit.
++- **A small popularity tie-breaker** so close scores don't feel arbitrary.
++
++The recommendation explanation is built directly from which of these
++factors actually pushed the winner ahead — every claim in the explanation
++traces back to a specific score component, which is also why this is
++fully unit-testable (`tests/unit/destination-comparison-engine.test.js`)
++without any network call or fixture recording.
++
++## Derived attributes — and their honest limits
++
++`trip-data.js` has `bestSeason`, `costPerDay`, `highlights`, `minDays`/
++`maxDays`, `categories`, and `popularity` for ~96 destinations, but no
++explicit weather, adventure-level, family-friendliness, accessibility, or
++review-based rating fields. Rather than hand-curating a large new dataset
++across all 96 entries (a huge, hard-to-verify lift), these are computed
++with transparent heuristics from the fields that already exist:
++
++| Attribute | Derived from | Range |
++| --------- | ------------- | ----- |
++| Weather | `categories` (desert/mountains/beaches/etc.) | Text description |
++| Adventure level | `categories` (adventure/mountains/desert/wildlife push it up) | 1-5 |
++| Family friendliness | `categories` (historical/heritage/city/spiritual/beaches push up, adventure/desert push down) | 1-5 |
++| Accessibility | `popularity` and `minDays` as a proxy for how well-connected a destination tends to be | 1-5 |
++| Nearby destinations | Haversine distance to every other destination in the dataset, within 200km | Up to 3 |
++| User rating | `popularity` field, relabeled honestly as "traveler popularity" | 1-10 |
++
++These are documented here and in the module's own comments as **editorial
++heuristics, not measured or crowd-sourced data**. If this dataset later
++gains real per-destination weather/accessibility/review data, the derived
++functions in `destination-comparison-engine.js` are the only place that
++would need to change — the comparison and recommendation logic around them
++stays the same.
++
++## Architecture
++
++- `js-modules/destination-comparison-engine.js` — pure logic, no DOM
++  dependency, depends only on the shared `tripDestinations` global from
++  `trip-data.js` (same dependency `js-modules/trip-planner.js` already
++  has). Exposes `window.DestinationComparison`.
++- `frontend/destination-comparison/destination-comparison.html` +
++  `destination-comparison-ui.js` — a standalone page (same pattern as
++  `route-planner.html`/`island-explorer/index.html`: shared `styles.css`,
++  direct `<script>` includes, `DOMContentLoaded` wiring) rather than the
++  SPA router (`js-modules/router-init.js`) that `trip-planner.html` uses.
++  Both patterns already coexist in this codebase; the standalone pattern
++  was chosen here to keep the page self-contained and easy to verify in
++  isolation.
++- `tests/unit/destination-comparison-engine.test.js` — 20 vitest tests,
++  following the exact pattern `tests/unit/trip-planner.test.js` already
++  uses (load `trip-data.js` and the engine source via `readFileSync` +
++  `new Function()`, exercise the resulting global).
++
++## Testing
++
++```bash
++npx vitest run tests/unit/destination-comparison-engine.test.js
++```
++
++Covers: derived-attribute ranges and category sensitivity, nearby-search
++correctness (sorted, radius-bounded, excludes self), the 4-destination cap
++and other input validation, cost-tier sensitivity, live recalculation on
++a changed destination set, preference-driven recommendation correctness
++(budget-only and adventure-only cases produce the expected winner),
++trip-length penalty behavior, graceful handling of an empty comparison,
++export text/JSON completeness, and save/load/delete against `localStorage`.
++
++## Known limitations / future work
++
++- Derived attributes (weather, adventure, family, accessibility) are
++  heuristics from existing categorical data, not verified per-destination
++  data — see the table above.
++- "Nearby destinations" only searches within this project's existing
++  ~96-destination `trip-data.js` list, not all of India.
++- No backend means no real user-review aggregation for the "user ratings"
++  field — it's `trip-data.js`'s existing editorial `popularity` score,
++  relabeled honestly rather than presented as crowd-sourced.
++- Saved comparisons store only the destination-id selection, not a
++  point-in-time snapshot of the comparison output — if `trip-data.js`
++  changes later, a loaded saved comparison reflects current data, not
++  what was on screen when it was saved.
+diff --git a/js-modules/destination-comparison-engine.js b/js-modules/destination-comparison-engine.js
+new file mode 100644
+index 0000000..5efc874
+--- /dev/null
++++ b/js-modules/destination-comparison-engine.js
+@@ -0,0 +1,339 @@
++/**
++ * js-modules/destination-comparison-engine.js
++ * Intelligent Destination Comparison Tool — rule-based, client-side only,
++ * no backend. Compares up to four destinations from trip-data.js across
++ * budget, weather, duration, adventure level, family-friendliness,
++ * accessibility, and nearby destinations, and produces an explainable
++ * preference-based recommendation.
++ *
++ * "AI-powered" in the feature request is implemented here as transparent,
++ * explainable weighted scoring against user-stated preferences — the same
++ * honest framing trip-data.js already uses ("Rule-based, client-side
++ * only"). There's no model call; every score can be traced back to a
++ * specific preference weight and destination attribute, which also makes
++ * it something this module can unit test deterministically.
++ *
++ * Depends on `tripDestinations` (from trip-data.js) being loaded first,
++ * mirroring js-modules/trip-planner.js's dependency on the same dataset.
++ * Exposes window.DestinationComparison, loaded the same way trip-planner.js
++ * is (see app.js's route-based module loading).
++ */
++(function (root) {
++  "use strict";
++
++  const MAX_COMPARE = 4;
++  const NEARBY_RADIUS_KM = 200;
++  const NEARBY_LIMIT = 3;
++  const SAVED_COMPARISONS_KEY = "destinationComparisonSaved";
++
++  // ---------------------------------------------------------------------
++  // Geometry (mirrors TripPlanner.haversineDistanceKm — kept local so this
++  // module has no runtime dependency on trip-planner.js, only on the
++  // shared trip-data.js dataset).
++  // ---------------------------------------------------------------------
++  function haversineDistanceKm(lat1, lng1, lat2, lng2) {
++    const toRad = (deg) => (deg * Math.PI) / 180;
++    const R = 6371;
++    const dLat = toRad(lat2 - lat1);
++    const dLng = toRad(lng2 - lng1);
++    const a =
++      Math.sin(dLat / 2) ** 2 +
++      Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2;
++    return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
++  }
++
++  // ---------------------------------------------------------------------
++  // Derived attributes
++  // ---------------------------------------------------------------------
++  // trip-data.js has no explicit weather/adventure/family/accessibility
++  // fields. Rather than inventing a large hand-curated dataset across all
++  // ~96 destinations, these are transparent heuristics derived from fields
++  // that already exist (categories, bestSeason, popularity, minDays). Each
++  // is documented here and in docs/DESTINATION_COMPARISON.md as an
++  // editorial approximation, not verified/live data.
++
++  const CLIMATE_BY_CATEGORY = {
++    desert: "Hot, dry days; cold nights",
++    mountains: "Cool to cold; snow possible in winter",
++    beaches: "Warm, humid, coastal",
++    backwaters: "Warm, humid, coastal",
++    wildlife: "Warm; varies by region and season",
++    spiritual: "Varies by region — check bestSeason",
++    historical: "Varies by region — check bestSeason",
++    heritage: "Varies by region — check bestSeason",
++    adventure: "Varies by region — check bestSeason",
++    city: "Varies by region — check bestSeason",
++  };
++  const CLIMATE_PRIORITY = ["desert", "mountains", "beaches", "backwaters", "wildlife"];
++
++  function estimateClimate(destination) {
++    const match = CLIMATE_PRIORITY.find((cat) => destination.categories.includes(cat));
++    return CLIMATE_BY_CATEGORY[match] || "Varies by region — check bestSeason";
++  }
++
++  // 1 (low) - 5 (high). Categories associated with physically demanding or
++  // outdoor-risk activity push this up; every destination starts at a
++  // baseline of 2 so a purely historical/spiritual city doesn't read as
++  // "zero adventure".
++  function estimateAdventureLevel(destination) {
++    let score = 2;
++    if (destination.categories.includes("adventure")) score += 2;
++    if (destination.categories.includes("mountains")) score += 1;
++    if (destination.categories.includes("desert")) score += 1;
++    if (destination.categories.includes("wildlife")) score += 1;
++    return Math.max(1, Math.min(5, score));
++  }
++
++  // 1 (low) - 5 (high). Categories with broad, low-physical-demand appeal
++  // score higher; pure high-adventure destinations score lower as a
++  // simple inverse of estimateAdventureLevel, nudged by category.
++  function estimateFamilyFriendliness(destination) {
++    let score = 3;
++    if (destination.categories.some((c) => ["historical", "heritage", "city", "spiritual"].includes(c))) score += 1;
++    if (destination.categories.includes("beaches")) score += 1;
++    if (destination.categories.includes("adventure")) score -= 1;
++    if (destination.categories.includes("desert")) score -= 1;
++    return Math.max(1, Math.min(5, score));
++  }
++
++  // 1 (remote) - 5 (very accessible). Proxy from popularity (well-known
++  // destinations tend to have better flight/rail connectivity in
++  // practice) and minDays (destinations worth only a short stop tend to
++  // sit closer to a hub than multi-day remote trips). Documented as a
++  // heuristic proxy, not a measured transit-time score.
++  function estimateAccessibility(destination) {
++    const popularityScore = destination.popularity / 2; // 0.5-5
++    const proximityBonus = destination.minDays <= 1 ? 1 : destination.minDays >= 3 ? -1 : 0;
++    return Math.max(1, Math.min(5, Math.round(popularityScore + proximityBonus)));
++  }
++
++  function findNearbyDestinations(destination, allDestinations) {
++    return allDestinations
++      .filter((d) => d.id !== destination.id)
++      .map((d) => ({ id: d.id, name: d.name, distanceKm: haversineDistanceKm(destination.lat, destination.lng, d.lat, d.lng) }))
++      .filter((d) => d.distanceKm <= NEARBY_RADIUS_KM)
++      .sort((a, b) => a.distanceKm - b.distanceKm)
++      .slice(0, NEARBY_LIMIT);
++  }
++
++  // ---------------------------------------------------------------------
++  // Comparison
++  // ---------------------------------------------------------------------
++  /**
++   * @param {string[]} ids - 1 to 4 destination ids
++   * @param {Array} [allDestinations] - defaults to global tripDestinations
++   * @param {string} [costTier="mid"] - "budget" | "mid" | "luxury"
++   */
++  function compareDestinations(ids, allDestinations, costTier) {
++    const pool = allDestinations || root.tripDestinations || [];
++    const tier = costTier || "mid";
++    if (!ids || ids.length === 0) {
++      throw new Error("Select at least one destination to compare.");
++    }
++    if (ids.length > MAX_COMPARE) {
++      throw new Error(`You can compare up to ${MAX_COMPARE} destinations at a time.`);
++    }
++
++    const rows = ids.map((id) => {
++      const destination = pool.find((d) => d.id === id);
++      if (!destination) throw new Error(`Unknown destination: ${id}`);
++      return {
++        id: destination.id,
++        name: destination.name,
++        state: destination.state,
++        bestTimeToVisit: destination.bestSeason,
++        estimatedBudgetPerDay: destination.costPerDay[tier] ?? destination.costPerDay.mid,
++        budgetTiers: destination.costPerDay,
++        popularAttractions: destination.highlights,
++        weather: estimateClimate(destination),
++        idealTripDuration: { minDays: destination.minDays, maxDays: destination.maxDays },
++        adventureLevel: estimateAdventureLevel(destination),
++        familyFriendliness: estimateFamilyFriendliness(destination),
++        accessibility: estimateAccessibility(destination),
++        nearbyDestinations: findNearbyDestinations(destination, pool),
++        userRating: destination.popularity,
++        description: destination.description,
++      };
++    });
++
++    return { costTier: tier, destinations: rows };
++  }
++
++  // ---------------------------------------------------------------------
++  // Preference-based recommendation
++  // ---------------------------------------------------------------------
++  // preferences: { budgetWeight, adventureWeight, familyWeight,
++  //                accessibilityWeight, maxBudgetPerDay, maxDays }
++  // Each weight is 0-5 (0 = don't care, 5 = very important). Missing
++  // weights default to 1 (mild default relevance) so a comparison with no
++  // stated preferences still produces a reasoned, if generic, pick.
++  function scoreDestination(row, preferences) {
++    const w = {
++      budget: preferences.budgetWeight ?? 1,
++      adventure: preferences.adventureWeight ?? 1,
++      family: preferences.familyWeight ?? 1,
++      accessibility: preferences.accessibilityWeight ?? 1,
++    };
++
++    const reasons = [];
++    let score = 0;
++
++    // Lower cost scores higher when budget matters; normalize against a
++    // generous ceiling so the score stays in a sane 0-5-ish range per term.
++    const budgetCeiling = preferences.maxBudgetPerDay || 15000;
++    const budgetFit = Math.max(0, 1 - row.estimatedBudgetPerDay / budgetCeiling) * 5;
++    score += budgetFit * w.budget;
++    if (w.budget >= 3 && budgetFit >= 3) reasons.push(`fits comfortably within your budget (~₹${row.estimatedBudgetPerDay}/day)`);
++
++    score += row.adventureLevel * w.adventure;
++    if (w.adventure >= 3 && row.adventureLevel >= 4) reasons.push("offers a high level of adventure activity");
++
++    score += row.familyFriendliness * w.family;
++    if (w.family >= 3 && row.familyFriendliness >= 4) reasons.push("is well suited to family travel");
++
++    score += row.accessibility * w.accessibility;
++    if (w.accessibility >= 3 && row.accessibility >= 4) reasons.push("is easy to reach");
++
++    if (preferences.maxDays && row.idealTripDuration.minDays <= preferences.maxDays) {
++      score += 3;
++      reasons.push(`fits within your ${preferences.maxDays}-day trip window`);
++    } else if (preferences.maxDays && row.idealTripDuration.minDays > preferences.maxDays) {
++      score -= 5;
++      reasons.push(`typically needs more than ${preferences.maxDays} day(s), longer than your window`);
++    }
++
++    // Small, transparent tie-breaker so the recommendation isn't silent
++    // about popularity when everything else is close.
++    score += row.userRating * 0.2;
++
++    return { score, reasons };
++  }
++
++  /**
++   * @param {Object} comparison - output of compareDestinations()
++   * @param {Object} [preferences]
++   * @returns {{ winner: Object, ranked: Array, explanation: string }}
++   */
++  function getRecommendation(comparison, preferences) {
++    const prefs = preferences || {};
++    const ranked = comparison.destinations
++      .map((row) => {
++        const { score, reasons } = scoreDestination(row, prefs);
++        return { ...row, score, reasons };
++      })
++      .sort((a, b) => b.score - a.score);
++
++    const winner = ranked[0];
++    const runnerUp = ranked[1];
++
++    let explanation;
++    if (!winner) {
++      explanation = "Add destinations to compare before requesting a recommendation.";
++    } else if (winner.reasons.length === 0) {
++      explanation = `${winner.name} is the best overall match based on your comparison — no single factor stands out sharply, but it scores most consistently well across your priorities.`;
++    } else {
++      explanation = `${winner.name} is the best match because it ${winner.reasons.join(", and ")}.`;
++    }
++    if (runnerUp && winner && Math.abs(winner.score - runnerUp.score) < 1) {
++      explanation += ` ${runnerUp.name} is a very close second — worth a second look if any single priority above matters more than the others.`;
++    }
++
++    return { winner, ranked, explanation };
++  }
++
++  // ---------------------------------------------------------------------
++  // Export comparison report
++  // ---------------------------------------------------------------------
++  function exportComparisonText(comparison, recommendation) {
++    const lines = ["Destination Comparison Report", ""];
++    comparison.destinations.forEach((row) => {
++      lines.push(`${row.name}, ${row.state}`);
++      lines.push(`  Best time to visit: ${row.bestTimeToVisit}`);
++      lines.push(`  Weather: ${row.weather}`);
++      lines.push(`  Estimated budget: ₹${row.estimatedBudgetPerDay}/day (${comparison.costTier} tier)`);
++      lines.push(`  Ideal trip duration: ${row.idealTripDuration.minDays}-${row.idealTripDuration.maxDays} days`);
++      lines.push(`  Adventure level: ${row.adventureLevel}/5`);
++      lines.push(`  Family friendliness: ${row.familyFriendliness}/5`);
++      lines.push(`  Accessibility: ${row.accessibility}/5`);
++      lines.push(`  Popular attractions: ${row.popularAttractions.join(", ")}`);
++      if (row.nearbyDestinations.length) {
++        lines.push(`  Nearby: ${row.nearbyDestinations.map((n) => `${n.name} (${n.distanceKm.toFixed(0)}km)`).join(", ")}`);
++      }
++      lines.push(`  Traveler popularity: ${row.userRating}/10`);
++      lines.push("");
++    });
++    if (recommendation) {
++      lines.push("Recommendation:");
++      lines.push(`  ${recommendation.explanation}`);
++    }
++    return lines.join("\n");
++  }
++
++  function exportComparisonJSON(comparison, recommendation) {
++    return JSON.stringify(
++      { generatedAt: new Date().toISOString(), costTier: comparison.costTier, destinations: comparison.destinations, recommendation: recommendation ? recommendation.explanation : null },
++      null,
++      2
++    );
++  }
++
++  // ---------------------------------------------------------------------
++  // Save comparisons for future reference (localStorage, same pattern as
++  // TripPlanner's SAVED_TRIPS_KEY — no backend in this project).
++  // ---------------------------------------------------------------------
++  function getStorage() {
++    try {
++      return typeof localStorage !== "undefined" ? localStorage : null;
++    } catch (e) {
++      return null;
++    }
++  }
++
++  function getSavedComparisons() {
++    const storage = getStorage();
++    if (!storage) return [];
++    try {
++      return JSON.parse(storage.getItem(SAVED_COMPARISONS_KEY) || "[]");
++    } catch (e) {
++      return [];
++    }
++  }
++
++  function saveComparison(name, ids) {
++    const storage = getStorage();
++    const saved = getSavedComparisons();
++    const entry = { id: `cmp_${Date.now()}`, name: name || ids.join(" vs "), ids, savedAt: new Date().toISOString() };
++    const updated = [...saved, entry];
++    if (storage) storage.setItem(SAVED_COMPARISONS_KEY, JSON.stringify(updated));
++    return entry;
++  }
++
++  function deleteSavedComparison(entryId) {
++    const storage = getStorage();
++    const updated = getSavedComparisons().filter((c) => c.id !== entryId);
++    if (storage) storage.setItem(SAVED_COMPARISONS_KEY, JSON.stringify(updated));
++    return updated;
++  }
++
++  // ---------------------------------------------------------------------
++  root.DestinationComparison = {
++    MAX_COMPARE,
++    haversineDistanceKm,
++    estimateClimate,
++    estimateAdventureLevel,
++    estimateFamilyFriendliness,
++    estimateAccessibility,
++    findNearbyDestinations,
++    compareDestinations,
++    getRecommendation,
++    exportComparisonText,
++    exportComparisonJSON,
++    getSavedComparisons,
++    saveComparison,
++    deleteSavedComparison,
++  };
++
++  if (typeof module !== "undefined" && module.exports) {
++    module.exports = root.DestinationComparison;
++  }
++})(typeof window !== "undefined" ? window : globalThis);
+diff --git a/tests/unit/destination-comparison-engine.test.js b/tests/unit/destination-comparison-engine.test.js
+new file mode 100644
+index 0000000..80bc47e
+--- /dev/null
++++ b/tests/unit/destination-comparison-engine.test.js
+@@ -0,0 +1,174 @@
++import { describe, it, expect, beforeEach } from 'vitest';
++import { readFileSync } from 'node:fs';
++import { resolve, dirname } from 'node:path';
++import { fileURLToPath } from 'node:url';
++
++const __dirname = dirname(fileURLToPath(import.meta.url));
++
++// Load trip-data.js (shared destination dataset)
++const tripDataCode = readFileSync(resolve(__dirname, '../../trip-data.js'), 'utf-8');
++const getTripData = new Function(tripDataCode + '\nreturn { tripDestinations };');
++const { tripDestinations } = getTripData();
++globalThis.tripDestinations = tripDestinations;
++
++// Load destination-comparison-engine.js
++const engineCode = readFileSync(resolve(__dirname, '../../js-modules/destination-comparison-engine.js'), 'utf-8');
++new Function(engineCode)();
++const DestinationComparison = globalThis.DestinationComparison;
++
++describe('DestinationComparison: derived attributes', () => {
++  const agra = tripDestinations.find((d) => d.id === 'agra');
++  const manali = tripDestinations.find((d) => d.id === 'manali');
++  const jaisalmer = tripDestinations.find((d) => d.id === 'jaisalmer');
++
++  it('estimates climate from category, preferring the most climate-specific category', () => {
++    expect(DestinationComparison.estimateClimate(jaisalmer)).toMatch(/hot|dry/i);
++    expect(DestinationComparison.estimateClimate(manali)).toMatch(/cool|cold/i);
++  });
++
++  it('gives adventure-tagged, mountain destinations a higher adventure level than a historical city', () => {
++    expect(DestinationComparison.estimateAdventureLevel(manali)).toBeGreaterThan(DestinationComparison.estimateAdventureLevel(agra));
++  });
++
++  it('keeps every derived score within its documented 1-5 range', () => {
++    tripDestinations.forEach((d) => {
++      expect(DestinationComparison.estimateAdventureLevel(d)).toBeGreaterThanOrEqual(1);
++      expect(DestinationComparison.estimateAdventureLevel(d)).toBeLessThanOrEqual(5);
++      expect(DestinationComparison.estimateFamilyFriendliness(d)).toBeGreaterThanOrEqual(1);
++      expect(DestinationComparison.estimateFamilyFriendliness(d)).toBeLessThanOrEqual(5);
++      expect(DestinationComparison.estimateAccessibility(d)).toBeGreaterThanOrEqual(1);
++      expect(DestinationComparison.estimateAccessibility(d)).toBeLessThanOrEqual(5);
++    });
++  });
++
++  it('finds nearby destinations within the search radius, nearest first', () => {
++    const nearby = DestinationComparison.findNearbyDestinations(agra, tripDestinations);
++    for (let i = 1; i < nearby.length; i++) {
++      expect(nearby[i - 1].distanceKm).toBeLessThanOrEqual(nearby[i].distanceKm);
++    }
++    nearby.forEach((n) => expect(n.distanceKm).toBeLessThanOrEqual(200));
++    expect(nearby.some((n) => n.id === agra.id)).toBe(false); // never includes itself
++  });
++});
++
++describe('DestinationComparison: compareDestinations', () => {
++  it('compares 1 to 4 destinations and includes every required attribute', () => {
++    const result = DestinationComparison.compareDestinations(['agra', 'jaipur', 'manali', 'goa'], tripDestinations, 'mid');
++    expect(result.destinations).toHaveLength(4);
++    result.destinations.forEach((row) => {
++      expect(row).toHaveProperty('bestTimeToVisit');
++      expect(row).toHaveProperty('estimatedBudgetPerDay');
++      expect(row).toHaveProperty('popularAttractions');
++      expect(row).toHaveProperty('weather');
++      expect(row).toHaveProperty('idealTripDuration');
++      expect(row).toHaveProperty('adventureLevel');
++      expect(row).toHaveProperty('familyFriendliness');
++      expect(row).toHaveProperty('accessibility');
++      expect(row).toHaveProperty('nearbyDestinations');
++      expect(row).toHaveProperty('userRating');
++    });
++  });
++
++  it('rejects more than four destinations', () => {
++    expect(() =>
++      DestinationComparison.compareDestinations(['agra', 'jaipur', 'manali', 'goa', 'shimla'], tripDestinations)
++    ).toThrow(/up to 4/);
++  });
++
++  it('rejects an empty selection', () => {
++    expect(() => DestinationComparison.compareDestinations([], tripDestinations)).toThrow(/at least one/i);
++  });
++
++  it('rejects an unknown destination id', () => {
++    expect(() => DestinationComparison.compareDestinations(['not-a-real-place'], tripDestinations)).toThrow(/unknown destination/i);
++  });
++
++  it('reflects the requested cost tier in estimatedBudgetPerDay', () => {
++    const budget = DestinationComparison.compareDestinations(['agra'], tripDestinations, 'budget').destinations[0];
++    const luxury = DestinationComparison.compareDestinations(['agra'], tripDestinations, 'luxury').destinations[0];
++    expect(budget.estimatedBudgetPerDay).toBeLessThan(luxury.estimatedBudgetPerDay);
++  });
++
++  it('updates dynamically — recomparing with a different destination set changes the result, not a cached one', () => {
++    const first = DestinationComparison.compareDestinations(['agra'], tripDestinations);
++    const second = DestinationComparison.compareDestinations(['manali'], tripDestinations);
++    expect(first.destinations[0].name).not.toBe(second.destinations[0].name);
++  });
++});
++
++describe('DestinationComparison: getRecommendation', () => {
++  it('recommends the cheaper destination when budget is weighted heavily and nothing else is', () => {
++    const comparison = DestinationComparison.compareDestinations(['udaipur', 'haridwar'], tripDestinations, 'mid');
++    const rec = DestinationComparison.getRecommendation(comparison, { budgetWeight: 5, adventureWeight: 0, familyWeight: 0, accessibilityWeight: 0 });
++    expect(rec.winner.id).toBe('haridwar'); // cheaper per-day cost in trip-data.js
++  });
++
++  it('recommends the more adventurous destination when adventure is weighted heavily and nothing else is', () => {
++    const comparison = DestinationComparison.compareDestinations(['agra', 'manali'], tripDestinations, 'mid');
++    const rec = DestinationComparison.getRecommendation(comparison, { budgetWeight: 0, adventureWeight: 5, familyWeight: 0, accessibilityWeight: 0 });
++    expect(rec.winner.id).toBe('manali');
++  });
++
++  it('produces a human-readable explanation naming the winning destination', () => {
++    const comparison = DestinationComparison.compareDestinations(['jaipur', 'shimla'], tripDestinations, 'mid');
++    const rec = DestinationComparison.getRecommendation(comparison, { familyWeight: 4 });
++    expect(rec.explanation).toContain(rec.winner.name);
++  });
++
++  it('penalizes destinations that need longer than the stated trip window', () => {
++    const comparison = DestinationComparison.compareDestinations(['haridwar', 'lakshadweep'], tripDestinations, 'mid');
++    const rec = DestinationComparison.getRecommendation(comparison, { maxDays: 1 });
++    const lakshadweepRow = rec.ranked.find((r) => r.id === 'lakshadweep');
++    expect(lakshadweepRow.reasons.join(' ')).toMatch(/longer than your window/);
++  });
++
++  it('handles an empty comparison gracefully instead of throwing', () => {
++    const comparison = { costTier: 'mid', destinations: [] };
++    const rec = DestinationComparison.getRecommendation(comparison, {});
++    expect(rec.winner).toBeUndefined();
++    expect(rec.explanation).toMatch(/add destinations/i);
++  });
++});
++
++describe('DestinationComparison: export', () => {
++  const comparison = DestinationComparison.compareDestinations(['agra', 'jaipur'], tripDestinations, 'mid');
++  const recommendation = DestinationComparison.getRecommendation(comparison, { budgetWeight: 3 });
++
++  it('exportComparisonText includes every compared destination and the recommendation', () => {
++    const text = DestinationComparison.exportComparisonText(comparison, recommendation);
++    expect(text).toContain('Agra');
++    expect(text).toContain('Jaipur');
++    expect(text).toContain(recommendation.winner.name);
++  });
++
++  it('exportComparisonJSON produces valid, parseable JSON with matching destination count', () => {
++    const json = DestinationComparison.exportComparisonJSON(comparison, recommendation);
++    const parsed = JSON.parse(json);
++    expect(parsed.destinations).toHaveLength(2);
++    expect(parsed.recommendation).toContain(recommendation.winner.name);
++  });
++});
++
++describe('DestinationComparison: saved comparisons (localStorage)', () => {
++  beforeEach(() => {
++    localStorage.clear();
++  });
++
++  it('starts with no saved comparisons', () => {
++    expect(DestinationComparison.getSavedComparisons()).toEqual([]);
++  });
++
++  it('saves a comparison and retrieves it later', () => {
++    const entry = DestinationComparison.saveComparison('Rajasthan trip', ['jaipur', 'jodhpur', 'udaipur']);
++    const saved = DestinationComparison.getSavedComparisons();
++    expect(saved).toHaveLength(1);
++    expect(saved[0].id).toBe(entry.id);
++    expect(saved[0].ids).toEqual(['jaipur', 'jodhpur', 'udaipur']);
++  });
++
++  it('deletes a saved comparison by id', () => {
++    const entry = DestinationComparison.saveComparison('Hills trip', ['shimla', 'manali']);
++    DestinationComparison.deleteSavedComparison(entry.id);
++    expect(DestinationComparison.getSavedComparisons()).toEqual([]);
++  });
++});
+diff --git a/frontend/destination-comparison/destination-comparison.html b/frontend/destination-comparison/destination-comparison.html
+new file mode 100644
+index 0000000..425e036
+--- /dev/null
++++ b/frontend/destination-comparison/destination-comparison.html
+@@ -0,0 +1,229 @@
++<!DOCTYPE html>
++<html lang="en">
++<head>
++<script>
++  (function () {
++    const theme = localStorage.getItem('theme') || 'dark';
++    if (theme === 'light') document.body.classList.add('light-theme');
++  })();
++</script>
++<meta charset="UTF-8">
++<meta name="viewport" content="width=device-width, initial-scale=1.0">
++<title>Destination Comparison Tool | Incredible India Explorer</title>
++<meta name="description" content="Compare up to four Indian destinations side by side — budget, weather, attractions, adventure level, and family friendliness — with a personalized recommendation.">
++<link href="https://fonts.googleapis.com" rel="preconnect">
++<link crossorigin href="https://fonts.gstatic.com" rel="preconnect">
++<link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:wght@500;600;700&display=swap" rel="stylesheet">
++<link rel="stylesheet" href="../../styles.css">
++<style>
++  .dc-hero {
++    padding: 120px 0 50px;
++    text-align: center;
++  }
++  .dc-hero h1 { font-family: "Playfair Display", serif; font-size: clamp(2.2rem, 5vw, 3.4rem); margin: 0 0 12px; }
++  .dc-hero p { max-width: 680px; margin: 0 auto; color: var(--text-secondary, #b7b7b7); line-height: 1.7; }
++
++  .dc-container { width: min(1180px, 94%); margin: 0 auto; padding-bottom: 80px; }
++
++  .dc-panel {
++    background: var(--glass-bg, rgba(255,255,255,.05));
++    border: 1px solid var(--glass-border, rgba(255,255,255,.12));
++    border-radius: 16px;
++    padding: 24px;
++    margin-bottom: 24px;
++  }
++  .dc-panel h2 { font-family: "Playfair Display", serif; font-size: 1.4rem; margin: 0 0 16px; }
++
++  /* --- Destination picker --- */
++  .dc-picker-row { display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 14px; }
++  .dc-picker-row select {
++    flex: 1; min-width: 220px; padding: 10px 12px; border-radius: 10px;
++    border: 1px solid var(--glass-border, rgba(255,255,255,.14));
++    background: rgba(255,255,255,.05); color: inherit; font-family: 'Outfit', sans-serif;
++  }
++  .dc-picker-row button {
++    padding: 10px 18px; border-radius: 10px; border: none; cursor: pointer;
++    background: var(--green, #138808); color: #fff; font-weight: 600; font-family: 'Outfit', sans-serif;
++  }
++  .dc-picker-row button:disabled { opacity: .5; cursor: not-allowed; }
++  .dc-chips { display: flex; gap: 8px; flex-wrap: wrap; }
++  .dc-chip {
++    display: inline-flex; align-items: center; gap: 8px;
++    background: rgba(23,184,176,.14); border: 1px solid rgba(23,184,176,.35);
++    padding: 6px 8px 6px 14px; border-radius: 999px; font-size: .88rem;
++  }
++  .dc-chip button {
++    background: none; border: none; color: inherit; cursor: pointer; font-size: 1rem;
++    width: 22px; height: 22px; border-radius: 50%; display: grid; place-items: center;
++  }
++  .dc-chip button:hover { background: rgba(255,255,255,.15); }
++  .dc-hint { font-size: .82rem; color: var(--text-secondary, #b7b7b7); margin-top: 6px; }
++
++  /* --- Preferences --- */
++  .dc-pref-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 18px; }
++  .dc-pref-field label { display: block; font-size: .85rem; margin-bottom: 6px; color: var(--text-secondary, #b7b7b7); }
++  .dc-pref-field input[type="range"] { width: 100%; }
++  .dc-pref-field input[type="number"], .dc-pref-field select {
++    width: 100%; padding: 8px 10px; border-radius: 8px; border: 1px solid var(--glass-border, rgba(255,255,255,.14));
++    background: rgba(255,255,255,.05); color: inherit; font-family: 'Outfit', sans-serif;
++  }
++  .dc-pref-value { font-weight: 600; color: var(--gold); }
++
++  .dc-actions { display: flex; gap: 12px; flex-wrap: wrap; margin-top: 18px; }
++  .dc-actions button {
++    padding: 12px 22px; border-radius: 10px; border: 1px solid var(--glass-border, rgba(255,255,255,.14));
++    background: rgba(255,255,255,.06); color: inherit; font-weight: 600; cursor: pointer; font-family: 'Outfit', sans-serif;
++  }
++  .dc-actions .primary { background: var(--saffron, #ff9933); border-color: transparent; color: #1a1a1a; }
++  .dc-actions button:hover { filter: brightness(1.08); }
++
++  /* --- Recommendation --- */
++  .dc-recommendation {
++    border-radius: 16px; padding: 22px 24px; margin-bottom: 24px;
++    background: linear-gradient(135deg, rgba(255,153,51,.14), rgba(19,136,8,.1));
++    border: 1px solid rgba(255,153,51,.35);
++  }
++  .dc-recommendation h3 { margin: 0 0 8px; font-family: "Playfair Display", serif; font-size: 1.25rem; }
++  .dc-recommendation p { margin: 0; line-height: 1.7; }
++
++  /* --- Comparison cards --- */
++  .dc-compare-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 18px; }
++  .dc-compare-card {
++    background: var(--glass-bg, rgba(255,255,255,.05)); border: 1px solid var(--glass-border, rgba(255,255,255,.12));
++    border-radius: 14px; padding: 18px; position: relative;
++  }
++  .dc-compare-card.is-winner { border-color: var(--saffron, #ff9933); box-shadow: 0 0 0 1px rgba(255,153,51,.3); }
++  .dc-compare-card .winner-badge {
++    position: absolute; top: -10px; right: 14px; background: var(--saffron, #ff9933); color: #1a1a1a;
++    font-size: .72rem; font-weight: 700; padding: 3px 10px; border-radius: 999px;
++  }
++  .dc-compare-card h4 { margin: 0 0 2px; font-family: "Playfair Display", serif; font-size: 1.15rem; }
++  .dc-compare-card .state { font-size: .82rem; color: var(--text-secondary, #b7b7b7); margin-bottom: 12px; }
++  .dc-attr { display: flex; justify-content: space-between; gap: 8px; padding: 6px 0; border-bottom: 1px solid rgba(255,255,255,.06); font-size: .87rem; }
++  .dc-attr:last-of-type { border-bottom: none; }
++  .dc-attr span:first-child { color: var(--text-secondary, #b7b7b7); }
++  .dc-attr span:last-child { text-align: right; font-weight: 600; }
++  .dc-attractions { margin: 10px 0 0; font-size: .85rem; color: var(--text-secondary, #b7b7b7); line-height: 1.6; }
++  .dc-nearby { margin: 8px 0 0; font-size: .8rem; color: var(--text-secondary, #b7b7b7); }
++
++  /* --- Saved comparisons --- */
++  .dc-saved-list { display: flex; flex-direction: column; gap: 8px; }
++  .dc-saved-item {
++    display: flex; justify-content: space-between; align-items: center; gap: 10px;
++    padding: 10px 14px; border-radius: 10px; background: rgba(255,255,255,.04); border: 1px solid var(--glass-border, rgba(255,255,255,.1));
++    font-size: .88rem;
++  }
++  .dc-saved-item .actions { display: flex; gap: 8px; }
++  .dc-saved-item button {
++    background: none; border: 1px solid var(--glass-border, rgba(255,255,255,.16)); color: inherit;
++    border-radius: 8px; padding: 4px 10px; cursor: pointer; font-size: .8rem;
++  }
++  .dc-empty { color: var(--text-secondary, #b7b7b7); font-size: .88rem; font-style: italic; }
++  .dc-status { font-size: .85rem; margin-top: 10px; min-height: 1.2em; }
++  .dc-status.error { color: #ff6b6b; }
++  .dc-status.ok { color: var(--green, #138808); }
++</style>
++</head>
++<body>
++<header class="navbar scrolled" id="navbar">
++  <div class="nav-container">
++    <a href="../../index.html#home" class="nav-logo">
++      <span class="saffron">Incredible</span><span class="gold">India</span><span class="green">Explorer</span>
++    </a>
++    <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
++      <span class="bar"></span><span class="bar"></span><span class="bar"></span>
++    </button>
++    <nav class="nav-menu" id="nav-menu">
++      <a href="../../index.html#home" class="nav-link">Home</a>
++      <a href="../trip-planner/trip-planner.html" class="nav-link">Trip Planner</a>
++      <a href="destination-comparison.html" class="nav-link current-link">Compare Destinations</a>
++      <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
++    </nav>
++  </div>
++</header>
++
++<main>
++  <section class="dc-hero">
++    <h1>Destination Comparison Tool</h1>
++    <p>Pick up to four destinations, tell us what matters to you, and get a side-by-side comparison with a personalized, explainable recommendation.</p>
++  </section>
++
++  <div class="dc-container">
++
++    <div class="dc-panel">
++      <h2>1. Choose destinations <span style="font-weight:400; font-size:.85rem; color:var(--text-secondary,#b7b7b7);">(up to 4)</span></h2>
++      <div class="dc-picker-row">
++        <select id="dc-destination-select" aria-label="Choose a destination to add"></select>
++        <button type="button" id="dc-add-btn">+ Add</button>
++      </div>
++      <div class="dc-chips" id="dc-chips"></div>
++      <p class="dc-hint">Add at least one destination, then set your preferences below and compare.</p>
++    </div>
++
++    <div class="dc-panel">
++      <h2>2. What matters to you?</h2>
++      <div class="dc-pref-grid">
++        <div class="dc-pref-field">
++          <label for="dc-cost-tier">Travel style</label>
++          <select id="dc-cost-tier">
++            <option value="budget">Budget</option>
++            <option value="mid" selected>Mid-range</option>
++            <option value="luxury">Luxury</option>
++          </select>
++        </div>
++        <div class="dc-pref-field">
++          <label for="dc-max-days">Max trip length (days)</label>
++          <input type="number" id="dc-max-days" min="1" max="30" placeholder="e.g. 5">
++        </div>
++        <div class="dc-pref-field">
++          <label for="dc-budget-weight">Budget priority: <span class="dc-pref-value" id="dc-budget-weight-val">3</span></label>
++          <input type="range" id="dc-budget-weight" min="0" max="5" value="3">
++        </div>
++        <div class="dc-pref-field">
++          <label for="dc-adventure-weight">Adventure priority: <span class="dc-pref-value" id="dc-adventure-weight-val">2</span></label>
++          <input type="range" id="dc-adventure-weight" min="0" max="5" value="2">
++        </div>
++        <div class="dc-pref-field">
++          <label for="dc-family-weight">Family-friendliness priority: <span class="dc-pref-value" id="dc-family-weight-val">2</span></label>
++          <input type="range" id="dc-family-weight" min="0" max="5" value="2">
++        </div>
++        <div class="dc-pref-field">
++          <label for="dc-accessibility-weight">Ease of access priority: <span class="dc-pref-value" id="dc-accessibility-weight-val">2</span></label>
++          <input type="range" id="dc-accessibility-weight" min="0" max="5" value="2">
++        </div>
++      </div>
++
++      <div class="dc-actions">
++        <button type="button" id="dc-compare-btn" class="primary">Compare</button>
++        <button type="button" id="dc-save-btn">💾 Save this comparison</button>
++        <button type="button" id="dc-export-btn">⬇ Export report (.txt)</button>
++      </div>
++      <p class="dc-status" id="dc-status"></p>
++    </div>
++
++    <div id="dc-recommendation-panel" hidden></div>
++
++    <div class="dc-panel" id="dc-results-panel" hidden>
++      <h2>Side-by-side comparison</h2>
++      <div class="dc-compare-grid" id="dc-compare-grid"></div>
++    </div>
++
++    <div class="dc-panel">
++      <h2>Saved comparisons</h2>
++      <div class="dc-saved-list" id="dc-saved-list"></div>
++    </div>
++
++  </div>
++</main>
++
++<footer style="padding: 30px 0; text-align: center; color: var(--text-secondary,#b7b7b7); border-top: 1px solid var(--glass-border, rgba(255,255,255,.1));">
++  <p>Part of <a href="../../index.html" style="color: var(--saffron,#ff9933);">Incredible India Explorer</a></p>
++</footer>
++
++<button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
++<script src="../../app.js" defer></script>
++<script src="../../trip-data.js"></script>
++<script src="../../js-modules/destination-comparison-engine.js"></script>
++<script src="destination-comparison-ui.js" defer></script>
++</body>
++</html>
+diff --git a/frontend/destination-comparison/destination-comparison-ui.js b/frontend/destination-comparison/destination-comparison-ui.js
+new file mode 100644
+index 0000000..a73a920
+--- /dev/null
++++ b/frontend/destination-comparison/destination-comparison-ui.js
+@@ -0,0 +1,248 @@
++(function () {
++  "use strict";
++
++  const MAX_COMPARE = window.DestinationComparison.MAX_COMPARE;
++  const ALL_DESTINATIONS = (window.tripDestinations || []).slice().sort((a, b) => a.name.localeCompare(b.name));
++
++  let selectedIds = [];
++  let lastComparison = null;
++  let lastRecommendation = null;
++
++  function $(id) {
++    return document.getElementById(id);
++  }
++
++  function setStatus(message, kind) {
++    const el = $("dc-status");
++    el.textContent = message || "";
++    el.className = "dc-status" + (kind ? ` ${kind}` : "");
++  }
++
++  // -------------------------------------------------------------------
++  // Destination picker
++  // -------------------------------------------------------------------
++  function populateDestinationSelect() {
++    const select = $("dc-destination-select");
++    select.innerHTML = ALL_DESTINATIONS
++      .filter((d) => !selectedIds.includes(d.id))
++      .map((d) => `<option value="${d.id}">${d.name}, ${d.state}</option>`)
++      .join("");
++  }
++
++  function renderChips() {
++    const container = $("dc-chips");
++    container.innerHTML = selectedIds
++      .map((id) => {
++        const d = ALL_DESTINATIONS.find((dest) => dest.id === id);
++        return `<span class="dc-chip">${d ? d.name : id} <button type="button" data-remove="${id}" aria-label="Remove ${d ? d.name : id}">✕</button></span>`;
++      })
++      .join("");
++
++    container.querySelectorAll("[data-remove]").forEach((btn) => {
++      btn.addEventListener("click", () => {
++        selectedIds = selectedIds.filter((id) => id !== btn.dataset.remove);
++        renderChips();
++        populateDestinationSelect();
++        invalidateResults();
++      });
++    });
++
++    $("dc-add-btn").disabled = selectedIds.length >= MAX_COMPARE;
++  }
++
++  function handleAddDestination() {
++    const select = $("dc-destination-select");
++    const id = select.value;
++    if (!id || selectedIds.includes(id) || selectedIds.length >= MAX_COMPARE) return;
++    selectedIds.push(id);
++    renderChips();
++    populateDestinationSelect();
++    invalidateResults();
++  }
++
++  // -------------------------------------------------------------------
++  // Preferences
++  // -------------------------------------------------------------------
++  function readPreferences() {
++    return {
++      budgetWeight: Number($("dc-budget-weight").value),
++      adventureWeight: Number($("dc-adventure-weight").value),
++      familyWeight: Number($("dc-family-weight").value),
++      accessibilityWeight: Number($("dc-accessibility-weight").value),
++      maxDays: $("dc-max-days").value ? Number($("dc-max-days").value) : undefined,
++    };
++  }
++
++  function wireRangeDisplay(id) {
++    const input = $(id);
++    const display = $(`${id}-val`);
++    input.addEventListener("input", () => {
++      display.textContent = input.value;
++      // Preferences changed — recompute immediately if a comparison is on screen.
++      if (lastComparison) runComparison({ silent: true });
++    });
++  }
++
++  // -------------------------------------------------------------------
++  // Comparison + recommendation rendering
++  // -------------------------------------------------------------------
++  function invalidateResults() {
++    lastComparison = null;
++    lastRecommendation = null;
++    $("dc-results-panel").hidden = true;
++    $("dc-recommendation-panel").hidden = true;
++  }
++
++  function runComparison(opts) {
++    const silent = opts && opts.silent;
++    if (selectedIds.length === 0) {
++      if (!silent) setStatus("Add at least one destination to compare.", "error");
++      return;
++    }
++
++    const costTier = $("dc-cost-tier").value;
++    try {
++      const comparison = window.DestinationComparison.compareDestinations(selectedIds, ALL_DESTINATIONS, costTier);
++      const recommendation = window.DestinationComparison.getRecommendation(comparison, readPreferences());
++      lastComparison = comparison;
++      lastRecommendation = recommendation;
++      renderRecommendation(recommendation);
++      renderComparison(comparison, recommendation);
++      if (!silent) setStatus(`Compared ${comparison.destinations.length} destination(s).`, "ok");
++    } catch (err) {
++      setStatus(err.message, "error");
++    }
++  }
++
++  function renderRecommendation(recommendation) {
++    const panel = $("dc-recommendation-panel");
++    if (!recommendation.winner) {
++      panel.hidden = true;
++      return;
++    }
++    panel.hidden = false;
++    panel.innerHTML = `
++      <div class="dc-recommendation">
++        <h3>🤖 Recommended for you: ${recommendation.winner.name}</h3>
++        <p>${recommendation.explanation}</p>
++      </div>`;
++  }
++
++  function renderComparison(comparison, recommendation) {
++    const panel = $("dc-results-panel");
++    const grid = $("dc-compare-grid");
++    panel.hidden = false;
++
++    grid.innerHTML = comparison.destinations
++      .map((row) => {
++        const isWinner = recommendation.winner && recommendation.winner.id === row.id;
++        return `
++        <div class="dc-compare-card ${isWinner ? "is-winner" : ""}">
++          ${isWinner ? '<span class="winner-badge">Recommended</span>' : ""}
++          <h4>${row.name}</h4>
++          <div class="state">${row.state}</div>
++          <div class="dc-attr"><span>Best time to visit</span><span>${row.bestTimeToVisit}</span></div>
++          <div class="dc-attr"><span>Weather</span><span>${row.weather}</span></div>
++          <div class="dc-attr"><span>Est. budget/day</span><span>₹${row.estimatedBudgetPerDay.toLocaleString("en-IN")}</span></div>
++          <div class="dc-attr"><span>Ideal duration</span><span>${row.idealTripDuration.minDays}-${row.idealTripDuration.maxDays} days</span></div>
++          <div class="dc-attr"><span>Adventure level</span><span>${"★".repeat(row.adventureLevel)}${"☆".repeat(5 - row.adventureLevel)}</span></div>
++          <div class="dc-attr"><span>Family friendly</span><span>${"★".repeat(row.familyFriendliness)}${"☆".repeat(5 - row.familyFriendliness)}</span></div>
++          <div class="dc-attr"><span>Accessibility</span><span>${"★".repeat(row.accessibility)}${"☆".repeat(5 - row.accessibility)}</span></div>
++          <div class="dc-attr"><span>Traveler popularity</span><span>${row.userRating}/10</span></div>
++          <p class="dc-attractions"><strong>Attractions:</strong> ${row.popularAttractions.join(", ")}</p>
++          ${row.nearbyDestinations.length ? `<p class="dc-nearby">Nearby: ${row.nearbyDestinations.map((n) => `${n.name} (${n.distanceKm.toFixed(0)}km)`).join(", ")}</p>` : ""}
++        </div>`;
++      })
++      .join("");
++  }
++
++  // -------------------------------------------------------------------
++  // Save / Export
++  // -------------------------------------------------------------------
++  function handleSave() {
++    if (selectedIds.length === 0) {
++      setStatus("Add destinations before saving a comparison.", "error");
++      return;
++    }
++    const names = selectedIds.map((id) => (ALL_DESTINATIONS.find((d) => d.id === id) || {}).name || id);
++    window.DestinationComparison.saveComparison(names.join(" vs "), selectedIds);
++    renderSavedComparisons();
++    setStatus("Comparison saved.", "ok");
++  }
++
++  function handleExport() {
++    if (!lastComparison) {
++      setStatus("Run a comparison first, then export.", "error");
++      return;
++    }
++    const text = window.DestinationComparison.exportComparisonText(lastComparison, lastRecommendation);
++    const blob = new Blob([text], { type: "text/plain" });
++    const url = URL.createObjectURL(blob);
++    const a = document.createElement("a");
++    a.href = url;
++    a.download = "destination-comparison.txt";
++    document.body.appendChild(a);
++    a.click();
++    a.remove();
++    URL.revokeObjectURL(url);
++  }
++
++  function renderSavedComparisons() {
++    const list = $("dc-saved-list");
++    const saved = window.DestinationComparison.getSavedComparisons();
++    if (!saved.length) {
++      list.innerHTML = '<p class="dc-empty">No saved comparisons yet.</p>';
++      return;
++    }
++    list.innerHTML = saved
++      .slice()
++      .reverse()
++      .map(
++        (entry) => `
++        <div class="dc-saved-item">
++          <span>${entry.name}</span>
++          <span class="actions">
++            <button type="button" data-load="${entry.id}">Load</button>
++            <button type="button" data-delete="${entry.id}">Delete</button>
++          </span>
++        </div>`
++      )
++      .join("");
++
++    list.querySelectorAll("[data-load]").forEach((btn) => {
++      btn.addEventListener("click", () => {
++        const entry = saved.find((s) => s.id === btn.dataset.load);
++        if (!entry) return;
++        selectedIds = entry.ids.filter((id) => ALL_DESTINATIONS.some((d) => d.id === id)).slice(0, MAX_COMPARE);
++        renderChips();
++        populateDestinationSelect();
++        runComparison({});
++      });
++    });
++    list.querySelectorAll("[data-delete]").forEach((btn) => {
++      btn.addEventListener("click", () => {
++        window.DestinationComparison.deleteSavedComparison(btn.dataset.delete);
++        renderSavedComparisons();
++      });
++    });
++  }
++
++  // -------------------------------------------------------------------
++  document.addEventListener("DOMContentLoaded", () => {
++    populateDestinationSelect();
++    renderChips();
++    renderSavedComparisons();
++
++    $("dc-add-btn").addEventListener("click", handleAddDestination);
++    $("dc-compare-btn").addEventListener("click", () => runComparison({}));
++    $("dc-save-btn").addEventListener("click", handleSave);
++    $("dc-export-btn").addEventListener("click", handleExport);
++    $("dc-cost-tier").addEventListener("change", () => {
++      if (lastComparison) runComparison({ silent: true });
++    });
++    $("dc-max-days").addEventListener("input", () => {
++      if (lastComparison) runComparison({ silent: true });
++    });
++    ["dc-budget-weight", "dc-adventure-weight", "dc-family-weight", "dc-accessibility-weight"].forEach(wireRangeDisplay);
++  });
++})();

--- a/js-modules/destination-comparison-engine.js
+++ b/js-modules/destination-comparison-engine.js
@@ -1,0 +1,339 @@
+/**
+ * js-modules/destination-comparison-engine.js
+ * Intelligent Destination Comparison Tool — rule-based, client-side only,
+ * no backend. Compares up to four destinations from trip-data.js across
+ * budget, weather, duration, adventure level, family-friendliness,
+ * accessibility, and nearby destinations, and produces an explainable
+ * preference-based recommendation.
+ *
+ * "AI-powered" in the feature request is implemented here as transparent,
+ * explainable weighted scoring against user-stated preferences — the same
+ * honest framing trip-data.js already uses ("Rule-based, client-side
+ * only"). There's no model call; every score can be traced back to a
+ * specific preference weight and destination attribute, which also makes
+ * it something this module can unit test deterministically.
+ *
+ * Depends on `tripDestinations` (from trip-data.js) being loaded first,
+ * mirroring js-modules/trip-planner.js's dependency on the same dataset.
+ * Exposes window.DestinationComparison, loaded the same way trip-planner.js
+ * is (see app.js's route-based module loading).
+ */
+(function (root) {
+  "use strict";
+
+  const MAX_COMPARE = 4;
+  const NEARBY_RADIUS_KM = 200;
+  const NEARBY_LIMIT = 3;
+  const SAVED_COMPARISONS_KEY = "destinationComparisonSaved";
+
+  // ---------------------------------------------------------------------
+  // Geometry (mirrors TripPlanner.haversineDistanceKm — kept local so this
+  // module has no runtime dependency on trip-planner.js, only on the
+  // shared trip-data.js dataset).
+  // ---------------------------------------------------------------------
+  function haversineDistanceKm(lat1, lng1, lat2, lng2) {
+    const toRad = (deg) => (deg * Math.PI) / 180;
+    const R = 6371;
+    const dLat = toRad(lat2 - lat1);
+    const dLng = toRad(lng2 - lng1);
+    const a =
+      Math.sin(dLat / 2) ** 2 +
+      Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLng / 2) ** 2;
+    return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  }
+
+  // ---------------------------------------------------------------------
+  // Derived attributes
+  // ---------------------------------------------------------------------
+  // trip-data.js has no explicit weather/adventure/family/accessibility
+  // fields. Rather than inventing a large hand-curated dataset across all
+  // ~96 destinations, these are transparent heuristics derived from fields
+  // that already exist (categories, bestSeason, popularity, minDays). Each
+  // is documented here and in docs/DESTINATION_COMPARISON.md as an
+  // editorial approximation, not verified/live data.
+
+  const CLIMATE_BY_CATEGORY = {
+    desert: "Hot, dry days; cold nights",
+    mountains: "Cool to cold; snow possible in winter",
+    beaches: "Warm, humid, coastal",
+    backwaters: "Warm, humid, coastal",
+    wildlife: "Warm; varies by region and season",
+    spiritual: "Varies by region — check bestSeason",
+    historical: "Varies by region — check bestSeason",
+    heritage: "Varies by region — check bestSeason",
+    adventure: "Varies by region — check bestSeason",
+    city: "Varies by region — check bestSeason",
+  };
+  const CLIMATE_PRIORITY = ["desert", "mountains", "beaches", "backwaters", "wildlife"];
+
+  function estimateClimate(destination) {
+    const match = CLIMATE_PRIORITY.find((cat) => destination.categories.includes(cat));
+    return CLIMATE_BY_CATEGORY[match] || "Varies by region — check bestSeason";
+  }
+
+  // 1 (low) - 5 (high). Categories associated with physically demanding or
+  // outdoor-risk activity push this up; every destination starts at a
+  // baseline of 2 so a purely historical/spiritual city doesn't read as
+  // "zero adventure".
+  function estimateAdventureLevel(destination) {
+    let score = 2;
+    if (destination.categories.includes("adventure")) score += 2;
+    if (destination.categories.includes("mountains")) score += 1;
+    if (destination.categories.includes("desert")) score += 1;
+    if (destination.categories.includes("wildlife")) score += 1;
+    return Math.max(1, Math.min(5, score));
+  }
+
+  // 1 (low) - 5 (high). Categories with broad, low-physical-demand appeal
+  // score higher; pure high-adventure destinations score lower as a
+  // simple inverse of estimateAdventureLevel, nudged by category.
+  function estimateFamilyFriendliness(destination) {
+    let score = 3;
+    if (destination.categories.some((c) => ["historical", "heritage", "city", "spiritual"].includes(c))) score += 1;
+    if (destination.categories.includes("beaches")) score += 1;
+    if (destination.categories.includes("adventure")) score -= 1;
+    if (destination.categories.includes("desert")) score -= 1;
+    return Math.max(1, Math.min(5, score));
+  }
+
+  // 1 (remote) - 5 (very accessible). Proxy from popularity (well-known
+  // destinations tend to have better flight/rail connectivity in
+  // practice) and minDays (destinations worth only a short stop tend to
+  // sit closer to a hub than multi-day remote trips). Documented as a
+  // heuristic proxy, not a measured transit-time score.
+  function estimateAccessibility(destination) {
+    const popularityScore = destination.popularity / 2; // 0.5-5
+    const proximityBonus = destination.minDays <= 1 ? 1 : destination.minDays >= 3 ? -1 : 0;
+    return Math.max(1, Math.min(5, Math.round(popularityScore + proximityBonus)));
+  }
+
+  function findNearbyDestinations(destination, allDestinations) {
+    return allDestinations
+      .filter((d) => d.id !== destination.id)
+      .map((d) => ({ id: d.id, name: d.name, distanceKm: haversineDistanceKm(destination.lat, destination.lng, d.lat, d.lng) }))
+      .filter((d) => d.distanceKm <= NEARBY_RADIUS_KM)
+      .sort((a, b) => a.distanceKm - b.distanceKm)
+      .slice(0, NEARBY_LIMIT);
+  }
+
+  // ---------------------------------------------------------------------
+  // Comparison
+  // ---------------------------------------------------------------------
+  /**
+   * @param {string[]} ids - 1 to 4 destination ids
+   * @param {Array} [allDestinations] - defaults to global tripDestinations
+   * @param {string} [costTier="mid"] - "budget" | "mid" | "luxury"
+   */
+  function compareDestinations(ids, allDestinations, costTier) {
+    const pool = allDestinations || root.tripDestinations || [];
+    const tier = costTier || "mid";
+    if (!ids || ids.length === 0) {
+      throw new Error("Select at least one destination to compare.");
+    }
+    if (ids.length > MAX_COMPARE) {
+      throw new Error(`You can compare up to ${MAX_COMPARE} destinations at a time.`);
+    }
+
+    const rows = ids.map((id) => {
+      const destination = pool.find((d) => d.id === id);
+      if (!destination) throw new Error(`Unknown destination: ${id}`);
+      return {
+        id: destination.id,
+        name: destination.name,
+        state: destination.state,
+        bestTimeToVisit: destination.bestSeason,
+        estimatedBudgetPerDay: destination.costPerDay[tier] ?? destination.costPerDay.mid,
+        budgetTiers: destination.costPerDay,
+        popularAttractions: destination.highlights,
+        weather: estimateClimate(destination),
+        idealTripDuration: { minDays: destination.minDays, maxDays: destination.maxDays },
+        adventureLevel: estimateAdventureLevel(destination),
+        familyFriendliness: estimateFamilyFriendliness(destination),
+        accessibility: estimateAccessibility(destination),
+        nearbyDestinations: findNearbyDestinations(destination, pool),
+        userRating: destination.popularity,
+        description: destination.description,
+      };
+    });
+
+    return { costTier: tier, destinations: rows };
+  }
+
+  // ---------------------------------------------------------------------
+  // Preference-based recommendation
+  // ---------------------------------------------------------------------
+  // preferences: { budgetWeight, adventureWeight, familyWeight,
+  //                accessibilityWeight, maxBudgetPerDay, maxDays }
+  // Each weight is 0-5 (0 = don't care, 5 = very important). Missing
+  // weights default to 1 (mild default relevance) so a comparison with no
+  // stated preferences still produces a reasoned, if generic, pick.
+  function scoreDestination(row, preferences) {
+    const w = {
+      budget: preferences.budgetWeight ?? 1,
+      adventure: preferences.adventureWeight ?? 1,
+      family: preferences.familyWeight ?? 1,
+      accessibility: preferences.accessibilityWeight ?? 1,
+    };
+
+    const reasons = [];
+    let score = 0;
+
+    // Lower cost scores higher when budget matters; normalize against a
+    // generous ceiling so the score stays in a sane 0-5-ish range per term.
+    const budgetCeiling = preferences.maxBudgetPerDay || 15000;
+    const budgetFit = Math.max(0, 1 - row.estimatedBudgetPerDay / budgetCeiling) * 5;
+    score += budgetFit * w.budget;
+    if (w.budget >= 3 && budgetFit >= 3) reasons.push(`fits comfortably within your budget (~₹${row.estimatedBudgetPerDay}/day)`);
+
+    score += row.adventureLevel * w.adventure;
+    if (w.adventure >= 3 && row.adventureLevel >= 4) reasons.push("offers a high level of adventure activity");
+
+    score += row.familyFriendliness * w.family;
+    if (w.family >= 3 && row.familyFriendliness >= 4) reasons.push("is well suited to family travel");
+
+    score += row.accessibility * w.accessibility;
+    if (w.accessibility >= 3 && row.accessibility >= 4) reasons.push("is easy to reach");
+
+    if (preferences.maxDays && row.idealTripDuration.minDays <= preferences.maxDays) {
+      score += 3;
+      reasons.push(`fits within your ${preferences.maxDays}-day trip window`);
+    } else if (preferences.maxDays && row.idealTripDuration.minDays > preferences.maxDays) {
+      score -= 5;
+      reasons.push(`typically needs more than ${preferences.maxDays} day(s), longer than your window`);
+    }
+
+    // Small, transparent tie-breaker so the recommendation isn't silent
+    // about popularity when everything else is close.
+    score += row.userRating * 0.2;
+
+    return { score, reasons };
+  }
+
+  /**
+   * @param {Object} comparison - output of compareDestinations()
+   * @param {Object} [preferences]
+   * @returns {{ winner: Object, ranked: Array, explanation: string }}
+   */
+  function getRecommendation(comparison, preferences) {
+    const prefs = preferences || {};
+    const ranked = comparison.destinations
+      .map((row) => {
+        const { score, reasons } = scoreDestination(row, prefs);
+        return { ...row, score, reasons };
+      })
+      .sort((a, b) => b.score - a.score);
+
+    const winner = ranked[0];
+    const runnerUp = ranked[1];
+
+    let explanation;
+    if (!winner) {
+      explanation = "Add destinations to compare before requesting a recommendation.";
+    } else if (winner.reasons.length === 0) {
+      explanation = `${winner.name} is the best overall match based on your comparison — no single factor stands out sharply, but it scores most consistently well across your priorities.`;
+    } else {
+      explanation = `${winner.name} is the best match because it ${winner.reasons.join(", and ")}.`;
+    }
+    if (runnerUp && winner && Math.abs(winner.score - runnerUp.score) < 1) {
+      explanation += ` ${runnerUp.name} is a very close second — worth a second look if any single priority above matters more than the others.`;
+    }
+
+    return { winner, ranked, explanation };
+  }
+
+  // ---------------------------------------------------------------------
+  // Export comparison report
+  // ---------------------------------------------------------------------
+  function exportComparisonText(comparison, recommendation) {
+    const lines = ["Destination Comparison Report", ""];
+    comparison.destinations.forEach((row) => {
+      lines.push(`${row.name}, ${row.state}`);
+      lines.push(`  Best time to visit: ${row.bestTimeToVisit}`);
+      lines.push(`  Weather: ${row.weather}`);
+      lines.push(`  Estimated budget: ₹${row.estimatedBudgetPerDay}/day (${comparison.costTier} tier)`);
+      lines.push(`  Ideal trip duration: ${row.idealTripDuration.minDays}-${row.idealTripDuration.maxDays} days`);
+      lines.push(`  Adventure level: ${row.adventureLevel}/5`);
+      lines.push(`  Family friendliness: ${row.familyFriendliness}/5`);
+      lines.push(`  Accessibility: ${row.accessibility}/5`);
+      lines.push(`  Popular attractions: ${row.popularAttractions.join(", ")}`);
+      if (row.nearbyDestinations.length) {
+        lines.push(`  Nearby: ${row.nearbyDestinations.map((n) => `${n.name} (${n.distanceKm.toFixed(0)}km)`).join(", ")}`);
+      }
+      lines.push(`  Traveler popularity: ${row.userRating}/10`);
+      lines.push("");
+    });
+    if (recommendation) {
+      lines.push("Recommendation:");
+      lines.push(`  ${recommendation.explanation}`);
+    }
+    return lines.join("\n");
+  }
+
+  function exportComparisonJSON(comparison, recommendation) {
+    return JSON.stringify(
+      { generatedAt: new Date().toISOString(), costTier: comparison.costTier, destinations: comparison.destinations, recommendation: recommendation ? recommendation.explanation : null },
+      null,
+      2
+    );
+  }
+
+  // ---------------------------------------------------------------------
+  // Save comparisons for future reference (localStorage, same pattern as
+  // TripPlanner's SAVED_TRIPS_KEY — no backend in this project).
+  // ---------------------------------------------------------------------
+  function getStorage() {
+    try {
+      return typeof localStorage !== "undefined" ? localStorage : null;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  function getSavedComparisons() {
+    const storage = getStorage();
+    if (!storage) return [];
+    try {
+      return JSON.parse(storage.getItem(SAVED_COMPARISONS_KEY) || "[]");
+    } catch (e) {
+      return [];
+    }
+  }
+
+  function saveComparison(name, ids) {
+    const storage = getStorage();
+    const saved = getSavedComparisons();
+    const entry = { id: `cmp_${Date.now()}`, name: name || ids.join(" vs "), ids, savedAt: new Date().toISOString() };
+    const updated = [...saved, entry];
+    if (storage) storage.setItem(SAVED_COMPARISONS_KEY, JSON.stringify(updated));
+    return entry;
+  }
+
+  function deleteSavedComparison(entryId) {
+    const storage = getStorage();
+    const updated = getSavedComparisons().filter((c) => c.id !== entryId);
+    if (storage) storage.setItem(SAVED_COMPARISONS_KEY, JSON.stringify(updated));
+    return updated;
+  }
+
+  // ---------------------------------------------------------------------
+  root.DestinationComparison = {
+    MAX_COMPARE,
+    haversineDistanceKm,
+    estimateClimate,
+    estimateAdventureLevel,
+    estimateFamilyFriendliness,
+    estimateAccessibility,
+    findNearbyDestinations,
+    compareDestinations,
+    getRecommendation,
+    exportComparisonText,
+    exportComparisonJSON,
+    getSavedComparisons,
+    saveComparison,
+    deleteSavedComparison,
+  };
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = root.DestinationComparison;
+  }
+})(typeof window !== "undefined" ? window : globalThis);

--- a/tests/unit/destination-comparison-engine.test.js
+++ b/tests/unit/destination-comparison-engine.test.js
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// Load trip-data.js (shared destination dataset)
+const tripDataCode = readFileSync(resolve(__dirname, '../../trip-data.js'), 'utf-8');
+const getTripData = new Function(tripDataCode + '\nreturn { tripDestinations };');
+const { tripDestinations } = getTripData();
+globalThis.tripDestinations = tripDestinations;
+
+// Load destination-comparison-engine.js
+const engineCode = readFileSync(resolve(__dirname, '../../js-modules/destination-comparison-engine.js'), 'utf-8');
+new Function(engineCode)();
+const DestinationComparison = globalThis.DestinationComparison;
+
+describe('DestinationComparison: derived attributes', () => {
+  const agra = tripDestinations.find((d) => d.id === 'agra');
+  const manali = tripDestinations.find((d) => d.id === 'manali');
+  const jaisalmer = tripDestinations.find((d) => d.id === 'jaisalmer');
+
+  it('estimates climate from category, preferring the most climate-specific category', () => {
+    expect(DestinationComparison.estimateClimate(jaisalmer)).toMatch(/hot|dry/i);
+    expect(DestinationComparison.estimateClimate(manali)).toMatch(/cool|cold/i);
+  });
+
+  it('gives adventure-tagged, mountain destinations a higher adventure level than a historical city', () => {
+    expect(DestinationComparison.estimateAdventureLevel(manali)).toBeGreaterThan(DestinationComparison.estimateAdventureLevel(agra));
+  });
+
+  it('keeps every derived score within its documented 1-5 range', () => {
+    tripDestinations.forEach((d) => {
+      expect(DestinationComparison.estimateAdventureLevel(d)).toBeGreaterThanOrEqual(1);
+      expect(DestinationComparison.estimateAdventureLevel(d)).toBeLessThanOrEqual(5);
+      expect(DestinationComparison.estimateFamilyFriendliness(d)).toBeGreaterThanOrEqual(1);
+      expect(DestinationComparison.estimateFamilyFriendliness(d)).toBeLessThanOrEqual(5);
+      expect(DestinationComparison.estimateAccessibility(d)).toBeGreaterThanOrEqual(1);
+      expect(DestinationComparison.estimateAccessibility(d)).toBeLessThanOrEqual(5);
+    });
+  });
+
+  it('finds nearby destinations within the search radius, nearest first', () => {
+    const nearby = DestinationComparison.findNearbyDestinations(agra, tripDestinations);
+    for (let i = 1; i < nearby.length; i++) {
+      expect(nearby[i - 1].distanceKm).toBeLessThanOrEqual(nearby[i].distanceKm);
+    }
+    nearby.forEach((n) => expect(n.distanceKm).toBeLessThanOrEqual(200));
+    expect(nearby.some((n) => n.id === agra.id)).toBe(false); // never includes itself
+  });
+});
+
+describe('DestinationComparison: compareDestinations', () => {
+  it('compares 1 to 4 destinations and includes every required attribute', () => {
+    const result = DestinationComparison.compareDestinations(['agra', 'jaipur', 'manali', 'goa'], tripDestinations, 'mid');
+    expect(result.destinations).toHaveLength(4);
+    result.destinations.forEach((row) => {
+      expect(row).toHaveProperty('bestTimeToVisit');
+      expect(row).toHaveProperty('estimatedBudgetPerDay');
+      expect(row).toHaveProperty('popularAttractions');
+      expect(row).toHaveProperty('weather');
+      expect(row).toHaveProperty('idealTripDuration');
+      expect(row).toHaveProperty('adventureLevel');
+      expect(row).toHaveProperty('familyFriendliness');
+      expect(row).toHaveProperty('accessibility');
+      expect(row).toHaveProperty('nearbyDestinations');
+      expect(row).toHaveProperty('userRating');
+    });
+  });
+
+  it('rejects more than four destinations', () => {
+    expect(() =>
+      DestinationComparison.compareDestinations(['agra', 'jaipur', 'manali', 'goa', 'shimla'], tripDestinations)
+    ).toThrow(/up to 4/);
+  });
+
+  it('rejects an empty selection', () => {
+    expect(() => DestinationComparison.compareDestinations([], tripDestinations)).toThrow(/at least one/i);
+  });
+
+  it('rejects an unknown destination id', () => {
+    expect(() => DestinationComparison.compareDestinations(['not-a-real-place'], tripDestinations)).toThrow(/unknown destination/i);
+  });
+
+  it('reflects the requested cost tier in estimatedBudgetPerDay', () => {
+    const budget = DestinationComparison.compareDestinations(['agra'], tripDestinations, 'budget').destinations[0];
+    const luxury = DestinationComparison.compareDestinations(['agra'], tripDestinations, 'luxury').destinations[0];
+    expect(budget.estimatedBudgetPerDay).toBeLessThan(luxury.estimatedBudgetPerDay);
+  });
+
+  it('updates dynamically — recomparing with a different destination set changes the result, not a cached one', () => {
+    const first = DestinationComparison.compareDestinations(['agra'], tripDestinations);
+    const second = DestinationComparison.compareDestinations(['manali'], tripDestinations);
+    expect(first.destinations[0].name).not.toBe(second.destinations[0].name);
+  });
+});
+
+describe('DestinationComparison: getRecommendation', () => {
+  it('recommends the cheaper destination when budget is weighted heavily and nothing else is', () => {
+    const comparison = DestinationComparison.compareDestinations(['udaipur', 'haridwar'], tripDestinations, 'mid');
+    const rec = DestinationComparison.getRecommendation(comparison, { budgetWeight: 5, adventureWeight: 0, familyWeight: 0, accessibilityWeight: 0 });
+    expect(rec.winner.id).toBe('haridwar'); // cheaper per-day cost in trip-data.js
+  });
+
+  it('recommends the more adventurous destination when adventure is weighted heavily and nothing else is', () => {
+    const comparison = DestinationComparison.compareDestinations(['agra', 'manali'], tripDestinations, 'mid');
+    const rec = DestinationComparison.getRecommendation(comparison, { budgetWeight: 0, adventureWeight: 5, familyWeight: 0, accessibilityWeight: 0 });
+    expect(rec.winner.id).toBe('manali');
+  });
+
+  it('produces a human-readable explanation naming the winning destination', () => {
+    const comparison = DestinationComparison.compareDestinations(['jaipur', 'shimla'], tripDestinations, 'mid');
+    const rec = DestinationComparison.getRecommendation(comparison, { familyWeight: 4 });
+    expect(rec.explanation).toContain(rec.winner.name);
+  });
+
+  it('penalizes destinations that need longer than the stated trip window', () => {
+    const comparison = DestinationComparison.compareDestinations(['haridwar', 'lakshadweep'], tripDestinations, 'mid');
+    const rec = DestinationComparison.getRecommendation(comparison, { maxDays: 1 });
+    const lakshadweepRow = rec.ranked.find((r) => r.id === 'lakshadweep');
+    expect(lakshadweepRow.reasons.join(' ')).toMatch(/longer than your window/);
+  });
+
+  it('handles an empty comparison gracefully instead of throwing', () => {
+    const comparison = { costTier: 'mid', destinations: [] };
+    const rec = DestinationComparison.getRecommendation(comparison, {});
+    expect(rec.winner).toBeUndefined();
+    expect(rec.explanation).toMatch(/add destinations/i);
+  });
+});
+
+describe('DestinationComparison: export', () => {
+  const comparison = DestinationComparison.compareDestinations(['agra', 'jaipur'], tripDestinations, 'mid');
+  const recommendation = DestinationComparison.getRecommendation(comparison, { budgetWeight: 3 });
+
+  it('exportComparisonText includes every compared destination and the recommendation', () => {
+    const text = DestinationComparison.exportComparisonText(comparison, recommendation);
+    expect(text).toContain('Agra');
+    expect(text).toContain('Jaipur');
+    expect(text).toContain(recommendation.winner.name);
+  });
+
+  it('exportComparisonJSON produces valid, parseable JSON with matching destination count', () => {
+    const json = DestinationComparison.exportComparisonJSON(comparison, recommendation);
+    const parsed = JSON.parse(json);
+    expect(parsed.destinations).toHaveLength(2);
+    expect(parsed.recommendation).toContain(recommendation.winner.name);
+  });
+});
+
+describe('DestinationComparison: saved comparisons (localStorage)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('starts with no saved comparisons', () => {
+    expect(DestinationComparison.getSavedComparisons()).toEqual([]);
+  });
+
+  it('saves a comparison and retrieves it later', () => {
+    const entry = DestinationComparison.saveComparison('Rajasthan trip', ['jaipur', 'jodhpur', 'udaipur']);
+    const saved = DestinationComparison.getSavedComparisons();
+    expect(saved).toHaveLength(1);
+    expect(saved[0].id).toBe(entry.id);
+    expect(saved[0].ids).toEqual(['jaipur', 'jodhpur', 'udaipur']);
+  });
+
+  it('deletes a saved comparison by id', () => {
+    const entry = DestinationComparison.saveComparison('Hills trip', ['shimla', 'manali']);
+    DestinationComparison.deleteSavedComparison(entry.id);
+    expect(DestinationComparison.getSavedComparisons()).toEqual([]);
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description
Adds an Intelligent Destination Comparison Tool. Previously users could
only browse destinations one at a time — no way to compare options
side by side before deciding where to go.

This adds a `destination-comparison-engine.js` module (reusing the
existing `trip-data.js` dataset of ~96 destinations) plus a new
Destination Comparison page that lets users:
- Compare up to 4 destinations across best time to visit, budget,
  attractions, weather, ideal trip duration, adventure level, family
  friendliness, accessibility, nearby destinations, and traveler
  popularity
- Set preference weights (budget/adventure/family/accessibility priority
  + max trip length) and get a personalized recommendation with a plain-
  language explanation of *why* that destination won
- Export the comparison as a downloadable `.txt` report
- Save a comparison to `localStorage` and reload it later

The recommendation is transparent, deterministic weighted scoring against
stated preferences — not a model call — consistent with `trip-data.js`'s
own "rule-based, client-side only" description. Every claim in the
explanation traces back to a specific score component, which is also why
it's fully unit-testable without network calls or fixtures.

Where `trip-data.js` doesn't have a field (weather, adventure level,
family-friendliness, accessibility), it's derived transparently from
fields that do exist (`categories`, `popularity`, `minDays`) and
documented as an editorial heuristic, not measured data — see
`docs/DESTINATION_COMPARISON.md` for the full breakdown per attribute.

Fixes #863

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?
- [x] Tested locally in browser
- [ ] Tested in both dark and light themes
- [ ] Tested at mobile viewport widths
- [x] Verified no console errors
- [x] Automated tests: 20 new vitest unit tests in
      `tests/unit/destination-comparison-engine.test.js`, run via
      `npx vitest run` — covers derived-attribute ranges, nearby-search
      correctness, the 4-destination cap and input validation, cost-tier
      sensitivity, live recalculation on itinerary change,
      preference-driven recommendation correctness, trip-length
      penalties, empty-comparison handling, export completeness, and
      save/load/delete against localStorage. Full existing suite
      (632 tests) still passes — no regressions.

## Checklist
- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [ ] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)


## Notes for reviewers
- The comparison grid uses a responsive CSS card layout (wraps per
  viewport) rather than a `<table>`, specifically so it holds up at
  mobile widths without a horizontal-scroll workaround — still worth an
  actual visual check before merging.
- Derived attributes (weather/adventure/family/accessibility) are
  heuristics, not verified per-destination data — flagged clearly in
  code comments and in `docs/DESTINATION_COMPARISON.md` so this doesn't
  get mistaken for sourced data later.
- The page follows the standalone-page pattern (`route-planner.html`,
  `island-explorer/index.html`) rather than the SPA router
  (`js-modules/router-init.js`) that `trip-planner.html` uses — both
  patterns already coexist in this codebase; noted in the docs in case a
  reviewer expects router-init.js integration instead.