### PR TITLE
feat: add Valmiki National Park Explorer highlighting Bihar's only Tiger Reservee

### DIFF
--- a/frontend/national-parks-explorer/data.js
+++ b/frontend/national-parks-explorer/data.js
@@ -155,6 +155,27 @@ const NATIONAL_PARKS = [
         image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Sundarbans_National_Park.jpg/960px-Sundarbans_National_Park.jpg'
     },
     {
+        id: 'valmiki',
+        name: 'Valmiki National Park',
+        state: 'Bihar',
+        stateId: 'br',
+        established: 1990,
+        area: 898,
+        areaUnit: 'km²',
+        type: 'Tiger Reserve',
+        isTigerReserve: true,
+        isUNESCO: false,
+        description: "Bihar's only National Park and a critical Tiger Reserve. Located in the Terai region at the Himalayan foothills, it features rich Sal forests, tall grasslands, and the Gandak River.",
+        keyFauna: ['Bengal Tiger', 'Asian Elephant', 'Sloth Bear', 'Hispid Hare', 'Pygmy Hog', 'Gangetic Dolphin'],
+        keyFlora: ['Sal Forest', 'Tall Grasslands', 'Riverine Vegetation', 'Shisham'],
+        coordinates: { lat: 27.35, lng: 83.95 },
+        climate: 'Subtropical Monsoon',
+        bestTime: 'November to April',
+        entryFee: '₹100 (Indian), ₹500 (Foreign)',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/f/fe/Royal_Bengal_Tiger_at_Nandankanan.jpg/960px-Royal_Bengal_Tiger_at_Nandankanan.jpg',
+        explorerUrl: '../valmiki-national-park-explorer/index.html'
+    },
+    {
         id: 'gir',
         name: 'Gir National Park & Sanctuary',
         state: 'Gujarat',

--- a/frontend/valmiki-national-park-explorer/index.html
+++ b/frontend/valmiki-national-park-explorer/index.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script>
+    (function() {
+      const theme = localStorage.getItem('theme') || 'dark';
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Explore Valmiki National Park in Bihar — the state's only National Park and a vital Tiger Reserve in the Terai region." />
+  <title>Valmiki National Park Explorer | Incredible India</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="../../styles.css" />
+  <link rel="stylesheet" href="valmiki.css" />
+  <meta property="og:title" content="Valmiki National Park Explorer | Incredible India" />
+  <meta property="og:description" content="Interactive guide to Valmiki National Park, Bihar — a critical Tiger Reserve featuring the Gandak River and rich Terai biodiversity." />
+  <meta property="og:type" content="website" />
+</head>
+<body class="valmiki-main">
+  <header class="navbar scrolled" id="navbar">
+    <div class="nav-container">
+      <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+        <span class="saffron">Incredible</span> <span class="gold">India</span> <span class="green">Explorer</span>
+      </a>
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+        <span class="bar"></span><span class="bar"></span><span class="bar"></span>
+      </button>
+      <nav class="nav-menu" id="nav-menu">
+        <a href="../../index.html#home" class="nav-link">Home</a>
+        <a href="../national-parks-explorer/index.html" class="nav-link">National Parks</a>
+        <a href="index.html" class="nav-link active" style="color: var(--saffron)">Valmiki Explorer</a>
+        <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">☀️</button>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="valmiki-hero">
+      <div class="section-container">
+        <h1>Valmiki <span>National Park</span> Explorer</h1>
+        <p class="hero-subtitle">
+          Discover Bihar's only National Park and a vital Tiger Reserve. Nestled in the Terai region at the base of the
+          Himalayan foothills, Valmiki is a sanctuary of rich biodiversity, dense Sal forests, and the mighty Gandak River.
+        </p>
+        <div id="stats-grid" class="stats-grid"></div>
+      </div>
+    </section>
+
+    <section class="section-container">
+      <div class="section-header">
+        <span class="section-badge">Heritage</span>
+        <h2>History & Conservation</h2>
+        <p class="section-subtitle">From a protected wildlife sanctuary to a cornerstone of India's Project Tiger.</p>
+      </div>
+      <div id="history-timeline" class="timeline-container"></div>
+    </section>
+
+    <section class="section-container">
+      <div class="section-header">
+        <span class="section-badge">Apex Predator</span>
+        <h2>Tiger Reserve</h2>
+        <p class="section-subtitle">The 19th Tiger Reserve of India, playing a pivotal role in the Terai Arc Landscape.</p>
+      </div>
+      <div id="tiger-reserve-box" class="glass-card feature-box"></div>
+    </section>
+
+    <section class="section-container" style="background: rgba(21, 128, 61, 0.05); border-radius: 24px;">
+      <div class="section-header">
+        <span class="section-badge">Geography</span>
+        <h2>Gandak River & Himalayan Foothills</h2>
+        <p class="section-subtitle">The unique ecotone that defines Valmiki's rich and diverse ecosystem.</p>
+      </div>
+      <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(400px, 1fr)); gap: 2rem;">
+        <div id="gandak-river-box" class="glass-card feature-box"></div>
+        <div id="foothills-box" class="glass-card feature-box"></div>
+      </div>
+    </section>
+
+    <section class="section-container">
+      <div class="section-header">
+        <span class="section-badge">Biodiversity</span>
+        <h2>Wildlife of Valmiki</h2>
+        <p class="section-subtitle">Home to the majestic Bengal tiger, Asian elephants, and rare Terai specialists.</p>
+      </div>
+      <div id="wildlife-grid" class="wildlife-grid"></div>
+    </section>
+
+    <section class="section-container">
+      <div class="section-header">
+        <span class="section-badge">Avian Life</span>
+        <h2>Bird Species</h2>
+        <p class="section-subtitle">Over 250 species of resident and migratory birds thrive in the diverse habitats.</p>
+      </div>
+      <div id="birds-grid" class="birds-grid"></div>
+    </section>
+
+    <section class="section-container">
+      <div class="section-header">
+        <span class="section-badge">Geography</span>
+        <h2>Interactive Map</h2>
+        <p class="section-subtitle">Click on the map pins to explore key entry points, rivers, and grasslands.</p>
+      </div>
+      <div class="glass-card" style="padding: 1.5rem;">
+        <div class="map-svg-container">
+          <svg class="park-map-svg" viewBox="0 0 1000 600" xmlns="http://www.w3.org/2000/svg" style="width:100%; display:block;">
+            <rect width="1000" height="600" fill="var(--valmiki-bg)" />
+            <path d="M100,100 Q500,50 900,150 L850,500 L150,500 Z" fill="rgba(21, 128, 61, 0.1)" stroke="var(--valmiki-accent)" stroke-width="2" />
+            <path d="M50,150 Q150,300 100,500" fill="none" stroke="#3b82f6" stroke-width="25" opacity="0.5" />
+            <text x="120" y="350" fill="#60a5fa" font-size="16" font-family="Outfit">Gandak River</text>
+          </svg>
+          <div id="map-hotspots-layer"></div>
+          <div id="map-info-popup" class="map-info-popup hidden"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-container">
+      <div class="section-header">
+        <span class="section-badge">Visuals</span>
+        <h2>Photo Gallery</h2>
+        <p class="section-subtitle">Glimpses of the tigers, elephants, and the lush Terai landscape of Valmiki.</p>
+      </div>
+      <div id="gallery-grid" class="gallery-grid"></div>
+    </section>
+  </main>
+
+  <div id="lightbox-modal" class="lightbox-modal hidden" role="dialog" aria-modal="true" aria-label="Photo Lightbox">
+    <div class="lightbox-content">
+      <button type="button" id="lightbox-close" class="lightbox-close" aria-label="Close Lightbox">&times;</button>
+      <img id="lightbox-img" class="lightbox-img" src="" alt="Gallery Preview" />
+      <div id="lightbox-caption" class="lightbox-caption"></div>
+    </div>
+  </div>
+
+  <footer class="footer" style="margin-top: 4rem; border-top: 1px solid var(--valmiki-border); padding: 3rem 1.5rem; text-align: center; color: var(--valmiki-muted);">
+    <p>&copy; 2026 Incredible India Explorer. Valmiki National Park Explorer.</p>
+  </footer>
+
+  <script src="../../app.js" defer></script>
+  <script src="valmiki-data.js" defer></script>
+  <script src="valmiki.js" defer></script>
+  <script type="module" src="../../auth.js"></script>
+</body>
+</html>

--- a/frontend/valmiki-national-park-explorer/valmiki-data.js
+++ b/frontend/valmiki-national-park-explorer/valmiki-data.js
@@ -1,0 +1,194 @@
+/**
+ * Valmiki National Park Explorer — Data Module
+ * Comprehensive dataset covering History, Tiger Reserve, Gandak River,
+ * Himalayan Foothills, Wildlife, Bird Species, Gallery, and Interactive Map.
+ *
+ * This module exports constants used by valmiki.js to dynamically render
+ * the DOM elements, ensuring a clean separation of concerns.
+ */
+
+const VALMIKI_INFO = {
+  id: "valmiki",
+  name: "Valmiki National Park",
+  aka: "Valmiki Tiger Reserve",
+  location: "West Champaran District, Bihar, India",
+  state: "Bihar",
+  coordinates: { lat: 27.35, lng: 83.95 },
+  area: "898.45 km² (Core: 336.45 km², Buffer: 562 km²)",
+  establishedYear: 1989,
+  tigerReserveYear: 1989,
+  etymology: "Named after Sage Valmiki, the author of the ancient Indian epic Ramayana, who is believed to have meditated in this serene region.",
+  climate: "Subtropical monsoon, with hot, humid summers, heavy monsoon rainfall, and cool, foggy winters.",
+  bestTime: "November to April (Pleasant weather, high wildlife visibility, park open)",
+  entryFees: "₹100 (Indian Nationals), ₹500 (Foreigners)",
+  nearestTransport: {
+    railway: "Narkatiaganj Junction (25 km)",
+    airport: "Gorakhpur Airport (80 km) / Patna Airport (200 km)",
+    gatewayTown: "Narkatiaganj"
+  },
+  quickStats: [
+    { label: "Bihar's Only NP", value: "Yes", icon: "🏛️" },
+    { label: "Tiger Reserve", value: "Since 1989", icon: "🐅" },
+    { label: "Total Area", value: "898 km²", icon: "🌲" },
+    { label: "Bird Species", value: "250+", icon: "🦅" },
+    { label: "Mammal Species", value: "50+", icon: "🦌" },
+    { label: "Elevation", value: "100m - 800m", icon: "⛰️" }
+  ]
+};
+
+const HISTORY = [
+  {
+    year: "1978",
+    title: "Wildlife Sanctuary Notified",
+    description: "The area was first notified as the Valmiki Wildlife Sanctuary to protect the unique and fragile Terai ecosystem bordering Nepal."
+  },
+  {
+    year: "1989",
+    title: "Tiger Reserve Status",
+    description: "Included under Project Tiger, recognizing its critical role in conserving the Bengal tiger population and maintaining the Terai Arc Landscape."
+  },
+  {
+    year: "1990",
+    title: "National Park Designation",
+    description: "The core area was officially upgraded to a National Park, affording it the highest level of legal protection under the Wildlife Protection Act."
+  }
+];
+
+const TIGER_RESERVE = {
+  title: "Valmiki Tiger Reserve",
+  description: "As the 19th Tiger Reserve of India and the only one in Bihar, Valmiki plays a pivotal role in the Terai Arc Landscape. It serves as a vital corridor connecting the protected areas of India and Nepal, allowing for genetic exchange of tiger populations. Rigorous anti-poaching measures, community engagement, and habitat restoration have led to a steady and promising increase in the tiger population in recent years.",
+  keyInitiatives: [
+    "Intensive anti-poaching patrols and M-STrIPES monitoring",
+    "Prey base augmentation through habitat management",
+    "Community-based conservation and eco-development programs",
+    "Cross-border collaboration with Nepal's Chitwan National Park"
+  ]
+};
+
+const GANDAK_RIVER = {
+  title: "The Gandak River",
+  description: "The Gandak River forms the natural western boundary of Valmiki National Park, separating it from Nepal. This mighty river, originating in the Himalayas, is the lifeline of the reserve. Its dynamic riverine ecosystems support a rich diversity of aquatic life, including the endangered Gangetic Dolphin and the critically endangered Gharial. The riverbanks also serve as crucial watering holes for terrestrial wildlife, especially during the dry summer months."
+};
+
+const HIMALAYAN_FOOTHILLS = {
+  title: "Himalayan Foothills & Terai Ecosystem",
+  description: "Valmiki is situated in the Terai region, a lowland area at the base of the Himalayan foothills. This unique ecotone features a mosaic of tall, dense grasslands (phantas), moist deciduous Sal forests, and riverine vegetation. This diverse habitat structure is ideal for supporting a wide variety of species, from the elusive Hispid Hare in the grasslands to the majestic Bengal Tiger in the dense forest cover."
+};
+
+const WILDLIFE = [
+  {
+    id: "tiger",
+    name: "Bengal Tiger",
+    scientificName: "Panthera tigris tigris",
+    status: "Endangered",
+    icon: "🐅",
+    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fe/Royal_Bengal_Tiger_at_Nandankanan.jpg/800px-Royal_Bengal_Tiger_at_Nandankanan.jpg",
+    description: "The apex predator of Valmiki. Camera trap data shows a healthy and growing population, a testament to successful conservation efforts."
+  },
+  {
+    id: "elephant",
+    name: "Asian Elephant",
+    scientificName: "Elephas maximus",
+    status: "Endangered",
+    icon: "🐘",
+    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5b/Asian_Elephant_Bull_%28Elephas_maximus%29_%287856743588%29.jpg/800px-Asian_Elephant_Bull_%28Elephas_maximus%29_%287856743588%29.jpg",
+    description: "Valmiki hosts a significant resident elephant population and acts as a crucial corridor for migratory herds moving between India and Nepal."
+  },
+  {
+    id: "hispid-hare",
+    name: "Hispid Hare",
+    scientificName: "Caprolagus hispidus",
+    status: "Endangered",
+    icon: "🐇",
+    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8c/Hispid_hare.jpg/800px-Hispid_hare.jpg",
+    description: "A rare and elusive mammal entirely dependent on the tall, dense grasslands of the Terai region for survival."
+  },
+  {
+    id: "sloth-bear",
+    name: "Sloth Bear",
+    scientificName: "Melursus ursinus",
+    status: "Vulnerable",
+    icon: "🐻",
+    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Sloth_Bear.jpg/800px-Sloth_Bear.jpg",
+    description: "Frequently spotted foraging for termites and fruits in the dry and moist deciduous forest patches of the reserve."
+  }
+];
+
+const BIRD_SPECIES = [
+  {
+    id: "hornbill",
+    name: "Indian Grey Hornbill",
+    scientificName: "Ocyceros birostris",
+    status: "Least Concern",
+    icon: "🦜",
+    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6f/Indian_Grey_Hornbill.jpg/800px-Indian_Grey_Hornbill.jpg",
+    description: "Commonly seen and heard in the Sal forests, playing a vital role in seed dispersal and maintaining forest health."
+  },
+  {
+    id: "peafowl",
+    name: "Indian Peafowl",
+    scientificName: "Pavo cristatus",
+    status: "Least Concern",
+    icon: "🦚",
+    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/3a/Peacock_displaying.jpg/800px-Peacock_displaying.jpg",
+    description: "The national bird of India, frequently spotted displaying its magnificent plumage in the open grasslands and forest edges."
+  },
+  {
+    id: "junglefowl",
+    name: "Red Junglefowl",
+    scientificName: "Gallus gallus",
+    status: "Least Concern",
+    icon: "🐓",
+    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/4/4d/Red_junglefowl.jpg/800px-Red_junglefowl.jpg",
+    description: "The wild ancestor of the domestic chicken, thriving in the dense undergrowth of Valmiki's deciduous forests."
+  }
+];
+
+const MAP_HOTSPOTS = [
+  {
+    id: "spot-gandak",
+    name: "Gandak River Boundary",
+    category: "water",
+    x: 25,
+    y: 50,
+    description: "The western boundary of the park, rich in aquatic life and a vital watering hole for terrestrial wildlife."
+  },
+  {
+    id: "spot-terai",
+    name: "Terai Grasslands",
+    category: "wildlife",
+    x: 60,
+    y: 60,
+    description: "Tall grassland habitat critical for the Hispid hare, pygmy hog, and grazing herbivores like deer and elephants."
+  },
+  {
+    id: "spot-entry",
+    name: "Valmiki Nagar Entry",
+    category: "gate",
+    x: 50,
+    y: 40,
+    description: "The main entry point for tourists, featuring the interpretation center, forest rest house, and safari booking office."
+  }
+];
+
+const GALLERY_IMAGES = [
+  {
+    url: "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fe/Royal_Bengal_Tiger_at_Nandankanan.jpg/800px-Royal_Bengal_Tiger_at_Nandankanan.jpg",
+    title: "Bengal Tiger",
+    caption: "A Bengal tiger roaming the dense Sal forests of Valmiki National Park, the apex predator of the Terai."
+  },
+  {
+    url: "https://upload.wikimedia.org/wikipedia/commons/thumb/8/8c/Gandak_River_Bihar.jpg/800px-Gandak_River_Bihar.jpg",
+    title: "Gandak River",
+    caption: "The mighty Gandak river forming the natural western boundary of the reserve, separating India and Nepal."
+  },
+  {
+    url: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5b/Asian_Elephant_Bull_%28Elephas_maximus%29_%287856743588%29.jpg/800px-Asian_Elephant_Bull_%28Elephas_maximus%29_%287856743588%29.jpg",
+    title: "Asian Elephant",
+    caption: "An Asian elephant moving through the Terai grasslands, highlighting Valmiki's role as a crucial migration corridor."
+  }
+];
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { VALMIKI_INFO, HISTORY, TIGER_RESERVE, GANDAK_RIVER, HIMALAYAN_FOOTHILLS, WILDLIFE, BIRD_SPECIES, MAP_HOTSPOTS, GALLERY_IMAGES };
+}

--- a/frontend/valmiki-national-park-explorer/valmiki.css
+++ b/frontend/valmiki-national-park-explorer/valmiki.css
@@ -1,0 +1,370 @@
+/**
+ * Valmiki National Park Explorer — Stylesheet
+ * Supports both dark and light themes using CSS variables.
+ * Designed for readability, accessibility, and responsive layouts.
+ */
+
+:root {
+  --valmiki-bg-dark: #0f172a;
+  --valmiki-bg-light: #f8fafc;
+  --valmiki-card-dark: rgba(30, 41, 59, 0.85);
+  --valmiki-card-light: rgba(255, 255, 255, 0.95);
+  --valmiki-text-dark: #e2e8f0;
+  --valmiki-text-light: #1e293b;
+  --valmiki-muted-dark: #94a3b8;
+  --valmiki-muted-light: #64748b;
+  --valmiki-accent: #15803d; /* Forest Green */
+  --valmiki-accent-bright: #22c55e;
+  --valmiki-border-dark: rgba(255, 255, 255, 0.1);
+  --valmiki-border-light: rgba(0, 0, 0, 0.08);
+}
+
+body.light-theme {
+  --valmiki-bg: var(--valmiki-bg-light);
+  --valmiki-card: var(--valmiki-card-light);
+  --valmiki-text: var(--valmiki-text-light);
+  --valmiki-muted: var(--valmiki-muted-light);
+  --valmiki-border: var(--valmiki-border-light);
+}
+
+body:not(.light-theme) {
+  --valmiki-bg: var(--valmiki-bg-dark);
+  --valmiki-card: var(--valmiki-card-dark);
+  --valmiki-text: var(--valmiki-text-dark);
+  --valmiki-muted: var(--valmiki-muted-dark);
+  --valmiki-border: var(--valmiki-border-dark);
+}
+
+.valmiki-main {
+  background-color: var(--valmiki-bg);
+  color: var(--valmiki-text);
+  font-family: 'Outfit', sans-serif;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.section-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 4rem 1.5rem;
+}
+
+.section-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.section-badge {
+  display: inline-block;
+  padding: 0.4rem 1rem;
+  background: rgba(21, 128, 61, 0.15);
+  color: var(--valmiki-accent-bright);
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.section-header h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  color: var(--valmiki-text);
+}
+
+.section-subtitle {
+  font-size: 1.1rem;
+  color: var(--valmiki-muted);
+  max-width: 700px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.glass-card {
+  background: var(--valmiki-card);
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--valmiki-border);
+  border-radius: 16px;
+  padding: 2rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.glass-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
+}
+
+/* Hero Section */
+.valmiki-hero {
+  padding: 6rem 1.5rem 4rem;
+  text-align: center;
+  background: linear-gradient(rgba(15, 23, 42, 0.7), rgba(15, 23, 42, 0.9)),
+              url('https://upload.wikimedia.org/wikipedia/commons/thumb/f/fe/Royal_Bengal_Tiger_at_Nandankanan.jpg/1200px-Royal_Bengal_Tiger_at_Nandankanan.jpg') center/cover no-repeat;
+}
+
+body.light-theme .valmiki-hero {
+  background: linear-gradient(rgba(248, 250, 252, 0.8), rgba(248, 250, 252, 0.95)),
+              url('https://upload.wikimedia.org/wikipedia/commons/thumb/f/fe/Royal_Bengal_Tiger_at_Nandankanan.jpg/1200px-Royal_Bengal_Tiger_at_Nandankanan.jpg') center/cover no-repeat;
+}
+
+.valmiki-hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: 3.5rem;
+  margin-bottom: 1.5rem;
+  color: var(--valmiki-text);
+}
+
+.valmiki-hero h1 span {
+  color: var(--valmiki-accent-bright);
+}
+
+.hero-subtitle {
+  font-size: 1.2rem;
+  color: var(--valmiki-muted);
+  max-width: 800px;
+  margin: 0 auto 3rem;
+  line-height: 1.7;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1.5rem;
+  margin-top: 3rem;
+}
+
+.stat-card {
+  text-align: center;
+  padding: 1.5rem 1rem;
+}
+
+.stat-icon {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.stat-value {
+  display: block;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--valmiki-accent-bright);
+}
+
+.stat-label {
+  font-size: 0.85rem;
+  color: var(--valmiki-muted);
+}
+
+/* Wildlife & Bird Grids */
+.wildlife-grid, .birds-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 2rem;
+}
+
+.wildlife-card img, .bird-card img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  border-radius: 12px;
+  margin-bottom: 1rem;
+}
+
+/* Timeline */
+.timeline-container {
+  position: relative;
+  max-width: 800px;
+  margin: 0 auto;
+  padding-left: 2rem;
+}
+
+.timeline-container::before {
+  content: '';
+  position: absolute;
+  left: 8px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--valmiki-accent);
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: 2.5rem;
+  padding-left: 2rem;
+}
+
+.timeline-dot {
+  position: absolute;
+  left: -1.6rem;
+  top: 0.5rem;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--valmiki-accent-bright);
+  border: 3px solid var(--valmiki-bg);
+}
+
+/* Feature Boxes (Tiger Reserve, Gandak, Foothills) */
+.feature-box {
+  border-left: 4px solid var(--valmiki-accent);
+  background: rgba(21, 128, 61, 0.05);
+  margin-bottom: 2rem;
+}
+
+.initiatives-list {
+  list-style: none;
+  padding: 0;
+  margin-top: 1rem;
+}
+
+.initiatives-list li {
+  padding: 0.5rem 0;
+  padding-left: 1.5rem;
+  position: relative;
+  color: var(--valmiki-muted);
+}
+
+.initiatives-list li::before {
+  content: '🌿';
+  position: absolute;
+  left: 0;
+}
+
+/* Map */
+.map-svg-container {
+  position: relative;
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+  border-radius: 16px;
+  overflow: hidden;
+  background: var(--valmiki-card);
+}
+
+.map-hotspot-pin {
+  position: absolute;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 2px solid var(--valmiki-accent-bright);
+  background: var(--valmiki-card);
+  font-size: 1.2rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform: translate(-50%, -50%);
+  transition: transform 0.2s ease;
+}
+
+.map-hotspot-pin:hover {
+  transform: translate(-50%, -50%) scale(1.2);
+}
+
+.map-info-popup {
+  position: absolute;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--valmiki-card);
+  border: 1px solid var(--valmiki-border);
+  border-radius: 12px;
+  padding: 1rem 1.5rem;
+  max-width: 300px;
+  text-align: center;
+  backdrop-filter: blur(8px);
+}
+
+.hidden {
+  display: none !important;
+}
+
+/* Gallery */
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.5rem;
+}
+
+.gallery-item {
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  cursor: pointer;
+  height: 220px;
+}
+
+.gallery-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.4s ease;
+}
+
+.gallery-item:hover .gallery-img {
+  transform: scale(1.05);
+}
+
+.gallery-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 1rem;
+  background: linear-gradient(transparent, rgba(0, 0, 0, 0.8));
+  color: white;
+}
+
+/* Lightbox */
+.lightbox-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.95);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 2rem;
+}
+
+.lightbox-content {
+  position: relative;
+  max-width: 900px;
+  text-align: center;
+}
+
+.lightbox-close {
+  position: absolute;
+  top: -3rem;
+  right: 0;
+  background: none;
+  border: none;
+  color: white;
+  font-size: 2.5rem;
+  cursor: pointer;
+}
+
+.lightbox-img {
+  max-width: 100%;
+  max-height: 70vh;
+  border-radius: 12px;
+}
+
+.lightbox-caption {
+  margin-top: 1rem;
+  color: #cbd5e1;
+  font-size: 1rem;
+}
+
+/* Responsive Adjustments */
+@media (max-width: 768px) {
+  .valmiki-hero h1 { font-size: 2.5rem; }
+  .section-header h2 { font-size: 2rem; }
+  .stats-grid { grid-template-columns: repeat(2, 1fr); }
+  .timeline-container { padding-left: 1.5rem; }
+}

