### PR TITLE
feat: Create Kavaratti Island Explorer

### DIFF
--- a/frontend/car-nicobar-island/car-nicobar-island.css
+++ b/frontend/car-nicobar-island/car-nicobar-island.css
@@ -1,0 +1,411 @@
+/* ============================================================
+   Car Nicobar Explorer — car-nicobar-island.css
+   Uses the shared design tokens defined in ../../styles.css
+   ============================================================ */
+
+.car-nicobar-page {
+  padding-top: var(--navbar-height);
+  overflow-x: hidden;
+}
+
+.car-nicobar-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* ---------- Hero ---------- */
+.car-nicobar-hero {
+  position: relative;
+  padding: 90px 24px 70px;
+  text-align: center;
+  background:
+    linear-gradient(180deg, rgba(4, 23, 42, 0.55) 0%, rgba(4, 23, 42, 0.92) 100%),
+    url("../../assets/travel_beaches.png") center/cover no-repeat;
+}
+
+.car-nicobar-hero-content {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.car-nicobar-hero-kicker {
+  display: inline-block;
+  padding: 6px 16px;
+  border-radius: 999px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  color: var(--primary-saffron);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-bottom: 20px;
+}
+
+.car-nicobar-hero h1 {
+  font-family: var(--font-heading);
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  line-height: 1.15;
+  margin-bottom: 18px;
+  color: var(--text-light);
+}
+
+.car-nicobar-hero h1 span {
+  background: var(--gradient-saffron-gold);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.car-nicobar-hero p {
+  color: var(--text-secondary);
+  font-size: 1.08rem;
+  line-height: 1.7;
+  margin-bottom: 36px;
+}
+
+.car-nicobar-hero-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+
+.car-nicobar-stat-box {
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 18px 12px;
+  transition: var(--transition-snappy);
+}
+
+.car-nicobar-stat-box:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-glow);
+}
+
+.car-nicobar-stat-box strong {
+  display: block;
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--primary-saffron);
+}
+
+.car-nicobar-stat-box span {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+/* ---------- Section heading ---------- */
+.car-nicobar-section {
+  padding: 70px 0;
+}
+
+.car-nicobar-section-heading {
+  text-align: center;
+  max-width: 680px;
+  margin: 0 auto 44px;
+}
+
+.car-nicobar-section-badge {
+  display: inline-block;
+  color: var(--primary-gold);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+
+.car-nicobar-section-heading h2 {
+  font-family: var(--font-heading);
+  font-size: clamp(1.7rem, 3.5vw, 2.4rem);
+  color: var(--text-light);
+  margin-bottom: 14px;
+}
+
+.car-nicobar-section-heading p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+/* ---------- Tabs (Geography / Culture / Coconut Plantations / Economy / Beaches / History) ---------- */
+.car-nicobar-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  margin-bottom: 32px;
+}
+
+.car-nicobar-tab-btn {
+  padding: 10px 20px;
+  border-radius: 999px;
+  border: 1px solid var(--glass-border);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: var(--transition-snappy);
+}
+
+.car-nicobar-tab-btn:hover {
+  border-color: var(--primary-saffron);
+  color: var(--text-light);
+}
+
+.car-nicobar-tab-btn.active {
+  background: var(--gradient-saffron-gold);
+  color: #1a1200;
+  border-color: transparent;
+  font-weight: 600;
+}
+
+.car-nicobar-tab-panel {
+  display: none;
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 32px;
+  animation: car-nicobar-fade-in 0.3s ease;
+}
+
+.car-nicobar-tab-panel.active {
+  display: block;
+}
+
+@keyframes car-nicobar-fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.car-nicobar-tab-panel h3 {
+  font-family: var(--font-heading);
+  color: var(--primary-gold);
+  margin-bottom: 14px;
+  font-size: 1.3rem;
+}
+
+.car-nicobar-tab-panel p {
+  color: var(--text-secondary);
+  line-height: 1.8;
+  margin-bottom: 14px;
+}
+
+.car-nicobar-tab-panel ul {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.car-nicobar-tab-panel ul li {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  padding-left: 24px;
+  position: relative;
+  line-height: 1.6;
+}
+
+.car-nicobar-tab-panel ul li::before {
+  content: "🥥";
+  position: absolute;
+  left: 0;
+}
+
+/* ---------- Map ---------- */
+.car-nicobar-map-wrap {
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow-soft);
+}
+
+#car-nicobar-map {
+  height: 440px;
+  width: 100%;
+  background: var(--bg-dark-deep);
+}
+
+/* ---------- Gallery ---------- */
+.car-nicobar-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 18px;
+}
+
+.car-nicobar-gallery-item {
+  margin: 0;
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+  cursor: pointer;
+  border: 1px solid var(--glass-border);
+  transition: var(--transition-snappy);
+  position: relative;
+}
+
+.car-nicobar-gallery-item:hover {
+  transform: translateY(-4px);
+  border-color: var(--primary-saffron);
+  box-shadow: var(--shadow-glow);
+}
+
+.car-nicobar-gallery-item img {
+  width: 100%;
+  height: 190px;
+  object-fit: cover;
+  display: block;
+}
+
+.car-nicobar-gallery-item figcaption {
+  padding: 10px 14px;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  background: var(--bg-dark-card);
+}
+
+/* ---------- Lightbox ---------- */
+.car-nicobar-lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 10, 20, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 24px;
+}
+
+.car-nicobar-lightbox-overlay[hidden] {
+  display: none;
+}
+
+.car-nicobar-lightbox-content {
+  max-width: 800px;
+  width: 100%;
+  text-align: center;
+  position: relative;
+}
+
+.car-nicobar-lightbox-content img {
+  width: 100%;
+  max-height: 65vh;
+  object-fit: contain;
+  border-radius: var(--border-radius-lg);
+}
+
+.car-nicobar-lightbox-caption {
+  color: var(--text-light);
+  margin-top: 14px;
+  font-size: 0.95rem;
+}
+
+.car-nicobar-lightbox-close {
+  position: absolute;
+  top: -44px;
+  right: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-light);
+  font-size: 1.4rem;
+  cursor: pointer;
+}
+
+.car-nicobar-lightbox-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-light);
+  font-size: 1.3rem;
+  cursor: pointer;
+}
+
+.car-nicobar-lightbox-nav.prev { left: -20px; }
+.car-nicobar-lightbox-nav.next { right: -20px; }
+
+/* ---------- Did You Know ---------- */
+.car-nicobar-fact-panel {
+  max-width: 760px;
+  margin: 0 auto;
+  background: var(--gradient-card-border);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 40px 36px;
+  text-align: center;
+}
+
+.car-nicobar-fact-icon {
+  font-size: 2.2rem;
+  margin-bottom: 14px;
+}
+
+#car-nicobar-fact-text {
+  font-family: var(--font-heading);
+  font-size: 1.15rem;
+  color: var(--text-light);
+  line-height: 1.6;
+  transition: opacity 0.2s ease;
+  min-height: 84px;
+}
+
+.car-nicobar-fact-dots {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.car-nicobar-fact-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+  background: var(--glass-border);
+  cursor: pointer;
+  transition: var(--transition-snappy);
+}
+
+.car-nicobar-fact-dot.active {
+  background: var(--primary-saffron);
+  width: 22px;
+  border-radius: 4px;
+}
+
+/* ---------- Back to Islands link ---------- */
+.car-nicobar-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--primary-saffron);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 14px;
+}
+
+.car-nicobar-back-link:hover {
+  text-decoration: underline;
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 768px) {
+  .car-nicobar-hero-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  #car-nicobar-map {
+    height: 320px;
+  }
+
+  .car-nicobar-lightbox-nav.prev { left: 4px; }
+  .car-nicobar-lightbox-nav.next { right: 4px; }
+}

