### PR TITLE
feat: add Rajaji National Park Explorer with interactive map, wildlif…

### DIFF
--- a/frontend/national-parks-explorer/data.js
+++ b/frontend/national-parks-explorer/data.js
@@ -6,6 +6,27 @@
 
 const NATIONAL_PARKS = [
     {
+        id: 'rajaji',
+        name: 'Rajaji National Park',
+        state: 'Uttarakhand',
+        stateId: 'uk',
+        established: 1983,
+        area: 820,
+        areaUnit: 'km²',
+        type: 'Tiger Reserve',
+        isTigerReserve: true,
+        isUNESCO: false,
+        description: 'Spread across the Shivalik Hills, Rajaji is famous for its large population of Asian elephants and diverse Shivalik ecosystem. It was formed by merging three sanctuaries.',
+        keyFauna: ['Asian Elephant', 'Bengal Tiger', 'Leopard', 'Himalayan Black Bear', 'Sambar'],
+        keyFlora: ['Sal Forest', 'Shisham', 'Khair', 'Tall Grasslands'],
+        coordinates: { lat: 30.05, lng: 78.15 },
+        climate: 'Subtropical',
+        bestTime: 'November to June',
+        entryFee: '₹150 (Indian), ₹600 (Foreign)',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/Elephants_in_Rajaji_National_Park.jpg/960px-Elephants_in_Rajaji_National_Park.jpg',
+        explorerUrl: '../rajaji-national-park-explorer/index.html'
+    },
+    {
         id: 'jim-corbett',
         name: 'Jim Corbett National Park',
         state: 'Uttarakhand',

--- a/frontend/rajaji-national-park-explorer/index.html
+++ b/frontend/rajaji-national-park-explorer/index.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script>
+    (function() {
+      const theme = localStorage.getItem('theme') || 'dark';
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Explore Rajaji National Park in Uttarakhand — a vital elephant corridor and tiger reserve nestled in the Shivalik Hills." />
+  <title>Rajaji National Park Explorer | Incredible India</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="../../styles.css" />
+  <link rel="stylesheet" href="rajaji.css" />
+  <meta property="og:title" content="Rajaji National Park Explorer | Incredible India" />
+  <meta property="og:description" content="Interactive guide to Rajaji National Park, Uttarakhand — home to Asian elephants, Bengal tigers, and the majestic Shivalik ecosystem." />
+  <meta property="og:type" content="website" />
+</head>
+<body class="rajaji-main">
+  <header class="navbar scrolled" id="navbar">
+    <div class="nav-container">
+      <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+        <span class="saffron">Incredible</span> <span class="gold">India</span> <span class="green">Explorer</span>
+      </a>
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+        <span class="bar"></span><span class="bar"></span><span class="bar"></span>
+      </button>
+      <nav class="nav-menu" id="nav-menu">
+        <a href="../../index.html#home" class="nav-link">Home</a>
+        <a href="../national-parks-explorer/index.html" class="nav-link">National Parks</a>
+        <a href="index.html" class="nav-link active" style="color: var(--saffron)">Rajaji Explorer</a>
+        <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">☀️</button>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="rajaji-hero">
+      <div class="section-container">
+        <h1>Rajaji <span>National Park</span> Explorer</h1>
+        <p class="hero-subtitle">
+          Immerse yourself in the Shivalik foothills of Uttarakhand. Rajaji is a vital elephant corridor,
+          a thriving tiger reserve, and a sanctuary of rich biodiversity where the Ganga river meets the forest.
+        </p>
+        <div id="stats-grid" class="stats-grid"></div>
+      </div>
+    </section>
+
+    <section class="section-container">
+      <div class="section-header">
+        <span class="section-badge">Heritage</span>
+        <h2>History & Conservation</h2>
+        <p class="section-subtitle">From separate sanctuaries to a unified tiger reserve, tracing the journey of Rajaji.</p>
+      </div>
+      <div id="history-timeline" class="timeline-container"></div>
+    </section>
+
+    <section class="section-container" style="background: rgba(5, 150, 105, 0.05); border-radius: 24px;">
+      <div class="section-header">
+        <span class="section-badge">Megafauna</span>
+        <h2>Wildlife of Rajaji</h2>
+        <p class="section-subtitle">Home to the majestic Asian elephant, elusive Bengal tiger, and diverse Shivalik fauna.</p>
+      </div>
+      <div id="wildlife-grid" class="wildlife-grid"></div>
+    </section>
+
+    <section class="section-container">
+      <div class="section-header">
+        <span class="section-badge">Avian Life</span>
+        <h2>Bird Species</h2>
+        <p class="section-subtitle">Over 315 species of resident and migratory birds call the Rajaji forests home.</p>
+      </div>
+      <div id="birds-grid" class="birds-grid"></div>
+    </section>
+
+    <section class="section-container">
+      <div class="section-header">
+        <span class="section-badge">Hydrology</span>
+        <h2>Rivers & Waterways</h2>
+        <p class="section-subtitle">The lifeblood of the park, shaping the landscape and sustaining its wildlife.</p>
+      </div>
+      <div id="rivers-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); gap: 1.5rem;"></div>
+    </section>
+
+    <section class="section-container">
+      <div class="section-header">
+        <span class="section-badge">Experience</span>
+        <h2>Safari Options</h2>
+        <p class="section-subtitle">Explore the wilderness through guided jeep safaris in the Chilla and Motichur ranges.</p>
+      </div>
+      <div id="safari-grid" style="display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 2rem;"></div>
+    </section>
+
+    <section class="section-container">
+      <div class="section-header">
+        <span class="section-badge">Geography</span>
+        <h2>Interactive Map</h2>
+        <p class="section-subtitle">Click on the map pins to explore key entry points and wildlife corridors.</p>
+      </div>
+      <div class="glass-card" style="padding: 1.5rem;">
+        <div class="map-svg-container">
+          <svg class="park-map-svg" viewBox="0 0 1000 600" xmlns="http://www.w3.org/2000/svg" style="width:100%; display:block;">
+            <rect width="1000" height="600" fill="var(--rajaji-bg)" />
+            <path d="M100,150 Q400,50 800,150 L850,500 L150,500 Z" fill="rgba(5, 150, 105, 0.1)" stroke="var(--rajaji-accent)" stroke-width="2" />
+            <path d="M50,200 Q300,300 600,250 T950,350" fill="none" stroke="#3b82f6" stroke-width="30" opacity="0.4" />
+            <text x="400" y="280" fill="#60a5fa" font-size="16" font-family="Outfit">Ganga River Corridor</text>
+          </svg>
+          <div id="map-hotspots-layer"></div>
+          <div id="map-info-popup" class="map-info-popup hidden"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-container">
+      <div class="section-header">
+        <span class="section-badge">Visuals</span>
+        <h2>Photo Gallery</h2>
+        <p class="section-subtitle">Glimpses of the elephants, rivers, and Shivalik landscapes of Rajaji.</p>
+      </div>
+      <div id="gallery-grid" class="gallery-grid"></div>
+    </section>
+  </main>
+
+  <div id="lightbox-modal" class="lightbox-modal hidden" role="dialog" aria-modal="true" aria-label="Photo Lightbox">
+    <div class="lightbox-content">
+      <button type="button" id="lightbox-close" class="lightbox-close" aria-label="Close Lightbox">&times;</button>
+      <img id="lightbox-img" class="lightbox-img" src="" alt="Gallery Preview" />
+      <div id="lightbox-caption" class="lightbox-caption"></div>
+    </div>
+  </div>
+
+  <footer class="footer" style="margin-top: 4rem; border-top: 1px solid var(--rajaji-border); padding: 3rem 1.5rem; text-align: center; color: var(--rajaji-muted);">
+    <p>&copy; 2026 Incredible India Explorer. Rajaji National Park Explorer.</p>
+  </footer>
+
+  <script src="../../app.js" defer></script>
+  <script src="rajaji-data.js" defer></script>
+  <script src="rajaji.js" defer></script>
+  <script type="module" src="../../auth.js"></script>
+</body>
+</html>

--- a/frontend/rajaji-national-park-explorer/rajaji-data.js
+++ b/frontend/rajaji-national-park-explorer/rajaji-data.js
@@ -1,0 +1,191 @@
+/**
+ * Rajaji National Park Explorer — Data Module
+ * Comprehensive dataset covering History, Elephant Reserve, Shivalik Hills,
+ * Wildlife, Rivers, Bird Species, Safari, Interactive Map, and Gallery.
+ */
+
+const RAJAJI_INFO = {
+  id: "rajaji",
+  name: "Rajaji National Park",
+  aka: "Rajaji Tiger Reserve",
+  location: "Haridwar, Dehradun & Pauri Garhwal Districts, Uttarakhand, India",
+  state: "Uttarakhand",
+  coordinates: { lat: 30.05, lng: 78.15 },
+  area: "820.42 km² (Core: 560.42 km², Buffer: 260 km²)",
+  establishedYear: 1983,
+  tigerReserveYear: 2015,
+  etymology: "Named after C. Rajagopalachari (popularly known as Rajaji), the first Indian Governor-General of independent India and a prominent freedom fighter.",
+  climate: "Subtropical with hot summers and cold winters. Annual rainfall ~2000 mm.",
+  bestTime: "Mid-November to Mid-June (Park closed during monsoon)",
+  entryFees: "₹150 (Indian Nationals), ₹600 (Foreigners), Vehicle entry extra.",
+  nearestTransport: {
+    railway: "Haridwar Junction (10 km from Chilla entry)",
+    airport: "Jolly Grant Airport, Dehradun (35 km)",
+    gatewayTown: "Haridwar / Dehradun"
+  },
+  quickStats: [
+    { label: "Asian Elephants", value: "400+", icon: "🐘" },
+    { label: "Tiger Reserve", value: "Since 2015", icon: "🐅" },
+    { label: "Total Area", value: "820 km²", icon: "🌲" },
+    { label: "Bird Species", value: "315+", icon: "🦅" },
+    { label: "Mammal Species", value: "50+", icon: "🦌" },
+    { label: "Elevation", value: "300m - 1200m", icon: "⛰️" }
+  ]
+};
+
+const HISTORY = [
+  {
+    year: "1948",
+    title: "Motichur Sanctuary Established",
+    description: "The Motichur area was first declared a wildlife sanctuary to protect the depleting wildlife populations in the Shivalik foothills."
+  },
+  {
+    year: "1976",
+    title: "Rajaji & Chilla Sanctuaries",
+    description: "The Rajaji and Chilla areas were subsequently notified as separate wildlife sanctuaries, recognizing the ecological continuity of the region."
+  },
+  {
+    year: "1983",
+    title: "Formation of Rajaji National Park",
+    description: "The three sanctuaries (Rajaji, Motichur, and Chilla) were merged to form the Rajaji National Park, named after the freedom fighter C. Rajagopalachari."
+  },
+  {
+    year: "2015",
+    title: "Declared a Tiger Reserve",
+    description: "Owing to its growing tiger population and critical elephant corridor status, it was officially notified as the Rajaji Tiger Reserve under Project Tiger."
+  }
+];
+
+const WILDLIFE = [
+  {
+    id: "wild-elephant",
+    name: "Asian Elephant",
+    scientificName: "Elephas maximus",
+    status: "Endangered",
+    icon: "🐘",
+    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/Elephants_in_Rajaji_National_Park.jpg/800px-Elephants_in_Rajaji_National_Park.jpg",
+    description: "Rajaji hosts one of the highest densities of Asian elephants in northern India, serving as a vital corridor between the Shivaliks and the Himalayas."
+  },
+  {
+    id: "wild-tiger",
+    name: "Bengal Tiger",
+    scientificName: "Panthera tigris tigris",
+    status: "Endangered",
+    icon: "🐅",
+    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fe/Royal_Bengal_Tiger_at_Nandankanan.jpg/800px-Royal_Bengal_Tiger_at_Nandankanan.jpg",
+    description: "The park has seen a steady increase in its tiger population, with camera traps regularly capturing images of tigers roaming the sal forests."
+  },
+  {
+    id: "wild-bear",
+    name: "Himalayan Black Bear",
+    scientificName: "Ursus thibetanus",
+    status: "Vulnerable",
+    icon: "🐻",
+    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/9/90/Asian_black_bear.jpg/800px-Asian_black_bear.jpg",
+    description: "Often spotted foraging for fruits and insects in the higher altitudes of the park, especially during the summer months."
+  }
+];
+
+const BIRD_SPECIES = [
+  {
+    id: "bird-hornbill",
+    name: "Great Hornbill",
+    scientificName: "Buceros bicornis",
+    status: "Vulnerable",
+    icon: "🦜",
+    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6f/Great_Hornbill.jpg/800px-Great_Hornbill.jpg",
+    description: "A magnificent bird with a massive casque on its beak, often heard before it is seen in the dense canopy of the sal forests."
+  },
+  {
+    id: "bird-pheasant",
+    name: "Kalij Pheasant",
+    scientificName: "Lophura leucomelanos",
+    status: "Least Concern",
+    icon: "🐦",
+    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Kalij_Pheasant.jpg/800px-Kalij_Pheasant.jpg",
+    description: "The state bird of Uttarakhand, frequently seen foraging on the forest floor in the undergrowth of Rajaji."
+  }
+];
+
+const RIVERS = [
+  {
+    name: "Ganga River",
+    description: "Forms the western boundary of the park. The riverine ecosystems support marsh crocodiles and provide vital water sources for wildlife."
+  },
+  {
+    name: "Song River",
+    description: "Flows through the heart of the Chilla range, creating beautiful pebble beds and shallow pools used by elephants for bathing."
+  },
+  {
+    name: "Chilla Stream",
+    description: "A seasonal tributary that swells during the monsoon, carving deep ravines and supporting unique riparian vegetation."
+  }
+];
+
+const SAFARI_OPTIONS = [
+  {
+    id: "safari-chilla",
+    title: "Chilla Range Jeep Safari",
+    duration: "2.5 – 3 hours",
+    timing: "6:00 AM – 9:00 AM & 3:00 PM – 6:00 PM",
+    cost: "₹3,000 per vehicle (up to 6 persons)",
+    capacity: "6 persons per gypsy",
+    zones: "Chilla Range (Motichur to Ranipur)",
+    highlights: [
+      "Highest probability of elephant sightings",
+      "Scenic drive alongside the Song River",
+      "Dense sal forest canopy coverage",
+      "Excellent birdwatching opportunities"
+    ],
+    description: "The most popular safari route, offering a perfect blend of riverine landscapes and dense forest, ideal for spotting elephants, deer, and occasionally tigers."
+  }
+];
+
+const MAP_HOTSPOTS = [
+  {
+    id: "spot-chilla",
+    name: "Chilla Range Entry",
+    category: "gate",
+    x: 40,
+    y: 50,
+    description: "Main entry point for safaris, featuring the interpretation center and forest rest house."
+  },
+  {
+    id: "spot-motichur",
+    name: "Motichur Gate",
+    category: "gate",
+    x: 60,
+    y: 60,
+    description: "Southern entry point, known for its proximity to the Ganga riverbed and high elephant movement."
+  },
+  {
+    id: "spot-ganga",
+    name: "Ganga River Corridor",
+    category: "water",
+    x: 25,
+    y: 40,
+    description: "Critical wildlife corridor and watering hole, especially active during early mornings."
+  }
+];
+
+const GALLERY_IMAGES = [
+  {
+    url: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/Elephants_in_Rajaji_National_Park.jpg/800px-Elephants_in_Rajaji_National_Park.jpg",
+    title: "Elephant Herd",
+    caption: "A family herd of Asian elephants crossing the Song riverbed in the Chilla range."
+  },
+  {
+    url: "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8c/Shivalik_Hills_Uttarakhand.jpg/800px-Shivalik_Hills_Uttarakhand.jpg",
+    title: "Shivalik Foothills",
+    caption: "The majestic Shivalik hills forming the northern backdrop of the national park."
+  },
+  {
+    url: "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2a/Ganga_River_Haridwar.jpg/800px-Ganga_River_Haridwar.jpg",
+    title: "Ganga River",
+    caption: "The holy Ganga river forming the natural western boundary of the reserve."
+  }
+];
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { RAJAJI_INFO, HISTORY, WILDLIFE, BIRD_SPECIES, RIVERS, SAFARI_OPTIONS, MAP_HOTSPOTS, GALLERY_IMAGES };
+}

--- a/frontend/rajaji-national-park-explorer/rajaji.css
+++ b/frontend/rajaji-national-park-explorer/rajaji.css
@@ -1,0 +1,342 @@
+/**
+ * Rajaji National Park Explorer — Stylesheet
+ * Supports both dark and light themes using CSS variables.
+ */
+
+:root {
+  --rajaji-bg-dark: #0f172a;
+  --rajaji-bg-light: #f8fafc;
+  --rajaji-card-dark: rgba(30, 41, 59, 0.8);
+  --rajaji-card-light: rgba(255, 255, 255, 0.9);
+  --rajaji-text-dark: #e2e8f0;
+  --rajaji-text-light: #1e293b;
+  --rajaji-muted-dark: #94a3b8;
+  --rajaji-muted-light: #64748b;
+  --rajaji-accent: #059669; /* Forest Green */
+  --rajaji-accent-bright: #10b981;
+  --rajaji-border-dark: rgba(255, 255, 255, 0.1);
+  --rajaji-border-light: rgba(0, 0, 0, 0.1);
+}
+
+body.light-theme {
+  --rajaji-bg: var(--rajaji-bg-light);
+  --rajaji-card: var(--rajaji-card-light);
+  --rajaji-text: var(--rajaji-text-light);
+  --rajaji-muted: var(--rajaji-muted-light);
+  --rajaji-border: var(--rajaji-border-light);
+}
+
+body:not(.light-theme) {
+  --rajaji-bg: var(--rajaji-bg-dark);
+  --rajaji-card: var(--rajaji-card-dark);
+  --rajaji-text: var(--rajaji-text-dark);
+  --rajaji-muted: var(--rajaji-muted-dark);
+  --rajaji-border: var(--rajaji-border-dark);
+}
+
+.rajaji-main {
+  background-color: var(--rajaji-bg);
+  color: var(--rajaji-text);
+  font-family: 'Outfit', sans-serif;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.section-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 4rem 1.5rem;
+}
+
+.section-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.section-badge {
+  display: inline-block;
+  padding: 0.4rem 1rem;
+  background: rgba(5, 150, 105, 0.15);
+  color: var(--rajaji-accent-bright);
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.section-header h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  color: var(--rajaji-text);
+}
+
+.section-subtitle {
+  font-size: 1.1rem;
+  color: var(--rajaji-muted);
+  max-width: 700px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.glass-card {
+  background: var(--rajaji-card);
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--rajaji-border);
+  border-radius: 16px;
+  padding: 2rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.glass-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+}
+
+/* Hero Section */
+.rajaji-hero {
+  padding: 6rem 1.5rem 4rem;
+  text-align: center;
+  background: linear-gradient(rgba(15, 23, 42, 0.7), rgba(15, 23, 42, 0.9)),
+              url('https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/Elephants_in_Rajaji_National_Park.jpg/1200px-Elephants_in_Rajaji_National_Park.jpg') center/cover no-repeat;
+}
+
+body.light-theme .rajaji-hero {
+  background: linear-gradient(rgba(248, 250, 252, 0.8), rgba(248, 250, 252, 0.95)),
+              url('https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/Elephants_in_Rajaji_National_Park.jpg/1200px-Elephants_in_Rajaji_National_Park.jpg') center/cover no-repeat;
+}
+
+.rajaji-hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: 3.5rem;
+  margin-bottom: 1.5rem;
+  color: var(--rajaji-text);
+}
+
+.rajaji-hero h1 span {
+  color: var(--rajaji-accent-bright);
+}
+
+.hero-subtitle {
+  font-size: 1.2rem;
+  color: var(--rajaji-muted);
+  max-width: 800px;
+  margin: 0 auto 3rem;
+  line-height: 1.7;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1.5rem;
+  margin-top: 3rem;
+}
+
+.stat-card {
+  text-align: center;
+  padding: 1.5rem 1rem;
+}
+
+.stat-icon {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.stat-value {
+  display: block;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--rajaji-accent-bright);
+}
+
+.stat-label {
+  font-size: 0.85rem;
+  color: var(--rajaji-muted);
+}
+
+/* Wildlife & Bird Grids */
+.wildlife-grid, .birds-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 2rem;
+}
+
+.wildlife-card img, .bird-card img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  border-radius: 12px;
+  margin-bottom: 1rem;
+}
+
+/* Timeline */
+.timeline-container {
+  position: relative;
+  max-width: 800px;
+  margin: 0 auto;
+  padding-left: 2rem;
+}
+
+.timeline-container::before {
+  content: '';
+  position: absolute;
+  left: 8px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--rajaji-accent);
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: 2.5rem;
+  padding-left: 2rem;
+}
+
+.timeline-dot {
+  position: absolute;
+  left: -1.6rem;
+  top: 0.5rem;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--rajaji-accent-bright);
+  border: 3px solid var(--rajaji-bg);
+}
+
+/* Map */
+.map-svg-container {
+  position: relative;
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+  border-radius: 16px;
+  overflow: hidden;
+  background: var(--rajaji-card);
+}
+
+.map-hotspot-pin {
+  position: absolute;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 2px solid var(--rajaji-accent-bright);
+  background: var(--rajaji-card);
+  font-size: 1.2rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform: translate(-50%, -50%);
+  transition: transform 0.2s ease;
+}
+
+.map-hotspot-pin:hover {
+  transform: translate(-50%, -50%) scale(1.2);
+}
+
+.map-info-popup {
+  position: absolute;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--rajaji-card);
+  border: 1px solid var(--rajaji-border);
+  border-radius: 12px;
+  padding: 1rem 1.5rem;
+  max-width: 300px;
+  text-align: center;
+  backdrop-filter: blur(8px);
+}
+
+.hidden {
+  display: none !important;
+}
+
+/* Gallery */
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.5rem;
+}
+
+.gallery-item {
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  cursor: pointer;
+  height: 220px;
+}
+
+.gallery-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.4s ease;
+}
+
+.gallery-item:hover .gallery-img {
+  transform: scale(1.05);
+}
+
+.gallery-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 1rem;
+  background: linear-gradient(transparent, rgba(0, 0, 0, 0.8));
+  color: white;
+}
+
+/* Lightbox */
+.lightbox-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.95);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 2rem;
+}
+
+.lightbox-content {
+  position: relative;
+  max-width: 900px;
+  text-align: center;
+}
+
+.lightbox-close {
+  position: absolute;
+  top: -3rem;
+  right: 0;
+  background: none;
+  border: none;
+  color: white;
+  font-size: 2.5rem;
+  cursor: pointer;
+}
+
+.lightbox-img {
+  max-width: 100%;
+  max-height: 70vh;
+  border-radius: 12px;
+}
+
+.lightbox-caption {
+  margin-top: 1rem;
+  color: #cbd5e1;
+  font-size: 1rem;
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .rajaji-hero h1 { font-size: 2.5rem; }
+  .section-header h2 { font-size: 2rem; }
+  .stats-grid { grid-template-columns: repeat(2, 1fr); }
+}