--- a/frontend/valmiki-national-park-explorer/valmiki.js
+++ b/frontend/valmiki-national-park-explorer/valmiki.js
@@ -1,0 +1,231 @@
+/**
+ * Valmiki National Park Explorer — Interactive Logic
+ * Handles DOM rendering, theme toggling, and interactive map/gallery features.
+ * Uses an IIFE to prevent global scope pollution.
+ */
+
+(function() {
+  'use strict';
+
+  // Wait for DOM to be fully loaded before executing
+  document.addEventListener('DOMContentLoaded', function() {
+    initTheme();
+    renderQuickStats();
+    renderHistory();
+    renderTigerReserve();
+    renderGandakRiver();
+    renderHimalayanFoothills();
+    renderWildlife();
+    renderBirdSpecies();
+    renderInteractiveMap();
+    renderGalleryGrid();
+    bindEvents();
+  });
+
+  /**
+   * Initializes the theme based on localStorage or defaults to dark mode.
+   */
+  function initTheme() {
+    const savedTheme = localStorage.getItem('theme') || 'dark';
+    if (savedTheme === 'light') {
+      document.body.classList.add('light-theme');
+    }
+  }
+
+  /**
+   * Binds event listeners for theme toggle, lightbox, and keyboard navigation.
+   */
+  function bindEvents() {
+    const themeBtn = document.getElementById('theme-toggle');
+    if (themeBtn) {
+      themeBtn.addEventListener('click', function() {
+        document.body.classList.toggle('light-theme');
+        const isLight = document.body.classList.contains('light-theme');
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        themeBtn.textContent = isLight ? '🌙' : '☀️';
+      });
+    }
+
+    const lbClose = document.getElementById('lightbox-close');
+    if (lbClose) lbClose.addEventListener('click', closeLightbox);
+
+    const lbModal = document.getElementById('lightbox-modal');
+    if (lbModal) {
+      lbModal.addEventListener('click', function(e) {
+        if (e.target === lbModal) closeLightbox();
+      });
+    }
+
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape') closeLightbox();
+    });
+  }
+
+  function renderQuickStats() {
+    const container = document.getElementById('stats-grid');
+    if (!container || typeof VALMIKI_INFO === 'undefined') return;
+
+    let html = '';
+    VALMIKI_INFO.quickStats.forEach(function(st) {
+      html += `
+        <div class="glass-card stat-card">
+          <div class="stat-icon">${st.icon}</div>
+          <span class="stat-value">${st.value}</span>
+          <span class="stat-label">${st.label}</span>
+        </div>`;
+    });
+    container.innerHTML = html;
+  }
+
+  function renderHistory() {
+    const container = document.getElementById('history-timeline');
+    if (!container || typeof HISTORY === 'undefined') return;
+
+    let html = '';
+    HISTORY.forEach(function(item) {
+      html += `
+        <div class="timeline-item">
+          <div class="timeline-dot"></div>
+          <div class="glass-card">
+            <div style="font-weight:800; font-size:1.2rem; color:var(--valmiki-accent-bright); margin-bottom:0.4rem;">${item.year}</div>
+            <h4 style="margin-bottom:0.5rem;">${item.title}</h4>
+            <p style="font-size:0.92rem; color:var(--valmiki-muted); line-height:1.6;">${item.description}</p>
+          </div>
+        </div>`;
+    });
+    container.innerHTML = html;
+  }
+
+  function renderTigerReserve() {
+    const container = document.getElementById('tiger-reserve-box');
+    if (!container || typeof TIGER_RESERVE === 'undefined') return;
+
+    const initiativesHtml = TIGER_RESERVE.keyInitiatives.map(i => `<li>${i}</li>`).join('');
+
+    container.innerHTML = `
+      <h3 style="font-size:1.5rem; color:var(--valmiki-accent-bright); margin-bottom:0.5rem;">${TIGER_RESERVE.title}</h3>
+      <p style="line-height:1.7; margin-bottom:1rem;">${TIGER_RESERVE.description}</p>
+      <h4 style="margin-top:1.5rem; margin-bottom:0.5rem;">Key Conservation Initiatives:</h4>
+      <ul class="initiatives-list">${initiativesHtml}</ul>
+    `;
+  }
+
+  function renderGandakRiver() {
+    const container = document.getElementById('gandak-river-box');
+    if (!container || typeof GANDAK_RIVER === 'undefined') return;
+
+    container.innerHTML = `
+      <h3 style="font-size:1.5rem; color:var(--valmiki-accent-bright); margin-bottom:0.5rem;">💧 ${GANDAK_RIVER.title}</h3>
+      <p style="line-height:1.7; color:var(--valmiki-muted);">${GANDAK_RIVER.description}</p>
+    `;
+  }
+
+  function renderHimalayanFoothills() {
+    const container = document.getElementById('foothills-box');
+    if (!container || typeof HIMALAYAN_FOOTHILLS === 'undefined') return;
+
+    container.innerHTML = `
+      <h3 style="font-size:1.5rem; color:var(--valmiki-accent-bright); margin-bottom:0.5rem;">⛰️ ${HIMALAYAN_FOOTHILLS.title}</h3>
+      <p style="line-height:1.7; color:var(--valmiki-muted);">${HIMALAYAN_FOOTHILLS.description}</p>
+    `;
+  }
+
+  function renderWildlife() {
+    const container = document.getElementById('wildlife-grid');
+    if (!container || typeof WILDLIFE === 'undefined') return;
+
+    let html = '';
+    WILDLIFE.forEach(function(w) {
+      html += `
+        <div class="glass-card wildlife-card">
+          <img src="${w.image}" alt="${w.name}" loading="lazy" onerror="this.style.display='none'">
+          <h3 style="font-size:1.3rem; margin-bottom:0.2rem;">${w.icon} ${w.name}</h3>
+          <div style="font-style:italic; font-size:0.85rem; color:var(--valmiki-accent-bright); margin-bottom:0.8rem;">${w.scientificName}</div>
+          <span style="display:inline-block; padding:0.2rem 0.6rem; background:rgba(220,38,38,0.2); color:#f87171; border-radius:999px; font-size:0.75rem; font-weight:700; margin-bottom:0.8rem;">${w.status}</span>
+          <p style="font-size:0.9rem; color:var(--valmiki-muted); line-height:1.5;">${w.description}</p>
+        </div>`;
+    });
+    container.innerHTML = html;
+  }
+
+  function renderBirdSpecies() {
+    const container = document.getElementById('birds-grid');
+    if (!container || typeof BIRD_SPECIES === 'undefined') return;
+
+    let html = '';
+    BIRD_SPECIES.forEach(function(b) {
+      html += `
+        <div class="glass-card bird-card">
+          <img src="${b.image}" alt="${b.name}" loading="lazy" onerror="this.style.display='none'">
+          <h3 style="font-size:1.2rem; margin-bottom:0.2rem;">${b.icon} ${b.name}</h3>
+          <div style="font-style:italic; font-size:0.82rem; color:var(--valmiki-accent-bright); margin-bottom:0.8rem;">${b.scientificName}</div>
+          <p style="font-size:0.88rem; color:var(--valmiki-muted); line-height:1.5;">${b.description}</p>
+        </div>`;
+    });
+    container.innerHTML = html;
+  }
+
+  function renderInteractiveMap() {
+    const container = document.getElementById('map-hotspots-layer');
+    const infoPopup = document.getElementById('map-info-popup');
+    if (!container || typeof MAP_HOTSPOTS === 'undefined') return;
+
+    let html = '';
+    MAP_HOTSPOTS.forEach(function(spot) {
+      const icon = spot.category === 'gate' ? '🚪' : spot.category === 'water' ? '💧' : '📍';
+      html += `<button type="button" class="map-hotspot-pin" style="left:${spot.x}%; top:${spot.y}%;" data-spot-id="${spot.id}" aria-label="${spot.name}">${icon}</button>`;
+    });
+    container.innerHTML = html;
+
+    container.querySelectorAll('.map-hotspot-pin').forEach(function(pin) {
+      pin.addEventListener('click', function() {
+        const spot = MAP_HOTSPOTS.find(s => s.id === pin.dataset.spotId);
+        if (spot && infoPopup) {
+          infoPopup.innerHTML = `<h4 style="color:var(--valmiki-accent-bright); margin-bottom:0.3rem;">${spot.name}</h4><p style="font-size:0.85rem; color:var(--valmiki-muted);">${spot.description}</p>`;
+          infoPopup.classList.remove('hidden');
+        }
+      });
+    });
+  }
+
+  function renderGalleryGrid() {
+    const container = document.getElementById('gallery-grid');
+    if (!container || typeof GALLERY_IMAGES === 'undefined') return;
+
+    let html = '';
+    GALLERY_IMAGES.forEach(function(img, idx) {
+      html += `
+        <div class="gallery-item" data-idx="${idx}">
+          <img class="gallery-img" src="${img.url}" alt="${img.title}" loading="lazy">
+          <div class="gallery-overlay">
+            <h4 style="margin-bottom:0.2rem;">${img.title}</h4>
+            <p style="font-size:0.8rem; opacity:0.9;">${img.caption}</p>
+          </div>
+        </div>`;
+    });
+    container.innerHTML = html;
+
+    container.querySelectorAll('.gallery-item').forEach(function(item) {
+      item.addEventListener('click', function() {
+        openLightbox(parseInt(item.dataset.idx, 10));
+      });
+    });
+  }
+
+  function openLightbox(idx) {
+    if (typeof GALLERY_IMAGES === 'undefined' || !GALLERY_IMAGES[idx]) return;
+    const modal = document.getElementById('lightbox-modal');
+    const imgEl = document.getElementById('lightbox-img');
+    const capEl = document.getElementById('lightbox-caption');
+    if (!modal || !imgEl || !capEl) return;
+
+    imgEl.src = GALLERY_IMAGES[idx].url;
+    capEl.textContent = GALLERY_IMAGES[idx].title + ' — ' + GALLERY_IMAGES[idx].caption;
+    modal.classList.remove('hidden');
+  }
+
+  function closeLightbox() {
+    const modal = document.getElementById('lightbox-modal');
+    if (modal) modal.classList.add('hidden');
+  }
+})();


### PR DESCRIPTION

# Pull Request

## Description

This PR implements the Valmiki National Park Explorer as requested in issue #923. It adds a comprehensive, interactive educational page showcasing Bihar's only National Park, covering history, tiger reserve status, Gandak River, Himalayan foothills geography, wildlife, bird species, gallery, and an interactive map. It also integrates the park into the main National Parks Explorer landing page.

Fixes #923

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Tested locally in browser
- [x] Tested in both dark and light themes
- [x] Tested at mobile viewport widths
- [x] Verified no console errors

## Checklist

- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)