--- a/frontend/car-nicobar-island/car-nicobar-island.html
+++ b/frontend/car-nicobar-island/car-nicobar-island.html
@@ -1,0 +1,286 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Explore Car Nicobar — the most populated island in the Nicobar group, home to the Nicobarese people, coconut plantations, sandy beaches and a rich cultural history.">
+    <title>Car Nicobar Explorer | Incredible India</title>
+    <link rel="icon" href="data:,">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="car-nicobar-island.css">
+
+    <!-- Open Graph / Social Media Tags -->
+    <meta property="og:title" content="Car Nicobar Explorer | Incredible India Explorer">
+    <meta property="og:description" content="Geography, culture, coconut plantations, economy, beaches and history of Car Nicobar.">
+    <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/assets/travel_beaches.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/car-nicobar-island/car-nicobar-island.html">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Incredible India Explorer">
+    <meta property="og:locale" content="en_IN">
+
+    <!-- Twitter Card Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Car Nicobar Explorer | Incredible India Explorer">
+    <meta name="twitter:description" content="Geography, culture, coconut plantations, economy, beaches and history of Car Nicobar.">
+    <meta name="twitter:image" content="https://incredibleindiaexplorer.gov.in/assets/travel_beaches.png">
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/car-nicobar-island/car-nicobar-island.html">
+</head>
+
+<body class="car-nicobar-body">
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html#home" class="nav-link" id="link-home">Home</a>
+                <a href="../../index.html#map" class="nav-link" id="link-map">Interactive Map</a>
+                <a href="../islands/islands.html" class="nav-link">Islands</a>
+                <a href="car-nicobar-island.html" class="nav-link active" style="color: var(--saffron)">Car Nicobar</a>
+
+                <div class="nav-dropdown">
+                    <button class="nav-link dropdown-toggle" id="link-explore-more">
+                        Explore More ▾
+                    </button>
+                    <div class="dropdown-menu">
+                        <a href="../travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                        <a href="../wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                        <a href="../coastal-india/coastal-india.html" class="dropdown-item">Coastal India</a>
+                        <a href="../heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    </div>
+                </div>
+
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
+                    ☀️
+                </button>
+                <a href="../../login.html" class="nav-link" id="link-login">Login</a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="car-nicobar-page">
+        <!-- Hero -->
+        <section class="car-nicobar-hero">
+            <div class="car-nicobar-hero-content">
+                <a href="../islands/islands.html" class="car-nicobar-back-link">← Back to Islands of India</a>
+                <span class="car-nicobar-hero-kicker">🥥 Land of Coconut Groves & the Nicobarese</span>
+                <h1>Car <span>Nicobar</span></h1>
+                <p>A flat, coral-fringed island and the administrative headquarters of the Nicobar district — home to the largest Nicobarese population, sweeping coconut plantations, quiet beaches and a distinct island culture.</p>
+
+                <div class="car-nicobar-hero-stats">
+                    <div class="car-nicobar-stat-box">
+                        <strong>~127 sq km</strong>
+                        <span>Total Land Area</span>
+                    </div>
+                    <div class="car-nicobar-stat-box">
+                        <strong>Malacca</strong>
+                        <span>Administrative Headquarters</span>
+                    </div>
+                    <div class="car-nicobar-stat-box">
+                        <strong>15+</strong>
+                        <span>Traditional Villages</span>
+                    </div>
+                    <div class="car-nicobar-stat-box">
+                        <strong>Nicobarese</strong>
+                        <span>Indigenous Community</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Tabbed info -->
+        <section class="car-nicobar-section" id="car-nicobar-explore">
+            <div class="car-nicobar-container">
+                <div class="car-nicobar-section-heading">
+                    <span class="car-nicobar-section-badge">Explore Car Nicobar</span>
+                    <h2>Geography, Culture &amp; Everyday Life</h2>
+                    <p>Select a tab to learn more.</p>
+                </div>
+
+                <div class="car-nicobar-tabs" role="tablist">
+                    <button type="button" class="car-nicobar-tab-btn active" data-tab="geography">Geography</button>
+                    <button type="button" class="car-nicobar-tab-btn" data-tab="culture">Culture</button>
+                    <button type="button" class="car-nicobar-tab-btn" data-tab="coconut">Coconut Plantations</button>
+                    <button type="button" class="car-nicobar-tab-btn" data-tab="economy">Economy</button>
+                    <button type="button" class="car-nicobar-tab-btn" data-tab="beaches">Beaches</button>
+                    <button type="button" class="car-nicobar-tab-btn" data-tab="history">History</button>
+                </div>
+
+                <div class="car-nicobar-tab-panel active" id="tab-geography">
+                    <h3>🗺️ Geography</h3>
+                    <p>Car Nicobar is a low-lying, roughly oval island in the northern Nicobar group, unlike the hillier, forested islands further south. Its flat terrain and sandy soil are ringed by coral reefs and fringing beaches.</p>
+                    <p>Malacca, on the island's western coast, serves as the administrative headquarters of the Nicobar district, connecting the island to Port Blair by air and sea.</p>
+                    <ul>
+                        <li>Flat, low-lying island in the northern Nicobar group</li>
+                        <li>Surrounded by coral reefs and sandy beaches</li>
+                        <li>Malacca is the Nicobar district's administrative headquarters</li>
+                    </ul>
+                </div>
+
+                <div class="car-nicobar-tab-panel" id="tab-culture">
+                    <h3>🎎 Culture</h3>
+                    <p>Car Nicobar is home to the largest population of the Nicobarese, an indigenous community with their own language, customs and communal way of life organised around villages rather than individual land ownership.</p>
+                    <p>Traditional round or oval huts on stilts, communal feasts, and the annual Ossuary Feast (a ceremony honouring ancestors) are central to Nicobarese cultural life, alongside more recent Christian influences introduced in the 19th century.</p>
+                    <ul>
+                        <li>Home to the largest Nicobarese population in the islands</li>
+                        <li>Traditional stilt huts and community-based village life</li>
+                        <li>Ossuary Feast honouring ancestors is a key cultural event</li>
+                    </ul>
+                </div>
+
+                <div class="car-nicobar-tab-panel" id="tab-coconut">
+                    <h3>🥥 Coconut Plantations</h3>
+                    <p>Coconut palms dominate the island's landscape, planted in dense groves that shape both its scenery and its economy. Nearly every household is connected to coconut cultivation in some way, whether for food, oil or trade.</p>
+                    <p>Copra (dried coconut kernel) production has traditionally been a mainstay of the local economy, with coconut products used in cooking, construction and craftwork across Nicobarese villages.</p>
+                    <ul>
+                        <li>Dense coconut groves cover much of the island</li>
+                        <li>Copra production is a long-standing local industry</li>
+                        <li>Coconut products used in food, construction and crafts</li>
+                    </ul>
+                </div>
+
+                <div class="car-nicobar-tab-panel" id="tab-economy">
+                    <h3>💰 Economy</h3>
+                    <p>Alongside coconut and copra production, the island's economy includes fishing, small-scale agriculture, and government services centred around Malacca, since the island hosts key administrative offices for the Nicobar district.</p>
+                    <p>An Indian Air Force base on the island also contributes to local employment and infrastructure, while sea and air links to Port Blair support trade and the movement of goods and people.</p>
+                    <ul>
+                        <li>Coconut, copra production and fishing form the traditional economy</li>
+                        <li>Government offices in Malacca support local employment</li>
+                        <li>Indian Air Force base contributes to infrastructure and jobs</li>
+                    </ul>
+                </div>
+
+                <div class="car-nicobar-tab-panel" id="tab-beaches">
+                    <h3>🏖️ Beaches</h3>
+                    <p>Car Nicobar's coastline features quiet, coral-fringed beaches such as those near Malacca and Kakana, with calm, shallow waters that reflect the island's flat, sheltered geography.</p>
+                    <p>Traditional hodi (dugout canoe) races are held along the coast during local festivals, combining the island's beach culture with its seafaring traditions.</p>
+                    <ul>
+                        <li>Coral-fringed beaches near Malacca and Kakana</li>
+                        <li>Calm, shallow coastal waters</li>
+                        <li>Traditional hodi boat races held during festivals</li>
+                    </ul>
+                </div>
+
+                <div class="car-nicobar-tab-panel" id="tab-history">
+                    <h3>📜 History</h3>
+                    <p>Car Nicobar has long been inhabited by the Nicobarese, with historical trade contacts across the Bay of Bengal. Danish and later British administrations established a presence in the wider Nicobar Islands from the 18th and 19th centuries onward.</p>
+                    <p>Christian missionary activity from the 1800s introduced significant cultural and religious change, while the island later became part of independent India's Union Territory of Andaman & Nicobar Islands, retaining strong Nicobarese self-governance in village affairs.</p>
+                    <ul>
+                        <li>Long history of Nicobarese settlement and regional trade</li>
+                        <li>Danish and British colonial contact from the 18th-19th centuries</li>
+                        <li>Part of the Andaman & Nicobar Union Territory since Indian independence</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <!-- Interactive Map -->
+        <section class="car-nicobar-section" id="car-nicobar-map-section">
+            <div class="car-nicobar-container">
+                <div class="car-nicobar-section-heading">
+                    <span class="car-nicobar-section-badge">Interactive Map</span>
+                    <h2>Key Locations Around Car Nicobar</h2>
+                    <p>Click a marker to learn about that location.</p>
+                </div>
+                <div class="car-nicobar-map-wrap">
+                    <div id="car-nicobar-map"></div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Image Gallery -->
+        <section class="car-nicobar-section" id="car-nicobar-gallery-section">
+            <div class="car-nicobar-container">
+                <div class="car-nicobar-section-heading">
+                    <span class="car-nicobar-section-badge">Image Gallery</span>
+                    <h2>Glimpses of Car Nicobar</h2>
+                    <p>Click an image to view it larger.</p>
+                </div>
+                <div id="car-nicobar-gallery-grid" class="car-nicobar-gallery-grid"></div>
+            </div>
+        </section>
+
+        <!-- Interesting Facts -->
+        <section class="car-nicobar-section">
+            <div class="car-nicobar-container">
+                <div class="car-nicobar-section-heading">
+                    <span class="car-nicobar-section-badge">Did You Know?</span>
+                    <h2>Interesting Facts</h2>
+                </div>
+                <div class="car-nicobar-fact-panel">
+                    <div class="car-nicobar-fact-icon">💡</div>
+                    <p id="car-nicobar-fact-text">Loading fact...</p>
+                    <div class="car-nicobar-fact-dots" id="car-nicobar-fact-dots"></div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <!-- Lightbox -->
+    <div class="car-nicobar-lightbox-overlay" id="car-nicobar-lightbox" hidden>
+        <div class="car-nicobar-lightbox-content">
+            <button class="car-nicobar-lightbox-close" data-close-lightbox="true" aria-label="Close">&times;</button>
+            <button class="car-nicobar-lightbox-nav prev" id="car-nicobar-lightbox-prev" aria-label="Previous image">‹</button>
+            <img id="car-nicobar-lightbox-image" src="" alt="">
+            <button class="car-nicobar-lightbox-nav next" id="car-nicobar-lightbox-next" aria-label="Next image">›</button>
+            <p class="car-nicobar-lightbox-caption" id="car-nicobar-lightbox-caption"></p>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <footer class="site-footer">
+        <div class="footer-container">
+            <div class="footer-brand">
+                <a href="../../index.html#home" class="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <p>Preserving and celebrating India's rich island territories, coastlines and culture.</p>
+            </div>
+            <div class="footer-links">
+                <h4>Quick Links</h4>
+                <a href="../../index.html#home">Home</a>
+                <a href="../islands/islands.html">Islands of India</a>
+                <a href="../wildlife/wildlife.html">Nature & Wildlife</a>
+                <a href="car-nicobar-island.html">Car Nicobar</a>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2026 Incredible India Explorer. Open Source Cultural Heritage Initiative.</p>
+        </div>
+    </footer>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+    <script type="module" src="car-nicobar-island.js"></script>
+    <script src="../../pages-common.js"></script>
+</body>
+</html>

