### PR TITLE
feat: add Sundarbans National Park explorer

### DIFF
--- a/frontend/sundarbans-national-park/index.html
+++ b/frontend/sundarbans-national-park/index.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sundarbans National Park Explorer | Incredible India Explorer</title>
+  <meta name="description" content="Explore Sundarbans National Park with mangrove forest, Royal Bengal tiger, UNESCO site, delta ecosystem, crocodiles, birds, conservation, and interactive map.">
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="navbar scrolled" id="navbar">
+    <div class="nav-container">
+      <a href="../../index.html#home" class="nav-logo">
+        <span class="saffron">Incredible</span>
+        <span class="gold">India</span>
+        <span class="green">Explorer</span>
+      </a>
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+        <span class="bar"></span><span class="bar"></span><span class="bar"></span>
+      </button>
+      <nav class="nav-menu" id="nav-menu">
+        <a href="../../index.html#home" class="nav-link">Home</a>
+        <a href="../../travel.html" class="nav-link">Travel</a>
+        <a href="../../learn.html" class="nav-link">Learn</a>
+        <a href="index.html" class="nav-link sundarbans-current">Sundarbans</a>
+        <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+      </nav>
+    </div>
+  </header>
+
+  <main class="sundarbans-page">
+    <section class="sundarbans-hero">
+      <div class="hero-content">
+        <span class="hero-kicker">West Bengal · Mangrove Forest · UNESCO Site</span>
+        <h1>Sundarbans National Park <span>Explorer</span></h1>
+        <p>
+          Journey through the world's legendary mangrove delta with Royal Bengal tigers,
+          crocodiles, birds, tidal channels, conservation stories, and an interactive map.
+        </p>
+        <div class="hero-stats">
+          <div><strong>🐅 Tiger</strong><span>Flagship species</span></div>
+          <div><strong>Mangrove</strong><span>Forest ecosystem</span></div>
+          <div><strong>UNESCO</strong><span>World Heritage</span></div>
+        </div>
+        <a href="#overview" class="hero-cta">Start exploring ↓</a>
+      </div>
+    </section>
+
+    <section class="overview-section" id="overview">
+      <div class="page-container">
+        <div class="section-heading">
+          <span class="section-badge">Park overview</span>
+          <h2>A living delta of tides, roots, and wildlife</h2>
+          <p>
+            Sundarbans National Park protects an extraordinary mangrove ecosystem
+            shaped by rivers, sea tides, mudflats, islands, and brackish channels.
+            It is famous for Royal Bengal tigers, crocodiles, birds, and conservation challenges.
+          </p>
+        </div>
+        <div class="overview-grid">
+          <article class="overview-card large">
+            <h3>Mangrove forest</h3>
+            <p>
+              The Sundarbans landscape is built by salt-tolerant mangrove trees,
+              breathing roots, tidal creeks, and sediment-rich waterways. These
+              habitats protect coasts, support fisheries, and shelter diverse wildlife.
+            </p>
+          </article>
+          <article class="overview-card">
+            <h3>Royal Bengal tiger</h3>
+            <p>
+              Tigers in the Sundarbans live in a demanding tidal environment where
+              water, mudflats, dense cover, and prey movement shape behaviour.
+            </p>
+          </article>
+          <article class="overview-card">
+            <h3>UNESCO value</h3>
+            <p>
+              The park is recognised globally for its unique mangrove biodiversity,
+              ecological processes, and conservation importance.
+            </p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="facts-section">
+      <div class="page-container">
+        <div class="section-heading">
+          <span class="section-badge">Quick facts</span>
+          <h2>Sundarbans at a glance</h2>
+        </div>
+        <div class="facts-grid" id="facts-grid"></div>
+      </div>
+    </section>
+
+    <section class="wildlife-section">
+      <div class="page-container">
+        <div class="section-heading">
+          <span class="section-badge">Wildlife</span>
+          <h2>Meet delta biodiversity</h2>
+          <p>Filter wildlife cards to explore mammals, reptiles, and birds of the mangrove ecosystem.</p>
+        </div>
+        <div class="filter-row" role="group" aria-label="Wildlife filters">
+          <button class="filter-btn active" data-filter="All" type="button">All</button>
+          <button class="filter-btn" data-filter="Mammal" type="button">Mammals</button>
+          <button class="filter-btn" data-filter="Reptile" type="button">Reptiles</button>
+          <button class="filter-btn" data-filter="Bird" type="button">Birds</button>
+        </div>
+        <div class="wildlife-grid" id="wildlife-grid"></div>
+      </div>
+    </section>
+
+    <section class="map-section">
+      <div class="page-container">
+        <div class="section-heading">
+          <span class="section-badge">Interactive map</span>
+          <h2>Explore the mangrove delta</h2>
+          <p>Tap each point to learn about interpretation zones, watchtowers, creeks, and tidal-delta habitats.</p>
+        </div>
+        <div class="map-layout">
+          <div class="sundarbans-map" id="sundarbans-map" aria-label="Interactive Sundarbans map">
+            <div class="delta-shape"></div>
+            <div class="water-channel channel-one"></div>
+            <div class="water-channel channel-two"></div>
+            <div class="water-channel channel-three"></div>
+            <div id="map-pins"></div>
+          </div>
+          <aside class="map-info" id="map-info">
+            <span>Selected point</span>
+            <h3>Tap a map pin</h3>
+            <p>Map points explain visitor zones, creeks, watchtowers, and delta habitats.</p>
+          </aside>
+        </div>
+      </div>
+    </section>
+
+    <section class="ecosystem-section">
+      <div class="page-container">
+        <div class="section-heading">
+          <span class="section-badge">Delta ecosystem</span>
+          <h2>How the Sundarbans works</h2>
+        </div>
+        <div class="ecosystem-grid" id="ecosystem-grid"></div>
+      </div>
+    </section>
+
+    <section class="conservation-section">
+      <div class="page-container">
+        <div class="section-heading">
+          <span class="section-badge">Conservation</span>
+          <h2>Protecting a fragile mangrove world</h2>
+        </div>
+        <div class="conservation-grid" id="conservation-grid"></div>
+      </div>
+    </section>
+
+    <section class="gallery-section">
+      <div class="page-container">
+        <div class="section-heading">
+          <span class="section-badge">Gallery</span>
+          <h2>Visual story of Sundarbans</h2>
+          <p>Existing project assets are used as visual placeholders for mangroves, delta waters, tigers, birds, and tidal landscapes.</p>
+        </div>
+        <div class="gallery-grid" id="gallery-grid"></div>
+      </div>
+    </section>
+
+    <section class="source-section">
+      <div class="page-container">
+        <h2>Source notes</h2>
+        <p>
+          This page is an educational explorer built from the issue requirements:
+          Mangrove Forest, Royal Bengal Tiger, UNESCO Site, Delta Ecosystem,
+          Crocodiles, Birds, Conservation, Interactive Map, and Landing Page Integration.
+          Visitor content is awareness guidance, not official booking or route advice.
+        </p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="sundarbans-footer">
+    <p>Part of <a href="../../index.html">Incredible India Explorer</a> · Dedicated national park explorer for Sundarbans.</p>
+  </footer>
+
+  <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+  <script src="../../app.js"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/sundarbans-national-park/script.js
+++ b/frontend/sundarbans-national-park/script.js
@@ -1,0 +1,124 @@
+
+document.addEventListener("DOMContentLoaded", () => {
+  const facts = [{"label": "State", "value": "West Bengal", "detail": "Sundarbans National Park is in the Indian Sundarbans delta region of West Bengal."}, {"label": "Known for", "value": "Mangrove Forest", "detail": "The Sundarbans is one of the world's most iconic mangrove landscapes."}, {"label": "Flagship species", "value": "Royal Bengal Tiger", "detail": "The tiger is the most famous predator of the Sundarbans mangrove ecosystem."}, {"label": "Recognition", "value": "UNESCO Site", "detail": "The Sundarbans National Park is recognised as a UNESCO World Heritage Site."}, {"label": "Ecosystem", "value": "Delta + tidal forest", "detail": "The landscape is shaped by tidal channels, mudflats, islands, estuaries, and mangroves."}, {"label": "Explorer focus", "value": "Wildlife + conservation", "detail": "This page teaches biodiversity, habitat, responsible tourism, threats, and protection."}];
+  const wildlife = [{"name": "Royal Bengal Tiger", "type": "Mammal", "emoji": "🐅", "detail": "The iconic predator of the Sundarbans, adapted to a tidal mangrove habitat."}, {"name": "Estuarine Crocodile", "type": "Reptile", "emoji": "🐊", "detail": "A powerful reptile associated with brackish water channels, creeks, and estuaries."}, {"name": "Fishing Cat", "type": "Mammal", "emoji": "🐈", "detail": "A wetland-specialist cat that reflects the delta's aquatic food web."}, {"name": "Spotted Deer", "type": "Mammal", "emoji": "🦌", "detail": "An important herbivore species in the forest and prey base for predators."}, {"name": "Water Monitor", "type": "Reptile", "emoji": "🦎", "detail": "A large reptile often linked with riverbanks, mudflats, and mangrove edges."}, {"name": "Kingfisher", "type": "Bird", "emoji": "🐦", "detail": "Colourful kingfishers are part of the Sundarbans' bird-rich water landscape."}, {"name": "Egret", "type": "Bird", "emoji": "🪽", "detail": "Wading birds feed along creeks, mudflats, and shallow wetland areas."}, {"name": "Olive Ridley Turtle", "type": "Reptile", "emoji": "🐢", "detail": "Marine and coastal ecosystems around the region support turtle conservation awareness."}];
+  const ecosystems = [{"title": "Mangrove roots", "text": "Breathing roots and salt-tolerant trees stabilise mudflats, reduce erosion, and create shelter for young fish and crustaceans."}, {"title": "Tidal channels", "text": "Daily tides move nutrients through creeks and river mouths, shaping animal movement and forest life."}, {"title": "Delta islands", "text": "Islands, mudflats, riverbanks, and brackish waters create a shifting mosaic of habitats."}, {"title": "Human-nature edge", "text": "Local communities live near a powerful ecosystem where livelihoods, storms, wildlife, and conservation are closely linked."}];
+  const conservation = [{"title": "Protect mangroves", "text": "Mangroves buffer storms, store carbon, support fisheries, and provide habitat for wildlife."}, {"title": "Reduce disturbance", "text": "Responsible tourism avoids noise, litter, unsafe boat behaviour, and wildlife harassment."}, {"title": "Climate resilience", "text": "Sea-level rise, cyclones, salinity, erosion, and habitat pressure make conservation urgent."}, {"title": "Community role", "text": "Long-term protection depends on local livelihoods, awareness, monitoring, and sustainable tourism."}];
+  const mapPoints = [{"id": "sajnekhali", "name": "Sajnekhali", "x": 50, "y": 46, "type": "Interpretation zone", "detail": "A major visitor interpretation area often associated with birdwatching and forest awareness."}, {"id": "dobanki", "name": "Dobanki", "x": 64, "y": 54, "type": "Canopy / creek zone", "detail": "Represents creek-side forest learning and mangrove canopy experience."}, {"id": "sudhanyakhali", "name": "Sudhanyakhali", "x": 45, "y": 58, "type": "Watchtower zone", "detail": "A commonly known watchtower area used for understanding the forest and wildlife habitat."}, {"id": "netidhopani", "name": "Netidhopani", "x": 71, "y": 67, "type": "Deep forest story", "detail": "Represents deeper mangrove forest interpretation and tiger-habitat awareness."}, {"id": "delta", "name": "Tidal Delta Channels", "x": 35, "y": 63, "type": "Delta ecosystem", "detail": "The channels, mudflats, islands, and brackish water form the core of the Sundarbans landscape."}];
+  const gallery = [{"title": "Mangrove forest", "image": "../../assets/travel_rivers.png", "caption": "Mangrove roots and tidal water define the Sundarbans ecosystem."}, {"title": "Tiger landscape", "image": "../../assets/heritage_forts.png", "caption": "Visual placeholder for the Royal Bengal tiger's protected mangrove habitat."}, {"title": "Bird-rich wetlands", "image": "../../assets/travel_hidden.png", "caption": "Creeks and mudflats support birds, fish, reptiles, and mammals."}, {"title": "Delta waters", "image": "../../assets/hero_banner.png", "caption": "Rivers, tides, and islands shape the Sundarbans explorer story."}];
+
+  const escapeHtml = (value) => String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+
+  const factsGrid = document.getElementById("facts-grid");
+  const wildlifeGrid = document.getElementById("wildlife-grid");
+  const ecosystemGrid = document.getElementById("ecosystem-grid");
+  const conservationGrid = document.getElementById("conservation-grid");
+  const galleryGrid = document.getElementById("gallery-grid");
+  const mapPins = document.getElementById("map-pins");
+  const mapInfo = document.getElementById("map-info");
+
+  function renderFacts() {
+    factsGrid.innerHTML = facts.map((fact) => `
+      <article class="fact-card">
+        <span>${escapeHtml(fact.label)}</span>
+        <strong>${escapeHtml(fact.value)}</strong>
+        <p>${escapeHtml(fact.detail)}</p>
+      </article>
+    `).join("");
+  }
+
+  function renderWildlife(filter = "All") {
+    const filtered = filter === "All"
+      ? wildlife
+      : wildlife.filter((item) => item.type === filter);
+
+    wildlifeGrid.innerHTML = filtered.map((item) => `
+      <article class="wildlife-card">
+        <div class="wildlife-emoji" aria-hidden="true">${escapeHtml(item.emoji)}</div>
+        <span>${escapeHtml(item.type)}</span>
+        <strong>${escapeHtml(item.name)}</strong>
+        <p>${escapeHtml(item.detail)}</p>
+      </article>
+    `).join("");
+  }
+
+  function renderSimpleCards(target, data, className) {
+    target.innerHTML = data.map((item, index) => `
+      <article class="${className}">
+        <span>0${index + 1}</span>
+        <h3>${escapeHtml(item.title)}</h3>
+        <p>${escapeHtml(item.text)}</p>
+      </article>
+    `).join("");
+  }
+
+  function renderGallery() {
+    galleryGrid.innerHTML = gallery.map((item) => `
+      <article class="gallery-card">
+        <img src="${escapeHtml(item.image)}" alt="${escapeHtml(item.title)}" onerror="this.src='../../assets/hero_banner.png'">
+        <div>
+          <h3>${escapeHtml(item.title)}</h3>
+          <p>${escapeHtml(item.caption)}</p>
+        </div>
+      </article>
+    `).join("");
+  }
+
+  function selectMapPoint(pointId) {
+    const point = mapPoints.find((item) => item.id === pointId) || mapPoints[0];
+
+    document.querySelectorAll(".map-pin").forEach((pin) => {
+      pin.classList.toggle("active", pin.dataset.point === point.id);
+    });
+
+    mapInfo.innerHTML = `
+      <span>${escapeHtml(point.type)}</span>
+      <h3>${escapeHtml(point.name)}</h3>
+      <p>${escapeHtml(point.detail)}</p>
+    `;
+  }
+
+  function renderMap() {
+    mapPins.innerHTML = mapPoints.map((point, index) => `
+      <button
+        class="map-pin"
+        type="button"
+        data-point="${escapeHtml(point.id)}"
+        style="left:${point.x}%; top:${point.y}%"
+        aria-label="${escapeHtml(point.name)}"
+      >${index + 1}</button>
+    `).join("");
+
+    document.querySelectorAll(".map-pin").forEach((pin) => {
+      pin.addEventListener("click", () => selectMapPoint(pin.dataset.point));
+    });
+
+    selectMapPoint(mapPoints[0].id);
+  }
+
+  document.querySelectorAll(".filter-btn").forEach((button) => {
+    button.addEventListener("click", () => {
+      document.querySelectorAll(".filter-btn").forEach((item) => item.classList.remove("active"));
+      button.classList.add("active");
+      renderWildlife(button.dataset.filter);
+    });
+  });
+
+  renderFacts();
+  renderWildlife();
+  renderMap();
+  renderSimpleCards(ecosystemGrid, ecosystems, "ecosystem-card");
+  renderSimpleCards(conservationGrid, conservation, "conservation-card");
+  renderGallery();
+
+  window.SundarbansNationalParkExplorer = {
+    facts: () => [...facts],
+    wildlife: () => [...wildlife],
+    mapPoints: () => [...mapPoints],
+  };
+});

