### PR TITLE
feat: Create Pench National Park Explorer with Jungle Book connection

### DIFF
--- a/frontend/kanha-national-park-explorer/kanha-data.html
+++ b/frontend/kanha-national-park-explorer/kanha-data.html
@@ -1,0 +1,286 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    document.body.classList.add('light-theme');
+                }
+            })();
+        </script>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Explore Kanha National Park in Madhya Pradesh — home of the hard-ground Barasingha, a thriving Bengal Tiger Reserve, jungle safaris, sal forests, and rich biodiversity."
+        />
+        <title>Kanha National Park Explorer | Incredible India</title>
+
+        <!-- Google Fonts -->
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+            rel="stylesheet"
+        />
+
+        <!-- Stylesheets -->
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="kanha.css" />
+    </head>
+
+    <body class="kanha-main">
+        <!-- Site Navbar -->
+        <header class="navbar scrolled" id="navbar">
+            <div class="nav-container">
+                <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </button>
+                <nav class="nav-menu" id="nav-menu">
+                    <a href="../../index.html#home" class="nav-link">Home</a>
+                    <a href="../national-parks-explorer/index.html" class="nav-link">National Parks</a>
+                    <a href="../wildlife/wildlife.html" class="nav-link">Wildlife</a>
+                    <a href="index.html" class="nav-link active" style="color: var(--saffron)">Kanha Explorer</a>
+                    <button
+                        id="theme-toggle"
+                        class="btn-theme-toggle"
+                        aria-label="Toggle Dark/Light Mode"
+                        title="Toggle Light Mode"
+                    >
+                        ☀️
+                    </button>
+                </nav>
+            </div>
+        </header>
+
+        <main>
+            <!-- Hero Section -->
+            <section class="kanha-hero">
+                <div class="section-container">
+                    <div class="hero-badges-row">
+                        <span class="hero-pill pill-mp">📍 Mandla, Madhya Pradesh</span>
+                        <span class="hero-pill pill-tiger">🐅 Project Tiger Reserve</span>
+                        <span class="hero-pill pill-barasingha">🦌 Home of the Barasingha</span>
+                    </div>
+                    <h1>Kanha <span>National Park</span> Explorer</h1>
+                    <p class="hero-subtitle">
+                        Journey into central India's most celebrated tiger reserve — the forest that inspired
+                        Kipling's "The Jungle Book". Discover the hard-ground Barasingha, thriving Bengal Tigers,
+                        jungle safaris, sal forests, and the Maikal Range wilderness.
+                    </p>
+
+                    <!-- Quick Stats Grid -->
+                    <div id="stats-grid" class="stats-grid">
+                        <!-- Populated by kanha.js -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Barasingha Section -->
+            <section class="ecosystem-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Conservation Icon</span>
+                        <h2 id="barasingha-title">The Hard-Ground Barasingha</h2>
+                        <p class="section-subtitle" id="barasingha-desc">
+                            <!-- Populated by kanha.js -->
+                        </p>
+                    </div>
+
+                    <div class="glass-card" style="margin-bottom: 2rem;">
+                        <h3 style="font-family: 'Playfair Display', serif; font-size: 1.5rem; color: var(--kanha-gold); margin-bottom: 0.8rem;">
+                            Rescued From the Brink of Extinction
+                        </h3>
+                        <div id="barasingha-facts">
+                            <!-- Populated by kanha.js -->
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Tiger Reserve Section -->
+            <section class="ecosystem-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Project Tiger</span>
+                        <h2 id="tiger-title">Tiger Reserve Since 1973</h2>
+                        <p class="section-subtitle" id="tiger-desc">
+                            <!-- Populated by kanha.js -->
+                        </p>
+                    </div>
+
+                    <div id="tiger-highlights" class="ecosystem-grid">
+                        <!-- Populated by kanha.js -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Wildlife Section -->
+            <section class="ecosystem-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Rich Biodiversity</span>
+                        <h2>Wildlife of Kanha</h2>
+                        <p class="section-subtitle">
+                            From apex predators to grassland grazers, Kanha's forests and meadows support a
+                            remarkable diversity of central Indian wildlife.
+                        </p>
+                    </div>
+
+                    <div id="wildlife-grid" class="ecosystem-grid">
+                        <!-- Populated by kanha.js -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Flora Section -->
+            <section class="ecosystem-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Green Canopy</span>
+                        <h2 id="flora-title">Flora of Kanha</h2>
+                        <p class="section-subtitle" id="flora-desc">
+                            <!-- Populated by kanha.js -->
+                        </p>
+                    </div>
+
+                    <div id="flora-grid" class="ecosystem-grid">
+                        <!-- Populated by kanha.js -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Forests Section -->
+            <section class="ecosystem-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Maikal Range</span>
+                        <h2 id="forests-title">Forests & Landscape Zones</h2>
+                        <p class="section-subtitle" id="forests-desc">
+                            <!-- Populated by kanha.js -->
+                        </p>
+                    </div>
+
+                    <div id="forests-grid" class="ecosystem-grid">
+                        <!-- Populated by kanha.js -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Jungle Safari Section -->
+            <section class="ecosystem-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Eco-Tourism Programs</span>
+                        <h2>Jungle Safari Zones</h2>
+                        <p class="section-subtitle">
+                            Select a safari gate to view timings, highlights, and what to expect.
+                        </p>
+                    </div>
+
+                    <div class="safari-wrapper">
+                        <div id="zone-selector" class="zone-list-selector">
+                            <!-- Populated by kanha.js -->
+                        </div>
+                        <div id="zone-details" class="zone-details-panel glass-card">
+                            <!-- Populated by kanha.js -->
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Interactive Park Map Section -->
+            <section class="ecosystem-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Geography & Hotspots</span>
+                        <h2>Interactive Map of Kanha Reserve</h2>
+                        <p class="section-subtitle">
+                            Click on map pins to discover Kisli Gate, Kanha Meadow, Mukki Gate, and Bamni Dadar.
+                        </p>
+                    </div>
+
+                    <div class="map-card-wrapper glass-card">
+                        <svg class="park-map-svg" viewBox="0 0 1000 600" xmlns="http://www.w3.org/2000/svg">
+                            <rect width="1000" height="600" fill="#04140c" />
+                            <path d="M60,100 Q480,30 940,150 L940,540 L60,540 Z" fill="#0c2b1d" stroke="rgba(16,185,129,0.3)" stroke-width="2"/>
+                            <ellipse cx="480" cy="300" rx="160" ry="80" fill="#7c5a2a" opacity="0.4"/>
+                            <text x="340" y="260" fill="#facc15" font-size="16" font-weight="bold" font-family="Outfit">Kanha Central Meadow</text>
+                        </svg>
+
+                        <!-- Map Hotspots Layer -->
+                        <div id="map-hotspots-layer">
+                            <!-- Populated by kanha.js -->
+                        </div>
+
+                        <!-- Info Popup -->
+                        <div id="map-info-popup" class="map-info-popup hidden">
+                            <!-- Populated by kanha.js -->
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Gallery Section -->
+            <section class="ecosystem-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Visual Exploration</span>
+                        <h2>Kanha Photo Gallery</h2>
+                        <p class="section-subtitle">
+                            Click any photo to view full-screen image with caption details.
+                        </p>
+                    </div>
+
+                    <div id="gallery-grid" class="gallery-grid">
+                        <!-- Populated by kanha.js -->
+                    </div>
+                </div>
+            </section>
+        </main>
+
+        <!-- Lightbox Modal -->
+        <div id="lightbox-modal" class="lightbox-modal hidden" role="dialog" aria-modal="true" aria-label="Photo Lightbox">
+            <div class="lightbox-content">
+                <button type="button" id="lightbox-close" class="lightbox-close" aria-label="Close Lightbox">&times;</button>
+                <img id="lightbox-img" class="lightbox-img" src="" alt="Gallery Preview" />
+                <div id="lightbox-caption"></div>
+            </div>
+        </div>
+
+        <!-- Site Footer -->
+        <footer class="footer">
+            <div class="footer-container">
+                <div class="footer-brand">
+                    <h3>Incredible India Explorer</h3>
+                    <p>An interactive digital guide to the wildlife, ecosystems, and culture of India.</p>
+                </div>
+                <div class="footer-links">
+                    <h3>Quick Navigation</h3>
+                    <ul>
+                        <li><a href="../../index.html#home">Home</a></li>
+                        <li><a href="../national-parks-explorer/index.html">National Parks Explorer</a></li>
+                        <li><a href="../wildlife/wildlife.html">Wildlife</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-credits footer-credits-center">
+                <p>&copy; 2026 Incredible India Explorer. Kanha National Park Explorer.</p>
+            </div>
+        </footer>
+
+        <!-- Scripts -->
+        <script src="../../app.js" defer></script>
+        <script src="kanha-data.js" defer></script>
+        <script src="kanha.js" defer></script>
+        <script type="module" src="../../auth.js"></script>
+    </body>
+</html>