--- a/frontend/car-nicobar-island/car-nicobar-island.js
+++ b/frontend/car-nicobar-island/car-nicobar-island.js
@@ -1,0 +1,207 @@
+/* ============================================================
+   Car Nicobar Explorer — car-nicobar-island.js
+   Handles: tab navigation, image gallery lightbox, facts
+   rotator, and the Leaflet map with key-location markers.
+   ============================================================ */
+
+// ---------- 1. KEY LOCATIONS FOR THE MAP ----------
+const CAR_NICOBAR_LOCATIONS = [
+  {
+    name: "Malacca",
+    lat: 9.2167,
+    lng: 92.7833,
+    description: "The administrative headquarters of the Nicobar district, on the island's western coast."
+  },
+  {
+    name: "Car Nicobar Airport",
+    lat: 9.1533,
+    lng: 92.8172,
+    description: "The island's air link to Port Blair, shared with the Indian Air Force base."
+  },
+  {
+    name: "Kakana Village",
+    lat: 9.2000,
+    lng: 92.7500,
+    description: "A traditional Nicobarese village known for its coconut groves and coastal beaches."
+  },
+  {
+    name: "Mus Village",
+    lat: 9.2333,
+    lng: 92.7667,
+    description: "One of the island's well-known traditional villages, rebuilt after the 2004 tsunami."
+  }
+];
+
+// ---------- 2. IMAGE GALLERY ----------
+const CAR_NICOBAR_GALLERY = [
+  { src: "../../assets/travel_beaches.png", caption: "Quiet coral-fringed beaches near Malacca" },
+  { src: "../../assets/travel_islands.png", caption: "Coconut groves covering much of the island" },
+  { src: "../../assets/travel_hidden.png", caption: "A traditional Nicobarese village" },
+  { src: "../../assets/travel_forests.png", caption: "Palm-lined shores of Car Nicobar" }
+];
+
+// ---------- 3. INTERESTING FACTS ----------
+const CAR_NICOBAR_FACTS = [
+  "Car Nicobar has the largest Nicobarese population of any island in the Nicobar group.",
+  "Coconut plantations cover much of the island and have long supported its copra-based economy.",
+  "Malacca serves as the administrative headquarters of the Nicobar district.",
+  "The Ossuary Feast, honouring ancestors, is one of the most important Nicobarese cultural events.",
+  "Traditional hodi (dugout canoe) races are held along the coast during local festivals.",
+  "Christian missionary activity from the 1800s brought significant cultural change to the island."
+];
+
+// ---------- 4. STATE ----------
+let map;
+let currentGalleryIndex = 0;
+let factIndex = 0;
+
+// ---------- 5. DOM READY ----------
+document.addEventListener("DOMContentLoaded", () => {
+  initTabs();
+  initGallery();
+  initFactsRotator();
+  initMap();
+  initLightbox();
+});
+
+// ---------- 6. TAB NAVIGATION ----------
+function initTabs() {
+  const tabButtons = document.querySelectorAll(".car-nicobar-tab-btn");
+  const tabPanels = document.querySelectorAll(".car-nicobar-tab-panel");
+
+  tabButtons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const target = btn.getAttribute("data-tab");
+
+      tabButtons.forEach((b) => b.classList.remove("active"));
+      btn.classList.add("active");
+
+      tabPanels.forEach((panel) => {
+        panel.classList.toggle("active", panel.id === "tab-" + target);
+      });
+    });
+  });
+}
+
+// ---------- 7. IMAGE GALLERY ----------
+function initGallery() {
+  const galleryGrid = document.getElementById("car-nicobar-gallery-grid");
+  if (!galleryGrid) return;
+
+  galleryGrid.innerHTML = "";
+  CAR_NICOBAR_GALLERY.forEach((item, index) => {
+    const fig = document.createElement("figure");
+    fig.className = "car-nicobar-gallery-item";
+    fig.innerHTML = `
+      <img src="${item.src}" alt="${item.caption}" loading="lazy">
+      <figcaption>${item.caption}</figcaption>
+    `;
+    fig.addEventListener("click", () => openLightbox(index));
+    galleryGrid.appendChild(fig);
+  });
+}
+
+// ---------- 8. LIGHTBOX ----------
+function initLightbox() {
+  document.querySelectorAll("[data-close-lightbox]").forEach((el) => {
+    el.addEventListener("click", closeLightbox);
+  });
+  const prevBtn = document.getElementById("car-nicobar-lightbox-prev");
+  const nextBtn = document.getElementById("car-nicobar-lightbox-next");
+  if (prevBtn) prevBtn.addEventListener("click", () => showGalleryImage(currentGalleryIndex - 1));
+  if (nextBtn) nextBtn.addEventListener("click", () => showGalleryImage(currentGalleryIndex + 1));
+
+  document.addEventListener("keydown", (e) => {
+    const lightbox = document.getElementById("car-nicobar-lightbox");
+    if (!lightbox || lightbox.hidden) return;
+    if (e.key === "Escape") closeLightbox();
+    if (e.key === "ArrowRight") showGalleryImage(currentGalleryIndex + 1);
+    if (e.key === "ArrowLeft") showGalleryImage(currentGalleryIndex - 1);
+  });
+}
+
+function openLightbox(index) {
+  const lightbox = document.getElementById("car-nicobar-lightbox");
+  if (!lightbox) return;
+  lightbox.hidden = false;
+  document.body.style.overflow = "hidden";
+  showGalleryImage(index);
+}
+
+function closeLightbox() {
+  const lightbox = document.getElementById("car-nicobar-lightbox");
+  if (!lightbox) return;
+  lightbox.hidden = true;
+  document.body.style.overflow = "";
+}
+
+function showGalleryImage(index) {
+  const total = CAR_NICOBAR_GALLERY.length;
+  currentGalleryIndex = (index + total) % total;
+  const item = CAR_NICOBAR_GALLERY[currentGalleryIndex];
+  const img = document.getElementById("car-nicobar-lightbox-image");
+  const caption = document.getElementById("car-nicobar-lightbox-caption");
+  if (img) img.src = item.src;
+  if (img) img.alt = item.caption;
+  if (caption) caption.textContent = item.caption;
+}
+
+// ---------- 9. FACTS ROTATOR ----------
+function initFactsRotator() {
+  const factEl = document.getElementById("car-nicobar-fact-text");
+  const dotsWrap = document.getElementById("car-nicobar-fact-dots");
+  if (!factEl) return;
+
+  if (dotsWrap) {
+    CAR_NICOBAR_FACTS.forEach((_, i) => {
+      const dot = document.createElement("button");
+      dot.className = "car-nicobar-fact-dot" + (i === 0 ? " active" : "");
+      dot.setAttribute("aria-label", "Show fact " + (i + 1));
+      dot.addEventListener("click", () => showFact(i));
+      dotsWrap.appendChild(dot);
+    });
+  }
+
+  function showFact(i) {
+    factIndex = i;
+    factEl.style.opacity = "0";
+    setTimeout(() => {
+      factEl.textContent = CAR_NICOBAR_FACTS[factIndex];
+      factEl.style.opacity = "1";
+    }, 200);
+    if (dotsWrap) {
+      [...dotsWrap.children].forEach((dot, di) => dot.classList.toggle("active", di === factIndex));
+    }
+  }
+
+  showFact(0);
+  setInterval(() => showFact((factIndex + 1) % CAR_NICOBAR_FACTS.length), 6000);
+}
+
+// ---------- 10. LEAFLET MAP ----------
+function initMap() {
+  const mapContainer = document.getElementById("car-nicobar-map");
+  if (!mapContainer || typeof L === "undefined") return;
+
+  map = L.map("car-nicobar-map", {
+    scrollWheelZoom: false,
+    minZoom: 6,
+  }).setView([9.19, 92.79], 10);
+
+  L.tileLayer("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png", {
+    attribution: "&copy; OpenStreetMap contributors &copy; CARTO",
+    maxZoom: 18,
+  }).addTo(map);
+
+  CAR_NICOBAR_LOCATIONS.forEach((loc) => {
+    const marker = L.circleMarker([loc.lat, loc.lng], {
+      radius: 8,
+      color: "#ff9933",
+      fillColor: "#ffb01f",
+      fillOpacity: 0.85,
+      weight: 2,
+    }).addTo(map);
+
+    marker.bindPopup(`<strong>${loc.name}</strong><br>${loc.description}`);
+  });
+}

