### PR TITLE
feat: Add dedicated Jim Corbett National Park Explorer page with landing page integration

### DIFF
--- a/frontend/jim-corbett-national-park-explorer/index.html
+++ b/frontend/jim-corbett-national-park-explorer/index.html
@@ -1,0 +1,285 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    document.body.classList.add('light-theme');
+                }
+            })();
+        </script>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Explore Jim Corbett National Park in Uttarakhand — India's first national park (1936) and birthplace of Project Tiger (1973). Discover its history, geography, Bengal Tigers, safari zones, and more."
+        />
+        <title>Jim Corbett National Park Explorer | Incredible India</title>
+
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+            rel="stylesheet"
+        />
+
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="jim-corbett.css" />
+
+        <meta property="og:title" content="Jim Corbett National Park Explorer | Incredible India" />
+        <meta
+            property="og:description"
+            content="Interactive guide to Jim Corbett National Park — India's oldest national park and the birthplace of Project Tiger."
+        />
+        <meta property="og:type" content="website" />
+    </head>
+
+    <body class="corbett-main">
+        <header class="navbar scrolled" id="navbar">
+            <div class="nav-container">
+                <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </button>
+                <nav class="nav-menu" id="nav-menu">
+                    <a href="../../index.html#home" class="nav-link">Home</a>
+                    <a href="../national-parks-explorer/index.html" class="nav-link">National Parks</a>
+                    <a href="index.html" class="nav-link active" style="color: var(--saffron)"
+                        >Corbett Explorer</a
+                    >
+                    <a href="../national-parks-timeline/national-parks-timeline.html" class="nav-link">Timeline</a>
+                    <button
+                        id="theme-toggle"
+                        class="btn-theme-toggle"
+                        aria-label="Toggle Dark/Light Mode"
+                        title="Toggle Light Mode"
+                    >
+                        ☀️
+                    </button>
+                </nav>
+            </div>
+        </header>
+
+        <main>
+            <!-- Hero -->
+            <section class="corbett-hero">
+                <div class="section-container">
+                    <div class="hero-badges-row">
+                        <span class="hero-pill">🏞️ India's First National Park</span>
+                        <span class="hero-pill">🐅 Birthplace of Project Tiger</span>
+                        <span class="hero-pill">📍 Uttarakhand</span>
+                    </div>
+                    <h1>Jim Corbett <span>National Park</span> Explorer</h1>
+                    <p class="hero-subtitle">
+                        Established in 1936, Jim Corbett is India's oldest national park and the site where
+                        Project Tiger was launched in 1973. Explore its Shivalik hills, the Ramganga River,
+                        dense Sal forests, and one of the country's densest Bengal Tiger populations.
+                    </p>
+                    <div id="stats-grid" class="stats-grid"></div>
+                </div>
+            </section>
+
+            <!-- History -->
+            <section class="history-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">History</span>
+                        <h2>From Hailey National Park to Corbett</h2>
+                        <p class="section-subtitle">
+                            Trace the park's journey from its founding in 1936 to becoming the birthplace of
+                            India's most important tiger conservation programme.
+                        </p>
+                    </div>
+                    <div id="history-timeline" class="timeline-container"></div>
+                </div>
+            </section>
+
+            <!-- Geography -->
+            <section class="geography-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Geography</span>
+                        <h2>Shivalik Hills & the Ramganga River</h2>
+                        <p class="section-subtitle">
+                            Corbett spans 1,318 km² across the Shivalik foothills, ranging from 360 m to 1,040 m
+                            in elevation, with the Ramganga River and its reservoir carving through riverine
+                            belts, ravines, and the Patli Dun valley.
+                        </p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Flora & Fauna -->
+            <section class="flora-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Flora</span>
+                        <h2>Sal Forests & Riverine Grasslands</h2>
+                        <p class="section-subtitle">
+                            Sal forest covers roughly 73% of the park, complemented by chaur grasslands,
+                            khair-sissoo riverine belts, and pine forest at higher elevations.
+                        </p>
+                    </div>
+                    <div id="flora-grid" class="flora-grid"></div>
+                </div>
+            </section>
+
+            <section class="wildlife-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Fauna</span>
+                        <h2>Wildlife of Corbett</h2>
+                        <p class="section-subtitle">
+                            From Bengal Tigers to gharials basking along the Ramganga, Corbett supports a
+                            remarkably diverse range of species.
+                        </p>
+                    </div>
+                    <div id="wildlife-grid" class="wildlife-grid"></div>
+                </div>
+            </section>
+
+            <!-- Bengal Tiger Spotlight -->
+            <section class="tiger-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Flagship Species</span>
+                        <h2>The Bengal Tiger of Corbett</h2>
+                        <p class="section-subtitle">
+                            Corbett is where Project Tiger began in 1973 — and remains home to one of India's
+                            densest Bengal Tiger populations today.
+                        </p>
+                    </div>
+                    <div class="glass-card" style="padding:1.5rem; max-width:800px; margin:0 auto;">
+                        <p style="line-height:1.7; color:var(--corbett-text-muted-dark);">
+                            Dense Sal forests, riverine cover, and abundant prey along the Ramganga floodplains
+                            make Corbett prime tiger habitat. As the pilot reserve for Project Tiger, its
+                            conservation model of anti-poaching camps and core-buffer zoning became the template
+                            later applied across dozens of other Indian tiger reserves.
+                        </p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Safari Zones -->
+            <section class="safari-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Experience the Wild</span>
+                        <h2>Safari Zones in Corbett</h2>
+                        <p class="section-subtitle">
+                            Six distinct zones — Dhikala, Bijrani, Jhirna, Dhela, Durga Devi, and Sonanadi —
+                            each offering a different slice of the park's terrain and wildlife.
+                        </p>
+                    </div>
+                    <div id="safari-grid" class="safari-grid"></div>
+                </div>
+            </section>
+
+            <!-- Best Time to Visit -->
+            <section class="best-time-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Plan Your Visit</span>
+                        <h2>Best Time to Visit</h2>
+                        <p class="section-subtitle">
+                            Open November through June; Dhikala zone closes mid-June to mid-November for the
+                            monsoon, but Jhirna zone stays open year-round.
+                        </p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Interactive Map -->
+            <section class="map-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Park Geography</span>
+                        <h2>Interactive Map of Jim Corbett National Park</h2>
+                        <p class="section-subtitle">
+                            Click the map pins to explore Dhikala, Bijrani, Jhirna, the Ramganga River, Durga
+                            Devi zone, and Corbett Falls.
+                        </p>
+                    </div>
+                    <div class="map-card-wrapper glass-card">
+                        <div class="map-svg-container">
+                            <svg class="park-map-svg" viewBox="0 0 1000 600" xmlns="http://www.w3.org/2000/svg">
+                                <rect width="1000" height="600" fill="#0a1f14" />
+                                <path d="M60,200 Q500,80 940,180 L940,520 L60,520 Z" fill="#0f2a1c" stroke="rgba(217,119,6,0.3)" stroke-width="2"/>
+                                <path d="M100,100 Q400,300 650,350 T950,300" fill="none" stroke="#0284c7" stroke-width="18" opacity="0.6"/>
+                                <text x="400" y="90" fill="#38bdf8" font-size="14" font-family="Outfit">Ramganga River</text>
+                            </svg>
+                            <div id="map-hotspots-layer"></div>
+                            <div id="map-info-popup" class="map-info-popup hidden"></div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Gallery -->
+            <section class="gallery-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Visual Journey</span>
+                        <h2>Jim Corbett Photo Gallery</h2>
+                        <p class="section-subtitle">Click any photo for a full-screen view.</p>
+                    </div>
+                    <div id="gallery-grid" class="gallery-grid"></div>
+                </div>
+            </section>
+
+            <!-- Facts -->
+            <section class="facts-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Did You Know?</span>
+                        <h2>Interesting Facts</h2>
+                    </div>
+                    <ul id="facts-list" class="facts-list"></ul>
+                </div>
+            </section>
+        </main>
+
+        <div id="lightbox-modal" class="lightbox-modal hidden" role="dialog" aria-modal="true" aria-label="Photo Lightbox">
+            <div class="lightbox-content">
+                <button type="button" id="lightbox-close" class="lightbox-close" aria-label="Close Lightbox">&times;</button>
+                <img id="lightbox-img" class="lightbox-img" src="" alt="Gallery Preview" />
+                <div id="lightbox-caption" class="lightbox-caption"></div>
+            </div>
+        </div>
+
+        <footer class="footer" style="margin-top:4rem; border-top:1px solid var(--corbett-border-dark);">
+            <div class="footer-container">
+                <div class="footer-brand">
+                    <h3>Incredible India Explorer</h3>
+                    <p>
+                        An interactive digital guide to the geography, food, festivals, wildlife, and cultural heritage of India.
+                    </p>
+                </div>
+                <div class="footer-links">
+                    <h3>Quick Navigation</h3>
+                    <ul>
+                        <li><a href="../../index.html#home">Home</a></li>
+                        <li><a href="../national-parks-explorer/index.html">National Parks Explorer</a></li>
+                        <li><a href="index.html">Corbett Explorer</a></li>
+                        <li><a href="../national-parks-timeline/national-parks-timeline.html">Parks Timeline</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-credits footer-credits-center">
+                <p>&copy; 2026 Incredible India Explorer. Jim Corbett National Park Explorer.</p>
+            </div>
+        </footer>
+
+        <script src="../../app.js" defer></script>
+        <script src="jim-corbett-data.js" defer></script>
+        <script src="jim-corbett.js" defer></script>
+        <script type="module" src="../../auth.js"></script>
+    </body>
+</html>