--- a/frontend/kanha-national-park-explorer/kanha-data.js
+++ b/frontend/kanha-national-park-explorer/kanha-data.js
@@ -1,0 +1,169 @@
+/**
+ * Kanha National Park Explorer Dataset
+ * Comprehensive data covering the Barasingha, Tiger Reserve status, Jungle Safaris,
+ * Wildlife, Flora, Forests, Interactive Map Hotspots, and Photo Gallery.
+ */
+
+const KANHA_DATA = {
+    id: 'kanha',
+    name: 'Kanha National Park & Tiger Reserve',
+    location: 'Mandla & Balaghat Districts, Madhya Pradesh',
+    established: 1955,
+    coreArea: '940 km²',
+    bufferArea: '1,067 km²',
+    totalArea: '2,007 km²',
+    altitude: '450m – 900m',
+    coordinates: { lat: 22.34, lng: 80.61 },
+
+    quickStats: [
+        { label: 'Bengal Tigers', value: '100+', icon: '🐅' },
+        { label: 'Hard-Ground Barasingha', value: '800+', icon: '🦌' },
+        { label: 'Core Zone Area', value: '940 km²', icon: '🌳' },
+        { label: 'Bird Species', value: '300+', icon: '🦅' }
+    ],
+
+    barasingha: {
+        title: 'The Hard-Ground Barasingha — Kanha\'s Conservation Icon',
+        description: 'Kanha is globally renowned for rescuing the hard-ground Barasingha (Rucervus duvaucelii branderi) from the brink of extinction. When numbers fell below 66 in the 1970s, a dedicated captive-breeding and habitat-restoration programme brought the population back to over 800 today, making Kanha the only home of this swamp deer subspecies in the world.',
+        facts: [
+            'State animal of Madhya Pradesh, found nowhere else in the wild.',
+            'Population crashed to under 66 individuals in 1970 before recovery efforts began.',
+            'Kanha meadows were specially managed to restore short-grass habitat for the species.',
+            'Now classified as Vulnerable, with a stable, closely monitored population.'
+        ]
+    },
+
+    tigerReserve: {
+        title: 'Project Tiger Reserve Since 1973',
+        description: 'Kanha was one of the original nine tiger reserves declared under India\'s Project Tiger in 1973. Its extensive sal and bamboo forests, interspersed with open meadows, provide an ideal habitat for a thriving Bengal Tiger population that inspired Rudyard Kipling\'s "The Jungle Book".',
+        highlights: [
+            'One of the founding reserves of Project Tiger (1973).',
+            'Core critical tiger habitat spans 940 km² of protected forest.',
+            'Estimated 100+ Bengal Tigers tracked via camera traps and pugmark census.',
+            'Buffer zone community programmes support human-wildlife coexistence.'
+        ]
+    },
+
+    wildlife: [
+        {
+            name: 'Bengal Tiger (Panthera tigris tigris)',
+            status: 'Apex Predator',
+            desc: 'Kanha supports one of central India\'s densest tiger populations, roaming sal forests and open meadows across the core zone.',
+            icon: '🐅'
+        },
+        {
+            name: 'Hard-Ground Barasingha (Rucervus duvaucelii branderi)',
+            status: 'Vulnerable — Flagship Species',
+            desc: 'Endemic swamp deer subspecies saved from near-extinction through decades of dedicated conservation at Kanha.',
+            icon: '🦌'
+        },
+        {
+            name: 'Indian Leopard (Panthera pardus fusca)',
+            status: 'Elusive Predator',
+            desc: 'Shares the forest canopy and rocky outcrops with tigers, often spotted along the park\'s fringes at dusk.',
+            icon: '🐆'
+        },
+        {
+            name: 'Dhole (Asiatic Wild Dog)',
+            status: 'Endangered Pack Hunter',
+            desc: 'Highly social pack hunters that roam Kanha\'s forests, known locally for coordinated hunting of chital and sambar.',
+            icon: '🐕'
+        },
+        {
+            name: 'Gaur (Indian Bison)',
+            status: 'Vulnerable Bovine',
+            desc: 'India\'s largest wild bovine, frequently seen grazing in the Kanha and Mukki meadows during winter months.',
+            icon: '🐂'
+        },
+        {
+            name: 'Indian Blackbuck',
+            status: 'Grassland Antelope',
+            desc: 'A small reintroduced population inhabits the open grasslands of Kanha, favouring short-grass meadow habitat.',
+            icon: '🦌'
+        }
+    ],
+
+    flora: {
+        title: 'Sal Forests, Bamboo Groves & Grassland Meadows',
+        description: 'Kanha\'s vegetation is a mosaic of moist and dry deciduous sal forest, bamboo thickets, and rolling grassland meadows called "maidans". This diversity of habitat supports everything from grazing Barasingha herds to canopy-dwelling langurs.',
+        types: [
+            { name: 'Sal Forest (Shorea robusta)', desc: 'Dominant tall-canopy tree covering the majority of Kanha\'s core zone.' },
+            { name: 'Bamboo Groves', desc: 'Dense thickets providing cover and forage along stream valleys.' },
+            { name: 'Grassland Meadows (Maidans)', desc: 'Open short-grass clearings vital for Barasingha and Blackbuck grazing.' },
+            { name: 'Mixed Deciduous Woodland', desc: 'Transitional forest zones with Tendu, Mahua, and Saja trees.' }
+        ]
+    },
+
+    forests: {
+        title: 'The Maikal Range Forest Landscape',
+        description: 'Kanha lies within the Maikal Hills, a spur of the Satpura mountain range, at elevations between 450m and 900m. The undulating terrain of forested ridges and valley meadows creates a mosaic of micro-habitats that supports Kanha\'s exceptional biodiversity.',
+        zones: [
+            { name: 'Kanha Core Zone', desc: 'The original protected core with the highest tiger and Barasingha density.' },
+            { name: 'Mukki Zone', desc: 'Remote southwestern zone known for excellent tiger sighting frequency.' },
+            { name: 'Kisli Zone', desc: 'Historic entry zone with dense sal forest and abundant deer species.' },
+            { name: 'Sarhi Buffer Zone', desc: 'Community-managed buffer forest supporting eco-tourism and local livelihoods.' }
+        ]
+    },
+
+    safariZones: [
+        {
+            id: 'zone-kisli',
+            name: 'Kisli Gate Safari',
+            timing: '6:00 AM – 11:00 AM, 3:00 PM – 6:00 PM',
+            highlight: 'Best for spotting Barasingha herds grazing in the central meadows.',
+            desc: 'The original and most popular entry gate, offering dense sal forest drives and open meadow crossings.'
+        },
+        {
+            id: 'zone-mukki',
+            name: 'Mukki Gate Safari',
+            timing: '6:00 AM – 11:00 AM, 3:00 PM – 6:00 PM',
+            highlight: 'Consistently rated the best zone for tiger sightings.',
+            desc: 'A remote, less-crowded zone in the southwest with dense forest and a high tiger encounter rate.'
+        },
+        {
+            id: 'zone-sarhi',
+            name: 'Sarhi Gate Safari',
+            timing: '6:00 AM – 11:00 AM, 3:00 PM – 6:00 PM',
+            highlight: 'Great for birdwatching and quieter buffer-zone forest trails.',
+            desc: 'A buffer zone gate offering community-guided drives through mixed deciduous woodland.'
+        },
+        {
+            id: 'zone-night-safari',
+            name: 'Kanha Museum & Nature Walk',
+            timing: '7:00 AM – 5:00 PM',
+            highlight: 'Interpretation centre detailing the Barasingha conservation story.',
+            desc: 'A guided walking exploration of Kanha\'s natural history museum near Kisli gate.'
+        }
+    ],
+
+    mapHotspots: [
+        { id: 'kisli-gate', name: 'Kisli Entrance Gate', x: 220, y: 150, desc: 'Primary entry checkpoint for safaris into the central core zone.' },
+        { id: 'kanha-meadow', name: 'Kanha Central Meadow', x: 480, y: 300, desc: 'Open grassland maidan where Barasingha herds gather to graze.' },
+        { id: 'mukki-gate', name: 'Mukki Entrance Gate', x: 700, y: 420, desc: 'Remote southwestern gate famed for high tiger sighting frequency.' },
+        { id: 'bamni-dadar', name: 'Bamni Dadar Sunset Point', x: 620, y: 180, desc: 'Elevated viewpoint overlooking the Maikal Range forest canopy.' },
+        { id: 'sarhi-gate', name: 'Sarhi Buffer Gate', x: 320, y: 460, desc: 'Community-managed buffer zone gate for birdwatching drives.' }
+    ],
+
+    gallery: [
+        {
+            src: 'https://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Jungle_safari_-_Kanha_National_Park.jpg/960px-Jungle_safari_-_Kanha_National_Park.jpg',
+            caption: 'Jungle safari jeep crossing the open meadows of Kanha National Park.'
+        },
+        {
+            src: 'https://upload.wikimedia.org/wikipedia/commons/thumb/6/6c/Barasingha_at_Kanha_National_Park.jpg/960px-Barasingha_at_Kanha_National_Park.jpg',
+            caption: 'Hard-ground Barasingha stag grazing in a Kanha grassland meadow.'
+        },
+        {
+            src: 'https://upload.wikimedia.org/wikipedia/commons/thumb/7/76/Kanha_Tiger_Reserve.jpg/960px-Kanha_Tiger_Reserve.jpg',
+            caption: 'Bengal Tiger resting in the dense sal forest of Kanha Tiger Reserve.'
+        },
+        {
+            src: 'https://upload.wikimedia.org/wikipedia/commons/thumb/9/95/Sal_forest_Kanha.jpg/960px-Sal_forest_Kanha.jpg',
+            caption: 'Towering sal forest canopy along Kanha\'s core zone trails.'
+        }
+    ]
+};
+
+if (typeof module !== 'undefined') {
+    module.exports = { KANHA_DATA };
+}