--- a/frontend/islands/islands.js
+++ b/frontend/islands/islands.js
@@ -169,10 +169,23 @@ highlights: ["Extinct volcanic cone rising steeply from the sea", "Endemic Narco
     islandCount: "36 islands",
     tagline: "India's smallest Union Territory",
     description: "A cluster of 36 coral islands and atolls scattered in the Arabian Sea off the Kerala coast. Built entirely from coral deposits, the islands are ringed by turquoise lagoons and are among the most pristine coral reef ecosystems in India.",
-    highlights: ["Kavaratti — administrative capital", "Agatti coral lagoon", "Bangaram atoll", "Minicoy — largest island in the group"],
+highlights: ["Kavaratti — administrative capital", "Agatti coral lagoon", "Bangaram atoll", "Minicoy — largest island in the group"],
     image: "../../assets/travel_beaches.png"
   },
   {
+    id: "kavaratti",
+    name: "Kavaratti Island",
+    group: "Lakshadweep",
+    location: "Arabian Sea",
+    state: "Union Territory",
+    lat: 10.5669,
+    lng: 72.6420,
+    islandCount: "1 island",
+    tagline: "The administrative capital of Lakshadweep",
+    description: "The capital of the Lakshadweep Union Territory, Kavaratti is known for its calm turquoise lagoon, vivid coral reefs, a well-known marine aquarium and several historic mosques woven into the island's small, close-knit community.",
+    highlights: ["Wide, calm lagoon ideal for swimming and boating", "Marine Aquarium showcasing lagoon and reef life", "Vibrant coral reefs for snorkelling and diving", "Ujra Mosque and other historic island mosques"],
+    image: "../../assets/travel_beaches.png"
+  },  {
     id: "majuli",
     name: "Majuli",
     group: "River Islands",
@@ -382,7 +395,7 @@ function openModal(islandId) {
   const island = ISLANDS_DATA.find((i) => i.id === islandId);
   if (!island) return;
 
-if (island.id === "great-nicobar" || island.id === "south-andaman" || island.id === "middle-andaman" || island.id === "shaheed-dweep" || island.id === "swaraj-dweep" || island.id === "narcondam" || island.id === "car-nicobar") {
+if (island.id === "great-nicobar" || island.id === "south-andaman" || island.id === "middle-andaman" || island.id === "shaheed-dweep" || island.id === "swaraj-dweep" || island.id === "narcondam" || island.id === "kavaratti") {
     const pageMap = {
       "great-nicobar": "../great-nicobar/great-nicobar.html",
       "south-andaman": "../south-andaman/south-andaman.html",
@@ -392,7 +405,7 @@ if (island.id === "great-nicobar" || island.id === "south-andaman" || island.id 
       "narcondam": "../narcondam-island/narcondam-island.html",
       "barren-island": "../barren-island/barren-island.html",
       "north-sentinel-island": "../north-sentinel-island/north-sentinel-island.html",
-      "car-nicobar": "../car-nicobar-island/car-nicobar-island.html"
+      "kavaratti": "../kavaratti-island/kavaratti-island.html"
     };    window.location.href = pageMap[island.id];
     return;
   }

--- a/frontend/islands/islands.js
+++ b/frontend/islands/islands.js
@@ -31,10 +31,23 @@ const ISLANDS_DATA = [
     islandCount: "1 island",
     tagline: "India's southernmost island, home to Indira Point",
     description: "The largest island in the Nicobar group and India's southernmost territory, home to Indira Point, Campbell Bay National Park, and rare endemic wildlife.",
-    highlights: ["Indira Point — southernmost tip of India", "Campbell Bay National Park", "UNESCO Biosphere Reserve (2013)", "Nesting ground for Giant Leatherback turtles"],
+highlights: ["Indira Point — southernmost tip of India", "Campbell Bay National Park", "UNESCO Biosphere Reserve (2013)", "Nesting ground for Giant Leatherback turtles"],
     image: "../../assets/travel_hidden.png"
   },
   {
+    id: "car-nicobar",
+    name: "Car Nicobar",
+    group: "Andaman & Nicobar",
+    location: "Nicobar Islands, Bay of Bengal",
+    state: "Union Territory",
+    lat: 9.1833,
+    lng: 92.7667,
+    islandCount: "1 island",
+    tagline: "The Nicobars' most populated island, home of the Nicobarese",
+    description: "A flat, coral-fringed island and the administrative headquarters of the Nicobar district, Car Nicobar is home to the indigenous Nicobarese community, vast coconut plantations, sandy beaches and traditional hodi boat races.",
+    highlights: ["Largest Nicobarese population in the islands", "Extensive coconut plantations and copra economy", "Traditional villages and Chowra-style huts", "Malacca and Kakana beaches"],
+    image: "../../assets/travel_beaches.png"
+  },  {
     id: "south-andaman",
     name: "South Andaman",
     group: "Andaman & Nicobar",
@@ -369,7 +382,7 @@ function openModal(islandId) {
   const island = ISLANDS_DATA.find((i) => i.id === islandId);
   if (!island) return;
 
-if (island.id === "great-nicobar" || island.id === "south-andaman" || island.id === "middle-andaman" || island.id === "shaheed-dweep" || island.id === "swaraj-dweep" || island.id === "narcondam" || island.id === "north-andaman") {
+if (island.id === "great-nicobar" || island.id === "south-andaman" || island.id === "middle-andaman" || island.id === "shaheed-dweep" || island.id === "swaraj-dweep" || island.id === "narcondam" || island.id === "car-nicobar") {
     const pageMap = {
       "great-nicobar": "../great-nicobar/great-nicobar.html",
       "south-andaman": "../south-andaman/south-andaman.html",
@@ -379,7 +392,7 @@ if (island.id === "great-nicobar" || island.id === "south-andaman" || island.id 
       "narcondam": "../narcondam-island/narcondam-island.html",
       "barren-island": "../barren-island/barren-island.html",
       "north-sentinel-island": "../north-sentinel-island/north-sentinel-island.html",
-      "north-andaman": "../north-andaman-island/north-andaman-island.html"
+      "car-nicobar": "../car-nicobar-island/car-nicobar-island.html"
     };    window.location.href = pageMap[island.id];
     return;
   }

--- a/frontend/islands/islands.js
+++ b/frontend/islands/islands.js
@@ -101,10 +101,23 @@ highlights: ["Radhanagar Beach — Asia's Best Beach (Time, 2004)", "Elephant Be
     islandCount: "1 island",
     tagline: "An extinct volcano and the only home of the Narcondam Hornbill",
     description: "A small, remote, densely-forested volcanic island east of the main Andaman group. Formed by an extinct volcano, it is the sole habitat of the endemic Narcondam Hornbill and is protected as a wildlife sanctuary.",
-    highlights: ["Extinct volcanic cone rising steeply from the sea", "Endemic Narcondam Hornbill found nowhere else on Earth", "Declared a Wildlife Sanctuary in 1977", "Dense tropical evergreen forest cover"],
+highlights: ["Extinct volcanic cone rising steeply from the sea", "Endemic Narcondam Hornbill found nowhere else on Earth", "Declared a Wildlife Sanctuary in 1977", "Dense tropical evergreen forest cover"],
     image: "../../assets/travel_hidden.png"
   },
   {
+    id: "north-andaman",
+    name: "North Andaman",
+    group: "Andaman & Nicobar",
+    location: "Andaman Islands, Bay of Bengal",
+    state: "Union Territory",
+    lat: 13.1136,
+    lng: 92.9508,
+    islandCount: "1 island",
+    tagline: "Saddle Peak, mangrove creeks & the Andamans' highest point",
+    description: "The northernmost of the main Andaman islands, home to Saddle Peak — the highest point in the Andaman & Nicobar Islands — the Saddle Peak National Park, sprawling mangrove creeks, and the trekking and birding hub of Diglipur.",
+    highlights: ["Saddle Peak — highest peak in the Andaman & Nicobar Islands", "Saddle Peak National Park", "Extensive mangrove creeks and forests", "Trekking trails through tropical rainforest"],
+    image: "../../assets/travel_mountains.png"
+  },  {
     id: "lakshadweep",    name: "Lakshadweep Islands",
     id: "barren-island",
     name: "Barren Island",
@@ -356,18 +369,18 @@ function openModal(islandId) {
   const island = ISLANDS_DATA.find((i) => i.id === islandId);
   if (!island) return;
 
-if (island.id === "great-nicobar" || island.id === "south-andaman" || island.id === "middle-andaman" || island.id === "shaheed-dweep" || island.id === "swaraj-dweep" || island.id === "narcondam") {
+if (island.id === "great-nicobar" || island.id === "south-andaman" || island.id === "middle-andaman" || island.id === "shaheed-dweep" || island.id === "swaraj-dweep" || island.id === "narcondam" || island.id === "north-andaman") {
     const pageMap = {
       "great-nicobar": "../great-nicobar/great-nicobar.html",
       "south-andaman": "../south-andaman/south-andaman.html",
       "middle-andaman": "../middle-andaman/middle-andaman.html",
       "shaheed-dweep": "../shaheed-dweep/shaheed-dweep.html",
       "swaraj-dweep": "../swaraj-dweep/swaraj-dweep.html",
-      "narcondam": "../narcondam-island/narcondam-island.html"
-      "barren-island": "../barren-island/barren-island.html"
-      "north-sentinel-island": "../north-sentinel-island/north-sentinel-island.html"
-    };
-    window.location.href = pageMap[island.id];
+      "narcondam": "../narcondam-island/narcondam-island.html",
+      "barren-island": "../barren-island/barren-island.html",
+      "north-sentinel-island": "../north-sentinel-island/north-sentinel-island.html",
+      "north-andaman": "../north-andaman-island/north-andaman-island.html"
+    };    window.location.href = pageMap[island.id];
     return;
   }
   document.getElementById("island-modal-title").textContent = island.name;

--- a/frontend/kavaratti-island/kavaratti-island.css
+++ b/frontend/kavaratti-island/kavaratti-island.css
@@ -1,0 +1,411 @@
+/* ============================================================
+   Kavaratti Island Explorer — kavaratti-island.css
+   Uses the shared design tokens defined in ../../styles.css
+   ============================================================ */
+
+.kavaratti-page {
+  padding-top: var(--navbar-height);
+  overflow-x: hidden;
+}
+
+.kavaratti-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* ---------- Hero ---------- */
+.kavaratti-hero {
+  position: relative;
+  padding: 90px 24px 70px;
+  text-align: center;
+  background:
+    linear-gradient(180deg, rgba(4, 23, 42, 0.55) 0%, rgba(4, 23, 42, 0.92) 100%),
+    url("../../assets/travel_beaches.png") center/cover no-repeat;
+}
+
+.kavaratti-hero-content {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.kavaratti-hero-kicker {
+  display: inline-block;
+  padding: 6px 16px;
+  border-radius: 999px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  color: var(--primary-saffron);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-bottom: 20px;
+}
+
+.kavaratti-hero h1 {
+  font-family: var(--font-heading);
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  line-height: 1.15;
+  margin-bottom: 18px;
+  color: var(--text-light);
+}
+
+.kavaratti-hero h1 span {
+  background: var(--gradient-saffron-gold);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.kavaratti-hero p {
+  color: var(--text-secondary);
+  font-size: 1.08rem;
+  line-height: 1.7;
+  margin-bottom: 36px;
+}
+
+.kavaratti-hero-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+
+.kavaratti-stat-box {
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 18px 12px;
+  transition: var(--transition-snappy);
+}
+
+.kavaratti-stat-box:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-glow);
+}
+
+.kavaratti-stat-box strong {
+  display: block;
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--primary-saffron);
+}
+
+.kavaratti-stat-box span {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+/* ---------- Section heading ---------- */
+.kavaratti-section {
+  padding: 70px 0;
+}
+
+.kavaratti-section-heading {
+  text-align: center;
+  max-width: 680px;
+  margin: 0 auto 44px;
+}
+
+.kavaratti-section-badge {
+  display: inline-block;
+  color: var(--primary-gold);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+
+.kavaratti-section-heading h2 {
+  font-family: var(--font-heading);
+  font-size: clamp(1.7rem, 3.5vw, 2.4rem);
+  color: var(--text-light);
+  margin-bottom: 14px;
+}
+
+.kavaratti-section-heading p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+/* ---------- Tabs (Lagoons / Marine Aquarium / Coral Reefs / Culture / Tourism / Mosques) ---------- */
+.kavaratti-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  margin-bottom: 32px;
+}
+
+.kavaratti-tab-btn {
+  padding: 10px 20px;
+  border-radius: 999px;
+  border: 1px solid var(--glass-border);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: var(--transition-snappy);
+}
+
+.kavaratti-tab-btn:hover {
+  border-color: var(--primary-saffron);
+  color: var(--text-light);
+}
+
+.kavaratti-tab-btn.active {
+  background: var(--gradient-saffron-gold);
+  color: #1a1200;
+  border-color: transparent;
+  font-weight: 600;
+}
+
+.kavaratti-tab-panel {
+  display: none;
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 32px;
+  animation: kavaratti-fade-in 0.3s ease;
+}
+
+.kavaratti-tab-panel.active {
+  display: block;
+}
+
+@keyframes kavaratti-fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.kavaratti-tab-panel h3 {
+  font-family: var(--font-heading);
+  color: var(--primary-gold);
+  margin-bottom: 14px;
+  font-size: 1.3rem;
+}
+
+.kavaratti-tab-panel p {
+  color: var(--text-secondary);
+  line-height: 1.8;
+  margin-bottom: 14px;
+}
+
+.kavaratti-tab-panel ul {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.kavaratti-tab-panel ul li {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  padding-left: 24px;
+  position: relative;
+  line-height: 1.6;
+}
+
+.kavaratti-tab-panel ul li::before {
+  content: "🌊";
+  position: absolute;
+  left: 0;
+}
+
+/* ---------- Map ---------- */
+.kavaratti-map-wrap {
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow-soft);
+}
+
+#kavaratti-map {
+  height: 440px;
+  width: 100%;
+  background: var(--bg-dark-deep);
+}
+
+/* ---------- Gallery ---------- */
+.kavaratti-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 18px;
+}
+
+.kavaratti-gallery-item {
+  margin: 0;
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+  cursor: pointer;
+  border: 1px solid var(--glass-border);
+  transition: var(--transition-snappy);
+  position: relative;
+}
+
+.kavaratti-gallery-item:hover {
+  transform: translateY(-4px);
+  border-color: var(--primary-saffron);
+  box-shadow: var(--shadow-glow);
+}
+
+.kavaratti-gallery-item img {
+  width: 100%;
+  height: 190px;
+  object-fit: cover;
+  display: block;
+}
+
+.kavaratti-gallery-item figcaption {
+  padding: 10px 14px;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  background: var(--bg-dark-card);
+}
+
+/* ---------- Lightbox ---------- */
+.kavaratti-lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 10, 20, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 24px;
+}
+
+.kavaratti-lightbox-overlay[hidden] {
+  display: none;
+}
+
+.kavaratti-lightbox-content {
+  max-width: 800px;
+  width: 100%;
+  text-align: center;
+  position: relative;
+}
+
+.kavaratti-lightbox-content img {
+  width: 100%;
+  max-height: 65vh;
+  object-fit: contain;
+  border-radius: var(--border-radius-lg);
+}
+
+.kavaratti-lightbox-caption {
+  color: var(--text-light);
+  margin-top: 14px;
+  font-size: 0.95rem;
+}
+
+.kavaratti-lightbox-close {
+  position: absolute;
+  top: -44px;
+  right: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-light);
+  font-size: 1.4rem;
+  cursor: pointer;
+}
+
+.kavaratti-lightbox-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-light);
+  font-size: 1.3rem;
+  cursor: pointer;
+}
+
+.kavaratti-lightbox-nav.prev { left: -20px; }
+.kavaratti-lightbox-nav.next { right: -20px; }
+
+/* ---------- Did You Know ---------- */
+.kavaratti-fact-panel {
+  max-width: 760px;
+  margin: 0 auto;
+  background: var(--gradient-card-border);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 40px 36px;
+  text-align: center;
+}
+
+.kavaratti-fact-icon {
+  font-size: 2.2rem;
+  margin-bottom: 14px;
+}
+
+#kavaratti-fact-text {
+  font-family: var(--font-heading);
+  font-size: 1.15rem;
+  color: var(--text-light);
+  line-height: 1.6;
+  transition: opacity 0.2s ease;
+  min-height: 84px;
+}
+
+.kavaratti-fact-dots {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.kavaratti-fact-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+  background: var(--glass-border);
+  cursor: pointer;
+  transition: var(--transition-snappy);
+}
+
+.kavaratti-fact-dot.active {
+  background: var(--primary-saffron);
+  width: 22px;
+  border-radius: 4px;
+}
+
+/* ---------- Back to Islands link ---------- */
+.kavaratti-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--primary-saffron);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 14px;
+}
+
+.kavaratti-back-link:hover {
+  text-decoration: underline;
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 768px) {
+  .kavaratti-hero-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  #kavaratti-map {
+    height: 320px;
+  }
+
+  .kavaratti-lightbox-nav.prev { left: 4px; }
+  .kavaratti-lightbox-nav.next { right: 4px; }
+}