--- a/frontend/sundarbans-national-park/style.css
+++ b/frontend/sundarbans-national-park/style.css
@@ -1,0 +1,417 @@
+/* Sundarbans National Park Explorer - Issue #813 */
+:root {
+  --sd-accent: var(--saffron, #ff9933);
+  --sd-green: var(--green, #138808);
+  --sd-blue: #4f8cff;
+  --sd-gold: #f6c453;
+  --sd-surface: var(--glass-bg, rgba(255, 255, 255, 0.08));
+  --sd-border: var(--glass-border, rgba(255, 255, 255, 0.14));
+  --sd-text: var(--text-primary, #f8fafc);
+  --sd-muted: var(--text-secondary, #cbd5e1);
+  --sd-shadow: 0 18px 50px rgba(0, 0, 0, 0.16);
+}
+
+.sundarbans-current {
+  color: var(--sd-accent);
+}
+
+.sundarbans-page {
+  min-height: 100vh;
+  color: var(--sd-text);
+}
+
+.sundarbans-hero {
+  min-height: 78vh;
+  display: grid;
+  place-items: center;
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(120deg, rgba(10, 28, 30, 0.96), rgba(21, 91, 73, 0.78)),
+    url("../../assets/travel_rivers.png") center / cover no-repeat;
+}
+
+.sundarbans-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 20% 18%, rgba(79, 140, 255, 0.22), transparent 30%),
+    radial-gradient(circle at 82% 24%, rgba(19, 136, 8, 0.28), transparent 26%),
+    linear-gradient(to top, rgba(8, 8, 14, 0.84), transparent 55%);
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  width: min(980px, 92%);
+  padding: 145px 0 76px;
+  text-align: center;
+  color: #fff;
+}
+
+.hero-kicker {
+  display: inline-block;
+  padding: 8px 15px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.25);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.sundarbans-hero h1 {
+  margin: 18px 0;
+  font-size: clamp(3rem, 7.2vw, 6.4rem);
+  line-height: 0.96;
+  letter-spacing: -0.045em;
+}
+
+.sundarbans-hero h1 span {
+  display: block;
+  color: var(--sd-accent);
+}
+
+.sundarbans-hero p {
+  max-width: 900px;
+  margin: 0 auto;
+  color: rgba(255, 255, 255, 0.88);
+  font-size: 1.08rem;
+  line-height: 1.75;
+}
+
+.hero-stats {
+  width: min(780px, 100%);
+  margin: 30px auto 26px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+
+.hero-stats div {
+  padding: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 15px;
+  background: rgba(0, 0, 0, 0.28);
+  backdrop-filter: blur(10px);
+}
+
+.hero-stats strong {
+  display: block;
+  color: var(--sd-gold);
+  font-size: 1.45rem;
+}
+
+.hero-stats span {
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.hero-cta {
+  display: inline-block;
+  padding: 8px 0;
+  border-bottom: 2px solid var(--sd-accent);
+  color: #fff;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.overview-section,
+.facts-section,
+.wildlife-section,
+.map-section,
+.ecosystem-section,
+.conservation-section,
+.gallery-section,
+.source-section {
+  padding: 78px 0;
+}
+
+.page-container {
+  width: min(1180px, 92%);
+  margin: 0 auto;
+}
+
+.section-heading {
+  max-width: 900px;
+  margin-bottom: 26px;
+}
+
+.section-heading h2,
+.source-section h2 {
+  margin: 9px 0 10px;
+  font-size: clamp(2.1rem, 4.4vw, 3.4rem);
+}
+
+.section-heading p,
+.overview-card p,
+.map-info p,
+.source-section p {
+  margin: 0;
+  color: var(--sd-muted);
+  line-height: 1.7;
+}
+
+.overview-grid,
+.map-layout {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 18px;
+}
+
+.overview-card,
+.fact-card,
+.wildlife-card,
+.map-info,
+.ecosystem-card,
+.conservation-card,
+.gallery-card,
+.source-section .page-container,
+.sundarbans-map {
+  border: 1px solid var(--sd-border);
+  border-radius: 26px;
+  background: var(--sd-surface);
+  box-shadow: var(--sd-shadow);
+  backdrop-filter: blur(12px);
+}
+
+.overview-card,
+.map-info,
+.source-section .page-container {
+  padding: 24px;
+}
+
+.overview-card.large {
+  grid-row: span 2;
+}
+
+.overview-card h3,
+.fact-card h3,
+.wildlife-card h3,
+.map-info h3,
+.ecosystem-card h3,
+.conservation-card h3,
+.gallery-card h3 {
+  margin: 0 0 10px;
+}
+
+.facts-grid,
+.wildlife-grid,
+.ecosystem-grid,
+.conservation-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.fact-card,
+.wildlife-card,
+.ecosystem-card,
+.conservation-card {
+  padding: 20px;
+}
+
+.fact-card span,
+.wildlife-card span,
+.map-info span,
+.ecosystem-card span,
+.conservation-card span {
+  display: block;
+  color: var(--sd-muted);
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.fact-card strong,
+.wildlife-card strong {
+  display: block;
+  margin: 7px 0;
+  color: var(--sd-accent);
+  font-size: 1.35rem;
+}
+
+.fact-card p,
+.wildlife-card p,
+.ecosystem-card p,
+.conservation-card p,
+.gallery-card p {
+  margin: 0;
+  color: var(--sd-muted);
+  line-height: 1.55;
+}
+
+.wildlife-emoji {
+  font-size: 2.2rem;
+  margin-bottom: 10px;
+}
+
+.filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 22px;
+}
+
+.filter-btn {
+  border: 1px solid var(--sd-border);
+  border-radius: 999px;
+  padding: 10px 14px;
+  background: transparent;
+  color: var(--sd-text);
+  font: inherit;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.filter-btn.active,
+.filter-btn:hover {
+  border-color: var(--sd-accent);
+  background: rgba(255, 153, 51, 0.16);
+}
+
+.sundarbans-map {
+  position: relative;
+  min-height: 470px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 24% 24%, rgba(79, 140, 255, 0.14), transparent 25%),
+    radial-gradient(circle at 72% 70%, rgba(19, 136, 8, 0.22), transparent 28%),
+    linear-gradient(135deg, rgba(17, 43, 46, 0.96), rgba(28, 74, 54, 0.9));
+}
+
+.delta-shape {
+  position: absolute;
+  inset: 12%;
+  clip-path: polygon(14% 25%, 34% 12%, 62% 18%, 86% 35%, 78% 59%, 92% 76%, 64% 84%, 42% 75%, 22% 88%, 10% 62%);
+  background:
+    linear-gradient(135deg, rgba(19, 136, 8, 0.38), rgba(79, 140, 255, 0.22));
+  border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.water-channel {
+  position: absolute;
+  height: 18px;
+  border-radius: 999px;
+  background: rgba(79, 140, 255, 0.38);
+  filter: blur(0.4px);
+  transform-origin: left center;
+}
+
+.channel-one { left: 18%; top: 46%; width: 66%; transform: rotate(13deg); }
+.channel-two { left: 24%; top: 60%; width: 58%; transform: rotate(-9deg); }
+.channel-three { left: 35%; top: 35%; width: 38%; transform: rotate(38deg); }
+
+.map-pin {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  border: 2px solid #fff;
+  border-radius: 999px;
+  width: 42px;
+  height: 42px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, var(--sd-blue), var(--sd-green));
+  color: #fff;
+  font-size: 1.1rem;
+  cursor: pointer;
+  box-shadow: 0 12px 26px rgba(0,0,0,0.28);
+}
+
+.map-pin.active {
+  transform: translate(-50%, -50%) scale(1.13);
+  box-shadow: 0 0 0 6px rgba(79,140,255,0.18), 0 12px 26px rgba(0,0,0,0.28);
+}
+
+.map-info h3,
+.ecosystem-card h3,
+.conservation-card h3 {
+  color: var(--sd-accent);
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.gallery-card {
+  overflow: hidden;
+}
+
+.gallery-card img {
+  width: 100%;
+  height: 190px;
+  object-fit: cover;
+}
+
+.gallery-card div {
+  padding: 16px;
+}
+
+.sundarbans-footer {
+  padding: 40px 20px;
+  border-top: 1px solid var(--sd-border);
+  color: var(--sd-muted);
+  text-align: center;
+}
+
+.sundarbans-footer a {
+  color: var(--sd-accent);
+  font-weight: 800;
+  text-decoration: none;
+}
+
+body.light-theme .overview-card,
+body.light-theme .fact-card,
+body.light-theme .wildlife-card,
+body.light-theme .map-info,
+body.light-theme .ecosystem-card,
+body.light-theme .conservation-card,
+body.light-theme .gallery-card,
+body.light-theme .source-section .page-container {
+  background: rgba(255,255,255,0.88);
+}
+
+@media (max-width: 1020px) {
+  .overview-grid,
+  .map-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .facts-grid,
+  .wildlife-grid,
+  .ecosystem-grid,
+  .conservation-grid,
+  .gallery-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .overview-card.large {
+    grid-row: auto;
+  }
+}
+
+@media (max-width: 680px) {
+  .hero-stats,
+  .facts-grid,
+  .wildlife-grid,
+  .ecosystem-grid,
+  .conservation-grid,
+  .gallery-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .sundarbans-map {
+    min-height: 380px;
+  }
+
+  .gallery-card img {
+    height: 220px;
+  }
+}


### PR DESCRIPTION
# Pull Request

## Description

Fixes #813

This PR adds a dedicated **Sundarbans National Park Explorer** page covering the mangrove forest, Royal Bengal tiger, UNESCO site context, delta ecosystem, crocodiles, birds, conservation, an interactive map, gallery, and landing-page integration.

### Summary

* Added a new Sundarbans National Park Explorer page:

  * `frontend/sundarbans-national-park/index.html`
  * `frontend/sundarbans-national-park/style.css`
  * `frontend/sundarbans-national-park/script.js`
* Added hero section.
* Added Sundarbans mangrove forest overview.
* Added Royal Bengal tiger context.
* Added UNESCO site context.
* Added quick facts grid.
* Added wildlife cards.
* Added wildlife category filters.
* Added interactive Sundarbans delta map.
* Added delta ecosystem cards.
* Added conservation cards.
* Added gallery section.
* Added source notes.
* Added landing-page card helper.
* Added responsive desktop, tablet, and mobile layout.
* Added dark/light theme compatibility.
* Added functional direct routing through:

  * `frontend/sundarbans-national-park/index.html`

### Issue Requirements Covered

* Mangrove Forest
* Royal Bengal Tiger
* UNESCO Site
* Delta Ecosystem
* Crocodiles
* Birds
* Conservation
* Interactive Map
* Landing Page Integration

### Interactive Features

* Wildlife filters:

  * All
  * Mammals
  * Reptiles
  * Birds
* Interactive map pins:

  * Sajnekhali
  * Dobanki
  * Sudhanyakhali
  * Netidhopani
  * Tidal Delta Channels
* Map info panel updates when a pin is selected.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Documentation update

## Testing

Manually verified:

* Sundarbans National Park Explorer page loads correctly.
* Hero section renders correctly.
* Overview section renders correctly.
* Mangrove Forest content is visible.
* Royal Bengal Tiger content is visible.
* UNESCO Site context is visible.
* Quick facts grid renders correctly.
* Wildlife cards render correctly.
* Wildlife filter buttons work correctly.
* Crocodile and bird cards are included.
* Interactive map pins render correctly.
* Map info panel updates when pins are clicked.
* Delta ecosystem cards render correctly.
* Conservation cards render correctly.
* Gallery cards render correctly.
* Source notes render correctly.
* Direct route works:

  * `frontend/sundarbans-national-park/index.html`
* Landing-page helper works when a matching landing page file exists.
* Dark/light theme compatibility works.
* Desktop responsiveness works.
* Tablet responsiveness works.
* Mobile responsiveness works.
* Browser console shows no JavaScript errors.

## Checklist

* [x] My code follows the style guidelines of this project.
* [x] I have performed a self-review.
* [x] My changes generate no new warnings.
* [x] The acceptance criteria are implemented.
* [x] The page is responsive.
* [x] Routing is functional.
* [x] Landing page integration helper is included.
  
## Screenshots
<img width="1919" height="972" alt="Screenshot 2026-07-29 212204" src="https://github.com/user-attachments/assets/aa7d7f05-8a47-4e2a-997f-0d319ffc68b7" />
<img width="1919" height="944" alt="Screenshot 2026-07-29 212207" src="https://github.com/user-attachments/assets/c209829f-5fb4-4d91-82f9-d4d07df3f08e" />
<img width="1919" height="965" alt="Screenshot 2026-07-29 212212" src="https://github.com/user-attachments/assets/7eef4efb-5839-4f0d-b562-ab4192efb56b" />
<img width="1913" height="987" alt="Screenshot 2026-07-29 212218" src="https://github.com/user-attachments/assets/c939b45b-bee3-4cce-90ee-fb8e018c02be" />
<img width="1919" height="983" alt="Screenshot 2026-07-29 212231" src="https://github.com/user-attachments/assets/3b7adde2-7826-46df-8936-c0d0411e3bca" />
<img width="1918" height="960" alt="Screenshot 2026-07-29 212237" src="https://github.com/user-attachments/assets/736b97fa-59cf-4e06-95df-46f3383b83df" />
<img width="1919" height="961" alt="Screenshot 2026-07-29 212242" src="https://github.com/user-attachments/assets/67614759-5f09-4300-8be3-17540aabaad1" />
<img width="1919" height="982" alt="Screenshot 2026-07-29 212246" src="https://github.com/user-attachments/assets/9b281da3-d98f-4bbf-b086-ce588c608525" />
<img width="1918" height="574" alt="Screenshot 2026-07-29 212250" src="https://github.com/user-attachments/assets/173adb26-a9ea-4c50-a62c-477e6aefa4f7" />