--- a/frontend/national-parks-explorer/data.js
+++ b/frontend/national-parks-explorer/data.js
@@ -514,10 +514,10 @@ const NATIONAL_PARKS = [
         coordinates: { lat: 21.74, lng: 79.29 },
         climate: 'Tropical Dry',
         bestTime: 'October to May',
-        entryFee: '₹100 (Indian), ₹500 (Foreign)',
-        image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f3/Pench_National_Park%2C_Madhya_Pradesh_-_by_Ishani_Mehta.jpg/960px-Pench_National_Park%2C_Madhya_Pradesh_-_by_Ishani_Mehta.jpg'
-    },
-    {
+entryFee: '₹100 (Indian), ₹500 (Foreign)',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f3/Pench_National_Park%2C_Madhya_Pradesh_-_by_Ishani_Mehta.jpg/960px-Pench_National_Park%2C_Madhya_Pradesh_-_by_Ishani_Mehta.jpg',
+        explorerUrl: '../pench-national-park-explorer/index.html'
+    },    {
         id: 'dachigam',
         name: 'Dachigam National Park',
         state: 'Jammu and Kashmir',

--- a/frontend/pench-national-park-explorer/index.html
+++ b/frontend/pench-national-park-explorer/index.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <script>
+    (function() {
+      const theme = localStorage.getItem('theme') || 'dark';
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Explore Pench National Park in Madhya Pradesh — the forest that inspired Rudyard Kipling's The Jungle Book." />
+  <title>Pench National Park Explorer | Incredible India</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="../../styles.css" />
+  <link rel="stylesheet" href="pench.css" />
+  <meta property="og:title" content="Pench National Park Explorer | Incredible India" />
+  <meta property="og:description" content="Interactive guide to Pench National Park, Madhya Pradesh — the forest behind The Jungle Book, home to Bengal tigers and leopards." />
+  <meta property="og:type" content="website" />
+</head>
+<body class="pench-main">
+  <header class="navbar scrolled" id="navbar">
+    <div class="nav-container">
+      <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+        <span class="saffron">Incredible</span> <span class="gold">India</span> <span class="green">Explorer</span>
+      </a>
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+        <span class="bar"></span><span class="bar"></span><span class="bar"></span>
+      </button>
+      <nav class="nav-menu" id="nav-menu">
+        <a href="../../index.html#home" class="nav-link">Home</a>
+        <a href="../national-parks-explorer/index.html" class="nav-link">National Parks</a>
+        <a href="index.html" class="nav-link active" style="color: var(--saffron)">Pench Explorer</a>
+        <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">☀️</button>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="pench-hero">
+      <div class="section-container">
+        <h1>Pench <span>National Park</span> Explorer</h1>
+        <p class="hero-subtitle">
+          Step into the real-life forest behind Rudyard Kipling's The Jungle Book. Straddling the Pench River in
+          Madhya Pradesh, this Tiger Reserve is home to Bengal tigers, leopards, and the wolves that inspired Mowgli's tale.
+        </p>
+        <div id="stats-grid" class="stats-grid"></div>
+      </div>
+    </section>
+
+    <section class="section-container">
+      <div class="section-header">
+        <span class="section-badge">Heritage</span>
+        <h2>History & Conservation</h2>
+        <p class="section-subtitle">From a protected sanctuary to one of India's most storied Tiger Reserves.</p>
+      </div>
+      <div id="history-timeline" class="timeline-container"></div>
+    </section>
+
+    <section class="section-container" style="background: rgba(180, 83, 9, 0.05); border-radius: 24px;">
+      <div class="section-header">
+        <span class="section-badge">Literary Legacy</span>
+        <h2>Jungle Book Connection</h2>
+        <p class="section-subtitle">The forests that gave Mowgli, Baloo, and Shere Khan their world.</p>
+      </div>
+      <div id="jungle-book-box" class="glass-card feature-box"></div>
+    </section>
+
+    <section class="section-container">
+      <div class="section-header">
+        <span class="section-badge">Geography</span>
+        <h2>Pench River</h2>
+        <p class="section-subtitle">The lifeline that gives the park its name and shapes its landscape.</p>
+      </div>
+      <div id="pench-river-box" class="glass-card feature-box"></div>
+    </section>
+
+    <section class="section-container">
+      <div class="section-header">
+        <span class="section-badge">Biodiversity</span>
+        <h2>Wildlife of Pench</h2>
+        <p class="section-subtitle">Home to Bengal tigers, leopards, and a rich diversity of forest mammals.</p>
+      </div>
+      <div id="wildlife-grid" class="wildlife-grid"></div>
+    </section>
+
+    <section class="section-container" style="background: rgba(180, 83, 9, 0.05); border-radius: 24px;">
+      <div class="section-header">
+        <span class="section-badge">Plan Your Visit</span>
+        <h2>Safari Information</h2>
+        <p class="section-subtitle">Gates, timings, and tips for making the most of your safari.</p>
+      </div>
+      <div id="safari-info-box" class="glass-card"></div>
+    </section>
+
+    <section class="section-container">
+      <div class="section-header">
+        <span class="section-badge">Geography</span>
+        <h2>Interactive Map</h2>
+        <p class="section-subtitle">Click on the map pins to explore key gates, rivers, and buffer zones.</p>
+      </div>
+      <div class="glass-card" style="padding: 1.5rem;">
+        <div class="map-svg-container">
+          <svg class="park-map-svg" viewBox="0 0 1000 600" xmlns="http://www.w3.org/2000/svg" style="width:100%; display:block;">
+            <rect width="1000" height="600" fill="var(--pench-bg)" />
+            <path d="M100,100 Q500,50 900,150 L850,500 L150,500 Z" fill="rgba(180, 83, 9, 0.1)" stroke="var(--pench-accent)" stroke-width="2" />
+            <path d="M500,50 Q480,300 520,550" fill="none" stroke="#3b82f6" stroke-width="20" opacity="0.5" />
+            <text x="530" y="300" fill="#60a5fa" font-size="16" font-family="Outfit">Pench River</text>
+          </svg>
+          <div id="map-hotspots-layer"></div>
+          <div id="map-info-popup" class="map-info-popup hidden"></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-container">
+      <div class="section-header">
+        <span class="section-badge">Visuals</span>
+        <h2>Photo Gallery</h2>
+        <p class="section-subtitle">Glimpses of the tigers, leopards, and teak forests of Pench.</p>
+      </div>
+      <div id="gallery-grid" class="gallery-grid"></div>
+    </section>
+  </main>
+
+  <div id="lightbox-modal" class="lightbox-modal hidden" role="dialog" aria-modal="true" aria-label="Photo Lightbox">
+    <div class="lightbox-content">
+      <button type="button" id="lightbox-close" class="lightbox-close" aria-label="Close Lightbox">&times;</button>
+      <img id="lightbox-img" class="lightbox-img" src="" alt="Gallery Preview" />
+      <div id="lightbox-caption" class="lightbox-caption"></div>
+    </div>
+  </div>
+
+  <footer class="footer" style="margin-top: 4rem; border-top: 1px solid var(--pench-border); padding: 3rem 1.5rem; text-align: center; color: var(--pench-muted);">
+    <p>&copy; 2026 Incredible India Explorer. Pench National Park Explorer.</p>
+  </footer>
+
+  <script src="../../app.js" defer></script>
+  <script src="pench-data.js" defer></script>
+  <script src="pench.js" defer></script>
+  <script type="module" src="../../auth.js"></script>
+</body>
+</html>

--- a/frontend/pench-national-park-explorer/pench-data.js
+++ b/frontend/pench-national-park-explorer/pench-data.js
@@ -1,0 +1,173 @@
+/**
+ * Pench National Park Explorer — Data Module
+ * Covers History, Jungle Book Connection, Pench River, Wildlife,
+ * Safari Information, Gallery, and Interactive Map.
+ */
+
+const PENCH_INFO = {
+  id: "pench",
+  name: "Pench National Park",
+  aka: "Indira Priyadarshini Pench National Park / Pench Tiger Reserve",
+  location: "Seoni and Chhindwara Districts, Madhya Pradesh, India",
+  state: "Madhya Pradesh",
+  coordinates: { lat: 21.74, lng: 79.29 },
+  area: "757.85 km² (Core: 411.33 km², Buffer: 346.52 km²)",
+  establishedYear: 1975,
+  tigerReserveYear: 1992,
+  etymology: "Named after the Pench River, which flows through the park from north to south, dividing it into almost two equal halves.",
+  climate: "Tropical, with hot summers, monsoon rains (park closed to visitors), and mild, dry winters.",
+  bestTime: "October to June (closed during the monsoon, 1 July – 30 September)",
+  entryFees: "₹100 (Indian Nationals), ₹1500 (Foreigners) — varies by zone and vehicle type",
+  nearestTransport: {
+    railway: "Seoni Railway Station (55 km) / Nagpur Junction (90 km)",
+    airport: "Dr. Babasaheb Ambedkar International Airport, Nagpur (~92 km)",
+    gatewayTown: "Turia / Khawasa"
+  },
+  quickStats: [
+    { label: "Jungle Book Muse", value: "Yes", icon: "📖" },
+    { label: "Tiger Reserve", value: "Since 1992", icon: "🐅" },
+    { label: "Total Area", value: "758 km²", icon: "🌲" },
+    { label: "Mammal Species", value: "39+", icon: "🦌" },
+    { label: "Bird Species", value: "285+", icon: "🦅" },
+    { label: "Safari Gates", value: "3", icon: "🚙" }
+  ]
+};
+
+const HISTORY = [
+  {
+    year: "1965",
+    title: "Wildlife Sanctuary Notified",
+    description: "The forests along the Pench River valley were first notified as a protected wildlife sanctuary to safeguard the region's dwindling tiger and prey populations."
+  },
+  {
+    year: "1975",
+    title: "National Park Established",
+    description: "The core forests on both banks of the Pench River were upgraded to full National Park status under the Wildlife Protection Act."
+  },
+  {
+    year: "1992",
+    title: "Project Tiger Reserve",
+    description: "Declared the 19th Tiger Reserve of India and renamed Indira Priyadarshini Pench National Park, marking a new chapter in its conservation history."
+  },
+  {
+    year: "2011",
+    title: "Buffer Zone Notified",
+    description: "A buffer zone was formally added around the core, extending protection to surrounding forest corridors that link Pench to Kanha and Satpura."
+  }
+];
+
+const JUNGLE_BOOK = {
+  title: "The Real Jungle Book",
+  description: "Pench's forests on the Seoni plateau are widely believed to have inspired Rudyard Kipling's classic 'The Jungle Book'. Although Kipling never visited India himself, he drew heavily on 'Seonee', an 1877 account of the region's wildlife and folklore written by British forest officer Robert Armitage Sterndale. The undulating teak forests, the winding Pench River, and local legends of wolf-raised children echo throughout Mowgli's story of Shere Khan, Baloo, and Bagheera.",
+  keyHighlights: [
+    "Seoni district's forests are the geographic namesake of Sterndale's 'Seonee'",
+    "A nature trail near Karmajhiri retraces landscapes associated with the tale",
+    "Interpretation centers at the park narrate the Kipling connection to visitors",
+    "The park's resident Indian Wolf population echoes Mowgli's wolf-pack origins"
+  ]
+};
+
+const PENCH_RIVER = {
+  title: "The Pench River",
+  description: "The Pench River rises in the Satpura Range and flows roughly north to south, splitting the park into nearly equal eastern and western halves before being dammed to form the Totladoh and Pench reservoirs. Its perennial pools and moist deciduous banks sustain the park through the dry months, drawing tigers, gaur, and sambar to drink even as surrounding water sources vanish — and giving the reserve its name."
+};
+
+const WILDLIFE = [
+  {
+    id: "bengal-tiger",
+    name: "Bengal Tiger",
+    scientificName: "Panthera tigris tigris",
+    status: "Endangered",
+    icon: "🐅",
+    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fe/Royal_Bengal_Tiger_at_Nandankanan.jpg/800px-Royal_Bengal_Tiger_at_Nandankanan.jpg",
+    description: "Pench's apex predator and star attraction. The reserve was once home to the famous tigress 'Collarwali', renowned for raising 29 cubs over her lifetime."
+  },
+  {
+    id: "leopard",
+    name: "Leopard",
+    scientificName: "Panthera pardus fusca",
+    status: "Vulnerable",
+    icon: "🐆",
+    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/Indian_leopard.jpg/800px-Indian_leopard.jpg",
+    description: "Thrives alongside tigers thanks to abundant prey and dense tree cover, often spotted resting on low branches during the day."
+  },
+  {
+    id: "indian-wolf",
+    name: "Indian Wolf",
+    scientificName: "Canis lupus pallipes",
+    status: "Endangered",
+    icon: "🐺",
+    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/30/Indian_wolf_%28Canis_lupus_pallipes%29_by_Sandeep_Thakur.jpg/800px-Indian_wolf_%28Canis_lupus_pallipes%29_by_Sandeep_Thakur.jpg",
+    description: "A rare sighting in the buffer grasslands, and the species most directly tied to the park's Jungle Book legend."
+  },
+  {
+    id: "dhole",
+    name: "Dhole (Indian Wild Dog)",
+    scientificName: "Cuon alpinus",
+    status: "Endangered",
+    icon: "🐕",
+    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b3/Dhole_%28Cuon_alpinus%29_in_Nagarhole_National_Park.jpg/800px-Dhole_%28Cuon_alpinus%29_in_Nagarhole_National_Park.jpg",
+    description: "Highly social pack hunters that patrol Pench's deciduous forests, frequently competing with tigers and leopards for prey."
+  },
+  {
+    id: "gaur",
+    name: "Gaur",
+    scientificName: "Bos gaurus",
+    status: "Vulnerable",
+    icon: "🐃",
+    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b5/Gaur%28Bos_gaurus%29.jpg/800px-Gaur%28Bos_gaurus%29.jpg",
+    description: "The world's largest wild bovine, commonly seen grazing near the Pench River's grassy banks."
+  },
+  {
+    id: "sloth-bear",
+    name: "Sloth Bear",
+    scientificName: "Melursus ursinus",
+    status: "Vulnerable",
+    icon: "🐻",
+    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Sloth_Bear.jpg/800px-Sloth_Bear.jpg",
+    description: "Often spotted foraging for termites and mahua flowers in the dry deciduous stretches of the reserve."
+  }
+];
+
+const SAFARI_INFO = {
+  title: "Planning Your Safari",
+  description: "Pench offers jeep safaris across three main gates, each with a distinct character — from high tiger-sighting frequency to quieter buffer-zone birding trails.",
+  zones: [
+    { name: "Turia Gate", description: "The main entry gate, closest to the Nagpur–Jabalpur highway, with the highest tiger sighting frequency." },
+    { name: "Karmajhiri Gate", description: "A quieter buffer-zone gate known for birdlife and the Jungle Book interpretation trail." },
+    { name: "Jamtara Gate", description: "Located on the Maharashtra side, popular for night safaris in the buffer zone." }
+  ],
+  timings: "Morning: 6:00 AM – 11:00 AM | Evening: 3:00 PM – 6:00 PM (varies seasonally)",
+  vehicleTypes: "6-seater open Gypsy (shared or private); canters for larger groups in select buffer zones",
+  closedDays: "Core zone closed on Wednesday afternoons; entire park closed 1 July – 30 September",
+  bookingTip: "Book safari permits online in advance via the MP Forest Department portal, especially during peak season (November–February)."
+};
+
+const MAP_HOTSPOTS = [
+  { id: "spot-turia", name: "Turia Gate", category: "gate", x: 50, y: 20, description: "The main entry point, closest to the highway, with excellent tiger sighting odds." },
+  { id: "spot-river", name: "Pench River & Totladoh Reservoir", category: "water", x: 50, y: 50, description: "The lifeline of the park, splitting it into eastern and western halves." },
+  { id: "spot-karmajhiri", name: "Karmajhiri Buffer Zone", category: "wildlife", x: 30, y: 65, description: "Known for birdlife and the trail retracing Kipling's Jungle Book setting." },
+  { id: "spot-jamtara", name: "Jamtara Gate", category: "gate", x: 70, y: 80, description: "The Maharashtra-side gate, popular for night safaris." }
+];
+
+const GALLERY_IMAGES = [
+  {
+    url: "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f3/Pench_National_Park%2C_Madhya_Pradesh_-_by_Ishani_Mehta.jpg/960px-Pench_National_Park%2C_Madhya_Pradesh_-_by_Ishani_Mehta.jpg",
+    title: "Pench Landscape",
+    caption: "The open teak canopy and rolling terrain of Pench National Park, Madhya Pradesh."
+  },
+  {
+    url: "https://upload.wikimedia.org/wikipedia/commons/thumb/f/fe/Royal_Bengal_Tiger_at_Nandankanan.jpg/800px-Royal_Bengal_Tiger_at_Nandankanan.jpg",
+    title: "Bengal Tiger",
+    caption: "A Bengal tiger in the dense forests of central India, Pench's most iconic resident."
+  },
+  {
+    url: "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/Indian_leopard.jpg/800px-Indian_leopard.jpg",
+    title: "Indian Leopard",
+    caption: "A leopard resting in the tree cover — a frequent sighting for early-morning safari-goers."
+  }
+];
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { PENCH_INFO, HISTORY, JUNGLE_BOOK, PENCH_RIVER, WILDLIFE, SAFARI_INFO, MAP_HOTSPOTS, GALLERY_IMAGES };
+}

--- a/frontend/pench-national-park-explorer/pench.css
+++ b/frontend/pench-national-park-explorer/pench.css
@@ -1,0 +1,397 @@
+/**
+ * Pench National Park Explorer — Stylesheet
+ * Supports both dark and light themes using CSS variables.
+ */
+
+:root {
+  --pench-bg-dark: #0f172a;
+  --pench-bg-light: #f8fafc;
+  --pench-card-dark: rgba(30, 41, 59, 0.85);
+  --pench-card-light: rgba(255, 255, 255, 0.95);
+  --pench-text-dark: #e2e8f0;
+  --pench-text-light: #1e293b;
+  --pench-muted-dark: #94a3b8;
+  --pench-muted-light: #64748b;
+  --pench-accent: #b45309; /* Teak / Jungle Amber */
+  --pench-accent-bright: #f59e0b;
+  --pench-border-dark: rgba(255, 255, 255, 0.1);
+  --pench-border-light: rgba(0, 0, 0, 0.08);
+}
+
+body.light-theme {
+  --pench-bg: var(--pench-bg-light);
+  --pench-card: var(--pench-card-light);
+  --pench-text: var(--pench-text-light);
+  --pench-muted: var(--pench-muted-light);
+  --pench-border: var(--pench-border-light);
+}
+
+body:not(.light-theme) {
+  --pench-bg: var(--pench-bg-dark);
+  --pench-card: var(--pench-card-dark);
+  --pench-text: var(--pench-text-dark);
+  --pench-muted: var(--pench-muted-dark);
+  --pench-border: var(--pench-border-dark);
+}
+
+.pench-main {
+  background-color: var(--pench-bg);
+  color: var(--pench-text);
+  font-family: 'Outfit', sans-serif;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.section-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 4rem 1.5rem;
+}
+
+.section-header {
+  text-align: center;
+  margin-bottom: 3rem;
+}
+
+.section-badge {
+  display: inline-block;
+  padding: 0.4rem 1rem;
+  background: rgba(180, 83, 9, 0.15);
+  color: var(--pench-accent-bright);
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.section-header h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  color: var(--pench-text);
+}
+
+.section-subtitle {
+  font-size: 1.1rem;
+  color: var(--pench-muted);
+  max-width: 700px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.glass-card {
+  background: var(--pench-card);
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--pench-border);
+  border-radius: 16px;
+  padding: 2rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.glass-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.15);
+}
+
+/* Hero Section */
+.pench-hero {
+  padding: 6rem 1.5rem 4rem;
+  text-align: center;
+  background: linear-gradient(rgba(15, 23, 42, 0.7), rgba(15, 23, 42, 0.9)),
+              url('https://upload.wikimedia.org/wikipedia/commons/thumb/f/f3/Pench_National_Park%2C_Madhya_Pradesh_-_by_Ishani_Mehta.jpg/1200px-Pench_National_Park%2C_Madhya_Pradesh_-_by_Ishani_Mehta.jpg') center/cover no-repeat;
+}
+
+body.light-theme .pench-hero {
+  background: linear-gradient(rgba(248, 250, 252, 0.8), rgba(248, 250, 252, 0.95)),
+              url('https://upload.wikimedia.org/wikipedia/commons/thumb/f/f3/Pench_National_Park%2C_Madhya_Pradesh_-_by_Ishani_Mehta.jpg/1200px-Pench_National_Park%2C_Madhya_Pradesh_-_by_Ishani_Mehta.jpg') center/cover no-repeat;
+}
+
+.pench-hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: 3.5rem;
+  margin-bottom: 1.5rem;
+  color: var(--pench-text);
+}
+
+.pench-hero h1 span {
+  color: var(--pench-accent-bright);
+}
+
+.hero-subtitle {
+  font-size: 1.2rem;
+  color: var(--pench-muted);
+  max-width: 800px;
+  margin: 0 auto 3rem;
+  line-height: 1.7;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1.5rem;
+  margin-top: 3rem;
+}
+
+.stat-card {
+  text-align: center;
+  padding: 1.5rem 1rem;
+}
+
+.stat-icon {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+}
+
+.stat-value {
+  display: block;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--pench-accent-bright);
+}
+
+.stat-label {
+  font-size: 0.85rem;
+  color: var(--pench-muted);
+}
+
+/* Wildlife Grid */
+.wildlife-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 2rem;
+}
+
+.wildlife-card img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  border-radius: 12px;
+  margin-bottom: 1rem;
+}
+
+/* Timeline */
+.timeline-container {
+  position: relative;
+  max-width: 800px;
+  margin: 0 auto;
+  padding-left: 2rem;
+}
+
+.timeline-container::before {
+  content: '';
+  position: absolute;
+  left: 8px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--pench-accent);
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: 2.5rem;
+  padding-left: 2rem;
+}
+
+.timeline-dot {
+  position: absolute;
+  left: -1.6rem;
+  top: 0.5rem;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--pench-accent-bright);
+  border: 3px solid var(--pench-bg);
+}
+
+/* Feature Boxes (Jungle Book, Pench River) */
+.feature-box {
+  border-left: 4px solid var(--pench-accent);
+  background: rgba(180, 83, 9, 0.05);
+  margin-bottom: 2rem;
+}
+
+.initiatives-list {
+  list-style: none;
+  padding: 0;
+  margin-top: 1rem;
+}
+
+.initiatives-list li {
+  padding: 0.5rem 0;
+  padding-left: 1.5rem;
+  position: relative;
+  color: var(--pench-muted);
+}
+
+.initiatives-list li::before {
+  content: '📖';
+  position: absolute;
+  left: 0;
+}
+
+/* Safari Info */
+.safari-zone-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.safari-zone-card {
+  border-top: 3px solid var(--pench-accent-bright);
+}
+
+.safari-meta-list {
+  list-style: none;
+  padding: 0;
+  margin-top: 1.5rem;
+}
+
+.safari-meta-list li {
+  padding: 0.5rem 0;
+  color: var(--pench-muted);
+  border-bottom: 1px solid var(--pench-border);
+}
+
+.safari-meta-list li strong {
+  color: var(--pench-text);
+}
+
+/* Map */
+.map-svg-container {
+  position: relative;
+  width: 100%;
+  max-width: 800px;
+  margin: 0 auto;
+  border-radius: 16px;
+  overflow: hidden;
+  background: var(--pench-card);
+}
+
+.map-hotspot-pin {
+  position: absolute;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 2px solid var(--pench-accent-bright);
+  background: var(--pench-card);
+  font-size: 1.2rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transform: translate(-50%, -50%);
+  transition: transform 0.2s ease;
+}
+
+.map-hotspot-pin:hover {
+  transform: translate(-50%, -50%) scale(1.2);
+}
+
+.map-info-popup {
+  position: absolute;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--pench-card);
+  border: 1px solid var(--pench-border);
+  border-radius: 12px;
+  padding: 1rem 1.5rem;
+  max-width: 300px;
+  text-align: center;
+  backdrop-filter: blur(8px);
+}
+
+.hidden {
+  display: none !important;
+}
+
+/* Gallery */
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.5rem;
+}
+
+.gallery-item {
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  cursor: pointer;
+  height: 220px;
+}
+
+.gallery-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.4s ease;
+}
+
+.gallery-item:hover .gallery-img {
+  transform: scale(1.05);
+}
+
+.gallery-overlay {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 1rem;
+  background: linear-gradient(transparent, rgba(0, 0, 0, 0.8));
+  color: white;
+}
+
+/* Lightbox */
+.lightbox-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.95);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 2rem;
+}
+
+.lightbox-content {
+  position: relative;
+  max-width: 900px;
+  text-align: center;
+}
+
+.lightbox-close {
+  position: absolute;
+  top: -3rem;
+  right: 0;
+  background: none;
+  border: none;
+  color: white;
+  font-size: 2.5rem;
+  cursor: pointer;
+}
+
+.lightbox-img {
+  max-width: 100%;
+  max-height: 70vh;
+  border-radius: 12px;
+}
+
+.lightbox-caption {
+  margin-top: 1rem;
+  color: #cbd5e1;
+  font-size: 1rem;
+}
+
+/* Responsive Adjustments */
+@media (max-width: 768px) {
+  .pench-hero h1 { font-size: 2.5rem; }
+  .section-header h2 { font-size: 2rem; }
+  .stats-grid { grid-template-columns: repeat(2, 1fr); }
+  .timeline-container { padding-left: 1.5rem; }
+}