--- a/frontend/kavaratti-island/kavaratti-island.html
+++ b/frontend/kavaratti-island/kavaratti-island.html
@@ -1,0 +1,286 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Explore Kavaratti Island — the administrative capital of Lakshadweep, known for its calm lagoon, marine aquarium, coral reefs, culture, tourism and historic mosques.">
+    <title>Kavaratti Island Explorer | Incredible India</title>
+    <link rel="icon" href="data:,">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="kavaratti-island.css">
+
+    <!-- Open Graph / Social Media Tags -->
+    <meta property="og:title" content="Kavaratti Island Explorer | Incredible India Explorer">
+    <meta property="og:description" content="Lagoons, Marine Aquarium, coral reefs, culture, tourism and mosques of Kavaratti Island.">
+    <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/assets/travel_beaches.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/kavaratti-island/kavaratti-island.html">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Incredible India Explorer">
+    <meta property="og:locale" content="en_IN">
+
+    <!-- Twitter Card Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Kavaratti Island Explorer | Incredible India Explorer">
+    <meta name="twitter:description" content="Lagoons, Marine Aquarium, coral reefs, culture, tourism and mosques of Kavaratti Island.">
+    <meta name="twitter:image" content="https://incredibleindiaexplorer.gov.in/assets/travel_beaches.png">
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/kavaratti-island/kavaratti-island.html">
+</head>
+
+<body class="kavaratti-body">
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html#home" class="nav-link" id="link-home">Home</a>
+                <a href="../../index.html#map" class="nav-link" id="link-map">Interactive Map</a>
+                <a href="../islands/islands.html" class="nav-link">Islands</a>
+                <a href="kavaratti-island.html" class="nav-link active" style="color: var(--saffron)">Kavaratti Island</a>
+
+                <div class="nav-dropdown">
+                    <button class="nav-link dropdown-toggle" id="link-explore-more">
+                        Explore More ▾
+                    </button>
+                    <div class="dropdown-menu">
+                        <a href="../travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                        <a href="../wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                        <a href="../coastal-india/coastal-india.html" class="dropdown-item">Coastal India</a>
+                        <a href="../heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    </div>
+                </div>
+
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
+                    ☀️
+                </button>
+                <a href="../../login.html" class="nav-link" id="link-login">Login</a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="kavaratti-page">
+        <!-- Hero -->
+        <section class="kavaratti-hero">
+            <div class="kavaratti-hero-content">
+                <a href="../islands/islands.html" class="kavaratti-back-link">← Back to Islands of India</a>
+                <span class="kavaratti-hero-kicker">🕌 Capital of the Lakshadweep Islands</span>
+                <h1>Kavaratti <span>Island</span></h1>
+                <p>The administrative capital of Lakshadweep — a coral island ringed by a calm turquoise lagoon, home to vivid reefs, a well-loved marine aquarium, historic mosques and a close-knit island community.</p>
+
+                <div class="kavaratti-hero-stats">
+                    <div class="kavaratti-stat-box">
+                        <strong>~4.22 sq km</strong>
+                        <span>Total Land Area</span>
+                    </div>
+                    <div class="kavaratti-stat-box">
+                        <strong>Capital</strong>
+                        <span>Administrative Headquarters</span>
+                    </div>
+                    <div class="kavaratti-stat-box">
+                        <strong>52+</strong>
+                        <span>Mosques on the Island</span>
+                    </div>
+                    <div class="kavaratti-stat-box">
+                        <strong>Marine</strong>
+                        <span>Aquarium & Reef Ecosystem</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Tabbed info -->
+        <section class="kavaratti-section" id="kavaratti-explore">
+            <div class="kavaratti-container">
+                <div class="kavaratti-section-heading">
+                    <span class="kavaratti-section-badge">Explore Kavaratti</span>
+                    <h2>Lagoons, Reefs &amp; Island Life</h2>
+                    <p>Select a tab to learn more.</p>
+                </div>
+
+                <div class="kavaratti-tabs" role="tablist">
+                    <button type="button" class="kavaratti-tab-btn active" data-tab="lagoons">Lagoons</button>
+                    <button type="button" class="kavaratti-tab-btn" data-tab="aquarium">Marine Aquarium</button>
+                    <button type="button" class="kavaratti-tab-btn" data-tab="coral-reefs">Coral Reefs</button>
+                    <button type="button" class="kavaratti-tab-btn" data-tab="culture">Culture</button>
+                    <button type="button" class="kavaratti-tab-btn" data-tab="tourism">Tourism</button>
+                    <button type="button" class="kavaratti-tab-btn" data-tab="mosques">Mosques</button>
+                </div>
+
+                <div class="kavaratti-tab-panel active" id="tab-lagoons">
+                    <h3>🌊 Lagoons</h3>
+                    <p>Kavaratti is wrapped by a wide, shallow lagoon with calm, clear turquoise water that is protected from the open sea by a surrounding reef. The lagoon's gentle currents make it one of the safest and most inviting in Lakshadweep.</p>
+                    <p>Glass-bottom boat rides across the lagoon are a popular way to view the reef and marine life below without getting into the water, and the lagoon's calm shallows are also ideal for swimming and kayaking.</p>
+                    <ul>
+                        <li>Wide, shallow lagoon with calm turquoise water</li>
+                        <li>Protected from the open sea by the surrounding reef</li>
+                        <li>Popular for glass-bottom boat rides, swimming and kayaking</li>
+                    </ul>
+                </div>
+
+                <div class="kavaratti-tab-panel" id="tab-aquarium">
+                    <h3>🐠 Marine Aquarium</h3>
+                    <p>Kavaratti is home to one of Lakshadweep's few marine aquariums, showcasing the colourful reef fish, corals and other lagoon life found in the surrounding waters, giving visitors a close look at the ecosystem without diving.</p>
+                    <p>The aquarium serves as both a tourist attraction and an educational resource, helping visitors and locals alike understand the reef habitats that the island's economy and culture depend on.</p>
+                    <ul>
+                        <li>One of the few marine aquariums in Lakshadweep</li>
+                        <li>Displays reef fish, corals and lagoon species</li>
+                        <li>Doubles as an educational resource on reef ecology</li>
+                    </ul>
+                </div>
+
+                <div class="kavaratti-tab-panel" id="tab-coral-reefs">
+                    <h3>🪸 Coral Reefs</h3>
+                    <p>The reef encircling Kavaratti's lagoon supports a rich variety of coral formations and reef fish, making the island a popular spot for snorkelling and scuba diving in relatively calm, shallow water.</p>
+                    <p>Like other Lakshadweep reefs, Kavaratti's corals are sensitive to rising sea temperatures and bleaching events, and are part of wider conservation efforts across the archipelago to protect these coral ecosystems.</p>
+                    <ul>
+                        <li>Fringing reef with varied coral formations and reef fish</li>
+                        <li>Popular for snorkelling and scuba diving</li>
+                        <li>Subject to coral reef conservation efforts across Lakshadweep</li>
+                    </ul>
+                </div>
+
+                <div class="kavaratti-tab-panel" id="tab-culture">
+                    <h3>🎎 Culture</h3>
+                    <p>As the administrative capital, Kavaratti blends the traditional Lakshadweep way of life with the island's role as a centre of governance. The local community is predominantly Muslim, and daily life is closely tied to fishing, coconut cultivation and the sea.</p>
+                    <p>Traditional music, boat races and local cuisine built around fish, coconut and rice reflect the island's close relationship with the surrounding ocean.</p>
+                    <ul>
+                        <li>Predominantly Muslim island community</li>
+                        <li>Daily life closely tied to fishing and coconut cultivation</li>
+                        <li>Traditional boat races and coastal cuisine</li>
+                    </ul>
+                </div>
+
+                <div class="kavaratti-tab-panel" id="tab-tourism">
+                    <h3>🏝️ Tourism</h3>
+                    <p>Kavaratti is a key entry point for tourism in Lakshadweep, offering lagoon activities like kayaking, glass-bottom boat rides and snorkelling, alongside visits to the marine aquarium and the island's historic mosques.</p>
+                    <p>Because Lakshadweep tourism is regulated to protect its fragile ecosystem, visits to Kavaratti typically require permits, and eco-friendly practices are encouraged to preserve the island's lagoon and reefs.</p>
+                    <ul>
+                        <li>Lagoon activities: kayaking, boating and snorkelling</li>
+                        <li>Entry point for visits to the marine aquarium and mosques</li>
+                        <li>Permit-based, eco-conscious tourism to protect the ecosystem</li>
+                    </ul>
+                </div>
+
+                <div class="kavaratti-tab-panel" id="tab-mosques">
+                    <h3>🕌 Mosques</h3>
+                    <p>Kavaratti is known for having a large number of mosques for its size, with over 50 spread across the small island, reflecting the deep-rooted Islamic heritage of the Lakshadweep community.</p>
+                    <p>The Ujra Mosque is among the most notable, admired for its traditional coral-stone architecture and carved wooden ceiling, and stands as a symbol of the island's long-standing religious and architectural traditions.</p>
+                    <ul>
+                        <li>More than 50 mosques across the small island</li>
+                        <li>Ujra Mosque known for coral-stone architecture and carved ceiling</li>
+                        <li>Reflects the island's long-standing Islamic heritage</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <!-- Interactive Map -->
+        <section class="kavaratti-section" id="kavaratti-map-section">
+            <div class="kavaratti-container">
+                <div class="kavaratti-section-heading">
+                    <span class="kavaratti-section-badge">Interactive Map</span>
+                    <h2>Key Locations Around Kavaratti</h2>
+                    <p>Click a marker to learn about that location.</p>
+                </div>
+                <div class="kavaratti-map-wrap">
+                    <div id="kavaratti-map"></div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Image Gallery -->
+        <section class="kavaratti-section" id="kavaratti-gallery-section">
+            <div class="kavaratti-container">
+                <div class="kavaratti-section-heading">
+                    <span class="kavaratti-section-badge">Image Gallery</span>
+                    <h2>Glimpses of Kavaratti Island</h2>
+                    <p>Click an image to view it larger.</p>
+                </div>
+                <div id="kavaratti-gallery-grid" class="kavaratti-gallery-grid"></div>
+            </div>
+        </section>
+
+        <!-- Interesting Facts -->
+        <section class="kavaratti-section">
+            <div class="kavaratti-container">
+                <div class="kavaratti-section-heading">
+                    <span class="kavaratti-section-badge">Did You Know?</span>
+                    <h2>Interesting Facts</h2>
+                </div>
+                <div class="kavaratti-fact-panel">
+                    <div class="kavaratti-fact-icon">💡</div>
+                    <p id="kavaratti-fact-text">Loading fact...</p>
+                    <div class="kavaratti-fact-dots" id="kavaratti-fact-dots"></div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <!-- Lightbox -->
+    <div class="kavaratti-lightbox-overlay" id="kavaratti-lightbox" hidden>
+        <div class="kavaratti-lightbox-content">
+            <button class="kavaratti-lightbox-close" data-close-lightbox="true" aria-label="Close">&times;</button>
+            <button class="kavaratti-lightbox-nav prev" id="kavaratti-lightbox-prev" aria-label="Previous image">‹</button>
+            <img id="kavaratti-lightbox-image" src="" alt="">
+            <button class="kavaratti-lightbox-nav next" id="kavaratti-lightbox-next" aria-label="Next image">›</button>
+            <p class="kavaratti-lightbox-caption" id="kavaratti-lightbox-caption"></p>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <footer class="site-footer">
+        <div class="footer-container">
+            <div class="footer-brand">
+                <a href="../../index.html#home" class="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <p>Preserving and celebrating India's rich island territories, coastlines and culture.</p>
+            </div>
+            <div class="footer-links">
+                <h4>Quick Links</h4>
+                <a href="../../index.html#home">Home</a>
+                <a href="../islands/islands.html">Islands of India</a>
+                <a href="../wildlife/wildlife.html">Nature & Wildlife</a>
+                <a href="kavaratti-island.html">Kavaratti Island</a>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2026 Incredible India Explorer. Open Source Cultural Heritage Initiative.</p>
+        </div>
+    </footer>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+    <script type="module" src="kavaratti-island.js"></script>
+    <script src="../../pages-common.js"></script>
+</body>
+</html>

