### PR TITLE
feat: Create Wadhvana Wetland Explorer

### DIFF
--- a/frontend/wadhvana-wetland-explorer/index.html
+++ b/frontend/wadhvana-wetland-explorer/index.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    document.body.classList.add('light-theme');
+                }
+            })();
+        </script>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Explore Wadhvana Wetland — Ramsar Site in Gujarat, century-old reservoir built by Maharaja Sayajirao Gaekwad III, and a critical winter habitat for 80,000+ migratory birds."
+        />
+        <title>Wadhvana Wetland Explorer | Incredible India</title>
+
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+            rel="stylesheet"
+        />
+
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="wadhvana.css" />
+    </head>
+    <body class="wadhvana-main">
+        <header class="navbar scrolled" id="navbar">
+            <div class="nav-container">
+                <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </button>
+                <nav class="nav-menu" id="nav-menu">
+                    <a href="../../index.html#home" class="nav-link">Home</a>
+                    <a href="../wetlands/index.html" class="nav-link">Wetlands Landing</a>
+                    <a href="../national-parks-explorer/index.html" class="nav-link">National Parks</a>
+                    <a href="index.html" class="nav-link active" style="color: var(--saffron)">Wadhvana Explorer</a>
+                    <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
+                        ☀️
+                    </button>
+                </nav>
+            </div>
+        </header>
+
+        <main>
+            <section class="wadhvana-hero">
+                <div class="section-container">
+                    <div class="hero-badges-row">
+                        <span class="hero-pill pill-ramsar">💧 Ramsar Site No. 2454 (2021)</span>
+                        <span class="hero-pill pill-state">📍 Dabhoi, Vadodara, Gujarat</span>
+                        <span class="hero-pill pill-history">🏛️ Built by Maharaja Sayajirao Gaekwad III (1910)</span>
+                    </div>
+                    <h1>Wadhvana <span>Wetland</span> Explorer</h1>
+                    <p class="hero-subtitle">
+                        Discover Wadhvana Lake — a century-old reservoir transformed into an internationally acclaimed Ramsar wetland sanctuary hosting over 80,000 wintering waterfowl on the Central Asian Flyway.
+                    </p>
+                    <div id="stats-grid" class="stats-grid"></div>
+                </div>
+            </section>
+
+            <section class="wadhvana-info-section">
+                <div class="section-container">
+                    <h2>Ecology & Reservoir History</h2>
+                    <div class="info-card" id="ecology-info">
+                        <p id="eco-overview"></p>
+                        <p id="eco-hydrology"></p>
+                        <p id="eco-status"></p>
+                    </div>
+                </div>
+            </section>
+
+            <section class="species-section">
+                <div class="section-container">
+                    <h2>Key Migratory Birds & Wildlife</h2>
+                    <div class="species-grid" id="species-grid"></div>
+                </div>
+            </section>
+
+            <section class="hotspots-section">
+                <div class="section-container">
+                    <h2>Interactive Map Hotspots</h2>
+                    <div class="hotspots-grid" id="hotspots-grid"></div>
+                </div>
+            </section>
+
+            <section class="gallery-section">
+                <div class="section-container">
+                    <h2>Wetland Image Gallery</h2>
+                    <div class="gallery-grid" id="gallery-grid"></div>
+                </div>
+            </section>
+        </main>
+
+        <script src="wadhvana-data.js"></script>
+        <script src="wadhvana.js"></script>
+    </body>
+</html>