--- a/frontend/pench-national-park-explorer/pench.js
+++ b/frontend/pench-national-park-explorer/pench.js
@@ -1,0 +1,217 @@
+/**
+ * Pench National Park Explorer — Interactive Logic
+ * Handles DOM rendering, theme toggling, and interactive map/gallery features.
+ */
+
+(function() {
+  'use strict';
+
+  document.addEventListener('DOMContentLoaded', function() {
+    initTheme();
+    renderQuickStats();
+    renderHistory();
+    renderJungleBook();
+    renderPenchRiver();
+    renderWildlife();
+    renderSafariInfo();
+    renderInteractiveMap();
+    renderGalleryGrid();
+    bindEvents();
+  });
+
+  function initTheme() {
+    const savedTheme = localStorage.getItem('theme') || 'dark';
+    if (savedTheme === 'light') {
+      document.body.classList.add('light-theme');
+    }
+  }
+
+  function bindEvents() {
+    const themeBtn = document.getElementById('theme-toggle');
+    if (themeBtn) {
+      themeBtn.addEventListener('click', function() {
+        document.body.classList.toggle('light-theme');
+        const isLight = document.body.classList.contains('light-theme');
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        themeBtn.textContent = isLight ? '🌙' : '☀️';
+      });
+    }
+
+    const lbClose = document.getElementById('lightbox-close');
+    if (lbClose) lbClose.addEventListener('click', closeLightbox);
+
+    const lbModal = document.getElementById('lightbox-modal');
+    if (lbModal) {
+      lbModal.addEventListener('click', function(e) {
+        if (e.target === lbModal) closeLightbox();
+      });
+    }
+
+    document.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape') closeLightbox();
+    });
+  }
+
+  function renderQuickStats() {
+    const container = document.getElementById('stats-grid');
+    if (!container || typeof PENCH_INFO === 'undefined') return;
+
+    let html = '';
+    PENCH_INFO.quickStats.forEach(function(st) {
+      html += `
+        <div class="glass-card stat-card">
+          <div class="stat-icon">${st.icon}</div>
+          <span class="stat-value">${st.value}</span>
+          <span class="stat-label">${st.label}</span>
+        </div>`;
+    });
+    container.innerHTML = html;
+  }
+
+  function renderHistory() {
+    const container = document.getElementById('history-timeline');
+    if (!container || typeof HISTORY === 'undefined') return;
+
+    let html = '';
+    HISTORY.forEach(function(item) {
+      html += `
+        <div class="timeline-item">
+          <div class="timeline-dot"></div>
+          <div class="glass-card">
+            <div style="font-weight:800; font-size:1.2rem; color:var(--pench-accent-bright); margin-bottom:0.4rem;">${item.year}</div>
+            <h4 style="margin-bottom:0.5rem;">${item.title}</h4>
+            <p style="font-size:0.92rem; color:var(--pench-muted); line-height:1.6;">${item.description}</p>
+          </div>
+        </div>`;
+    });
+    container.innerHTML = html;
+  }
+
+  function renderJungleBook() {
+    const container = document.getElementById('jungle-book-box');
+    if (!container || typeof JUNGLE_BOOK === 'undefined') return;
+
+    const highlightsHtml = JUNGLE_BOOK.keyHighlights.map(i => `<li>${i}</li>`).join('');
+
+    container.innerHTML = `
+      <h3 style="font-size:1.5rem; color:var(--pench-accent-bright); margin-bottom:0.5rem;">📖 ${JUNGLE_BOOK.title}</h3>
+      <p style="line-height:1.7; margin-bottom:1rem;">${JUNGLE_BOOK.description}</p>
+      <h4 style="margin-top:1.5rem; margin-bottom:0.5rem;">Kipling Connection Highlights:</h4>
+      <ul class="initiatives-list">${highlightsHtml}</ul>
+    `;
+  }
+
+  function renderPenchRiver() {
+    const container = document.getElementById('pench-river-box');
+    if (!container || typeof PENCH_RIVER === 'undefined') return;
+
+    container.innerHTML = `
+      <h3 style="font-size:1.5rem; color:var(--pench-accent-bright); margin-bottom:0.5rem;">💧 ${PENCH_RIVER.title}</h3>
+      <p style="line-height:1.7; color:var(--pench-muted);">${PENCH_RIVER.description}</p>
+    `;
+  }
+
+  function renderWildlife() {
+    const container = document.getElementById('wildlife-grid');
+    if (!container || typeof WILDLIFE === 'undefined') return;
+
+    let html = '';
+    WILDLIFE.forEach(function(w) {
+      html += `
+        <div class="glass-card wildlife-card">
+          <img src="${w.image}" alt="${w.name}" loading="lazy" onerror="this.style.display='none'">
+          <h3 style="font-size:1.3rem; margin-bottom:0.2rem;">${w.icon} ${w.name}</h3>
+          <div style="font-style:italic; font-size:0.85rem; color:var(--pench-accent-bright); margin-bottom:0.8rem;">${w.scientificName}</div>
+          <span style="display:inline-block; padding:0.2rem 0.6rem; background:rgba(220,38,38,0.2); color:#f87171; border-radius:999px; font-size:0.75rem; font-weight:700; margin-bottom:0.8rem;">${w.status}</span>
+          <p style="font-size:0.9rem; color:var(--pench-muted); line-height:1.5;">${w.description}</p>
+        </div>`;
+    });
+    container.innerHTML = html;
+  }
+
+  function renderSafariInfo() {
+    const container = document.getElementById('safari-info-box');
+    if (!container || typeof SAFARI_INFO === 'undefined') return;
+
+    const zonesHtml = SAFARI_INFO.zones.map(z => `
+      <div class="glass-card safari-zone-card">
+        <h4 style="margin-bottom:0.5rem; color:var(--pench-accent-bright);">${z.name}</h4>
+        <p style="font-size:0.9rem; color:var(--pench-muted); line-height:1.5;">${z.description}</p>
+      </div>`).join('');
+
+    container.innerHTML = `
+      <p style="line-height:1.7; margin-bottom:1rem;">${SAFARI_INFO.description}</p>
+      <div class="safari-zone-grid">${zonesHtml}</div>
+      <ul class="safari-meta-list">
+        <li><strong>Timings:</strong> ${SAFARI_INFO.timings}</li>
+        <li><strong>Vehicles:</strong> ${SAFARI_INFO.vehicleTypes}</li>
+        <li><strong>Closed:</strong> ${SAFARI_INFO.closedDays}</li>
+        <li><strong>Tip:</strong> ${SAFARI_INFO.bookingTip}</li>
+      </ul>
+    `;
+  }
+
+  function renderInteractiveMap() {
+    const container = document.getElementById('map-hotspots-layer');
+    const infoPopup = document.getElementById('map-info-popup');
+    if (!container || typeof MAP_HOTSPOTS === 'undefined') return;
+
+    let html = '';
+    MAP_HOTSPOTS.forEach(function(spot) {
+      const icon = spot.category === 'gate' ? '🚪' : spot.category === 'water' ? '💧' : '📍';
+      html += `<button type="button" class="map-hotspot-pin" style="left:${spot.x}%; top:${spot.y}%;" data-spot-id="${spot.id}" aria-label="${spot.name}">${icon}</button>`;
+    });
+    container.innerHTML = html;
+
+    container.querySelectorAll('.map-hotspot-pin').forEach(function(pin) {
+      pin.addEventListener('click', function() {
+        const spot = MAP_HOTSPOTS.find(s => s.id === pin.dataset.spotId);
+        if (spot && infoPopup) {
+          infoPopup.innerHTML = `<h4 style="color:var(--pench-accent-bright); margin-bottom:0.3rem;">${spot.name}</h4><p style="font-size:0.85rem; color:var(--pench-muted);">${spot.description}</p>`;
+          infoPopup.classList.remove('hidden');
+        }
+      });
+    });
+  }
+
+  function renderGalleryGrid() {
+    const container = document.getElementById('gallery-grid');
+    if (!container || typeof GALLERY_IMAGES === 'undefined') return;
+
+    let html = '';
+    GALLERY_IMAGES.forEach(function(img, idx) {
+      html += `
+        <div class="gallery-item" data-idx="${idx}">
+          <img class="gallery-img" src="${img.url}" alt="${img.title}" loading="lazy">
+          <div class="gallery-overlay">
+            <h4 style="margin-bottom:0.2rem;">${img.title}</h4>
+            <p style="font-size:0.8rem; opacity:0.9;">${img.caption}</p>
+          </div>
+        </div>`;
+    });
+    container.innerHTML = html;
+
+    container.querySelectorAll('.gallery-item').forEach(function(item) {
+      item.addEventListener('click', function() {
+        openLightbox(parseInt(item.dataset.idx, 10));
+      });
+    });
+  }
+
+  function openLightbox(idx) {
+    if (typeof GALLERY_IMAGES === 'undefined' || !GALLERY_IMAGES[idx]) return;
+    const modal = document.getElementById('lightbox-modal');
+    const imgEl = document.getElementById('lightbox-img');
+    const capEl = document.getElementById('lightbox-caption');
+    if (!modal || !imgEl || !capEl) return;
+
+    imgEl.src = GALLERY_IMAGES[idx].url;
+    capEl.textContent = GALLERY_IMAGES[idx].title + ' — ' + GALLERY_IMAGES[idx].caption;
+    modal.classList.remove('hidden');
+  }
+
+  function closeLightbox() {
+    const modal = document.getElementById('lightbox-modal');
+    if (modal) modal.classList.add('hidden');
+  }
+})();