--- a/frontend/kavaratti-island/kavaratti-island.js
+++ b/frontend/kavaratti-island/kavaratti-island.js
@@ -1,0 +1,207 @@
+/* ============================================================
+   Kavaratti Island Explorer — kavaratti-island.js
+   Handles: tab navigation, image gallery lightbox, facts
+   rotator, and the Leaflet map with key-location markers.
+   ============================================================ */
+
+// ---------- 1. KEY LOCATIONS FOR THE MAP ----------
+const KAVARATTI_LOCATIONS = [
+  {
+    name: "Kavaratti Lagoon",
+    lat: 10.5669,
+    lng: 72.6420,
+    description: "The calm, shallow turquoise lagoon that encircles the island, popular for swimming, kayaking and glass-bottom boat rides."
+  },
+  {
+    name: "Marine Aquarium",
+    lat: 10.5651,
+    lng: 72.6430,
+    description: "A small aquarium showcasing the reef fish, corals and lagoon life found around Kavaratti."
+  },
+  {
+    name: "Ujra Mosque",
+    lat: 10.5680,
+    lng: 72.6415,
+    description: "One of the island's most notable mosques, known for its coral-stone architecture and carved wooden ceiling."
+  },
+  {
+    name: "Kavaratti Jetty",
+    lat: 10.5630,
+    lng: 72.6440,
+    description: "The main jetty connecting Kavaratti to ships arriving from Kochi and other Lakshadweep islands."
+  }
+];
+
+// ---------- 2. IMAGE GALLERY ----------
+const KAVARATTI_GALLERY = [
+  { src: "../../assets/travel_beaches.png", caption: "Kavaratti's calm turquoise lagoon" },
+  { src: "../../assets/travel_islands.png", caption: "Coral reef waters surrounding the island" },
+  { src: "../../assets/travel_hidden.png", caption: "A traditional coral-stone mosque on Kavaratti" },
+  { src: "../../assets/travel_forests.png", caption: "Palm-lined shores of the island" }
+];
+
+// ---------- 3. INTERESTING FACTS ----------
+const KAVARATTI_FACTS = [
+  "Kavaratti is the administrative capital of the Lakshadweep Union Territory.",
+  "The island's lagoon is protected by a surrounding reef, keeping its waters calm and shallow.",
+  "Kavaratti is home to one of the few marine aquariums in Lakshadweep.",
+  "The island has more than 50 mosques, an unusually high number for its small size.",
+  "The Ujra Mosque is known for its traditional coral-stone architecture and carved ceiling.",
+  "Lakshadweep's islands, including Kavaratti, are built entirely of coral, with no natural rock beneath the sand."
+];
+
+// ---------- 4. STATE ----------
+let map;
+let currentGalleryIndex = 0;
+let factIndex = 0;
+
+// ---------- 5. DOM READY ----------
+document.addEventListener("DOMContentLoaded", () => {
+  initTabs();
+  initGallery();
+  initFactsRotator();
+  initMap();
+  initLightbox();
+});
+
+// ---------- 6. TAB NAVIGATION ----------
+function initTabs() {
+  const tabButtons = document.querySelectorAll(".kavaratti-tab-btn");
+  const tabPanels = document.querySelectorAll(".kavaratti-tab-panel");
+
+  tabButtons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const target = btn.getAttribute("data-tab");
+
+      tabButtons.forEach((b) => b.classList.remove("active"));
+      btn.classList.add("active");
+
+      tabPanels.forEach((panel) => {
+        panel.classList.toggle("active", panel.id === "tab-" + target);
+      });
+    });
+  });
+}
+
+// ---------- 7. IMAGE GALLERY ----------
+function initGallery() {
+  const galleryGrid = document.getElementById("kavaratti-gallery-grid");
+  if (!galleryGrid) return;
+
+  galleryGrid.innerHTML = "";
+  KAVARATTI_GALLERY.forEach((item, index) => {
+    const fig = document.createElement("figure");
+    fig.className = "kavaratti-gallery-item";
+    fig.innerHTML = `
+      <img src="${item.src}" alt="${item.caption}" loading="lazy">
+      <figcaption>${item.caption}</figcaption>
+    `;
+    fig.addEventListener("click", () => openLightbox(index));
+    galleryGrid.appendChild(fig);
+  });
+}
+
+// ---------- 8. LIGHTBOX ----------
+function initLightbox() {
+  document.querySelectorAll("[data-close-lightbox]").forEach((el) => {
+    el.addEventListener("click", closeLightbox);
+  });
+  const prevBtn = document.getElementById("kavaratti-lightbox-prev");
+  const nextBtn = document.getElementById("kavaratti-lightbox-next");
+  if (prevBtn) prevBtn.addEventListener("click", () => showGalleryImage(currentGalleryIndex - 1));
+  if (nextBtn) nextBtn.addEventListener("click", () => showGalleryImage(currentGalleryIndex + 1));
+
+  document.addEventListener("keydown", (e) => {
+    const lightbox = document.getElementById("kavaratti-lightbox");
+    if (!lightbox || lightbox.hidden) return;
+    if (e.key === "Escape") closeLightbox();
+    if (e.key === "ArrowRight") showGalleryImage(currentGalleryIndex + 1);
+    if (e.key === "ArrowLeft") showGalleryImage(currentGalleryIndex - 1);
+  });
+}
+
+function openLightbox(index) {
+  const lightbox = document.getElementById("kavaratti-lightbox");
+  if (!lightbox) return;
+  lightbox.hidden = false;
+  document.body.style.overflow = "hidden";
+  showGalleryImage(index);
+}
+
+function closeLightbox() {
+  const lightbox = document.getElementById("kavaratti-lightbox");
+  if (!lightbox) return;
+  lightbox.hidden = true;
+  document.body.style.overflow = "";
+}
+
+function showGalleryImage(index) {
+  const total = KAVARATTI_GALLERY.length;
+  currentGalleryIndex = (index + total) % total;
+  const item = KAVARATTI_GALLERY[currentGalleryIndex];
+  const img = document.getElementById("kavaratti-lightbox-image");
+  const caption = document.getElementById("kavaratti-lightbox-caption");
+  if (img) img.src = item.src;
+  if (img) img.alt = item.caption;
+  if (caption) caption.textContent = item.caption;
+}
+
+// ---------- 9. FACTS ROTATOR ----------
+function initFactsRotator() {
+  const factEl = document.getElementById("kavaratti-fact-text");
+  const dotsWrap = document.getElementById("kavaratti-fact-dots");
+  if (!factEl) return;
+
+  if (dotsWrap) {
+    KAVARATTI_FACTS.forEach((_, i) => {
+      const dot = document.createElement("button");
+      dot.className = "kavaratti-fact-dot" + (i === 0 ? " active" : "");
+      dot.setAttribute("aria-label", "Show fact " + (i + 1));
+      dot.addEventListener("click", () => showFact(i));
+      dotsWrap.appendChild(dot);
+    });
+  }
+
+  function showFact(i) {
+    factIndex = i;
+    factEl.style.opacity = "0";
+    setTimeout(() => {
+      factEl.textContent = KAVARATTI_FACTS[factIndex];
+      factEl.style.opacity = "1";
+    }, 200);
+    if (dotsWrap) {
+      [...dotsWrap.children].forEach((dot, di) => dot.classList.toggle("active", di === factIndex));
+    }
+  }
+
+  showFact(0);
+  setInterval(() => showFact((factIndex + 1) % KAVARATTI_FACTS.length), 6000);
+}
+
+// ---------- 10. LEAFLET MAP ----------
+function initMap() {
+  const mapContainer = document.getElementById("kavaratti-map");
+  if (!mapContainer || typeof L === "undefined") return;
+
+  map = L.map("kavaratti-map", {
+    scrollWheelZoom: false,
+    minZoom: 6,
+  }).setView([10.566, 72.642], 12);
+
+  L.tileLayer("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png", {
+    attribution: "&copy; OpenStreetMap contributors &copy; CARTO",
+    maxZoom: 18,
+  }).addTo(map);
+
+  KAVARATTI_LOCATIONS.forEach((loc) => {
+    const marker = L.circleMarker([loc.lat, loc.lng], {
+      radius: 8,
+      color: "#ff9933",
+      fillColor: "#ffb01f",
+      fillOpacity: 0.85,
+      weight: 2,
+    }).addTo(map);
+
+    marker.bindPopup(`<strong>${loc.name}</strong><br>${loc.description}`);
+  });
+}

--- a/frontend/north-andaman-island/north-andaman-island.css
+++ b/frontend/north-andaman-island/north-andaman-island.css
@@ -1,0 +1,411 @@
+/* ============================================================
+   North Andaman Explorer — north-andaman-island.css
+   Uses the shared design tokens defined in ../../styles.css
+   ============================================================ */
+
+.north-andaman-page {
+  padding-top: var(--navbar-height);
+  overflow-x: hidden;
+}
+
+.north-andaman-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* ---------- Hero ---------- */
+.north-andaman-hero {
+  position: relative;
+  padding: 90px 24px 70px;
+  text-align: center;
+  background:
+    linear-gradient(180deg, rgba(4, 23, 42, 0.55) 0%, rgba(4, 23, 42, 0.92) 100%),
+    url("../../assets/travel_mountains.png") center/cover no-repeat;
+}
+
+.north-andaman-hero-content {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.north-andaman-hero-kicker {
+  display: inline-block;
+  padding: 6px 16px;
+  border-radius: 999px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  color: var(--primary-saffron);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-bottom: 20px;
+}
+
+.north-andaman-hero h1 {
+  font-family: var(--font-heading);
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  line-height: 1.15;
+  margin-bottom: 18px;
+  color: var(--text-light);
+}
+
+.north-andaman-hero h1 span {
+  background: var(--gradient-saffron-gold);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.north-andaman-hero p {
+  color: var(--text-secondary);
+  font-size: 1.08rem;
+  line-height: 1.7;
+  margin-bottom: 36px;
+}
+
+.north-andaman-hero-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+
+.north-andaman-stat-box {
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 18px 12px;
+  transition: var(--transition-snappy);
+}
+
+.north-andaman-stat-box:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-glow);
+}
+
+.north-andaman-stat-box strong {
+  display: block;
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--primary-saffron);
+}
+
+.north-andaman-stat-box span {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+/* ---------- Section heading ---------- */
+.north-andaman-section {
+  padding: 70px 0;
+}
+
+.north-andaman-section-heading {
+  text-align: center;
+  max-width: 680px;
+  margin: 0 auto 44px;
+}
+
+.north-andaman-section-badge {
+  display: inline-block;
+  color: var(--primary-gold);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+
+.north-andaman-section-heading h2 {
+  font-family: var(--font-heading);
+  font-size: clamp(1.7rem, 3.5vw, 2.4rem);
+  color: var(--text-light);
+  margin-bottom: 14px;
+}
+
+.north-andaman-section-heading p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+/* ---------- Tabs (Saddle Peak / National Park / Mangroves / Wildlife / Trekking / Climate) ---------- */
+.north-andaman-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  margin-bottom: 32px;
+}
+
+.north-andaman-tab-btn {
+  padding: 10px 20px;
+  border-radius: 999px;
+  border: 1px solid var(--glass-border);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: var(--transition-snappy);
+}
+
+.north-andaman-tab-btn:hover {
+  border-color: var(--primary-saffron);
+  color: var(--text-light);
+}
+
+.north-andaman-tab-btn.active {
+  background: var(--gradient-saffron-gold);
+  color: #1a1200;
+  border-color: transparent;
+  font-weight: 600;
+}
+
+.north-andaman-tab-panel {
+  display: none;
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 32px;
+  animation: north-andaman-fade-in 0.3s ease;
+}
+
+.north-andaman-tab-panel.active {
+  display: block;
+}
+
+@keyframes north-andaman-fade-in {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.north-andaman-tab-panel h3 {
+  font-family: var(--font-heading);
+  color: var(--primary-gold);
+  margin-bottom: 14px;
+  font-size: 1.3rem;
+}
+
+.north-andaman-tab-panel p {
+  color: var(--text-secondary);
+  line-height: 1.8;
+  margin-bottom: 14px;
+}
+
+.north-andaman-tab-panel ul {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.north-andaman-tab-panel ul li {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  padding-left: 24px;
+  position: relative;
+  line-height: 1.6;
+}
+
+.north-andaman-tab-panel ul li::before {
+  content: "⛰️";
+  position: absolute;
+  left: 0;
+}
+
+/* ---------- Map ---------- */
+.north-andaman-map-wrap {
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow-soft);
+}
+
+#north-andaman-map {
+  height: 440px;
+  width: 100%;
+  background: var(--bg-dark-deep);
+}
+
+/* ---------- Gallery ---------- */
+.north-andaman-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 18px;
+}
+
+.north-andaman-gallery-item {
+  margin: 0;
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+  cursor: pointer;
+  border: 1px solid var(--glass-border);
+  transition: var(--transition-snappy);
+  position: relative;
+}
+
+.north-andaman-gallery-item:hover {
+  transform: translateY(-4px);
+  border-color: var(--primary-saffron);
+  box-shadow: var(--shadow-glow);
+}
+
+.north-andaman-gallery-item img {
+  width: 100%;
+  height: 190px;
+  object-fit: cover;
+  display: block;
+}
+
+.north-andaman-gallery-item figcaption {
+  padding: 10px 14px;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  background: var(--bg-dark-card);
+}
+
+/* ---------- Lightbox ---------- */
+.north-andaman-lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 10, 20, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 24px;
+}
+
+.north-andaman-lightbox-overlay[hidden] {
+  display: none;
+}
+
+.north-andaman-lightbox-content {
+  max-width: 800px;
+  width: 100%;
+  text-align: center;
+  position: relative;
+}
+
+.north-andaman-lightbox-content img {
+  width: 100%;
+  max-height: 65vh;
+  object-fit: contain;
+  border-radius: var(--border-radius-lg);
+}
+
+.north-andaman-lightbox-caption {
+  color: var(--text-light);
+  margin-top: 14px;
+  font-size: 0.95rem;
+}
+
+.north-andaman-lightbox-close {
+  position: absolute;
+  top: -44px;
+  right: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-light);
+  font-size: 1.4rem;
+  cursor: pointer;
+}
+
+.north-andaman-lightbox-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-light);
+  font-size: 1.3rem;
+  cursor: pointer;
+}
+
+.north-andaman-lightbox-nav.prev { left: -20px; }
+.north-andaman-lightbox-nav.next { right: -20px; }
+
+/* ---------- Did You Know ---------- */
+.north-andaman-fact-panel {
+  max-width: 760px;
+  margin: 0 auto;
+  background: var(--gradient-card-border);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 40px 36px;
+  text-align: center;
+}
+
+.north-andaman-fact-icon {
+  font-size: 2.2rem;
+  margin-bottom: 14px;
+}
+
+#north-andaman-fact-text {
+  font-family: var(--font-heading);
+  font-size: 1.15rem;
+  color: var(--text-light);
+  line-height: 1.6;
+  transition: opacity 0.2s ease;
+  min-height: 84px;
+}
+
+.north-andaman-fact-dots {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.north-andaman-fact-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+  background: var(--glass-border);
+  cursor: pointer;
+  transition: var(--transition-snappy);
+}
+
+.north-andaman-fact-dot.active {
+  background: var(--primary-saffron);
+  width: 22px;
+  border-radius: 4px;
+}
+
+/* ---------- Back to Islands link ---------- */
+.north-andaman-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--primary-saffron);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 14px;
+}
+
+.north-andaman-back-link:hover {
+  text-decoration: underline;
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 768px) {
+  .north-andaman-hero-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  #north-andaman-map {
+    height: 320px;
+  }
+
+  .north-andaman-lightbox-nav.prev { left: 4px; }
+  .north-andaman-lightbox-nav.next { right: 4px; }
+}

