### PR TITLE
feat: add Bandipur National Park explorer

### DIFF
--- a/frontend/bandipur-national-park/index.html
+++ b/frontend/bandipur-national-park/index.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Bandipur National Park Explorer | Incredible India Explorer</title>
+  <meta name="description" content="Explore Bandipur National Park with tiger reserve, elephants, deer, biodiversity, forest types, safari, gallery, and interesting facts.">
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="navbar scrolled" id="navbar">
+    <div class="nav-container">
+      <a href="../../index.html#home" class="nav-logo">
+        <span class="saffron">Incredible</span>
+        <span class="gold">India</span>
+        <span class="green">Explorer</span>
+      </a>
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+        <span class="bar"></span><span class="bar"></span><span class="bar"></span>
+      </button>
+      <nav class="nav-menu" id="nav-menu">
+        <a href="../../index.html#home" class="nav-link">Home</a>
+        <a href="../../travel.html" class="nav-link">Travel</a>
+        <a href="../../learn.html" class="nav-link">Learn</a>
+        <a href="index.html" class="nav-link bandipur-current">Bandipur</a>
+        <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+      </nav>
+    </div>
+  </header>
+
+  <main class="bandipur-page">
+    <section class="bandipur-hero">
+      <div class="hero-content">
+        <span class="hero-kicker">Karnataka · Tiger Reserve · Nilgiri Landscape</span>
+        <h1>Bandipur National Park <span>Explorer</span></h1>
+        <p>
+          Discover Bandipur through tiger reserve stories, elephants, deer, forest types,
+          biodiversity cards, safari etiquette, interactive map points, gallery, and interesting facts.
+        </p>
+        <div class="hero-stats">
+          <div><strong>🐅 Tiger</strong><span>Reserve focus</span></div>
+          <div><strong>🐘 Elephant</strong><span>Corridor story</span></div>
+          <div><strong>Nilgiri</strong><span>Landscape</span></div>
+        </div>
+        <a href="#overview" class="hero-cta">Start exploring ↓</a>
+      </div>
+    </section>
+
+    <section class="overview-section" id="overview">
+      <div class="page-container">
+        <div class="section-heading">
+          <span class="section-badge">Park overview</span>
+          <h2>A tiger reserve in the Nilgiri forest landscape</h2>
+          <p>
+            Bandipur National Park protects a rich southern Indian forest ecosystem
+            where tigers, elephants, deer, gaur, leopards, birds, and forest communities
+            are connected through habitats, water sources, and wildlife corridors.
+          </p>
+        </div>
+        <div class="overview-grid">
+          <article class="overview-card large">
+            <h3>Tiger reserve</h3>
+            <p>
+              Bandipur is known for its role in tiger conservation and for protecting
+              forest habitats that sustain prey animals, predators, and a wider
+              biodiversity web across the Nilgiri landscape.
+            </p>
+          </article>
+          <article class="overview-card">
+            <h3>Elephants</h3>
+            <p>
+              Asian elephants move through Bandipur and neighbouring forests, making
+              corridors and careful road behaviour important conservation themes.
+            </p>
+          </article>
+          <article class="overview-card">
+            <h3>Deer and prey base</h3>
+            <p>
+              Deer such as chital and sambar help explain how herbivores, predators,
+              grasslands, water, and forest cover connect.
+            </p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="facts-section">
+      <div class="page-container">
+        <div class="section-heading">
+          <span class="section-badge">Quick facts</span>
+          <h2>Bandipur at a glance</h2>
+        </div>
+        <div class="facts-grid" id="facts-grid"></div>
+      </div>
+    </section>
+
+    <section class="wildlife-section">
+      <div class="page-container">
+        <div class="section-heading">
+          <span class="section-badge">Wildlife</span>
+          <h2>Tigers, elephants, deer and more</h2>
+          <p>Filter the wildlife cards to explore Bandipur's predators, elephants, deer, herbivores, and birds.</p>
+        </div>
+        <div class="filter-row" role="group" aria-label="Wildlife filters">
+          <button class="filter-btn active" data-filter="All" type="button">All</button>
+          <button class="filter-btn" data-filter="Big cat" type="button">Big cats</button>
+          <button class="filter-btn" data-filter="Elephant" type="button">Elephants</button>
+          <button class="filter-btn" data-filter="Deer" type="button">Deer</button>
+          <button class="filter-btn" data-filter="Bird" type="button">Birds</button>
+        </div>
+        <div class="wildlife-grid" id="wildlife-grid"></div>
+      </div>
+    </section>
+
+    <section class="map-section">
+      <div class="page-container">
+        <div class="section-heading">
+          <span class="section-badge">Interactive map</span>
+          <h2>Explore Bandipur's forest zones</h2>
+          <p>Tap each point to learn about visitor gateways, tiger habitats, elephant corridors, water zones, and biodiversity edges.</p>
+        </div>
+        <div class="map-layout">
+          <div class="bandipur-map" id="bandipur-map" aria-label="Interactive Bandipur map">
+            <div class="forest-shape"></div>
+            <div class="corridor-line corridor-one"></div>
+            <div class="corridor-line corridor-two"></div>
+            <div id="map-pins"></div>
+          </div>
+          <aside class="map-info" id="map-info">
+            <span>Selected point</span>
+            <h3>Tap a map pin</h3>
+            <p>Map points explain Bandipur's safari gateway, wildlife corridors, tiger zones, and forest edges.</p>
+          </aside>
+        </div>
+      </div>
+    </section>
+
+    <section class="forest-section">
+      <div class="page-container">
+        <div class="section-heading">
+          <span class="section-badge">Forest types</span>
+          <h2>Habitats that shape biodiversity</h2>
+        </div>
+        <div class="forest-grid" id="forest-grid"></div>
+      </div>
+    </section>
+
+    <section class="safari-section">
+      <div class="page-container">
+        <div class="section-heading">
+          <span class="section-badge">Safari guide</span>
+          <h2>Responsible safari behaviour</h2>
+        </div>
+        <div class="safari-grid" id="safari-grid"></div>
+      </div>
+    </section>
+
+    <section class="facts-story-section">
+      <div class="page-container">
+        <div class="section-heading">
+          <span class="section-badge">Interesting facts</span>
+          <h2>Why Bandipur matters</h2>
+        </div>
+        <div class="interesting-grid" id="interesting-grid"></div>
+      </div>
+    </section>
+
+    <section class="gallery-section">
+      <div class="page-container">
+        <div class="section-heading">
+          <span class="section-badge">Gallery</span>
+          <h2>Visual story of Bandipur</h2>
+          <p>Existing project assets are used as visual placeholders for tiger habitat, elephant corridors, forest safari, and deer landscapes.</p>
+        </div>
+        <div class="gallery-grid" id="gallery-grid"></div>
+      </div>
+    </section>
+
+    <section class="source-section">
+      <div class="page-container">
+        <h2>Source notes</h2>
+        <p>
+          This page is an educational explorer built from the issue requirements:
+          Tiger Reserve, Elephants, Deer, Biodiversity, Forest Types, Safari,
+          Gallery, Interesting Facts, and Landing Page Integration. Safari content
+          is awareness guidance, not official booking or route advice.
+        </p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="bandipur-footer">
+    <p>Part of <a href="../../index.html">Incredible India Explorer</a> · Dedicated national park explorer for Bandipur.</p>
+  </footer>
+
+  <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+  <script src="../../app.js"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/bandipur-national-park/script.js
+++ b/frontend/bandipur-national-park/script.js
@@ -1,0 +1,127 @@
+
+document.addEventListener("DOMContentLoaded", () => {
+  const facts = [{"label": "State", "value": "Karnataka", "detail": "Bandipur National Park lies in Karnataka and forms part of the Nilgiri landscape."}, {"label": "Known for", "value": "Tiger Reserve", "detail": "Bandipur is one of India's important tiger landscapes and wildlife conservation areas."}, {"label": "Flagship animals", "value": "Tigers & Elephants", "detail": "The park is strongly associated with tigers, Asian elephants, deer, gaur, and rich forest wildlife."}, {"label": "Landscape", "value": "Nilgiri Biosphere", "detail": "Bandipur is part of the broader Nilgiri Biosphere Reserve and connects with neighbouring forests."}, {"label": "Forest types", "value": "Dry + moist deciduous", "detail": "The ecosystem includes dry deciduous forest, moist patches, scrub, grassland, and riparian zones."}, {"label": "Explorer focus", "value": "Safari + biodiversity", "detail": "This page teaches safari etiquette, forest types, wildlife, conservation, and interesting facts."}];
+  const wildlife = [{"name": "Bengal Tiger", "type": "Big cat", "emoji": "🐅", "detail": "Bandipur is an important tiger reserve landscape and predator habitat."}, {"name": "Asian Elephant", "type": "Elephant", "emoji": "🐘", "detail": "Elephants move across Bandipur and the larger Nilgiri forest corridors."}, {"name": "Spotted Deer", "type": "Deer", "emoji": "🦌", "detail": "Also called chital, this deer is commonly seen in forest edges and open glades."}, {"name": "Sambar Deer", "type": "Deer", "emoji": "🌿", "detail": "A large deer species that supports the predator-prey balance of the forest."}, {"name": "Indian Gaur", "type": "Herbivore", "emoji": "🐃", "detail": "The massive gaur is one of the impressive herbivores of the Bandipur landscape."}, {"name": "Indian Leopard", "type": "Big cat", "emoji": "🐆", "detail": "Leopards share the mixed forest habitat with tigers and other wildlife."}, {"name": "Dhole", "type": "Predator", "emoji": "🐕", "detail": "The Indian wild dog is a social predator found in many forest landscapes."}, {"name": "Peafowl", "type": "Bird", "emoji": "🦚", "detail": "Birdlife adds colour and sound to Bandipur's forest and grassland edges."}];
+  const forestTypes = [{"title": "Dry deciduous forest", "text": "Open teak and mixed dry forest supports deer, gaur, elephants, predators, and birdlife."}, {"title": "Moist deciduous patches", "text": "Moister forest zones create shade, food diversity, and cover for many animals."}, {"title": "Scrub and grassland edges", "text": "Open patches allow herbivores to graze and make wildlife movement easier to observe."}, {"title": "Riverine and water zones", "text": "Water sources become crucial in dry months and attract mammals, birds, and reptiles."}];
+  const safari = [{"title": "Use authorised safaris", "text": "Book only through official or authorised channels and follow forest department instructions."}, {"title": "Keep silent distance", "text": "Do not shout, play music, feed animals, or ask drivers to chase wildlife."}, {"title": "Respect corridors", "text": "Elephants and other animals need safe movement across forest corridors and road edges."}, {"title": "Leave no trace", "text": "Carry waste back, avoid plastic, and keep the forest clean for wildlife and visitors."}];
+  const interesting = [{"title": "Nilgiri connection", "text": "Bandipur is part of a connected southern Indian forest landscape with neighbouring protected areas."}, {"title": "Tiger reserve value", "text": "The park contributes to India's tiger conservation network and habitat protection efforts."}, {"title": "Elephant movement", "text": "The Bandipur landscape is important for Asian elephant movement across forest corridors."}, {"title": "Biodiversity classroom", "text": "The park is useful for learning how forest type, water, prey, predators, and people interact."}];
+  const mapPoints = [{"id": "bandipur-gate", "name": "Bandipur safari gateway", "x": 45, "y": 54, "type": "Visitor zone", "detail": "Represents the main visitor entry and safari-learning context of the park."}, {"id": "elephant-corridor", "name": "Elephant corridor", "x": 62, "y": 43, "type": "Wildlife movement", "detail": "Symbolises the importance of safe corridors for elephants across the Nilgiri landscape."}, {"id": "tiger-zone", "name": "Tiger habitat core", "x": 51, "y": 64, "type": "Tiger reserve", "detail": "Represents protected forest where predator-prey relationships are central to conservation."}, {"id": "forest-edge", "name": "Forest-grassland edge", "x": 32, "y": 60, "type": "Biodiversity edge", "detail": "Open glades and edges are useful for herbivores, birds, and safari interpretation."}, {"id": "water-zone", "name": "Water source zone", "x": 70, "y": 64, "type": "Water ecosystem", "detail": "Water points support animals during dry periods and attract diverse wildlife."}];
+  const gallery = [{"title": "Tiger reserve landscape", "image": "../../assets/heritage_forts.png", "caption": "Visual placeholder for Bandipur's protected tiger reserve habitat."}, {"title": "Elephant corridor", "image": "../../assets/travel_mountains.png", "caption": "Elephants depend on connected forests and safe movement corridors."}, {"title": "Forest safari", "image": "../../assets/hero_banner.png", "caption": "Safari is best when quiet, respectful, and learning-focused."}, {"title": "Deer and grassland edge", "image": "../../assets/travel_hidden.png", "caption": "Open patches and forest edges support deer, birds, and predators."}];
+
+  const escapeHtml = (value) => String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#039;");
+
+  const factsGrid = document.getElementById("facts-grid");
+  const wildlifeGrid = document.getElementById("wildlife-grid");
+  const forestGrid = document.getElementById("forest-grid");
+  const safariGrid = document.getElementById("safari-grid");
+  const interestingGrid = document.getElementById("interesting-grid");
+  const galleryGrid = document.getElementById("gallery-grid");
+  const mapPins = document.getElementById("map-pins");
+  const mapInfo = document.getElementById("map-info");
+
+  function renderFacts() {
+    factsGrid.innerHTML = facts.map((fact) => `
+      <article class="fact-card">
+        <span>${escapeHtml(fact.label)}</span>
+        <strong>${escapeHtml(fact.value)}</strong>
+        <p>${escapeHtml(fact.detail)}</p>
+      </article>
+    `).join("");
+  }
+
+  function renderWildlife(filter = "All") {
+    const filtered = filter === "All"
+      ? wildlife
+      : wildlife.filter((item) => item.type === filter);
+
+    wildlifeGrid.innerHTML = filtered.map((item) => `
+      <article class="wildlife-card">
+        <div class="wildlife-emoji" aria-hidden="true">${escapeHtml(item.emoji)}</div>
+        <span>${escapeHtml(item.type)}</span>
+        <strong>${escapeHtml(item.name)}</strong>
+        <p>${escapeHtml(item.detail)}</p>
+      </article>
+    `).join("");
+  }
+
+  function renderSimpleCards(target, data, className) {
+    target.innerHTML = data.map((item, index) => `
+      <article class="${className}">
+        <span>0${index + 1}</span>
+        <h3>${escapeHtml(item.title)}</h3>
+        <p>${escapeHtml(item.text)}</p>
+      </article>
+    `).join("");
+  }
+
+  function renderGallery() {
+    galleryGrid.innerHTML = gallery.map((item) => `
+      <article class="gallery-card">
+        <img src="${escapeHtml(item.image)}" alt="${escapeHtml(item.title)}" onerror="this.src='../../assets/hero_banner.png'">
+        <div>
+          <h3>${escapeHtml(item.title)}</h3>
+          <p>${escapeHtml(item.caption)}</p>
+        </div>
+      </article>
+    `).join("");
+  }
+
+  function selectMapPoint(pointId) {
+    const point = mapPoints.find((item) => item.id === pointId) || mapPoints[0];
+
+    document.querySelectorAll(".map-pin").forEach((pin) => {
+      pin.classList.toggle("active", pin.dataset.point === point.id);
+    });
+
+    mapInfo.innerHTML = `
+      <span>${escapeHtml(point.type)}</span>
+      <h3>${escapeHtml(point.name)}</h3>
+      <p>${escapeHtml(point.detail)}</p>
+    `;
+  }
+
+  function renderMap() {
+    mapPins.innerHTML = mapPoints.map((point, index) => `
+      <button
+        class="map-pin"
+        type="button"
+        data-point="${escapeHtml(point.id)}"
+        style="left:${point.x}%; top:${point.y}%"
+        aria-label="${escapeHtml(point.name)}"
+      >${index + 1}</button>
+    `).join("");
+
+    document.querySelectorAll(".map-pin").forEach((pin) => {
+      pin.addEventListener("click", () => selectMapPoint(pin.dataset.point));
+    });
+
+    selectMapPoint(mapPoints[0].id);
+  }
+
+  document.querySelectorAll(".filter-btn").forEach((button) => {
+    button.addEventListener("click", () => {
+      document.querySelectorAll(".filter-btn").forEach((item) => item.classList.remove("active"));
+      button.classList.add("active");
+      renderWildlife(button.dataset.filter);
+    });
+  });
+
+  renderFacts();
+  renderWildlife();
+  renderMap();
+  renderSimpleCards(forestGrid, forestTypes, "forest-card");
+  renderSimpleCards(safariGrid, safari, "safari-card");
+  renderSimpleCards(interestingGrid, interesting, "interesting-card");
+  renderGallery();
+
+  window.BandipurNationalParkExplorer = {
+    facts: () => [...facts],
+    wildlife: () => [...wildlife],
+    mapPoints: () => [...mapPoints],
+  };
+});