### PR DESCRIPTION
## What this PR does
Adds a dedicated, self-contained explorer page for Pench National Park, following the
same pattern used by other parks (e.g. Valmiki, Kaziranga) in this repo.

## Changes
- New folder `frontend/pench-national-park-explorer/` with:
  - `index.html` — page structure with all required sections
  - `pench-data.js` — all park data (history, Jungle Book, river, wildlife, safari, map, gallery)
  - `pench.css` — themed stylesheet (dark/light mode support)
  - `pench.js` — DOM rendering + theme toggle + lightbox logic
- Updated `frontend/national-parks-explorer/data.js` to add an `explorerUrl` to the
  existing Pench card so it links to the new dedicated page.

## Sections included
- History
- Jungle Book Connection (the Seoni/Kipling backstory)
- Pench River
- Wildlife (Bengal Tigers, Leopards, and other key species)
- Safari Information (gates, timings, vehicles, booking tips)
- Interactive Map
- Photo Gallery

## How to test
1. Open `frontend/national-parks-explorer/index.html`, find the Pench card, click "Explore".
2. Confirm it opens `frontend/pench-national-park-explorer/index.html`.
3. Verify all sections render, dark/light theme toggle works, map pins show info popups,
   and gallery images open in the lightbox.

Closes #820 

@Eshajha19 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.