--- a/frontend/north-andaman-island/north-andaman-island.html
+++ b/frontend/north-andaman-island/north-andaman-island.html
@@ -1,0 +1,286 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Explore North Andaman — home to Saddle Peak, the highest point in the Andaman & Nicobar Islands, along with Saddle Peak National Park, mangrove creeks, wildlife, trekking trails and tropical climate.">
+    <title>North Andaman Explorer | Incredible India</title>
+    <link rel="icon" href="data:,">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="north-andaman-island.css">
+
+    <!-- Open Graph / Social Media Tags -->
+    <meta property="og:title" content="North Andaman Explorer | Incredible India Explorer">
+    <meta property="og:description" content="Saddle Peak, Saddle Peak National Park, mangroves, wildlife, trekking and climate of North Andaman.">
+    <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/assets/travel_mountains.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/north-andaman-island/north-andaman-island.html">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Incredible India Explorer">
+    <meta property="og:locale" content="en_IN">
+
+    <!-- Twitter Card Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="North Andaman Explorer | Incredible India Explorer">
+    <meta name="twitter:description" content="Saddle Peak, national park, mangroves, wildlife, trekking and climate of North Andaman.">
+    <meta name="twitter:image" content="https://incredibleindiaexplorer.gov.in/assets/travel_mountains.png">
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/north-andaman-island/north-andaman-island.html">
+</head>
+
+<body class="north-andaman-body">
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html#home" class="nav-link" id="link-home">Home</a>
+                <a href="../../index.html#map" class="nav-link" id="link-map">Interactive Map</a>
+                <a href="../islands/islands.html" class="nav-link">Islands</a>
+                <a href="north-andaman-island.html" class="nav-link active" style="color: var(--saffron)">North Andaman</a>
+
+                <div class="nav-dropdown">
+                    <button class="nav-link dropdown-toggle" id="link-explore-more">
+                        Explore More ▾
+                    </button>
+                    <div class="dropdown-menu">
+                        <a href="../travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                        <a href="../wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                        <a href="../coastal-india/coastal-india.html" class="dropdown-item">Coastal India</a>
+                        <a href="../heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    </div>
+                </div>
+
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
+                    ☀️
+                </button>
+                <a href="../../login.html" class="nav-link" id="link-login">Login</a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="north-andaman-page">
+        <!-- Hero -->
+        <section class="north-andaman-hero">
+            <div class="north-andaman-hero-content">
+                <a href="../islands/islands.html" class="north-andaman-back-link">← Back to Islands of India</a>
+                <span class="north-andaman-hero-kicker">⛰️ Home of the Andamans' Highest Peak</span>
+                <h1>North <span>Andaman</span></h1>
+                <p>The northernmost of the main Andaman islands — a land of rainforest-covered hills, tidal mangrove creeks and quiet beaches, anchored by Saddle Peak, the highest point in the Andaman & Nicobar Islands.</p>
+
+                <div class="north-andaman-hero-stats">
+                    <div class="north-andaman-stat-box">
+                        <strong>732 m</strong>
+                        <span>Saddle Peak — Highest Point</span>
+                    </div>
+                    <div class="north-andaman-stat-box">
+                        <strong>44.7 sq km</strong>
+                        <span>Saddle Peak National Park</span>
+                    </div>
+                    <div class="north-andaman-stat-box">
+                        <strong>1987</strong>
+                        <span>National Park Declared</span>
+                    </div>
+                    <div class="north-andaman-stat-box">
+                        <strong>Diglipur</strong>
+                        <span>Main Town & Gateway</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Tabbed info -->
+        <section class="north-andaman-section" id="north-andaman-explore">
+            <div class="north-andaman-container">
+                <div class="north-andaman-section-heading">
+                    <span class="north-andaman-section-badge">Explore North Andaman</span>
+                    <h2>Peaks, Parks, Mangroves &amp; More</h2>
+                    <p>Select a tab to learn more.</p>
+                </div>
+
+                <div class="north-andaman-tabs" role="tablist">
+                    <button type="button" class="north-andaman-tab-btn active" data-tab="saddle-peak">Saddle Peak</button>
+                    <button type="button" class="north-andaman-tab-btn" data-tab="national-park">National Park</button>
+                    <button type="button" class="north-andaman-tab-btn" data-tab="mangroves">Mangroves</button>
+                    <button type="button" class="north-andaman-tab-btn" data-tab="wildlife">Wildlife</button>
+                    <button type="button" class="north-andaman-tab-btn" data-tab="trekking">Trekking</button>
+                    <button type="button" class="north-andaman-tab-btn" data-tab="climate">Climate</button>
+                </div>
+
+                <div class="north-andaman-tab-panel active" id="tab-saddle-peak">
+                    <h3>⛰️ Saddle Peak</h3>
+                    <p>Saddle Peak rises to about 732 metres, making it the highest point anywhere in the Andaman & Nicobar Islands. Its distinctive saddle-shaped double summit gives the peak its name and makes it a landmark visible from much of North Andaman.</p>
+                    <p>The peak lies close to Diglipur and is reached via a forest trail that climbs steadily through changing vegetation zones, from coastal forest to montane rainforest near the summit.</p>
+                    <ul>
+                        <li>Highest point in the Andaman & Nicobar Islands at ~732 m</li>
+                        <li>Distinctive twin-summit "saddle" shape</li>
+                        <li>Accessible via forest trail from near Diglipur</li>
+                    </ul>
+                </div>
+
+                <div class="north-andaman-tab-panel" id="tab-national-park">
+                    <h3>🌳 National Park</h3>
+                    <p>Saddle Peak National Park covers roughly 44.7 sq km and was declared in 1987 to protect the island's highest hill range and its surrounding rainforest. It is the only national park in the Andaman & Nicobar Islands centred on a mountain ecosystem rather than a coastal or marine one.</p>
+                    <p>The park protects a corridor of tropical evergreen and semi-evergreen forest running from near sea level up to the summit, sheltering species found only in the northern Andamans.</p>
+                    <ul>
+                        <li>Declared a National Park in 1987</li>
+                        <li>Covers approximately 44.7 sq km around Saddle Peak</li>
+                        <li>Andaman & Nicobar's only mountain-ecosystem national park</li>
+                    </ul>
+                </div>
+
+                <div class="north-andaman-tab-panel" id="tab-mangroves">
+                    <h3>🌿 Mangroves</h3>
+                    <p>North Andaman's coastline is fringed by extensive mangrove creeks, particularly around Kalighat and the tidal inlets near Diglipur. These forests buffer the coast from erosion and storm surge while forming a nursery habitat for fish and crustaceans.</p>
+                    <p>Boat trips through the mangrove creeks are a popular way to see the tangled root systems and the birdlife that shelters within them, especially at dawn and dusk.</p>
+                    <ul>
+                        <li>Extensive tidal mangrove creeks along the coast</li>
+                        <li>Natural buffer against coastal erosion and storm surge</li>
+                        <li>Boat rides through creeks near Kalighat and Diglipur</li>
+                    </ul>
+                </div>
+
+                <div class="north-andaman-tab-panel" id="tab-wildlife">
+                    <h3>🦎 Wildlife</h3>
+                    <p>The forests of North Andaman support a range of wildlife adapted to island life, including the Andaman wild pig, saltwater crocodiles in the creeks and mangroves, and numerous endemic and migratory bird species drawn to the park's varied habitats.</p>
+                    <p>Ross & Smith Islands and the beaches near Aerial Bay also serve as nesting sites for marine turtles, adding to the region's ecological importance.</p>
+                    <ul>
+                        <li>Andaman wild pig and other endemic forest species</li>
+                        <li>Saltwater crocodiles in coastal creeks and mangroves</li>
+                        <li>Marine turtle nesting beaches near Aerial Bay</li>
+                    </ul>
+                </div>
+
+                <div class="north-andaman-tab-panel" id="tab-trekking">
+                    <h3>🥾 Trekking</h3>
+                    <p>The trek to Saddle Peak is the main draw for hikers, a roughly 4-5 km forest trail (one way) that begins near the park entrance and climbs through progressively denser rainforest to the summit ridge.</p>
+                    <p>The trail is best attempted with a local guide and during the drier months, since the path can turn slippery in monsoon rain and the dense canopy makes navigation difficult without local knowledge.</p>
+                    <ul>
+                        <li>Saddle Peak trail — approx. 4-5 km one way through rainforest</li>
+                        <li>Local guides recommended for the climb</li>
+                        <li>Best attempted outside the monsoon months</li>
+                    </ul>
+                </div>
+
+                <div class="north-andaman-tab-panel" id="tab-climate">
+                    <h3>🌦️ Climate</h3>
+                    <p>North Andaman has a tropical monsoon climate with warm temperatures year-round, typically ranging between 23°C and 31°C. Humidity stays high through most of the year, moderated by sea breezes along the coast.</p>
+                    <p>The island receives heavy rainfall from both the southwest monsoon (May to September) and the northeast monsoon (November to December), making the winter and early summer months the most favourable for trekking and outdoor exploration.</p>
+                    <ul>
+                        <li>Tropical monsoon climate, roughly 23°C to 31°C year-round</li>
+                        <li>Rainfall from both southwest and northeast monsoons</li>
+                        <li>December to April is the most favourable period to visit</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <!-- Interactive Map -->
+        <section class="north-andaman-section" id="north-andaman-map-section">
+            <div class="north-andaman-container">
+                <div class="north-andaman-section-heading">
+                    <span class="north-andaman-section-badge">Interactive Map</span>
+                    <h2>Key Locations Around North Andaman</h2>
+                    <p>Click a marker to learn about that location.</p>
+                </div>
+                <div class="north-andaman-map-wrap">
+                    <div id="north-andaman-map"></div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Image Gallery -->
+        <section class="north-andaman-section" id="north-andaman-gallery-section">
+            <div class="north-andaman-container">
+                <div class="north-andaman-section-heading">
+                    <span class="north-andaman-section-badge">Image Gallery</span>
+                    <h2>Glimpses of North Andaman</h2>
+                    <p>Click an image to view it larger.</p>
+                </div>
+                <div id="north-andaman-gallery-grid" class="north-andaman-gallery-grid"></div>
+            </div>
+        </section>
+
+        <!-- Interesting Facts -->
+        <section class="north-andaman-section">
+            <div class="north-andaman-container">
+                <div class="north-andaman-section-heading">
+                    <span class="north-andaman-section-badge">Did You Know?</span>
+                    <h2>Interesting Facts</h2>
+                </div>
+                <div class="north-andaman-fact-panel">
+                    <div class="north-andaman-fact-icon">💡</div>
+                    <p id="north-andaman-fact-text">Loading fact...</p>
+                    <div class="north-andaman-fact-dots" id="north-andaman-fact-dots"></div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <!-- Lightbox -->
+    <div class="north-andaman-lightbox-overlay" id="north-andaman-lightbox" hidden>
+        <div class="north-andaman-lightbox-content">
+            <button class="north-andaman-lightbox-close" data-close-lightbox="true" aria-label="Close">&times;</button>
+            <button class="north-andaman-lightbox-nav prev" id="north-andaman-lightbox-prev" aria-label="Previous image">‹</button>
+            <img id="north-andaman-lightbox-image" src="" alt="">
+            <button class="north-andaman-lightbox-nav next" id="north-andaman-lightbox-next" aria-label="Next image">›</button>
+            <p class="north-andaman-lightbox-caption" id="north-andaman-lightbox-caption"></p>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <footer class="site-footer">
+        <div class="footer-container">
+            <div class="footer-brand">
+                <a href="../../index.html#home" class="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <p>Preserving and celebrating India's rich island territories, coastlines and culture.</p>
+            </div>
+            <div class="footer-links">
+                <h4>Quick Links</h4>
+                <a href="../../index.html#home">Home</a>
+                <a href="../islands/islands.html">Islands of India</a>
+                <a href="../wildlife/wildlife.html">Nature & Wildlife</a>
+                <a href="north-andaman-island.html">North Andaman</a>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2026 Incredible India Explorer. Open Source Cultural Heritage Initiative.</p>
+        </div>
+    </footer>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+    <script type="module" src="north-andaman-island.js"></script>
+    <script src="../../pages-common.js"></script>
+</body>
+</html>

