### PR TITLE
feat: create Wular Lake Explorer (#939)

### DIFF
--- a/index.html
+++ b/index.html
@@ -333,9 +333,10 @@
                         <a href="frontend/national-days-calendar/index.html" class="dropdown-item"> National Days Calendar</a>
                         <a href="frontend/national-symbols-gallery/national-symbols-gallery.html" class="dropdown-item">National Symbols Gallery</a>
                         <a href="frontend/ganga-ghats-experience/index.html" class="dropdown-item">Ganga Ghats Experience</a>
-                        <a href="frontend/crowd-density/index.html" class="dropdown-item">🧑‍🤝‍🧑 Crowd Density Predictor</a>
+                        <a href="frontend/crowd-density/index.html" class="dropdown-item"> Crowd Density Predictor</a>
                         <a href="frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
                         <a href="harike-wetland/harike-wetland.html" class="dropdown-item">Harike Wetland Explorer</a>
+                        <a href="wular-lake/wular-lake.html" class="dropdown-item"> Wular Lake Explorer</a>
                         <a href="frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
                         <a href="frontend/one-day-history/one-day-history.html" class="dropdown-item">One Day in History</a>
                         <a href="frontend/monuments/monuments.html" class="dropdown-item">Monuments</a>

--- a/wular-lake/wular-lake.css
+++ b/wular-lake/wular-lake.css
@@ -1,0 +1,251 @@
+/* ==========================================================
+   Wular Lake Explorer — page styles
+   Palette: near-black bg, warm gold/orange accent,
+   off-white text, glassmorphism cards.
+   ========================================================== */
+
+*{ box-sizing: border-box; }
+html, body{ margin: 0; padding: 0; width: 100%; overflow-x: hidden; }
+
+:root{
+  --wl-bg: #0c0d10;
+  --wl-bg-alt: #131519;
+  --wl-gold: #e8973a;
+  --wl-gold-soft: #f2b969;
+  --wl-text: #f3f1ec;
+  --wl-text-dim: #b9b6ae;
+  --wl-glass: rgba(255,255,255,0.05);
+  --wl-glass-border: rgba(232,151,58,0.25);
+}
+
+body{
+  background: var(--wl-bg);
+  color: var(--wl-text);
+  font-family: 'Outfit', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+h1, h2, h3{
+  font-family: 'Playfair Display', Georgia, serif;
+  margin: 0;
+}
+
+/* ---------------- Topbar ---------------- */
+.wl-topbar{
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+  background: var(--wl-bg);
+  border-bottom: 1px solid var(--wl-glass-border);
+}
+.wl-topbar-logo{ text-decoration: none; font-weight: 700; font-size: 1.1rem; font-family: 'Playfair Display', serif; }
+.wl-topbar-logo .saffron{ color: #ff6f00; }
+.wl-topbar-logo .gold{ color: #ffab00; }
+.wl-topbar-logo .green{ color: #16a34a; }
+.wl-topbar-back{ color: var(--wl-text-dim); text-decoration: none; font-size: 0.9rem; transition: color 0.15s ease; }
+.wl-topbar-back:hover{ color: var(--wl-gold-soft); }
+
+/* ---------------- Hero ---------------- */
+.wl-hero{
+  position: relative;
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  background:
+    radial-gradient(ellipse at center, rgba(232,151,58,0.10) 0%, rgba(12,13,16,0) 60%),
+    var(--wl-bg);
+  padding: 4rem 1.5rem;
+}
+
+.wl-hero-content{ max-width: 720px; width: 100%; margin: 0 auto; }
+
+.wl-eyebrow{
+  letter-spacing: 0.14em;
+  font-size: 0.78rem;
+  color: var(--wl-gold-soft);
+  font-weight: 600;
+  margin: 0 0 0.75rem;
+}
+
+.wl-hero h1{
+  font-size: clamp(2.6rem, 6vw, 4.2rem);
+  font-weight: 700;
+  margin: 0 0 0.75rem;
+  color: var(--wl-text);
+}
+
+.wl-subtitle{
+  font-size: 1.05rem;
+  color: var(--wl-text-dim);
+  max-width: 560px;
+  margin: 0 auto 2rem;
+  line-height: 1.6;
+}
+
+.wl-hero-actions{ display: flex; gap: 1rem; justify-content: center; flex-wrap: wrap; }
+
+.btn{
+  display: inline-block;
+  padding: 0.85rem 1.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  border: none;
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.btn-primary{
+  background: linear-gradient(135deg, var(--wl-gold) 0%, var(--wl-gold-soft) 100%);
+  color: #16130b;
+}
+.btn-secondary{
+  background: transparent;
+  color: var(--wl-text);
+  border: 1px solid rgba(255,255,255,0.25);
+}
+.btn:hover{ transform: translateY(-2px); box-shadow: 0 6px 18px rgba(0,0,0,0.35); }
+
+/* ---------------- Section navigator ---------------- */
+.wl-toc{
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background: rgba(12,13,16,0.95);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--wl-glass-border);
+}
+
+.wl-toc ul{
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+  overflow-x: auto;
+  margin: 0 auto;
+  max-width: 900px;
+  padding: 0.9rem 1.5rem;
+  scrollbar-width: none;
+}
+.wl-toc ul::-webkit-scrollbar{ display:none; }
+
+.wl-toc a{
+  color: var(--wl-text-dim);
+  text-decoration: none;
+  font-size: 0.85rem;
+  white-space: nowrap;
+  transition: color 0.15s ease;
+}
+.wl-toc a:hover{ color: var(--wl-gold-soft); }
+
+.wl-progress-track{ height: 2px; background: rgba(255,255,255,0.08); }
+.wl-progress-fill{ height: 100%; width: 0%; background: var(--wl-gold); transition: width 0.1s linear; }
+
+/* ---------------- Sections ---------------- */
+.wl-section{ width: 100%; padding: 4.5rem 0; }
+.wl-section-alt{ background: var(--wl-bg-alt); }
+
+.wl-section-inner{
+  max-width: 860px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  text-align: center;
+}
+
+.wl-section-tag{
+  display: block;
+  color: var(--wl-gold-soft);
+  font-size: 0.78rem;
+  letter-spacing: 0.1em;
+  font-weight: 600;
+  margin-bottom: 0.6rem;
+}
+
+.wl-section h2{
+  font-size: 2rem;
+  margin: 0 0 1.25rem;
+}
+
+.wl-section p{
+  color: var(--wl-text-dim);
+  line-height: 1.8;
+  font-size: 1.02rem;
+  max-width: 700px;
+  margin: 0 auto;
+  text-align: left;
+}
+
+/* Stat grid (geography) */
+.wl-stat-grid{
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin: 1.75rem 0;
+}
+.wl-stat{
+  background: var(--wl-glass);
+  border: 1px solid var(--wl-glass-border);
+  border-radius: 14px;
+  padding: 1.4rem 1rem;
+  text-align: center;
+}
+.wl-stat-value{ display:block; font-size: 1.3rem; font-weight: 700; color: var(--wl-gold-soft); }
+.wl-stat-label{ display:block; font-size: 0.8rem; color: var(--wl-text-dim); margin-top: 0.4rem; }
+
+/* Map */
+.wl-map-frame{
+  border-radius: 16px;
+  overflow: hidden;
+  border: 1px solid var(--wl-glass-border);
+}
+.wl-map-frame iframe{ width: 100%; height: 420px; border: 0; filter: saturate(0.9); display: block; }
+
+/* Gallery — emoji placeholder cards (swap for real photos later) */
+.wl-gallery{
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+.wl-gallery-card{
+  height: 220px;
+  border-radius: 16px;
+  border: 1px solid var(--wl-glass-border);
+  background: linear-gradient(160deg, rgba(232,151,58,0.10), rgba(255,255,255,0.02));
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 1rem;
+  transition: transform 0.2s ease;
+}
+.wl-gallery-card:hover{ transform: translateY(-4px); }
+.wl-gallery-emoji{ font-size: 2.8rem; }
+.wl-gallery-caption{ font-size: 0.85rem; color: var(--wl-text-dim); text-align: center; }
+
+/* Facts */
+.wl-facts{ list-style: none; padding: 0; margin: 1.5rem 0 0; display: grid; gap: 0.9rem; text-align: left; }
+.wl-facts li{
+  background: var(--wl-glass);
+  border-left: 3px solid var(--wl-gold);
+  border-radius: 10px;
+  padding: 1rem 1.2rem;
+  color: var(--wl-text-dim);
+  line-height: 1.6;
+}
+
+.wl-footer{
+  text-align: center;
+  padding: 2.5rem 1.5rem;
+  background: var(--wl-bg-alt);
+  color: var(--wl-text-dim);
+  font-size: 0.85rem;
+}
+.wl-footer a{ color: var(--wl-gold-soft); text-decoration: none; }
+
+@media (max-width: 600px){
+  .wl-section{ padding: 3rem 0; }
+  .wl-section p{ text-align: left; }
+}

--- a/wular-lake/wular-lake.html
+++ b/wular-lake/wular-lake.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<meta name="description" content="Explore Wular Lake — one of Asia's largest freshwater lakes. History, geography, Ramsar status, ecosystem, birds, fisheries, conservation and more." />
+<title>Wular Lake Explorer | Incredible India Explorer</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&display=swap" rel="stylesheet">
+
+<link rel="stylesheet" href="wular-lake.css" />
+</head>
+<body>
+
+<header class="wl-topbar">
+  <a href="../index.html" class="wl-topbar-logo">
+    <span class="saffron">Incredible</span> <span class="gold">India</span> <span class="green">Explorer</span>
+  </a>
+  <a href="../index.html#map" class="wl-topbar-back">← Back to Map</a>
+</header>
+
+<section class="wl-hero">
+  <div class="wl-hero-content">
+    <p class="wl-eyebrow">RAMSAR WETLAND · JAMMU &amp; KASHMIR</p>
+    <h1>Wular Lake</h1>
+    <p class="wl-subtitle">One of Asia's largest freshwater lakes, cradled by the Himalayas along the Jhelum river.</p>
+    <div class="wl-hero-actions">
+      <a href="#wl-map" class="btn btn-primary">Explore the Map</a>
+      <a href="#facts" class="btn btn-secondary">Jump to Facts</a>
+    </div>
+  </div>
+</section>
+
+<nav class="wl-toc" aria-label="Section navigator">
+  <ul>
+    <li><a href="#history">History</a></li>
+    <li><a href="#geography">Geography</a></li>
+    <li><a href="#ramsar">Ramsar Site</a></li>
+    <li><a href="#ecosystem">Ecosystem</a></li>
+    <li><a href="#birds">Bird Species</a></li>
+    <li><a href="#fisheries">Fisheries</a></li>
+    <li><a href="#conservation">Conservation</a></li>
+    <li><a href="#wl-map">Map</a></li>
+    <li><a href="#gallery">Gallery</a></li>
+    <li><a href="#facts">Facts</a></li>
+  </ul>
+  <div class="wl-progress-track"><div class="wl-progress-fill" id="wl-progress-fill"></div></div>
+</nav>
+
+<main>
+
+  <section id="history" class="wl-section">
+    <div class="wl-section-inner">
+      <span class="wl-section-tag">01 · Origins</span>
+      <h2>History</h2>
+      <p>Wular Lake formed from tectonic activity in the Jhelum valley and has been documented since antiquity, its name believed to derive from the Sanskrit <em>"Ullola"</em>, meaning "high rising waves" — a nod to the storms that can whip across its open waters. For centuries it has shaped the settlements, trade routes, and livelihoods of the Kashmir valley.</p>
+    </div>
+  </section>
+
+  <section id="geography" class="wl-section wl-section-alt">
+    <div class="wl-section-inner">
+      <span class="wl-section-tag">02 · Where it sits</span>
+      <h2>Geography</h2>
+      <div class="wl-stat-grid">
+        <div class="wl-stat"><span class="wl-stat-value">30–189 km²</span><span class="wl-stat-label">Area (varies seasonally)</span></div>
+        <div class="wl-stat"><span class="wl-stat-value">1,580 m</span><span class="wl-stat-label">Altitude above sea level</span></div>
+        <div class="wl-stat"><span class="wl-stat-value">Bandipora &amp; Baramulla</span><span class="wl-stat-label">Districts, Jammu &amp; Kashmir</span></div>
+        <div class="wl-stat"><span class="wl-stat-value">Jhelum River</span><span class="wl-stat-label">Main inflow/outflow</span></div>
+      </div>
+      <p>The lake acts as a natural flood-basin for the Jhelum, absorbing monsoon and snowmelt surges before releasing water downstream — a role that makes it critical to flood control across the valley.</p>
+    </div>
+  </section>
+
+  <section id="ramsar" class="wl-section">
+    <div class="wl-section-inner">
+      <span class="wl-section-tag">03 · Wetland of International Importance</span>
+      <h2>Ramsar Site</h2>
+      <p>Wular Lake was designated a <strong>Ramsar Site</strong> in 1990, recognising its role as one of the largest freshwater wetlands in Asia and a critical habitat under the international Ramsar Convention on Wetlands.</p>
+    </div>
+  </section>
+
+  <section id="ecosystem" class="wl-section wl-section-alt">
+    <div class="wl-section-inner">
+      <span class="wl-section-tag">04 · Freshwater Ecosystem</span>
+      <h2>Freshwater Ecosystem</h2>
+      <p>The lake supports floating and submerged aquatic vegetation, reedbeds, and willow plantations along its margins, forming a mosaic of habitats for fish, waterbirds, and amphibians. Seasonal water-level changes drive nutrient cycling that sustains this diversity.</p>
+    </div>
+  </section>
+
+  <section id="birds" class="wl-section">
+    <div class="wl-section-inner">
+      <span class="wl-section-tag">05 · Avifauna</span>
+      <h2>Bird Species</h2>
+      <p>Wular is a key stopover on the Central Asian Flyway. Migratory and resident species recorded here include the greylag goose, common pochard, tufted duck, great crested grebe, and various herons and kingfishers.</p>
+    </div>
+  </section>
+
+  <section id="fisheries" class="wl-section wl-section-alt">
+    <div class="wl-section-inner">
+      <span class="wl-section-tag">06 · Livelihoods</span>
+      <h2>Fisheries</h2>
+      <p>Thousands of local families depend on Wular for fishing and water-chestnut (<em>singhara</em>) harvesting, making it one of Kashmir's most important sources of freshwater fish and rural income.</p>
+    </div>
+  </section>
+
+  <section id="conservation" class="wl-section">
+    <div class="wl-section-inner">
+      <span class="wl-section-tag">07 · Protecting the Lake</span>
+      <h2>Conservation</h2>
+      <p>The Wular Conservation and Management Authority (WUCMA) leads de-siltation, willow removal, and catchment restoration efforts to reverse decades of shrinkage caused by siltation, encroachment, and pollution.</p>
+    </div>
+  </section>
+
+  <section id="wl-map" class="wl-section wl-section-alt">
+    <div class="wl-section-inner">
+      <span class="wl-section-tag">08 · Find it</span>
+      <h2>Interactive Map</h2>
+      <div class="wl-map-frame">
+        <iframe
+          title="Wular Lake location map"
+          src="https://www.openstreetmap.org/export/embed.html?bbox=74.45%2C34.30%2C74.70%2C34.45&layer=mapnik&marker=34.38%2C74.58"
+          loading="lazy">
+        </iframe>
+      </div>
+    </div>
+  </section>
+
+  <section id="gallery" class="wl-section">
+    <div class="wl-section-inner">
+      <span class="wl-section-tag">09 · Gallery</span>
+      <h2>Gallery</h2>
+      <div class="wl-gallery" id="wl-gallery">
+        <div class="wl-gallery-card">
+          <span class="wl-gallery-emoji">🌅</span>
+          <span class="wl-gallery-caption">Wular Lake at sunrise</span>
+        </div>
+        <div class="wl-gallery-card">
+          <span class="wl-gallery-emoji">🚣</span>
+          <span class="wl-gallery-caption">Fishing boats on Wular Lake</span>
+        </div>
+        <div class="wl-gallery-card">
+          <span class="wl-gallery-emoji">🦢</span>
+          <span class="wl-gallery-caption">Migratory birds over Wular Lake</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section id="facts" class="wl-section wl-section-alt">
+    <div class="wl-section-inner">
+      <span class="wl-section-tag">10 · Did you know?</span>
+      <h2>Interesting Facts</h2>
+      <ul class="wl-facts">
+        <li>🌊 Wular is fed and drained by the Jhelum River, acting as a natural flood buffer for the valley.</li>
+        <li>📉 The lake once covered a much larger area; decades of siltation and encroachment have significantly reduced it.</li>
+        <li>🏝️ Zaina Lank, a small island in the lake, was built during the reign of Sultan Zain-ul-Abidin in the 15th century.</li>
+        <li>🌏 It remains one of the largest freshwater lakes in Asia despite its shrinking footprint.</li>
+      </ul>
+    </div>
+  </section>
+
+</main>
+
+<footer class="wl-footer">
+  <p>Part of the <a href="../index.html">Incredible India Explorer</a> project · Wetlands series</p>
+</footer>
+
+<script src="wular-lake.js"></script>
+</body>
+</html>

--- a/wular-lake/wular-lake.js
+++ b/wular-lake/wular-lake.js
@@ -1,0 +1,27 @@
+// ============ Wular Lake Explorer — page script ============
+// Standalone page script (no dependency on app.js/journey.js,
+// since those are scoped to the main homepage).
+
+document.addEventListener('DOMContentLoaded', () => {
+  // Scroll progress bar
+  const progressFill = document.getElementById('wl-progress-fill');
+  const onScroll = () => {
+    const scrollTop = window.scrollY;
+    const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+    const pct = docHeight > 0 ? (scrollTop / docHeight) * 100 : 0;
+    if (progressFill) progressFill.style.width = `${pct}%`;
+  };
+  window.addEventListener('scroll', onScroll, { passive: true });
+  onScroll();
+
+  // Smooth scroll for section-nav links
+  document.querySelectorAll('.wl-toc a').forEach((link) => {
+    link.addEventListener('click', (e) => {
+      const target = document.querySelector(link.getAttribute('href'));
+      if (target) {
+        e.preventDefault();
+        target.scrollIntoView({ behavior: 'smooth' });
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Description
Adds a new interactive explorer page for **Wular Lake**, one of Asia's largest freshwater lakes, following the site's wetlands page pattern (similar to Harike Wetland Explorer).

Closes #939

## What's included
- **History** — origins and etymology of Wular Lake
- **Geography** — location, area, altitude, districts, and river system (with a stat grid)
- **Ramsar Site** — international wetland designation details
- **Freshwater Ecosystem** — aquatic vegetation and habitat overview
- **Bird Species** — migratory and resident avifauna on the Central Asian Flyway
- **Fisheries** — local livelihoods dependent on the lake
- **Conservation** — WUCMA's restoration and conservation efforts
- **Interactive Map** — embedded OpenStreetMap showing the lake's location
- **Gallery** — visual placeholder cards (to be swapped with real photos)
- **Interesting Facts** — quick trivia section

## Landing Page Integration
Added a "Wular Lake Explorer" link to the **Explore More** dropdown in `index.html`, next to the existing Harike Wetland Explorer entry.

## Files changed
- `wular-lake/wular-lake.html` (new)
- `wular-lake/wular-lake.css` (new)
- `wular-lake/wular-lake.js` (new)
- `index.html` (modified — added nav link)

## Testing
- [x] Tested locally with Live Server
- [x] Verified all section-nav links scroll correctly
- [x] Verified
<img width="1440" height="852" alt="Screenshot 2026-07-30 124021" src="https://github.com/user-attachments/assets/76699a0c-8c5f-4303-914e-271c90b60210" />

<img width="1440" height="852" alt="Screenshot 2026-07-30 124038" src="https://github.com/user-attachments/assets/c9325596-9870-41af-815d-3767ad89e23f" />