--- a/frontend/wadhvana-wetland-explorer/wadhvana-data.js
+++ b/frontend/wadhvana-wetland-explorer/wadhvana-data.js
@@ -1,0 +1,143 @@
+/**
+ * Wadhvana Wetland Explorer — Data Module
+ * Comprehensive dataset covering Ramsar Site metadata, reservoir hydrology,
+ * bird species catalog, map hotspots, and image gallery.
+ */
+
+const WADHNAVANA_INFO = {
+    id: "wadhvana-wetland",
+    name: "Wadhvana Wetland",
+    location: "Dabhoi, Vadodara District, Gujarat, India",
+    state: "Gujarat",
+    coordinates: { lat: 22.174, lng: 73.483 },
+    area: "10.3 km² (1,030 hectares)",
+    establishedYear: 1910,
+    ramsarYear: 2021,
+    ramsarSiteNo: 2454,
+    reservoirBuilder: "Maharaja Sayajirao Gaekwad III",
+    climate: "Tropical Semi-Arid",
+    bestTime: "November to March (Peak Migratory Season)",
+    nearestTransport: {
+        railway: "Dabhoi Junction (10 km) / Vadodara Junction (45 km)",
+        airport: "Vadodara Airport (48 km)",
+        highway: "SH 11 / NH 48"
+    },
+    quickStats: [
+        { label: "Migratory Waterfowl", value: "80,000+", icon: "🦆" },
+        { label: "Bird Species", value: "140+", icon: "🦅" },
+        { label: "Ramsar Designated", value: "2021", icon: "💧" },
+        { label: "Reservoir Built", value: "1910", icon: "🏛️" },
+        { label: "Surface Area", value: "10.3 km²", icon: "🌾" },
+        { label: "Central Asian Flyway", value: "Key Stopover", icon: "🌐" }
+    ]
+};
+
+const ECOLOGY_HYDROLOGY = {
+    overview: "Wadhvana Wetland is an century-old man-made irrigation reservoir constructed by Maharaja Sayajirao Gaekwad III in 1910. Located in Dabhoi taluka of Vadodara district, it has evolved into an ecologically vital wetland habitat along the Central Asian Flyway.",
+    hydrology: "Fed by canal systems from the Orsang and Narmada river basins, Wadhvana holds water throughout the dry winter months, offering a crucial roosting and feeding oasis for wintering waterfowl.",
+    conservationStatus: "Designated as a Ramsar Site of International Importance in August 2021. Managed by the Gujarat State Forest Department with active eco-tourism and bird monitoring watchtowers."
+};
+
+const BIRD_SPECIES = [
+    {
+        id: "ferruginous-duck",
+        name: "Ferruginous Duck",
+        scientificName: "Aythya nyroca",
+        category: "migratory-waterfowl",
+        status: "Near Threatened",
+        season: "November to February",
+        diet: "Aquatic plants, mollusks, insects",
+        wingspan: "63–67 cm",
+        icon: "🦆",
+        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Ferruginous_duck_%28Aythya_nyroca%29_male.jpg/800px-Ferruginous_duck_%28Aythya_nyroca%29_male.jpg",
+        description: "Deep chestnut-brown diving duck with striking white undertail coverts and yellow eyes in males. Uses Wadhvana as a major wintering ground."
+    },
+    {
+        id: "greylag-goose",
+        name: "Greylag Goose",
+        scientificName: "Anser anser",
+        category: "migratory-waterfowl",
+        status: "Least Concern",
+        season: "December to February",
+        diet: "Grasses, grains, aquatic roots",
+        wingspan: "147–180 cm",
+        icon: "🪿",
+        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Greylag_Goose_Anser_anser.jpg/800px-Greylag_Goose_Anser_anser.jpg",
+        description: "Large grey goose with pink bill and orange legs. Flocks migrate thousands of kilometers from Central Asia to forage at Wadhvana Lake."
+    },
+    {
+        id: "greater-flamingo",
+        name: "Greater Flamingo",
+        scientificName: "Phoenicopterus roseus",
+        category: "wading-birds",
+        status: "Least Concern",
+        season: "October to March",
+        diet: "Algae, small crustaceans, diatoms",
+        wingspan: "140–165 cm",
+        icon: "🦩",
+        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Greater_Flamingo_Rann_of_Kutch.jpg/800px-Greater_Flamingo_Rann_of_Kutch.jpg",
+        description: "Tall wading bird with pinkish plumage and curved bill. Forages in the shallow shoreline waters of Wadhvana."
+    },
+    {
+        id: "common-pochard",
+        name: "Common Pochard",
+        scientificName: "Aythya ferina",
+        category: "migratory-waterfowl",
+        status: "Vulnerable",
+        season: "November to March",
+        diet: "Aquatic vegetation, seeds, aquatic insects",
+        wingspan: "72–82 cm",
+        icon: "🦆",
+        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Common_Pochard_male.jpg/800px-Common_Pochard_male.jpg",
+        description: "Medium-sized diving duck with a rusty red head, black chest, and grey body. Vulnerable species relying on protected wetlands."
+    }
+];
+
+const MAP_HOTSPOTS = [
+    {
+        id: "watchtower-1",
+        title: "Main Eco-Watchtower",
+        lat: 22.176,
+        lng: 73.481,
+        type: "Observation",
+        description: "Panoramic view tower equipped with spotting scopes for observing deep-water diving ducks and geese."
+    },
+    {
+        id: "north-embankment",
+        title: "North Embankment Promenade",
+        lat: 22.179,
+        lng: 73.485,
+        type: "Trail",
+        description: "Tree-lined walkway providing ideal vantage points for photography and morning bird walks."
+    },
+    {
+        id: "feeder-canal",
+        title: "Orsang Feeder Canal Inlet",
+        lat: 22.171,
+        lng: 73.478,
+        type: "Hydrology",
+        description: "Inflow canal mouth where shallow marshy vegetation attracts waders, storks, and herons."
+    }
+];
+
+const GALLERY_IMAGES = [
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Ferruginous_duck_%28Aythya_nyroca%29_male.jpg/800px-Ferruginous_duck_%28Aythya_nyroca%29_male.jpg",
+        caption: "Ferruginous Duck resting on Wadhvana waters",
+        category: "Fauna"
+    },
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Greylag_Goose_Anser_anser.jpg/800px-Greylag_Goose_Anser_anser.jpg",
+        caption: "Greylag Geese foraging along the reservoir banks",
+        category: "Fauna"
+    },
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b8/Greater_Flamingo_Rann_of_Kutch.jpg/800px-Greater_Flamingo_Rann_of_Kutch.jpg",
+        caption: "Greater Flamingos wading in shallow waters",
+        category: "Landscape"
+    }
+];
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { WADHNAVANA_INFO, ECOLOGY_HYDROLOGY, BIRD_SPECIES, MAP_HOTSPOTS, GALLERY_IMAGES };
+}