--- a/frontend/north-andaman-island/north-andaman-island.js
+++ b/frontend/north-andaman-island/north-andaman-island.js
@@ -1,0 +1,207 @@
+/* ============================================================
+   North Andaman Explorer — north-andaman-island.js
+   Handles: tab navigation, image gallery lightbox, facts
+   rotator, and the Leaflet map with key-location markers.
+   ============================================================ */
+
+// ---------- 1. KEY LOCATIONS FOR THE MAP ----------
+const NORTH_ANDAMAN_LOCATIONS = [
+  {
+    name: "Saddle Peak",
+    lat: 13.1836,
+    lng: 93.0181,
+    description: "The highest point in the Andaman & Nicobar Islands at about 732 metres, with a distinctive twin-summit 'saddle' shape."
+  },
+  {
+    name: "Saddle Peak National Park",
+    lat: 13.1780,
+    lng: 93.0050,
+    description: "A 44.7 sq km national park declared in 1987, protecting the hill range and rainforest around Saddle Peak."
+  },
+  {
+    name: "Diglipur",
+    lat: 13.2545,
+    lng: 92.9770,
+    description: "The main town in North Andaman and the gateway for treks to Saddle Peak and boat trips through the mangrove creeks."
+  },
+  {
+    name: "Ross & Smith Islands",
+    lat: 13.2870,
+    lng: 93.0540,
+    description: "A pair of twin islands near Aerial Bay connected by a natural sandbar, popular for beaches and turtle nesting."
+  }
+];
+
+// ---------- 2. IMAGE GALLERY ----------
+const NORTH_ANDAMAN_GALLERY = [
+  { src: "../../assets/travel_mountains.png", caption: "Saddle Peak rising above the North Andaman rainforest" },
+  { src: "../../assets/travel_forests.png", caption: "Dense tropical forest along the Saddle Peak trail" },
+  { src: "../../assets/travel_islands.png", caption: "Mangrove creeks along the North Andaman coastline" },
+  { src: "../../assets/travel_beaches.png", caption: "Quiet beaches near Diglipur and Aerial Bay" }
+];
+
+// ---------- 3. INTERESTING FACTS ----------
+const NORTH_ANDAMAN_FACTS = [
+  "Saddle Peak, at about 732 metres, is the highest point in the entire Andaman & Nicobar Islands.",
+  "Saddle Peak National Park, declared in 1987, is the only national park in the islands centred on a mountain ecosystem.",
+  "The trek to Saddle Peak passes through several distinct forest zones before reaching the summit ridge.",
+  "North Andaman's coast is lined with extensive tidal mangrove creeks around Kalighat and Diglipur.",
+  "Ross & Smith Islands near Aerial Bay are joined by a natural sandbar that appears at low tide.",
+  "The island receives rain from both the southwest and northeast monsoons, with December to April being the driest period."
+];
+
+// ---------- 4. STATE ----------
+let map;
+let currentGalleryIndex = 0;
+let factIndex = 0;
+
+// ---------- 5. DOM READY ----------
+document.addEventListener("DOMContentLoaded", () => {
+  initTabs();
+  initGallery();
+  initFactsRotator();
+  initMap();
+  initLightbox();
+});
+
+// ---------- 6. TAB NAVIGATION ----------
+function initTabs() {
+  const tabButtons = document.querySelectorAll(".north-andaman-tab-btn");
+  const tabPanels = document.querySelectorAll(".north-andaman-tab-panel");
+
+  tabButtons.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const target = btn.getAttribute("data-tab");
+
+      tabButtons.forEach((b) => b.classList.remove("active"));
+      btn.classList.add("active");
+
+      tabPanels.forEach((panel) => {
+        panel.classList.toggle("active", panel.id === "tab-" + target);
+      });
+    });
+  });
+}
+
+// ---------- 7. IMAGE GALLERY ----------
+function initGallery() {
+  const galleryGrid = document.getElementById("north-andaman-gallery-grid");
+  if (!galleryGrid) return;
+
+  galleryGrid.innerHTML = "";
+  NORTH_ANDAMAN_GALLERY.forEach((item, index) => {
+    const fig = document.createElement("figure");
+    fig.className = "north-andaman-gallery-item";
+    fig.innerHTML = `
+      <img src="${item.src}" alt="${item.caption}" loading="lazy">
+      <figcaption>${item.caption}</figcaption>
+    `;
+    fig.addEventListener("click", () => openLightbox(index));
+    galleryGrid.appendChild(fig);
+  });
+}
+
+// ---------- 8. LIGHTBOX ----------
+function initLightbox() {
+  document.querySelectorAll("[data-close-lightbox]").forEach((el) => {
+    el.addEventListener("click", closeLightbox);
+  });
+  const prevBtn = document.getElementById("north-andaman-lightbox-prev");
+  const nextBtn = document.getElementById("north-andaman-lightbox-next");
+  if (prevBtn) prevBtn.addEventListener("click", () => showGalleryImage(currentGalleryIndex - 1));
+  if (nextBtn) nextBtn.addEventListener("click", () => showGalleryImage(currentGalleryIndex + 1));
+
+  document.addEventListener("keydown", (e) => {
+    const lightbox = document.getElementById("north-andaman-lightbox");
+    if (!lightbox || lightbox.hidden) return;
+    if (e.key === "Escape") closeLightbox();
+    if (e.key === "ArrowRight") showGalleryImage(currentGalleryIndex + 1);
+    if (e.key === "ArrowLeft") showGalleryImage(currentGalleryIndex - 1);
+  });
+}
+
+function openLightbox(index) {
+  const lightbox = document.getElementById("north-andaman-lightbox");
+  if (!lightbox) return;
+  lightbox.hidden = false;
+  document.body.style.overflow = "hidden";
+  showGalleryImage(index);
+}
+
+function closeLightbox() {
+  const lightbox = document.getElementById("north-andaman-lightbox");
+  if (!lightbox) return;
+  lightbox.hidden = true;
+  document.body.style.overflow = "";
+}
+
+function showGalleryImage(index) {
+  const total = NORTH_ANDAMAN_GALLERY.length;
+  currentGalleryIndex = (index + total) % total;
+  const item = NORTH_ANDAMAN_GALLERY[currentGalleryIndex];
+  const img = document.getElementById("north-andaman-lightbox-image");
+  const caption = document.getElementById("north-andaman-lightbox-caption");
+  if (img) img.src = item.src;
+  if (img) img.alt = item.caption;
+  if (caption) caption.textContent = item.caption;
+}
+
+// ---------- 9. FACTS ROTATOR ----------
+function initFactsRotator() {
+  const factEl = document.getElementById("north-andaman-fact-text");
+  const dotsWrap = document.getElementById("north-andaman-fact-dots");
+  if (!factEl) return;
+
+  if (dotsWrap) {
+    NORTH_ANDAMAN_FACTS.forEach((_, i) => {
+      const dot = document.createElement("button");
+      dot.className = "north-andaman-fact-dot" + (i === 0 ? " active" : "");
+      dot.setAttribute("aria-label", "Show fact " + (i + 1));
+      dot.addEventListener("click", () => showFact(i));
+      dotsWrap.appendChild(dot);
+    });
+  }
+
+  function showFact(i) {
+    factIndex = i;
+    factEl.style.opacity = "0";
+    setTimeout(() => {
+      factEl.textContent = NORTH_ANDAMAN_FACTS[factIndex];
+      factEl.style.opacity = "1";
+    }, 200);
+    if (dotsWrap) {
+      [...dotsWrap.children].forEach((dot, di) => dot.classList.toggle("active", di === factIndex));
+    }
+  }
+
+  showFact(0);
+  setInterval(() => showFact((factIndex + 1) % NORTH_ANDAMAN_FACTS.length), 6000);
+}
+
+// ---------- 10. LEAFLET MAP ----------
+function initMap() {
+  const mapContainer = document.getElementById("north-andaman-map");
+  if (!mapContainer || typeof L === "undefined") return;
+
+  map = L.map("north-andaman-map", {
+    scrollWheelZoom: false,
+    minZoom: 6,
+  }).setView([13.2, 93.0], 10);
+
+  L.tileLayer("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png", {
+    attribution: "&copy; OpenStreetMap contributors &copy; CARTO",
+    maxZoom: 18,
+  }).addTo(map);
+
+  NORTH_ANDAMAN_LOCATIONS.forEach((loc) => {
+    const marker = L.circleMarker([loc.lat, loc.lng], {
+      radius: 8,
+      color: "#ff9933",
+      fillColor: "#ffb01f",
+      fillOpacity: 0.85,
+      weight: 2,
+    }).addTo(map);
+
+    marker.bindPopup(`<strong>${loc.name}</strong><br>${loc.description}`);
+  });
+}


### PR DESCRIPTION
## Summary
Adds a new Kavaratti Island Explorer page and integrates it into the Islands Landing Page, as requested in the issue.

## Changes
- Created `frontend/kavaratti-island/kavaratti-island.html` — new explorer page covering Lagoons, Marine Aquarium, Coral Reefs, Culture, Tourism and Mosques, with an interactive map, image gallery and facts rotator.
- Created `frontend/kavaratti-island/kavaratti-island.css` — styles for the new page, following the existing island-explorer design pattern.
- Created `frontend/kavaratti-island/kavaratti-island.js` — tab navigation, gallery lightbox, facts rotator and Leaflet map logic for the new page.
- Updated `frontend/islands/islands.js`:
  - Added a "Kavaratti Island" entry to `ISLANDS_DATA` so it appears as a card on the Islands Landing Page.
  - Updated `openModal()`'s routing so the Kavaratti card links to the new explorer page, and fixed missing commas in the `pageMap` object that were previously causing a JavaScript syntax error.

Closes #681 

@Eshajha19 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.