--- a/frontend/rajaji-national-park-explorer/rajaji.js
+++ b/frontend/rajaji-national-park-explorer/rajaji.js
@@ -1,0 +1,228 @@
+/**
+ * Rajaji National Park Explorer — Interactive Logic
+ * Handles DOM rendering, theme toggling, and interactive map/gallery features.
+ */
+
+(function() {
+  'use strict';
+
+  document.addEventListener('DOMContentLoaded', function() {
+    initTheme();
+    renderQuickStats();
+    renderHistory();
+    renderWildlife();
+    renderBirdSpecies();
+    renderRivers();
+    renderSafariOptions();
+    renderInteractiveMap();
+    renderGalleryGrid();
+    bindEvents();
+  });
+
+  function initTheme() {
+    const savedTheme = localStorage.getItem('theme') || 'dark';
+    if (savedTheme === 'light') {
+      document.body.classList.add('light-theme');
+    }
+  }
+
+  function bindEvents() {
+    const themeBtn = document.getElementById('theme-toggle');
+    if (themeBtn) {
+      themeBtn.addEventListener('click', function() {
+        document.body.classList.toggle('light-theme');
+        const isLight = document.body.classList.contains('light-theme');
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        themeBtn.textContent = isLight ? '🌙' : '☀️';
+      });
+    }
+
+    const lbClose = document.getElementById('lightbox-close');
+    if (lbClose) lbClose.addEventListener('click', closeLightbox);
+
+    const lbModal = document.getElementById('lightbox-modal');
+    if (lbModal) {
+      lbModal.addEventListener('click', function(e) {
+        if (e.target === lbModal) closeLightbox();
+      });
+    }
+
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape') closeLightbox();
+    });
+  }
+
+  function renderQuickStats() {
+    const container = document.getElementById('stats-grid');
+    if (!container || typeof RAJAJI_INFO === 'undefined') return;
+
+    let html = '';
+    RAJAJI_INFO.quickStats.forEach(function(st) {
+      html += `
+        <div class="glass-card stat-card">
+          <div class="stat-icon">${st.icon}</div>
+          <span class="stat-value">${st.value}</span>
+          <span class="stat-label">${st.label}</span>
+        </div>`;
+    });
+    container.innerHTML = html;
+  }
+
+  function renderHistory() {
+    const container = document.getElementById('history-timeline');
+    if (!container || typeof HISTORY === 'undefined') return;
+
+    let html = '';
+    HISTORY.forEach(function(item) {
+      html += `
+        <div class="timeline-item">
+          <div class="timeline-dot"></div>
+          <div class="glass-card">
+            <div style="font-weight:800; font-size:1.2rem; color:var(--rajaji-accent-bright); margin-bottom:0.4rem;">${item.year}</div>
+            <h4 style="margin-bottom:0.5rem;">${item.title}</h4>
+            <p style="font-size:0.92rem; color:var(--rajaji-muted); line-height:1.6;">${item.description}</p>
+          </div>
+        </div>`;
+    });
+    container.innerHTML = html;
+  }
+
+  function renderWildlife() {
+    const container = document.getElementById('wildlife-grid');
+    if (!container || typeof WILDLIFE === 'undefined') return;
+
+    let html = '';
+    WILDLIFE.forEach(function(w) {
+      html += `
+        <div class="glass-card wildlife-card">
+          <img src="${w.image}" alt="${w.name}" loading="lazy" onerror="this.style.display='none'">
+          <h3 style="font-size:1.3rem; margin-bottom:0.2rem;">${w.icon} ${w.name}</h3>
+          <div style="font-style:italic; font-size:0.85rem; color:var(--rajaji-accent-bright); margin-bottom:0.8rem;">${w.scientificName}</div>
+          <span style="display:inline-block; padding:0.2rem 0.6rem; background:rgba(220,38,38,0.2); color:#f87171; border-radius:999px; font-size:0.75rem; font-weight:700; margin-bottom:0.8rem;">${w.status}</span>
+          <p style="font-size:0.9rem; color:var(--rajaji-muted); line-height:1.5;">${w.description}</p>
+        </div>`;
+    });
+    container.innerHTML = html;
+  }
+
+  function renderBirdSpecies() {
+    const container = document.getElementById('birds-grid');
+    if (!container || typeof BIRD_SPECIES === 'undefined') return;
+
+    let html = '';
+    BIRD_SPECIES.forEach(function(b) {
+      html += `
+        <div class="glass-card bird-card">
+          <img src="${b.image}" alt="${b.name}" loading="lazy" onerror="this.style.display='none'">
+          <h3 style="font-size:1.2rem; margin-bottom:0.2rem;">${b.icon} ${b.name}</h3>
+          <div style="font-style:italic; font-size:0.82rem; color:var(--rajaji-accent-bright); margin-bottom:0.8rem;">${b.scientificName}</div>
+          <p style="font-size:0.88rem; color:var(--rajaji-muted); line-height:1.5;">${b.description}</p>
+        </div>`;
+    });
+    container.innerHTML = html;
+  }
+
+  function renderRivers() {
+    const container = document.getElementById('rivers-grid');
+    if (!container || typeof RIVERS === 'undefined') return;
+
+    let html = '';
+    RIVERS.forEach(function(r) {
+      html += `
+        <div class="glass-card" style="border-left: 4px solid var(--rajaji-accent);">
+          <h3 style="font-size:1.2rem; margin-bottom:0.5rem; color:var(--rajaji-accent-bright);">💧 ${r.name}</h3>
+          <p style="font-size:0.9rem; color:var(--rajaji-muted); line-height:1.5;">${r.description}</p>
+        </div>`;
+    });
+    container.innerHTML = html;
+  }
+
+  function renderSafariOptions() {
+    const container = document.getElementById('safari-grid');
+    if (!container || typeof SAFARI_OPTIONS === 'undefined') return;
+
+    let html = '';
+    SAFARI_OPTIONS.forEach(function(s) {
+      let highlightsHtml = s.highlights.map(h => `<li>✨ <span>${h}</span></li>`).join('');
+      html += `
+        <div class="glass-card">
+          <h3 style="font-size:1.4rem; color:var(--rajaji-accent-bright); margin-bottom:0.5rem;">${s.title}</h3>
+          <p style="font-size:0.9rem; color:var(--rajaji-muted); margin-bottom:1rem;">${s.description}</p>
+          <div style="display:grid; grid-template-columns:1fr 1fr; gap:0.5rem; font-size:0.85rem;">
+            <div><strong>⏱ Duration:</strong> ${s.duration}</div>
+            <div><strong>🕐 Timings:</strong> ${s.timing}</div>
+            <div><strong>💰 Cost:</strong> ${s.cost}</div>
+            <div><strong>👥 Capacity:</strong> ${s.capacity}</div>
+          </div>
+          <ul style="list-style:none; padding:0; margin-top:1rem; font-size:0.85rem; color:var(--rajaji-muted);">
+            ${highlightsHtml}
+          </ul>
+        </div>`;
+    });
+    container.innerHTML = html;
+  }
+
+  function renderInteractiveMap() {
+    const container = document.getElementById('map-hotspots-layer');
+    const infoPopup = document.getElementById('map-info-popup');
+    if (!container || typeof MAP_HOTSPOTS === 'undefined') return;
+
+    let html = '';
+    MAP_HOTSPOTS.forEach(function(spot) {
+      const icon = spot.category === 'gate' ? '🚪' : spot.category === 'water' ? '💧' : '📍';
+      html += `<button type="button" class="map-hotspot-pin" style="left:${spot.x}%; top:${spot.y}%;" data-spot-id="${spot.id}" aria-label="${spot.name}">${icon}</button>`;
+    });
+    container.innerHTML = html;
+
+    container.querySelectorAll('.map-hotspot-pin').forEach(function(pin) {
+      pin.addEventListener('click', function() {
+        const spot = MAP_HOTSPOTS.find(s => s.id === pin.dataset.spotId);
+        if (spot && infoPopup) {
+          infoPopup.innerHTML = `<h4 style="color:var(--rajaji-accent-bright); margin-bottom:0.3rem;">${spot.name}</h4><p style="font-size:0.85rem; color:var(--rajaji-muted);">${spot.description}</p>`;
+          infoPopup.classList.remove('hidden');
+        }
+      });
+    });
+  }
+
+  function renderGalleryGrid() {
+    const container = document.getElementById('gallery-grid');
+    if (!container || typeof GALLERY_IMAGES === 'undefined') return;
+
+    let html = '';
+    GALLERY_IMAGES.forEach(function(img, idx) {
+      html += `
+        <div class="gallery-item" data-idx="${idx}">
+          <img class="gallery-img" src="${img.url}" alt="${img.title}" loading="lazy">
+          <div class="gallery-overlay">
+            <h4 style="margin-bottom:0.2rem;">${img.title}</h4>
+            <p style="font-size:0.8rem; opacity:0.9;">${img.caption}</p>
+          </div>
+        </div>`;
+    });
+    container.innerHTML = html;
+
+    container.querySelectorAll('.gallery-item').forEach(function(item) {
+      item.addEventListener('click', function() {
+        openLightbox(parseInt(item.dataset.idx, 10));
+      });
+    });
+  }
+
+  function openLightbox(idx) {
+    if (typeof GALLERY_IMAGES === 'undefined' || !GALLERY_IMAGES[idx]) return;
+    const modal = document.getElementById('lightbox-modal');
+    const imgEl = document.getElementById('lightbox-img');
+    const capEl = document.getElementById('lightbox-caption');
+    if (!modal || !imgEl || !capEl) return;
+
+    imgEl.src = GALLERY_IMAGES[idx].url;
+    capEl.textContent = GALLERY_IMAGES[idx].title + ' — ' + GALLERY_IMAGES[idx].caption;
+    modal.classList.remove('hidden');
+  }
+
+  function closeLightbox() {
+    const modal = document.getElementById('lightbox-modal');
+    if (modal) modal.classList.add('hidden');
+  }
+})();


### PR DESCRIPTION

# Pull Request

## Description

This PR implements the Rajaji National Park Explorer as requested in issue #918. It adds a comprehensive, interactive educational page covering history, elephant reserve status, Shivalik Hills geography, wildlife, rivers, bird species, safari options, an interactive map, and a photo gallery. It also integrates the park into the main National Parks Explorer landing page.

Fixes #918 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Tested locally in browser
- [x] Tested in both dark and light themes
- [x] Tested at mobile viewport widths
- [x] Verified no console errors

## Checklist

- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Rajaji National Park Explorer page.
  * Explore park history, wildlife, birds, rivers, safari options, map hotspots, and photo galleries.
  * Added interactive map markers and a gallery lightbox for viewing images.
  * Added dark and light theme support with saved preferences.
  * Added Rajaji National Park to the broader national parks data and filtering experience.
  * Added responsive layouts for mobile and desktop viewing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->