--- a/frontend/wadhvana-wetland-explorer/wadhvana.css
+++ b/frontend/wadhvana-wetland-explorer/wadhvana.css
@@ -1,0 +1,156 @@
+.wadhvana-main {
+    background-color: var(--bg-primary, #0f172a);
+    color: var(--text-primary, #f8fafc);
+    font-family: 'Outfit', sans-serif;
+}
+
+.wadhvana-hero {
+    padding: 6rem 1.5rem 3rem;
+    background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(30, 58, 138, 0.85));
+    text-align: center;
+}
+
+.hero-badges-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+}
+
+.hero-pill {
+    padding: 0.4rem 1rem;
+    border-radius: 9999px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(8px);
+}
+
+.wadhvana-hero h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2.75rem;
+    font-weight: 800;
+    margin-bottom: 1rem;
+}
+
+.wadhvana-hero h1 span {
+    color: #38bdf8;
+}
+
+.hero-subtitle {
+    max-width: 800px;
+    margin: 0 auto 2.5rem;
+    font-size: 1.1rem;
+    color: #94a3b8;
+    line-height: 1.6;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1.25rem;
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.stat-card {
+    background: rgba(30, 41, 59, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 1.25rem;
+    border-radius: 12px;
+    text-align: center;
+}
+
+.stat-icon {
+    font-size: 1.75rem;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.stat-val {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #38bdf8;
+}
+
+.stat-lbl {
+    font-size: 0.85rem;
+    color: #94a3b8;
+}
+
+.section-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem;
+}
+
+.section-container h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2rem;
+    margin-bottom: 1.5rem;
+    color: #f1f5f9;
+}
+
+.info-card {
+    background: rgba(30, 41, 59, 0.6);
+    border-radius: 12px;
+    padding: 2rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    line-height: 1.7;
+}
+
+.info-card p {
+    margin-bottom: 1rem;
+}
+
+.species-grid, .hotspots-grid, .gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.species-card, .hotspot-card, .gallery-card {
+    background: rgba(30, 41, 59, 0.6);
+    border-radius: 12px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    transition: transform 0.2s ease;
+}
+
+.species-card:hover, .hotspot-card:hover, .gallery-card:hover {
+    transform: translateY(-4px);
+}
+
+.species-card img, .gallery-card img {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+}
+
+.species-card-body, .hotspot-card, .gallery-card p {
+    padding: 1.25rem;
+}
+
+.status-badge {
+    background: rgba(56, 189, 248, 0.2);
+    color: #38bdf8;
+    padding: 0.2rem 0.6rem;
+    border-radius: 6px;
+    font-size: 0.75rem;
+}
+
+.scientific-name {
+    color: #94a3b8;
+    margin-bottom: 0.75rem;
+}
+
+.spot-type {
+    display: inline-block;
+    background: rgba(16, 185, 129, 0.2);
+    color: #34d399;
+    padding: 0.2rem 0.6rem;
+    border-radius: 6px;
+    font-size: 0.75rem;
+    margin-bottom: 0.5rem;
+}

--- a/frontend/wadhvana-wetland-explorer/wadhvana.js
+++ b/frontend/wadhvana-wetland-explorer/wadhvana.js
@@ -1,0 +1,102 @@
+document.addEventListener('DOMContentLoaded', () => {
+    renderStats();
+    renderEcology();
+    renderSpecies();
+    renderHotspots();
+    renderGallery();
+    initThemeToggle();
+});
+
+function renderStats() {
+    const grid = document.getElementById('stats-grid');
+    if (!grid || typeof WADHNAVANA_INFO === 'undefined') return;
+
+    grid.innerHTML = WADHNAVANA_INFO.quickStats
+        .map(
+            stat => `
+        <div class="stat-card">
+            <span class="stat-icon">${stat.icon}</span>
+            <div class="stat-val">${stat.value}</div>
+            <div class="stat-lbl">${stat.label}</div>
+        </div>
+    `
+        )
+        .join('');
+}
+
+function renderEcology() {
+    if (typeof ECOLOGY_HYDROLOGY === 'undefined') return;
+    const overviewEl = document.getElementById('eco-overview');
+    const hydroEl = document.getElementById('eco-hydrology');
+    const statusEl = document.getElementById('eco-status');
+
+    if (overviewEl) overviewEl.innerHTML = `<strong>Overview:</strong> ${ECOLOGY_HYDROLOGY.overview}`;
+    if (hydroEl) hydroEl.innerHTML = `<strong>Hydrology & Water Source:</strong> ${ECOLOGY_HYDROLOGY.hydrology}`;
+    if (statusEl) statusEl.innerHTML = `<strong>Conservation Status:</strong> ${ECOLOGY_HYDROLOGY.conservationStatus}`;
+}
+
+function renderSpecies() {
+    const grid = document.getElementById('species-grid');
+    if (!grid || typeof BIRD_SPECIES === 'undefined') return;
+
+    grid.innerHTML = BIRD_SPECIES.map(
+        bird => `
+        <div class="species-card">
+            <img src="${bird.image}" alt="${bird.name}" loading="lazy" />
+            <div class="species-card-body">
+                <div class="species-header">
+                    <h3>${bird.name} ${bird.icon}</h3>
+                    <span class="status-badge">${bird.status}</span>
+                </div>
+                <p class="scientific-name"><em>${bird.scientificName}</em></p>
+                <p>${bird.description}</p>
+                <div class="bird-meta">
+                    <span>🗓️ ${bird.season}</span> | 
+                    <span>🪶 Wingspan: ${bird.wingspan}</span>
+                </div>
+            </div>
+        </div>
+    `
+    ).join('');
+}
+
+function renderHotspots() {
+    const grid = document.getElementById('hotspots-grid');
+    if (!grid || typeof MAP_HOTSPOTS === 'undefined') return;
+
+    grid.innerHTML = MAP_HOTSPOTS.map(
+        spot => `
+        <div class="hotspot-card">
+            <h3>📍 ${spot.title}</h3>
+            <span class="spot-type">${spot.type}</span>
+            <p>${spot.description}</p>
+            <small>Coordinates: ${spot.lat}° N, ${spot.lng}° E</small>
+        </div>
+    `
+    ).join('');
+}
+
+function renderGallery() {
+    const grid = document.getElementById('gallery-grid');
+    if (!grid || typeof GALLERY_IMAGES === 'undefined') return;
+
+    grid.innerHTML = GALLERY_IMAGES.map(
+        img => `
+        <div class="gallery-card">
+            <img src="${img.url}" alt="${img.caption}" loading="lazy" />
+            <p>${img.caption}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function initThemeToggle() {
+    const toggleBtn = document.getElementById('theme-toggle');
+    if (!toggleBtn) return;
+
+    toggleBtn.addEventListener('click', () => {
+        const isLight = document.body.classList.toggle('light-theme');
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        toggleBtn.textContent = isLight ? '🌙' : '☀️';
+    });
+}

--- a/frontend/wetlands/wetlands-data.js
+++ b/frontend/wetlands/wetlands-data.js
@@ -180,6 +180,22 @@ export const WETLANDS_DATA = {
             coordinates: { lat: 31.38, lng: 75.18 },
             keyFauna: ['Gharial', 'Indus River Dolphin', 'Smooth-coated Otter'],
             isFeatured: false
+        },
+        {
+            id: 'wadhvana-wetland',
+            name: 'Wadhvana Wetland',
+            state: 'Gujarat',
+            type: 'Reservoir',
+            area: '10.3 km²',
+            ramsarDeclared: 2021,
+            ramsarSiteNo: 2454,
+            image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Ferruginous_duck_%28Aythya_nyroca%29_male.jpg/800px-Ferruginous_duck_%28Aythya_nyroca%29_male.jpg',
+            shortDesc: 'Century-old reservoir built by Maharaja Sayajirao Gaekwad III, Ramsar Site supporting 80,000+ wintering migratory waterfowl.',
+            exploreUrl: '../wadhvana-wetland-explorer/index.html',
+            coordinates: { lat: 22.174, lng: 73.483 },
+            keyFauna: ['Ferruginous Duck', 'Greylag Goose', 'Greater Flamingo', 'Common Pochard'],
+            isFeatured: true
         }
     ]
 };
+

--- a/search-index.js
+++ b/search-index.js
@@ -1427,6 +1427,13 @@ window.indiaSearchIndex = [
     description: "Develop an educational page about Simlipal National Park & Biosphere Reserve in Odisha — featuring Barehipani (399m) & Joranda waterfalls, world's only Melanistic Black Tigers, Mayurbhanj elephants, 94+ orchids, and Santhal tribal heritage.",
     url: "frontend/simlipal-national-park-explorer/index.html"
   },
+  // --- Wadhvana Wetland Explorer ---
+  {
+    title: "Wadhvana Wetland Explorer",
+    category: "Wetlands & Ramsar Sites",
+    description: "Explore Wadhvana Wetland in Gujarat — a Ramsar Site and century-old reservoir built by Maharaja Sayajirao Gaekwad III, hosting 80,000+ wintering migratory birds.",
+    url: "frontend/wadhvana-wetland-explorer/index.html"
+  },
   // --- The Making of Modern India (1757–1947) Timeline ---
   {
     title: "The Making of Modern India (1757–1947) Interactive Timeline",

--- a/tests/unit/wadhvana-wetland-explorer.test.js
+++ b/tests/unit/wadhvana-wetland-explorer.test.js
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadWadhvanaData() {
+    const code = readFileSync(
+        resolve(__dirname, '../../frontend/wadhvana-wetland-explorer/wadhvana-data.js'),
+        'utf-8'
+    );
+    const fn = new Function(
+        code + '\nreturn { WADHNAVANA_INFO, ECOLOGY_HYDROLOGY, BIRD_SPECIES, MAP_HOTSPOTS, GALLERY_IMAGES };'
+    );
+    return fn();
+}
+
+function loadWetlandsLandingData() {
+    let code = readFileSync(
+        resolve(__dirname, '../../frontend/wetlands/wetlands-data.js'),
+        'utf-8'
+    );
+    code = code.replace(/export\s+const\s+/g, 'const ');
+    const fn = new Function(code + '\nreturn WETLANDS_DATA;');
+    return fn();
+}
+
+describe('Wadhvana Wetland Explorer — Data & Integration Tests', () => {
+    let data;
+
+    beforeAll(() => {
+        data = loadWadhvanaData();
+    });
+
+    describe('WADHNAVANA_INFO metadata', () => {
+        it('contains correct wetland metadata and status', () => {
+            expect(data.WADHNAVANA_INFO.id).toBe('wadhvana-wetland');
+            expect(data.WADHNAVANA_INFO.name).toBe('Wadhvana Wetland');
+            expect(data.WADHNAVANA_INFO.ramsarYear).toBe(2021);
+            expect(data.WADHNAVANA_INFO.ramsarSiteNo).toBe(2454);
+            expect(data.WADHNAVANA_INFO.state).toBe('Gujarat');
+        });
+
+        it('has quickStats array with 6 items', () => {
+            expect(Array.isArray(data.WADHNAVANA_INFO.quickStats)).toBe(true);
+            expect(data.WADHNAVANA_INFO.quickStats.length).toBe(6);
+        });
+    });
+
+    describe('ECOLOGY_HYDROLOGY', () => {
+        it('contains overview, hydrology, and conservation status', () => {
+            expect(data.ECOLOGY_HYDROLOGY.overview).toBeDefined();
+            expect(data.ECOLOGY_HYDROLOGY.hydrology).toBeDefined();
+            expect(data.ECOLOGY_HYDROLOGY.conservationStatus).toBeDefined();
+        });
+    });
+
+    describe('BIRD_SPECIES catalog', () => {
+        it('is a non-empty array of bird species', () => {
+            expect(Array.isArray(data.BIRD_SPECIES)).toBe(true);
+            expect(data.BIRD_SPECIES.length).toBeGreaterThanOrEqual(4);
+        });
+
+        it('includes Ferruginous Duck and Greylag Goose', () => {
+            const ferruginousDuck = data.BIRD_SPECIES.find(b => b.id === 'ferruginous-duck');
+            const greylagGoose = data.BIRD_SPECIES.find(b => b.id === 'greylag-goose');
+            expect(ferruginousDuck).toBeDefined();
+            expect(greylagGoose).toBeDefined();
+        });
+    });
+
+    describe('Landing Page Integration', () => {
+        it('is integrated in WETLANDS_DATA landing page dataset', () => {
+            const wetlandsData = loadWetlandsLandingData();
+            const wadhvanaCard = wetlandsData.wetlands.find(w => w.id === 'wadhvana-wetland');
+            expect(wadhvanaCard).toBeDefined();
+            expect(wadhvanaCard.exploreUrl).toBe('../wadhvana-wetland-explorer/index.html');
+        });
+    });
+});


### PR DESCRIPTION
## Title

feat: Create Wadhvana Wetland Explorer

## Description

Develop an informative page about Wadhvana Wetland, an important reservoir wetland supporting thousands of migratory birds.

## Included
- History & Maharaja Sayajirao Gaekwad III legacy (1910)
- Ramsar Site metadata (Site No. 2454, 2021)
- Reservoir Wetland Ecology & Hydrology
- Bird Migration & Species catalog (Ferruginous Duck, Greylag Goose, Flamingos)
- Aquatic Biodiversity & Conservation
- Interactive Map Hotspots & Photo Gallery
- Landing Page Integration in Wetlands Explorer Landing Page

Closes #1007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Wadhvana Wetland Explorer, featuring wetland facts, ecology and hydrology details, migratory bird information, map hotspots, and a photo gallery.
  * Added dark/light theme switching with saved preferences.
  * Added Wadhvana Wetland to the wetlands directory and site search results.
  * Added responsive layouts, interactive cards, and visual styling for the explorer.

* **Tests**
  * Added coverage for explorer content, wetland metadata, bird species, and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->