--- a/frontend/jim-corbett-national-park-explorer/jim-corbett-data.js
+++ b/frontend/jim-corbett-national-park-explorer/jim-corbett-data.js
@@ -1,0 +1,103 @@
+/**
+ * Jim Corbett National Park Explorer — Data Module
+ */
+
+const CORBETT_INFO = {
+    id: "jim-corbett",
+    name: "Jim Corbett National Park",
+    aka: "Formerly Hailey National Park / Ramganga National Park",
+    location: "Nainital & Pauri Garhwal Districts, Uttarakhand, India",
+    state: "Uttarakhand",
+    coordinates: { lat: 29.53, lng: 78.77 },
+    area: "1,318 km² (Core: 520 km², Buffer: 798 km²)",
+    establishedYear: 1936,
+    tigerReserveYear: 1973,
+    etymology: "Originally 'Hailey National Park' (1936), renamed 'Ramganga National Park' in 1954, then renamed again in 1957 in honour of hunter-turned-conservationist Jim Corbett.",
+    climate: "Subtropical — hot summers, monsoon rains, cool winters",
+    bestTime: "November to June (Dhikala zone closed mid-June to mid-November for monsoon)",
+    entryFees: "₹200 (Indian Nationals), ₹1,000 (Foreigners), Jeep Safari: ₹3,000–5,000/vehicle, Canter Safari: ₹700–1,200/person",
+    nearestTransport: {
+        railway: "Ramnagar Railway Station (adjacent to the park)",
+        airport: "Pantnagar Airport (75 km) / Delhi IGI Airport (260 km)",
+        gatewayTown: "Ramnagar"
+    },
+    quickStats: [
+        { label: "India's First National Park", value: "Est. 1936", icon: "🏞️" },
+        { label: "Project Tiger Launch Site", value: "1973", icon: "🐅" },
+        { label: "Total Area", value: "1,318 km²", icon: "📐" },
+        { label: "Safari Zones", value: "6", icon: "🚙" },
+        { label: "Bird Species", value: "600+", icon: "🦅" },
+        { label: "Bengal Tigers", value: "260+", icon: "🐾" }
+    ]
+};
+
+const CORBETT_HISTORY = [
+    { year: "1936", title: "Hailey National Park Founded", description: "India's first national park is established along the Ramganga river valley, named after Sir Malcolm Hailey, then Governor of the United Provinces." },
+    { year: "1954–55", title: "Renamed Ramganga National Park", description: "Following independence, the park is renamed after the Ramganga River that flows through it." },
+    { year: "1957", title: "Renamed Corbett National Park", description: "The park is renamed a second time in honour of Jim Corbett, the British-Indian hunter-turned-conservationist who championed its creation and famously tracked man-eating tigers in the region." },
+    { year: "1973", title: "Birthplace of Project Tiger", description: "India's flagship tiger conservation programme, Project Tiger, is launched from Corbett, marking a turning point for Bengal Tiger conservation nationwide." }
+];
+
+const CORBETT_GEOGRAPHY = {
+    description: "Corbett straddles the foothills of the Himalayas and the Shivalik range, with elevations ranging from 360 m to 1,040 m. The Ramganga River and its reservoir cut through the park, feeding riverine belts, ravines, and the Patli Dun valley — creating a striking mix of hills, marshy depressions (chaurs), and dense forest.",
+    riverSystem: "Ramganga River & Ramganga Reservoir",
+    terrain: ["Shivalik hills", "Riverine belts", "Patli Dun valley", "Chaur grasslands", "Ramganga Reservoir wetlands"]
+};
+
+const CORBETT_FLORA = [
+    { name: "Sal Forest", description: "Covers roughly 73% of the park; tall Sal (Shorea robusta) stands dominate the lower hill slopes." },
+    { name: "Chaur Grasslands", description: "Riverine grasslands and marshy depressions that support high densities of deer and grazing wildlife." },
+    { name: "Khair-Sissoo Forest", description: "Found along riverbanks and floodplains of the Ramganga, providing cover for elephants and deer." },
+    { name: "Pine & Mixed Forest", description: "Chir Pine forests appear at higher elevations in the park's northern reaches." }
+];
+
+const CORBETT_WILDLIFE = [
+    { name: "Bengal Tiger", scientificName: "Panthera tigris tigris", status: "Endangered", description: "Corbett's flagship predator and the site where Project Tiger began in 1973; the reserve now holds one of India's highest tiger densities.", image: "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fe/Royal_Bengal_Tiger_at_Nandankanan.jpg/800px-Royal_Bengal_Tiger_at_Nandankanan.jpg" },
+    { name: "Asian Elephant", scientificName: "Elephas maximus", status: "Endangered", description: "Large herds move between Corbett and neighbouring Rajaji National Park along traditional elephant corridors.", image: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Elephant_safari_in_Kaziranga.jpg/800px-Elephant_safari_in_Kaziranga.jpg" },
+    { name: "Leopard", scientificName: "Panthera pardus fusca", status: "Vulnerable", description: "Shares the forest with tigers, generally favouring denser cover and higher terrain to avoid direct competition.", image: "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/Indian_leopard.jpg/800px-Indian_leopard.jpg" },
+    { name: "Gharial", scientificName: "Gavialis gangeticus", status: "Critically Endangered", description: "This slender-snouted crocodilian basks along the Ramganga River, one of its few remaining strongholds.", image: "https://upload.wikimedia.org/wikipedia/commons/5/54/Jim_Corbett_National_Park_%28India%29.jpg" },
+    { name: "Chital (Spotted Deer)", scientificName: "Axis axis", status: "Least Concern", description: "The most commonly sighted deer species, grazing in large herds across the chaur grasslands.", image: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Jim_Corbett_National_Park_%28India%29.jpg/960px-Jim_Corbett_National_Park_%28India%29.jpg" }
+];
+
+const TIGER_INFO = {
+    title: "The Bengal Tiger of Corbett",
+    scientificName: "Panthera tigris tigris",
+    conservationStatus: "Endangered (IUCN Red List)",
+    population: "260+ tigers — one of the highest densities of any tiger reserve in India",
+    description: "Corbett is inseparable from the story of Indian tiger conservation. It was here that Project Tiger was launched in 1973 in response to alarming population declines nationwide. Dense Sal forests, riverine cover, and abundant prey along the Ramganga floodplains make it prime tiger habitat.",
+    significance: "As the pilot reserve for Project Tiger, Corbett's conservation model — anti-poaching camps, core-buffer zoning, and relocation of villages from core habitat — became the template later applied across dozens of other Indian tiger reserves."
+};
+
+const SAFARI_ZONES = [
+    { title: "Dhikala Zone", description: "The largest and most famous zone, bordering the Ramganga Reservoir with sweeping grasslands.", duration: "Full-day / Overnight", timing: "6:00 AM – 6:00 PM", cost: "₹4,500 (Jeep, approx.)", capacity: "6 persons/jeep", zones: "Ramganga floodplain, Reservoir", highlights: ["Best tiger sighting zone", "Elephant herds", "Overnight forest lodges"] },
+    { title: "Bijrani Zone", description: "Known as a 'mini Dhikala', open year-round and popular for its accessibility from Ramnagar.", duration: "3–4 hours", timing: "6:00 AM – 5:00 PM", cost: "₹3,500 (Jeep, approx.)", capacity: "6 persons/jeep", zones: "Sal forest, grasslands", highlights: ["Great for first-time visitors", "Rich birdlife"] },
+    { title: "Jhirna Zone", description: "The only zone open through the monsoon, offering safaris even when Dhikala is closed.", duration: "3–4 hours", timing: "6:00 AM – 5:00 PM", cost: "₹3,000 (Jeep, approx.)", capacity: "6 persons/jeep", zones: "Dry deciduous forest", highlights: ["Open all year", "Good leopard sightings"] },
+    { title: "Dhela Zone", description: "A community-run buffer zone that eases pressure on the core area while supporting local livelihoods.", duration: "3–4 hours", timing: "6:00 AM – 5:00 PM", cost: "₹2,500 (Jeep, approx.)", capacity: "6 persons/jeep", zones: "Buffer forest", highlights: ["Eco-tourism model", "Village-forest interface"] },
+    { title: "Durga Devi Zone", description: "A birder's favourite along the Mandal and Palain rivers, in the park's more rugged terrain.", duration: "3–4 hours", timing: "6:00 AM – 5:00 PM", cost: "₹3,000 (Jeep, approx.)", capacity: "6 persons/jeep", zones: "Mandal-Palain confluence", highlights: ["Excellent birdwatching", "Mahseer fish habitat"] },
+    { title: "Sonanadi Zone", description: "Part of the wider Corbett Tiger Reserve buffer, known for elephant corridors along the Sonanadi river.", duration: "Full-day", timing: "6:00 AM – 5:00 PM", cost: "₹3,500 (Jeep, approx.)", capacity: "6 persons/jeep", zones: "Sonanadi river belt", highlights: ["Elephant migration corridor", "Quieter, less-visited zone"] }
+];
+
+const MAP_HOTSPOTS = [
+    { id: "dhikala", name: "Dhikala Zone", x: 55, y: 35, category: "wildlife", description: "The park's premier zone bordering the Ramganga Reservoir grasslands." },
+    { id: "bijrani", name: "Bijrani Zone", x: 25, y: 55, category: "gate", description: "Popular, easily accessible zone close to Ramnagar." },
+    { id: "jhirna", name: "Jhirna Zone", x: 20, y: 75, category: "gate", description: "The only zone that stays open year-round through the monsoon." },
+    { id: "ramganga", name: "Ramganga River", x: 60, y: 55, category: "water", description: "The lifeline river of the park, home to gharials, mugger crocodiles, and mahseer fish." },
+    { id: "durgadevi", name: "Durga Devi Zone", x: 80, y: 30, category: "wildlife", description: "A quiet, birder-favourite zone at the Mandal-Palain confluence." },
+    { id: "corbettfalls", name: "Corbett Falls", x: 45, y: 80, category: "landmark", description: "A scenic waterfall near Kaladhungi, close to Jim Corbett's former residence." }
+];
+
+const GALLERY_IMAGES = [
+    { url: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Jim_Corbett_National_Park_%28India%29.jpg/960px-Jim_Corbett_National_Park_%28India%29.jpg", title: "Corbett Landscape", caption: "Sal forests along the Ramganga valley" },
+    { url: "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fe/Royal_Bengal_Tiger_at_Nandankanan.jpg/960px-Royal_Bengal_Tiger_at_Nandankanan.jpg", title: "Bengal Tiger", caption: "A Bengal Tiger, Corbett's flagship species" },
+    { url: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Elephant_safari_in_Kaziranga.jpg/960px-Elephant_safari_in_Kaziranga.jpg", title: "Elephant Safari", caption: "Elephant safari through the grasslands" },
+    { url: "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/Indian_leopard.jpg/960px-Indian_leopard.jpg", title: "Leopard", caption: "A leopard resting in dense cover" }
+];
+
+const CORBETT_FACTS = [
+    "Jim Corbett National Park is India's first and oldest national park, established in 1936.",
+    "Project Tiger, India's national tiger conservation programme, was launched from Corbett in 1973.",
+    "The park is named after Jim Corbett, a British-Indian hunter who later became a dedicated wildlife conservationist and author.",
+    "Corbett has one of the highest densities of Bengal Tigers of any reserve in India.",
+    "The Ramganga River, which flows through the park, is home to gharials, mugger crocodiles, and mahseer fish.",
+    "Dhikala zone, the park's most famous area, is only accessible by pre-booked forest lodges or day-safari permits."
+];

--- a/frontend/jim-corbett-national-park-explorer/jim-corbett.js
+++ b/frontend/jim-corbett-national-park-explorer/jim-corbett.js
@@ -1,0 +1,234 @@
+/**
+ * Jim Corbett National Park Explorer — Interactive Logic
+ */
+
+(function () {
+    'use strict';
+
+    document.addEventListener('DOMContentLoaded', function () {
+        initTheme();
+        renderQuickStats();
+        renderHistoryTimeline();
+        renderFlora();
+        renderWildlife();
+        renderSafariZones();
+        renderInteractiveMap();
+        renderGalleryGrid();
+        renderFacts();
+        bindEvents();
+    });
+
+    function initTheme() {
+        var savedTheme = localStorage.getItem('theme') || 'dark';
+        if (savedTheme === 'light') {
+            document.body.classList.add('light-theme');
+        }
+    }
+
+    function bindEvents() {
+        var themeBtn = document.getElementById('theme-toggle');
+        if (themeBtn) {
+            themeBtn.addEventListener('click', function () {
+                document.body.classList.toggle('light-theme');
+                var isLight = document.body.classList.contains('light-theme');
+                localStorage.setItem('theme', isLight ? 'light' : 'dark');
+            });
+        }
+
+        var lbClose = document.getElementById('lightbox-close');
+        if (lbClose) lbClose.addEventListener('click', closeLightbox);
+
+        var lbModal = document.getElementById('lightbox-modal');
+        if (lbModal) {
+            lbModal.addEventListener('click', function (e) {
+                if (e.target === lbModal) closeLightbox();
+            });
+        }
+
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape') closeLightbox();
+        });
+    }
+
+    function renderQuickStats() {
+        var container = document.getElementById('stats-grid');
+        if (!container || typeof CORBETT_INFO === 'undefined') return;
+
+        var html = '';
+        CORBETT_INFO.quickStats.forEach(function (st) {
+            html +=
+                '<div class="stat-card glass-card">' +
+                '<div class="stat-icon">' + st.icon + '</div>' +
+                '<span class="stat-value">' + st.value + '</span>' +
+                '<span class="stat-label">' + st.label + '</span>' +
+                '</div>';
+        });
+        container.innerHTML = html;
+    }
+
+    function renderHistoryTimeline() {
+        var container = document.getElementById('history-timeline');
+        if (!container || typeof CORBETT_HISTORY === 'undefined') return;
+
+        var html = '';
+        CORBETT_HISTORY.forEach(function (item) {
+            html +=
+                '<div class="timeline-item">' +
+                '<div class="timeline-dot"></div>' +
+                '<div class="timeline-card glass-card">' +
+                '<div style="font-weight:800; font-size:1.2rem; color:var(--gold-bright); margin-bottom:0.4rem;">' + item.year + '</div>' +
+                '<h4>' + item.title + '</h4>' +
+                '<p style="font-size:0.92rem; color:var(--corbett-text-muted-dark); line-height:1.6;">' + item.description + '</p>' +
+                '</div>' +
+                '</div>';
+        });
+        container.innerHTML = html;
+    }
+
+    function renderFlora() {
+        var container = document.getElementById('flora-grid');
+        if (!container || typeof CORBETT_FLORA === 'undefined') return;
+
+        var html = '';
+        CORBETT_FLORA.forEach(function (f) {
+            html +=
+                '<div class="glass-card" style="padding:1.5rem;">' +
+                '<h3 style="font-family:var(--font-heading); font-size:1.2rem; margin-bottom:0.5rem; color:var(--gold-bright);">' + f.name + '</h3>' +
+                '<p style="font-size:0.9rem; color:var(--corbett-text-muted-dark); line-height:1.55;">' + f.description + '</p>' +
+                '</div>';
+        });
+        container.innerHTML = html;
+    }
+
+    function renderWildlife() {
+        var container = document.getElementById('wildlife-grid');
+        if (!container || typeof CORBETT_WILDLIFE === 'undefined') return;
+
+        var html = '';
+        CORBETT_WILDLIFE.forEach(function (w) {
+            html +=
+                '<div class="glass-card" style="overflow:hidden; display:flex; flex-direction:column;">' +
+                '<div style="height:190px; position:relative; overflow:hidden; background:#0f172a;">' +
+                '<img src="' + w.image + '" alt="' + w.name + '" style="width:100%; height:100%; object-fit:cover;" loading="lazy">' +
+                '<span style="position:absolute; top:0.8rem; right:0.8rem; padding:0.3rem 0.7rem; border-radius:999px; font-size:0.75rem; font-weight:700; background:rgba(220,38,38,0.9); color:#fff;">' + w.status + '</span>' +
+                '</div>' +
+                '<div style="padding:1.5rem; display:flex; flex-direction:column; flex-grow:1;">' +
+                '<h3 style="font-family:var(--font-heading); font-size:1.3rem; margin-bottom:0.2rem;">' + w.name + '</h3>' +
+                '<div style="font-style:italic; font-size:0.85rem; color:var(--gold-bright); margin-bottom:0.8rem;">' + w.scientificName + '</div>' +
+                '<p style="font-size:0.9rem; color:var(--corbett-text-muted-dark); line-height:1.55;">' + w.description + '</p>' +
+                '</div>' +
+                '</div>';
+        });
+        container.innerHTML = html;
+    }
+
+    function renderSafariZones() {
+        var container = document.getElementById('safari-grid');
+        if (!container || typeof SAFARI_ZONES === 'undefined') return;
+
+        var html = '';
+        SAFARI_ZONES.forEach(function (s) {
+            var highlightsHtml = '';
+            s.highlights.forEach(function (h) {
+                highlightsHtml += '<li>✨ <span>' + h + '</span></li>';
+            });
+
+            html +=
+                '<div class="glass-card" style="overflow:hidden; display:flex; flex-direction:column;">' +
+                '<div style="padding:1.5rem 1.5rem 0.5rem;">' +
+                '<h3 style="font-family:var(--font-heading); font-size:1.4rem; color:var(--gold-bright); margin-bottom:0.3rem;">' + s.title + '</h3>' +
+                '<p style="font-size:0.9rem; color:var(--corbett-text-muted-dark); line-height:1.5;">' + s.description + '</p>' +
+                '</div>' +
+                '<div class="safari-card-body">' +
+                '<div class="safari-detail-row"><span class="safari-detail-label">⏱ Duration</span><span class="safari-detail-value">' + s.duration + '</span></div>' +
+                '<div class="safari-detail-row"><span class="safari-detail-label">🕐 Timings</span><span class="safari-detail-value">' + s.timing + '</span></div>' +
+                '<div class="safari-detail-row"><span class="safari-detail-label">💰 Cost</span><span class="safari-detail-value">' + s.cost + '</span></div>' +
+                '<div class="safari-detail-row"><span class="safari-detail-label">👥 Capacity</span><span class="safari-detail-value">' + s.capacity + '</span></div>' +
+                '<div class="safari-detail-row" style="flex-wrap:wrap;"><span class="safari-detail-label">📍 Terrain</span><span class="safari-detail-value" style="text-align:right; max-width:60%;">' + s.zones + '</span></div>' +
+                '<ul class="safari-highlights">' + highlightsHtml + '</ul>' +
+                '</div>' +
+                '</div>';
+        });
+        container.innerHTML = html;
+    }
+
+    function renderInteractiveMap() {
+        var container = document.getElementById('map-hotspots-layer');
+        var infoPopup = document.getElementById('map-info-popup');
+        if (!container || typeof MAP_HOTSPOTS === 'undefined') return;
+
+        var html = '';
+        MAP_HOTSPOTS.forEach(function (spot) {
+            var icon = spot.category === 'gate' ? '🚪' : spot.category === 'wildlife' ? '🐅' : spot.category === 'water' ? '💧' : '📍';
+            html +=
+                '<button type="button" class="map-hotspot-pin" style="left:' + spot.x + '%; top:' + spot.y + '%;" data-spot-id="' + spot.id + '" aria-label="' + spot.name + '">' +
+                icon +
+                '</button>';
+        });
+        container.innerHTML = html;
+
+        container.querySelectorAll('.map-hotspot-pin').forEach(function (pin) {
+            pin.addEventListener('click', function () {
+                var spot = MAP_HOTSPOTS.find(function (s) { return s.id === pin.dataset.spotId; });
+                if (spot && infoPopup) {
+                    infoPopup.innerHTML =
+                        '<h4>' + spot.name + '</h4>' +
+                        '<p>' + spot.description + '</p>';
+                    infoPopup.classList.remove('hidden');
+                }
+            });
+        });
+    }
+
+    function renderGalleryGrid() {
+        var container = document.getElementById('gallery-grid');
+        if (!container || typeof GALLERY_IMAGES === 'undefined') return;
+
+        var html = '';
+        GALLERY_IMAGES.forEach(function (img, idx) {
+            html +=
+                '<div class="gallery-item" data-idx="' + idx + '">' +
+                '<img class="gallery-img" src="' + img.url + '" alt="' + img.title + '" loading="lazy">' +
+                '<div class="gallery-overlay">' +
+                '<h4 style="color:#fff;">' + img.title + '</h4>' +
+                '<p style="color:#cbd5e1; font-size:0.82rem;">' + img.caption + '</p>' +
+                '</div>' +
+                '</div>';
+        });
+        container.innerHTML = html;
+
+        container.querySelectorAll('.gallery-item').forEach(function (item) {
+            item.addEventListener('click', function () {
+                openLightbox(parseInt(item.dataset.idx, 10));
+            });
+        });
+    }
+
+    function renderFacts() {
+        var container = document.getElementById('facts-list');
+        if (!container || typeof CORBETT_FACTS === 'undefined') return;
+
+        var html = '';
+        CORBETT_FACTS.forEach(function (fact) {
+            html += '<li class="fact-item glass-card">💡 <span>' + fact + '</span></li>';
+        });
+        container.innerHTML = html;
+    }
+
+    function openLightbox(idx) {
+        if (typeof GALLERY_IMAGES === 'undefined' || !GALLERY_IMAGES[idx]) return;
+        var modal = document.getElementById('lightbox-modal');
+        var imgEl = document.getElementById('lightbox-img');
+        var capEl = document.getElementById('lightbox-caption');
+        if (!modal || !imgEl || !capEl) return;
+
+        imgEl.src = GALLERY_IMAGES[idx].url;
+        capEl.textContent = GALLERY_IMAGES[idx].title + ' — ' + GALLERY_IMAGES[idx].caption;
+        modal.classList.remove('hidden');
+    }
+
+    function closeLightbox() {
+        var modal = document.getElementById('lightbox-modal');
+        if (modal) modal.classList.add('hidden');
+    }
+})();

--- a/frontend/national-parks-explorer/data.js
+++ b/frontend/national-parks-explorer/data.js
@@ -44,10 +44,10 @@ const NATIONAL_PARKS = [
         coordinates: { lat: 29.53, lng: 78.77 },
         climate: 'Subtropical',
         bestTime: 'November to June',
-        entryFee: '₹200 (Indian), ₹1000 (Foreign)',
-        image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Jim_Corbett_National_Park_%28India%29.jpg/960px-Jim_Corbett_National_Park_%28India%29.jpg'
-    },
-    {
+entryFee: '₹200 (Indian), ₹1000 (Foreign)',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/5/54/Jim_Corbett_National_Park_%28India%29.jpg/960px-Jim_Corbett_National_Park_%28India%29.jpg',
+        explorerUrl: '../jim-corbett-national-park-explorer/index.html'
+    },    {
         id: 'kaziranga',
         name: 'Kaziranga National Park',
         state: 'Assam',


### PR DESCRIPTION
## Summary
Adds a dedicated explorer page for Jim Corbett National Park (India's first
national park) and links it from the National Parks Explorer landing page.

## Changes
- frontend/national-parks-explorer/data.js
  - Added missing `explorerUrl` to the existing `jim-corbett` entry so the
    landing page card shows a "Launch Dedicated Explorer" button.
- frontend/jim-corbett-national-park-explorer/index.html (new)
  - New page with Hero, History, Geography, Flora & Fauna, Bengal Tiger
    spotlight, Safari Zones, Best Time to Visit, Interactive Map, Photo
    Gallery, and Interesting Facts sections.
- frontend/jim-corbett-national-park-explorer/jim-corbett-data.js (new)
  - Data module: park info, history timeline, geography, flora, wildlife,
    tiger info, safari zones, map hotspots, gallery images, and facts.
- frontend/jim-corbett-national-park-explorer/jim-corbett.js (new)
  - Rendering logic for all dynamic sections, map hotspot interactions,
    and the photo gallery lightbox.
- frontend/jim-corbett-national-park-explorer/jim-corbett.css (new)
  - Forest green / amber themed styling consistent with other park explorer
    pages, with dark/light theme support.

Closes #809 

@Eshajha19 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Jim Corbett National Park Explorer page.
  * Explore park history, geography, flora, wildlife, tiger information, safari zones, visitor guidance, and key facts.
  * Added interactive map hotspots, image gallery, and lightbox viewing.
  * Added light and dark theme support.
  * Linked the national parks listing to the new explorer page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->