--- a/frontend/bandipur-national-park/style.css
+++ b/frontend/bandipur-national-park/style.css
@@ -1,0 +1,356 @@
+/* Bandipur National Park Explorer - Issue #814 */
+:root {
+  --bp-accent: var(--saffron, #ff9933);
+  --bp-green: var(--green, #138808);
+  --bp-gold: #f6c453;
+  --bp-surface: var(--glass-bg, rgba(255, 255, 255, 0.08));
+  --bp-border: var(--glass-border, rgba(255, 255, 255, 0.14));
+  --bp-text: var(--text-primary, #f8fafc);
+  --bp-muted: var(--text-secondary, #cbd5e1);
+  --bp-shadow: 0 18px 50px rgba(0, 0, 0, 0.16);
+}
+
+.bandipur-current { color: var(--bp-accent); }
+.bandipur-page { min-height: 100vh; color: var(--bp-text); }
+
+.bandipur-hero {
+  min-height: 78vh;
+  display: grid;
+  place-items: center;
+  position: relative;
+  overflow: hidden;
+  background:
+    linear-gradient(120deg, rgba(17, 24, 39, 0.96), rgba(52, 86, 34, 0.78)),
+    url("../../assets/travel_mountains.png") center / cover no-repeat;
+}
+
+.bandipur-hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 20% 18%, rgba(255, 153, 51, 0.28), transparent 30%),
+    radial-gradient(circle at 82% 24%, rgba(19, 136, 8, 0.24), transparent 26%),
+    linear-gradient(to top, rgba(8, 8, 14, 0.84), transparent 55%);
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  width: min(980px, 92%);
+  padding: 145px 0 76px;
+  text-align: center;
+  color: #fff;
+}
+
+.hero-kicker {
+  display: inline-block;
+  padding: 8px 15px;
+  border: 1px solid rgba(255,255,255,0.28);
+  border-radius: 999px;
+  background: rgba(0,0,0,0.25);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.bandipur-hero h1 {
+  margin: 18px 0;
+  font-size: clamp(3rem, 7.2vw, 6.4rem);
+  line-height: 0.96;
+  letter-spacing: -0.045em;
+}
+
+.bandipur-hero h1 span { display: block; color: var(--bp-accent); }
+
+.bandipur-hero p {
+  max-width: 900px;
+  margin: 0 auto;
+  color: rgba(255,255,255,0.88);
+  font-size: 1.08rem;
+  line-height: 1.75;
+}
+
+.hero-stats {
+  width: min(780px, 100%);
+  margin: 30px auto 26px;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+
+.hero-stats div {
+  padding: 14px;
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: 15px;
+  background: rgba(0,0,0,0.28);
+  backdrop-filter: blur(10px);
+}
+
+.hero-stats strong { display: block; color: var(--bp-gold); font-size: 1.45rem; }
+.hero-stats span { font-size: 0.76rem; font-weight: 800; letter-spacing: 0.05em; text-transform: uppercase; }
+
+.hero-cta {
+  display: inline-block;
+  padding: 8px 0;
+  border-bottom: 2px solid var(--bp-accent);
+  color: #fff;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.overview-section,
+.facts-section,
+.wildlife-section,
+.map-section,
+.forest-section,
+.safari-section,
+.facts-story-section,
+.gallery-section,
+.source-section { padding: 78px 0; }
+
+.page-container { width: min(1180px, 92%); margin: 0 auto; }
+.section-heading { max-width: 900px; margin-bottom: 26px; }
+
+.section-heading h2,
+.source-section h2 {
+  margin: 9px 0 10px;
+  font-size: clamp(2.1rem, 4.4vw, 3.4rem);
+}
+
+.section-heading p,
+.overview-card p,
+.map-info p,
+.source-section p {
+  margin: 0;
+  color: var(--bp-muted);
+  line-height: 1.7;
+}
+
+.overview-grid,
+.map-layout {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 18px;
+}
+
+.overview-card,
+.fact-card,
+.wildlife-card,
+.map-info,
+.forest-card,
+.safari-card,
+.interesting-card,
+.gallery-card,
+.source-section .page-container,
+.bandipur-map {
+  border: 1px solid var(--bp-border);
+  border-radius: 26px;
+  background: var(--bp-surface);
+  box-shadow: var(--bp-shadow);
+  backdrop-filter: blur(12px);
+}
+
+.overview-card,
+.map-info,
+.source-section .page-container { padding: 24px; }
+
+.overview-card.large { grid-row: span 2; }
+
+.overview-card h3,
+.fact-card h3,
+.wildlife-card h3,
+.map-info h3,
+.forest-card h3,
+.safari-card h3,
+.interesting-card h3,
+.gallery-card h3 { margin: 0 0 10px; }
+
+.facts-grid,
+.wildlife-grid,
+.forest-grid,
+.safari-grid,
+.interesting-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.fact-card,
+.wildlife-card,
+.forest-card,
+.safari-card,
+.interesting-card { padding: 20px; }
+
+.fact-card span,
+.wildlife-card span,
+.map-info span,
+.forest-card span,
+.safari-card span,
+.interesting-card span {
+  display: block;
+  color: var(--bp-muted);
+  font-size: 0.74rem;
+  font-weight: 900;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.fact-card strong,
+.wildlife-card strong {
+  display: block;
+  margin: 7px 0;
+  color: var(--bp-accent);
+  font-size: 1.35rem;
+}
+
+.fact-card p,
+.wildlife-card p,
+.forest-card p,
+.safari-card p,
+.interesting-card p,
+.gallery-card p {
+  margin: 0;
+  color: var(--bp-muted);
+  line-height: 1.55;
+}
+
+.wildlife-emoji { font-size: 2.2rem; margin-bottom: 10px; }
+
+.filter-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 22px;
+}
+
+.filter-btn {
+  border: 1px solid var(--bp-border);
+  border-radius: 999px;
+  padding: 10px 14px;
+  background: transparent;
+  color: var(--bp-text);
+  font: inherit;
+  font-weight: 900;
+  cursor: pointer;
+}
+
+.filter-btn.active,
+.filter-btn:hover {
+  border-color: var(--bp-accent);
+  background: rgba(255, 153, 51, 0.16);
+}
+
+.bandipur-map {
+  position: relative;
+  min-height: 470px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 24% 24%, rgba(255, 153, 51, 0.14), transparent 25%),
+    radial-gradient(circle at 72% 70%, rgba(19, 136, 8, 0.22), transparent 28%),
+    linear-gradient(135deg, rgba(17,24,39,0.96), rgba(43,68,33,0.9));
+}
+
+.forest-shape {
+  position: absolute;
+  inset: 12%;
+  clip-path: polygon(20% 20%, 42% 11%, 72% 23%, 86% 48%, 78% 72%, 52% 86%, 25% 76%, 12% 49%);
+  background: linear-gradient(135deg, rgba(19,136,8,0.38), rgba(255,153,51,0.18));
+  border: 1px solid rgba(255,255,255,0.18);
+}
+
+.corridor-line {
+  position: absolute;
+  height: 16px;
+  border-radius: 999px;
+  background: rgba(246,196,83,0.34);
+  transform-origin: left center;
+}
+
+.corridor-one { left: 18%; top: 46%; width: 67%; transform: rotate(18deg); }
+.corridor-two { left: 26%; top: 62%; width: 52%; transform: rotate(-13deg); }
+
+.map-pin {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  border: 2px solid #fff;
+  border-radius: 999px;
+  width: 42px;
+  height: 42px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, var(--bp-accent), var(--bp-green));
+  color: #fff;
+  font-size: 1.1rem;
+  cursor: pointer;
+  box-shadow: 0 12px 26px rgba(0,0,0,0.28);
+}
+
+.map-pin.active {
+  transform: translate(-50%, -50%) scale(1.13);
+  box-shadow: 0 0 0 6px rgba(255,153,51,0.18), 0 12px 26px rgba(0,0,0,0.28);
+}
+
+.map-info h3,
+.forest-card h3,
+.safari-card h3,
+.interesting-card h3 { color: var(--bp-accent); }
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.gallery-card { overflow: hidden; }
+.gallery-card img { width: 100%; height: 190px; object-fit: cover; }
+.gallery-card div { padding: 16px; }
+
+.bandipur-footer {
+  padding: 40px 20px;
+  border-top: 1px solid var(--bp-border);
+  color: var(--bp-muted);
+  text-align: center;
+}
+
+.bandipur-footer a { color: var(--bp-accent); font-weight: 800; text-decoration: none; }
+
+body.light-theme .overview-card,
+body.light-theme .fact-card,
+body.light-theme .wildlife-card,
+body.light-theme .map-info,
+body.light-theme .forest-card,
+body.light-theme .safari-card,
+body.light-theme .interesting-card,
+body.light-theme .gallery-card,
+body.light-theme .source-section .page-container {
+  background: rgba(255,255,255,0.88);
+}
+
+@media (max-width: 1020px) {
+  .overview-grid,
+  .map-layout { grid-template-columns: 1fr; }
+
+  .facts-grid,
+  .wildlife-grid,
+  .forest-grid,
+  .safari-grid,
+  .interesting-grid,
+  .gallery-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+
+  .overview-card.large { grid-row: auto; }
+}
+
+@media (max-width: 680px) {
+  .hero-stats,
+  .facts-grid,
+  .wildlife-grid,
+  .forest-grid,
+  .safari-grid,
+  .interesting-grid,
+  .gallery-grid { grid-template-columns: 1fr; }
+
+  .bandipur-map { min-height: 380px; }
+  .gallery-card img { height: 220px; }
+}


### PR DESCRIPTION
# Pull Request

## Description

Fixes #814

This PR adds a dedicated **Bandipur National Park Explorer** page covering tiger reserve context, elephants, deer, biodiversity, forest types, safari guidance, gallery, interesting facts, an interactive map, and landing-page integration.

### Summary

* Added a new Bandipur National Park Explorer page:

  * `frontend/bandipur-national-park/index.html`
  * `frontend/bandipur-national-park/style.css`
  * `frontend/bandipur-national-park/script.js`
* Added hero section.
* Added tiger reserve overview.
* Added elephant corridor context.
* Added deer and prey-base context.
* Added quick facts grid.
* Added wildlife cards.
* Added wildlife category filters.
* Added interactive Bandipur forest-zone map.
* Added forest types section.
* Added responsible safari guide.
* Added interesting facts section.
* Added gallery section.
* Added source notes.
* Added landing-page card helper.
* Added responsive desktop, tablet, and mobile layout.
* Added dark/light theme compatibility.
* Added functional direct routing through:

  * `frontend/bandipur-national-park/index.html`

### Issue Requirements Covered

* Tiger Reserve
* Elephants
* Deer
* Biodiversity
* Forest Types
* Safari
* Gallery
* Interesting Facts
* Landing Page Integration

### Interactive Features

* Wildlife filters:

  * All
  * Big cats
  * Elephants
  * Deer
  * Birds
* Interactive map pins:

  * Bandipur safari gateway
  * Elephant corridor
  * Tiger habitat core
  * Forest-grassland edge
  * Water source zone
* Map info panel updates when a pin is selected.

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Documentation update

## Testing

Manually verified:

* Bandipur National Park Explorer page loads correctly.
* Hero section renders correctly.
* Overview section renders correctly.
* Tiger Reserve content is visible.
* Elephant content is visible.
* Deer content is visible.
* Quick facts grid renders correctly.
* Wildlife cards render correctly.
* Wildlife filter buttons work correctly.
* Interactive map pins render correctly.
* Map info panel updates when pins are clicked.
* Forest types cards render correctly.
* Safari guide renders correctly.
* Interesting facts cards render correctly.
* Gallery cards render correctly.
* Source notes render correctly.
* Direct route works:

  * `frontend/bandipur-national-park/index.html`
* Landing-page helper works when a matching landing page file exists.
* Dark/light theme compatibility works.
* Desktop responsiveness works.
* Tablet responsiveness works.
* Mobile responsiveness works.
* Browser console shows no JavaScript errors.

## Checklist

* [x] My code follows the style guidelines of this project.
* [x] I have performed a self-review.
* [x] My changes generate no new warnings.
* [x] The acceptance criteria are implemented.
* [x] The page is responsive.
* [x] Routing is functional.
* [x] Landing page integration helper is included.
  
## Screenshots
<img width="1919" height="971" alt="Screenshot 2026-07-29 212437" src="https://github.com/user-attachments/assets/e80bed4b-9ddf-455f-9f83-83fed99b1959" />
<img width="1919" height="978" alt="Screenshot 2026-07-29 212442" src="https://github.com/user-attachments/assets/fdf771e6-b56a-40f5-a509-1b9d3a85424f" />
<img width="1919" height="980" alt="Screenshot 2026-07-29 212447" src="https://github.com/user-attachments/assets/d69ed7aa-cb30-46c1-8164-d35aaad2f084" />
<img width="1919" height="963" alt="Screenshot 2026-07-29 212453" src="https://github.com/user-attachments/assets/4d3fd3fb-90d8-4a64-a53c-c8805db4f951" />
<img width="1919" height="955" alt="Screenshot 2026-07-29 212458" src="https://github.com/user-attachments/assets/3bc9d0fc-684a-4168-a295-5aebc9569252" />
<img width="1919" height="967" alt="Screenshot 2026-07-29 212504" src="https://github.com/user-attachments/assets/d82e5356-2d79-400a-beb7-0802a2970b53" />
<img width="1919" height="962" alt="Screenshot 2026-07-29 212508" src="https://github.com/user-attachments/assets/7bdeb2bd-6709-4803-82b9-0d302b95f657" />
<img width="1919" height="976" alt="Screenshot 2026-07-29 212523" src="https://github.com/user-attachments/assets/fa04efa8-1020-4ece-9d2d-de457289712c" />
<img width="1917" height="582" alt="Screenshot 2026-07-29 212527" src="https://github.com/user-attachments/assets/4d6692fd-1fca-4205-aedc-280304597a65" />
