### PR TITLE
feat: Create Nokrek National Park Explorer

### DIFF
--- a/frontend/dudhwa-national-park-explorer/dudhwa.js
+++ b/frontend/dudhwa-national-park-explorer/dudhwa.js
@@ -225,3 +225,4 @@
         if (modal) modal.classList.add('hidden');
     }
 })();
+

--- a/frontend/national-parks-explorer/data.js
+++ b/frontend/national-parks-explorer/data.js
@@ -696,7 +696,7 @@ const NATIONAL_PARKS = [
         areaUnit: 'km²',
         type: 'National Park',
         isTigerReserve: false,
-        isUNESCO: true,
+        isUNESCO: false,
         description:
             'A UNESCO Biosphere Reserve in the Garo Hills, globally significant as the center of origin of wild Citrus indica — the ancestor of most cultivated orange varieties. Its core zone protects the Red Panda alongside dense subtropical forests around Nokrek Peak, the highest point in the Garo Hills.',
         keyFauna: ['Red Panda', 'Clouded Leopard', 'Asian Elephant', 'Hoolock Gibbon', 'Marbled Cat'],

--- a/frontend/national-parks-explorer/data.js
+++ b/frontend/national-parks-explorer/data.js
@@ -685,6 +685,28 @@ const NATIONAL_PARKS = [
         bestTime: 'October to March',
         entryFee: '₹50 (Indian), ₹500 (Foreign)',
         image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/8/8c/View_of_Gulf_of_Mannar_from_Rameshwaram%2C_Tamil_Nadu.jpg/960px-View_of_Gulf_of_Mannar_from_Rameshwaram%2C_Tamil_Nadu.jpg'
+    },
+    {
+        id: 'nokrek',
+        name: 'Nokrek National Park',
+        state: 'Meghalaya',
+        stateId: 'ml',
+        established: 1986,
+        area: 47.48,
+        areaUnit: 'km²',
+        type: 'National Park',
+        isTigerReserve: false,
+        isUNESCO: true,
+        description:
+            'A UNESCO Biosphere Reserve in the Garo Hills, globally significant as the center of origin of wild Citrus indica — the ancestor of most cultivated orange varieties. Its core zone protects the Red Panda alongside dense subtropical forests around Nokrek Peak, the highest point in the Garo Hills.',
+        keyFauna: ['Red Panda', 'Clouded Leopard', 'Asian Elephant', 'Hoolock Gibbon', 'Marbled Cat'],
+        keyFlora: ['Wild Citrus (Citrus indica)', 'Subtropical Broadleaf Forest', 'Orchids', 'Bamboo'],
+        coordinates: { lat: 25.47, lng: 90.30 },
+        climate: 'Subtropical Monsoon',
+        bestTime: 'October to April',
+        entryFee: '₹50 (Indian), ₹300 (Foreign)',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/Red_Panda_%28Ailurus_fulgens%29.jpg/960px-Red_Panda_%28Ailurus_fulgens%29.jpg',
+        explorerUrl: '../nokrek-national-park-explorer/index.html'
     }
 ];
 
@@ -834,5 +856,6 @@ const STATES = [
     { id: 'as', name: 'Assam', region: 'northeast' },
     { id: 'wb', name: 'West Bengal', region: 'east' },
     { id: 'or', name: 'Odisha', region: 'east' },
-    { id: 'ar', name: 'Arunachal Pradesh', region: 'northeast' }
+    { id: 'ar', name: 'Arunachal Pradesh', region: 'northeast' },
+    { id: 'ml', name: 'Meghalaya', region: 'northeast' }
 ];

--- a/frontend/nokrek-national-park-explorer/index.html
+++ b/frontend/nokrek-national-park-explorer/index.html
@@ -1,0 +1,277 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    document.body.classList.add('light-theme');
+                }
+            })();
+        </script>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Explore Nokrek National Park in Meghalaya — a UNESCO Biosphere Reserve in the Garo Hills, birthplace of wild Citrus indica, and home to the Red Panda, Clouded Leopard, and Hoolock Gibbon."
+        />
+        <title>Nokrek National Park Explorer | Incredible India</title>
+
+        <!-- Google Fonts -->
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+            rel="stylesheet"
+        />
+
+        <!-- Stylesheets -->
+        <!-- Stylesheets -->
+        <link rel="stylesheet" href="/styles.css" />
+        <link rel="stylesheet" href="/frontend/nokrek-national-park-explorer/nokrek.css" />
+        <!-- Open Graph -->
+        <meta property="og:title" content="Nokrek National Park Explorer | Incredible India" />
+        <meta
+            property="og:description"
+            content="Interactive explorer for Nokrek National Park in Meghalaya — UNESCO Biosphere Reserve, birthplace of wild Citrus indica, and Red Panda habitat in the Garo Hills."
+        />
+        <meta property="og:type" content="website" />
+    </head>
+
+    <body class="nokrek-main">
+        <!-- Site Navbar -->
+        <header class="navbar scrolled" id="navbar">
+            <div class="nav-container">
+                <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </button>
+                <nav class="nav-menu" id="nav-menu">
+                    <a href="../../index.html#home" class="nav-link">Home</a>
+                    <a href="../national-parks-explorer/index.html" class="nav-link">National Parks</a>
+                    <a href="../wildlife/wildlife.html" class="nav-link">Wildlife</a>
+                    <a href="index.html" class="nav-link active" style="color: var(--saffron)"
+                        >Nokrek Explorer</a
+                    >
+                    <a href="../national-parks-timeline/national-parks-timeline.html" class="nav-link">Timeline</a>
+                    <button
+                        id="theme-toggle"
+                        class="btn-theme-toggle"
+                        aria-label="Toggle Dark/Light Mode"
+                        title="Toggle Light Mode"
+                    >
+                        ☀️
+                    </button>
+                </nav>
+            </div>
+        </header>
+
+        <main>
+            <!-- Hero Section -->
+            <section class="nokrek-hero">
+                <div class="section-container">
+                    <div class="hero-badges-row">
+                        <span class="hero-pill pill-unesco">🌍 UNESCO Biosphere Reserve</span>
+                        <span class="hero-pill pill-panda">🐼 Red Panda Habitat</span>
+                        <span class="hero-pill pill-state">📍 Garo Hills, Meghalaya</span>
+                    </div>
+                    <h1>Nokrek <span>National Park</span> Explorer</h1>
+                    <p class="hero-subtitle">
+                        Journey into the Garo Hills of Meghalaya — a UNESCO Biosphere Reserve crowned by Nokrek Peak,
+                        globally significant as the birthplace of wild Citrus indica, and home to a rare
+                        westward outpost of the elusive Red Panda.
+                    </p>
+
+                    <!-- Quick Stats Bar -->
+                    <div id="stats-grid" class="stats-grid">
+                        <!-- Populated by nokrek.js -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- UNESCO Biosphere Reserve Section -->
+            <section class="ecosystem-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Global Recognition</span>
+                        <h2>A UNESCO Biosphere Reserve</h2>
+                        <p class="section-subtitle" id="biosphere-overview-text">
+                            <!-- Populated by nokrek.js -->
+                        </p>
+                    </div>
+                    <div class="ecosystem-grid" id="forest-zones-grid">
+                        <!-- Populated by nokrek.js -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Red Panda & Wild Citrus Spotlight -->
+            <section class="conservation-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Conservation Flagships</span>
+                        <h2>Red Panda & the Wild Orange</h2>
+                        <p class="section-subtitle">
+                            Nokrek is defined by two remarkable stories of conservation — a rare mammal at the edge
+                            of its range, and a wild plant that gave rise to citrus fruit worldwide.
+                        </p>
+                    </div>
+
+                    <div class="conservation-grid">
+                        <div class="conserve-card glass-card">
+                            <h3 style="font-family:var(--font-heading); font-size:1.5rem; color:var(--gold-bright); margin-bottom:0.8rem;">🐼 Red Panda</h3>
+                            <p style="color:var(--nokrek-text-muted-dark); line-height:1.65; margin-bottom:1rem;" id="red-panda-text">
+                                <!-- Populated by nokrek.js -->
+                            </p>
+                            <div style="font-size:0.88rem; padding:0.8rem; border-radius:8px; background:rgba(217,119,6,0.1); border-left:3px solid var(--terai-amber); color:var(--gold-bright);">
+                                🐾 <strong>Elusive by Nature:</strong> Mostly confirmed through camera traps rather than direct sightings.
+                            </div>
+                        </div>
+
+                        <div class="conserve-card glass-card">
+                            <h3 style="font-family:var(--font-heading); font-size:1.5rem; color:var(--sal-emerald); margin-bottom:0.8rem;">🍊 Wild Citrus (Citrus indica)</h3>
+                            <p style="color:var(--nokrek-text-muted-dark); line-height:1.65; margin-bottom:1rem;" id="wild-citrus-text">
+                                <!-- Populated by nokrek.js -->
+                            </p>
+                            <div style="font-size:0.88rem; padding:0.8rem; border-radius:8px; background:rgba(21,128,61,0.1); border-left:3px solid var(--sal-emerald); color:#4ade80;">
+                                🌱 <strong>Memang Narang:</strong> Known locally as the "Spirit Orange" in the Garo language.
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Wildlife Section -->
+            <section class="ecosystem-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Fauna of the Garo Hills</span>
+                        <h2>Wildlife</h2>
+                        <p class="section-subtitle">
+                            Beyond the Red Panda, Nokrek's forests shelter a striking range of rare and threatened species.
+                        </p>
+                    </div>
+
+                    <div id="wildlife-grid" class="ecosystem-grid">
+                        <!-- Populated by nokrek.js -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Biodiversity Stats -->
+            <section class="safari-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">At a Glance</span>
+                        <h2>Biodiversity</h2>
+                        <p class="section-subtitle">
+                            A snapshot of what makes Nokrek's small core zone disproportionately significant for conservation.
+                        </p>
+                    </div>
+
+                    <div id="biodiversity-grid" class="stats-grid" style="max-width: 1000px; margin: 0 auto;">
+                        <!-- Populated by nokrek.js -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Interactive SVG Park Map -->
+            <section class="map-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Park Geography</span>
+                        <h2>Interactive Map of Nokrek National Park</h2>
+                        <p class="section-subtitle">
+                            Click on map hotspot pins to locate the Park Entry, Citrus Gene Sanctuary, Nokrek Peak, and Core Zone Forest Trail.
+                        </p>
+                    </div>
+
+                    <div class="map-card-wrapper glass-card">
+                        <div class="map-svg-container">
+                            <svg class="park-map-svg" viewBox="0 0 1000 600" xmlns="http://www.w3.org/2000/svg">
+                                <rect width="1000" height="600" fill="#0f1c15" />
+                                <path d="M50,150 Q450,60 950,180 L950,520 L50,520 Z" fill="#173225" stroke="rgba(217,119,6,0.3)" stroke-width="2"/>
+                                <path d="M100,300 Q400,180 700,220 T950,180" fill="none" stroke="#94a3b8" stroke-width="3" opacity="0.4"/>
+                                <path d="M180,400 L360,280 L560,230 L740,300 L860,190" fill="none" stroke="#f59e0b" stroke-width="4" stroke-dasharray="8,6"/>
+                                <text x="70" y="460" fill="#38bdf8" font-size="14" font-family="Outfit">Garo Hills Buffer Zone</text>
+                                <text x="380" y="210" fill="#fbbf24" font-size="14" font-weight="bold" font-family="Outfit">Nokrek Ridge</text>
+                            </svg>
+
+                            <!-- Pins Layer -->
+                            <div id="map-hotspots-layer">
+                                <!-- Populated by nokrek.js -->
+                            </div>
+
+                            <!-- Info Popup -->
+                            <div id="map-info-popup" class="map-info-popup hidden">
+                                <!-- Populated by nokrek.js -->
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Gallery Section -->
+            <section class="gallery-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Visual Journey</span>
+                        <h2>Nokrek Photo Gallery</h2>
+                        <p class="section-subtitle">
+                            Glimpses of the Red Panda, Clouded Leopard, and the forested ridgelines of the Garo Hills. Click any photo for a full-screen view.
+                        </p>
+                    </div>
+
+                    <div id="gallery-grid" class="gallery-grid">
+                        <!-- Populated by nokrek.js -->
+                    </div>
+                </div>
+            </section>
+        </main>
+
+        <!-- Lightbox Modal -->
+        <div id="lightbox-modal" class="lightbox-modal hidden" role="dialog" aria-modal="true" aria-label="Photo Lightbox">
+            <div class="lightbox-content">
+                <button type="button" id="lightbox-close" class="lightbox-close" aria-label="Close Lightbox">&times;</button>
+                <img id="lightbox-img" class="lightbox-img" src="" alt="Gallery Preview" />
+                <div id="lightbox-caption" class="lightbox-caption"></div>
+            </div>
+        </div>
+
+        <!-- Site Footer -->
+        <footer class="footer" style="margin-top:4rem; border-top:1px solid var(--nokrek-border-dark);">
+            <div class="footer-container">
+                <div class="footer-brand">
+                    <h3>Incredible India Explorer</h3>
+                    <p>
+                        An interactive digital guide to the geography, food, festivals, wildlife, and cultural heritage of India.
+                    </p>
+                </div>
+                <div class="footer-links">
+                    <h3>Quick Navigation</h3>
+                    <ul>
+                        <li><a href="../../index.html#home">Home</a></li>
+                        <li><a href="../national-parks-explorer/index.html">National Parks Explorer</a></li>
+                        <li><a href="../wildlife/wildlife.html">Nature & Wildlife</a></li>
+                        <li><a href="../national-parks-timeline/national-parks-timeline.html">Parks Timeline</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-credits footer-credits-center">
+                <p>&copy; 2026 Incredible India Explorer. Nokrek National Park Explorer.</p>
+            </div>
+        </footer>
+
+        <!-- Core Scripts -->
+       <script src="/app.js" defer></script>
+       <script src="/frontend/nokrek-national-park-explorer/nokrek-data.js" defer></script>
+       <script src="/frontend/nokrek-national-park-explorer/nokrek.js" defer></script>
+        <script type="module" src="/auth.js"></script>
+    </body>
+</html>

--- a/frontend/nokrek-national-park-explorer/index.html
+++ b/frontend/nokrek-national-park-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -26,9 +18,9 @@
         />
 
         <!-- Stylesheets -->
-        <!-- Stylesheets -->
         <link rel="stylesheet" href="/styles.css" />
         <link rel="stylesheet" href="/frontend/nokrek-national-park-explorer/nokrek.css" />
+
         <!-- Open Graph -->
         <meta property="og:title" content="Nokrek National Park Explorer | Incredible India" />
         <meta
@@ -39,6 +31,15 @@
     </head>
 
     <body class="nokrek-main">
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    document.body.classList.add('light-theme');
+                }
+            })();
+        </script>
+
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
@@ -269,9 +270,9 @@
         </footer>
 
         <!-- Core Scripts -->
-       <script src="/app.js" defer></script>
-       <script src="/frontend/nokrek-national-park-explorer/nokrek-data.js" defer></script>
-       <script src="/frontend/nokrek-national-park-explorer/nokrek.js" defer></script>
+        <script src="/app.js" defer></script>
+        <script src="/frontend/nokrek-national-park-explorer/nokrek-data.js" defer></script>
+        <script src="/frontend/nokrek-national-park-explorer/nokrek.js" defer></script>
         <script type="module" src="/auth.js"></script>
     </body>
 </html>

--- a/frontend/nokrek-national-park-explorer/nokrek-data.js
+++ b/frontend/nokrek-national-park-explorer/nokrek-data.js
@@ -46,7 +46,6 @@ const RED_PANDA_INFO = {
     scientificName: "Ailurus fulgens",
     status: "Endangered",
     icon: "🐼",
-    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/Red_Panda_%28Ailurus_fulgens%29.jpg/800px-Red_Panda_%28Ailurus_fulgens%29.jpg",
     significance: "Nokrek's core zone protects one of the westernmost-documented Red Panda populations in Northeast India, far from its better-known Eastern Himalayan strongholds.",
     adaptation: "A reclusive, largely arboreal mammal that favours dense bamboo understorey within cool, moist broadleaf forest — habitat conditions Nokrek's elevation and rainfall pattern reliably provide.",
     behavior: "Elusive and mostly crepuscular, Red Pandas are rarely sighted directly; their presence is more often confirmed through camera traps and indirect field signs."
@@ -82,7 +81,6 @@ const NOKREK_WILDLIFE = [
         scientificName: "Ailurus fulgens",
         status: "Endangered",
         icon: "🐼",
-        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/Red_Panda_%28Ailurus_fulgens%29.jpg/800px-Red_Panda_%28Ailurus_fulgens%29.jpg",
         description: "The park's flagship species — a small, bamboo-dependent mammal found in the cooler broadleaf forest belt of the core zone."
     },
     {
@@ -91,7 +89,6 @@ const NOKREK_WILDLIFE = [
         scientificName: "Neofelis nebulosa",
         status: "Vulnerable",
         icon: "🐆",
-        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/Neofelis_nebulosa.jpg/800px-Neofelis_nebulosa.jpg",
         description: "An elusive, tree-adapted big cat that ranges across Nokrek's dense forest cover, rarely seen but confirmed through camera-trap surveys."
     },
     {
@@ -100,7 +97,6 @@ const NOKREK_WILDLIFE = [
         scientificName: "Elephas maximus",
         status: "Endangered",
         icon: "🐘",
-        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Elephant_safari_in_Kaziranga.jpg/800px-Elephant_safari_in_Kaziranga.jpg",
         description: "Elephant herds move seasonally through the Garo Hills forest corridors surrounding the park's buffer zone."
     },
     {
@@ -109,7 +105,6 @@ const NOKREK_WILDLIFE = [
         scientificName: "Hoolock hoolock",
         status: "Endangered",
         icon: "🐒",
-        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Golden_Langur_Manas.jpg/800px-Golden_Langur_Manas.jpg",
         description: "India's only ape species, found in the reserve's evergreen canopy, known for its loud, far-carrying morning calls."
     },
     {
@@ -118,7 +113,6 @@ const NOKREK_WILDLIFE = [
         scientificName: "Pardofelis marmorata",
         status: "Near Threatened",
         icon: "🐈",
-        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Flying_squirrel_in_tree.jpg/800px-Flying_squirrel_in_tree.jpg",
         description: "A small, arboreal wild cat with a strikingly patterned coat, adapted to dense forest hunting in the park's mid-elevation zones."
     }
 ];
@@ -167,24 +161,24 @@ const MAP_HOTSPOTS = [
 
 const GALLERY_IMAGES = [
     {
-        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/Red_Panda_%28Ailurus_fulgens%29.jpg/800px-Red_Panda_%28Ailurus_fulgens%29.jpg",
         title: "Red Panda in the Canopy",
-        caption: "Nokrek protects one of the westernmost known Red Panda populations in Northeast India."
+        caption: "Nokrek protects one of the westernmost known Red Panda populations in Northeast India.",
+        icon: "🐼"
     },
     {
-        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/Neofelis_nebulosa.jpg/800px-Neofelis_nebulosa.jpg",
         title: "Clouded Leopard on the Move",
-        caption: "A rarely-seen big cat adapted to Nokrek's dense forest cover."
+        caption: "A rarely-seen big cat adapted to Nokrek's dense forest cover.",
+        icon: "🐆"
     },
     {
-        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Elephant_safari_in_Kaziranga.jpg/800px-Elephant_safari_in_Kaziranga.jpg",
         title: "Elephant Corridor",
-        caption: "Seasonal elephant movement through the Garo Hills buffer forest."
+        caption: "Seasonal elephant movement through the Garo Hills buffer forest.",
+        icon: "🐘"
     },
     {
-        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2b/Pushpawati_river_inside_the_Valley_of_Flowers_Uttarakhand_I.jpg/800px-Pushpawati_river_inside_the_Valley_of_Flowers_Uttarakhand_I.jpg",
         title: "Garo Hills Forest Stream",
-        caption: "A cool forest stream winding through the reserve's broadleaf belt."
+        caption: "A cool forest stream winding through the reserve's broadleaf belt.",
+        icon: "💧"
     }
 ];
 

--- a/frontend/nokrek-national-park-explorer/nokrek-data.js
+++ b/frontend/nokrek-national-park-explorer/nokrek-data.js
@@ -1,0 +1,203 @@
+/**
+ * Nokrek National Park Explorer — Data Module
+ * Comprehensive dataset covering the UNESCO Biosphere Reserve, Red Panda,
+ * wild Citrus indica gene sanctuary, forests, wildlife, biodiversity,
+ * map hotspots, and photo gallery.
+ */
+
+const NOKREK_INFO = {
+    id: "nokrek",
+    name: "Nokrek National Park",
+    aka: "Nokrek Biosphere Reserve",
+    location: "West Garo Hills District, Meghalaya, India",
+    state: "Meghalaya",
+    coordinates: { lat: 25.47, lng: 90.30 },
+    area: "47.48 km² (Core Zone), ~820 km² (Full Biosphere Reserve)",
+    establishedYear: 1986,
+    biosphereReserveYear: 1988,
+    unescoRecognitionYear: 2009,
+    ecosystem: "Subtropical Broadleaf & Tropical Semi-Evergreen Forest, Garo Hills Range",
+    climate: "Subtropical Monsoon with heavy seasonal rainfall",
+    bestTime: "October to April (drier, cooler months)",
+    entryFees: "₹50 (Indian Nationals), ₹300 (Foreigners)",
+    nearestTransport: {
+        railway: "Guwahati Railway Station (~220 km)",
+        airport: "Guwahati (LGBI) Airport (~220 km) / Tura Airstrip (nearest, limited service)",
+        gatewayTown: "Tura, West Garo Hills"
+    },
+    quickStats: [
+        { label: "Core Zone Area", value: "47.5 km²", icon: "🏞️" },
+        { label: "Highest Peak", value: "1,412 m", icon: "⛰️" },
+        { label: "UNESCO Status Since", value: "2009", icon: "🌍" },
+        { label: "Wild Citrus Origin Site", value: "Yes", icon: "🍊" },
+        { label: "Established Year", value: "1986", icon: "🏛️" },
+        { label: "Core Habitat", value: "Red Panda", icon: "🐼" }
+    ]
+};
+
+const BIOSPHERE_OVERVIEW = {
+    title: "A UNESCO Biosphere Reserve",
+    overview: "Nokrek sits atop the Garo Hills of Meghalaya, crowned by Nokrek Peak — the highest point in the range. Declared a Biosphere Reserve by India in 1988, it earned international recognition under UNESCO's Man and Biosphere Programme in 2009, placing it among a select network of ecosystems valued for both conservation and scientific research.",
+    zoning: "The reserve follows the classic biosphere model: a strictly protected core zone (the National Park itself) surrounded by buffer and transition zones where local Garo communities continue traditional, sustainable livelihoods."
+};
+
+const RED_PANDA_INFO = {
+    name: "Red Panda",
+    scientificName: "Ailurus fulgens",
+    status: "Endangered",
+    icon: "🐼",
+    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/Red_Panda_%28Ailurus_fulgens%29.jpg/800px-Red_Panda_%28Ailurus_fulgens%29.jpg",
+    significance: "Nokrek's core zone protects one of the westernmost-documented Red Panda populations in Northeast India, far from its better-known Eastern Himalayan strongholds.",
+    adaptation: "A reclusive, largely arboreal mammal that favours dense bamboo understorey within cool, moist broadleaf forest — habitat conditions Nokrek's elevation and rainfall pattern reliably provide.",
+    behavior: "Elusive and mostly crepuscular, Red Pandas are rarely sighted directly; their presence is more often confirmed through camera traps and indirect field signs."
+};
+
+const WILD_CITRUS_INFO = {
+    title: "Birthplace of the Wild Orange",
+    localName: "Memang Narang (\"Spirit Orange\" in Garo)",
+    overview: "Nokrek is globally significant as the presumed center of origin for Citrus indica, the wild ancestor believed to underlie most cultivated citrus varieties grown today — oranges, mandarins, and their relatives worldwide.",
+    conservation: "A dedicated Citrus Gene Sanctuary was established within the park specifically to conserve this and other wild citrus relatives in situ, preserving genetic diversity that could prove vital for future citrus breeding and disease resistance.",
+    significance: "Researchers and botanists consider this citrus gene pool one of the most important reasons for the park's UNESCO designation, alongside its wildlife."
+};
+
+const FOREST_ZONES = [
+    {
+        title: "Tropical Semi-Evergreen Belt",
+        description: "Lower elevations are cloaked in dense semi-evergreen forest with a closed canopy, supporting climbing lianas, ferns, and a rich understorey of shade-tolerant shrubs."
+    },
+    {
+        title: "Subtropical Broadleaf Forest",
+        description: "Higher up the slopes, oak and laurel-dominated broadleaf forest takes over — cooler, mistier, and structurally more open, forming the primary habitat band for the Red Panda."
+    },
+    {
+        title: "Citrus Gene Sanctuary",
+        description: "A specially demarcated conservation zone within the core area, set aside to protect wild Citrus indica and related species from genetic erosion and habitat loss."
+    }
+];
+
+const NOKREK_WILDLIFE = [
+    {
+        id: "red-panda",
+        name: "Red Panda",
+        scientificName: "Ailurus fulgens",
+        status: "Endangered",
+        icon: "🐼",
+        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/Red_Panda_%28Ailurus_fulgens%29.jpg/800px-Red_Panda_%28Ailurus_fulgens%29.jpg",
+        description: "The park's flagship species — a small, bamboo-dependent mammal found in the cooler broadleaf forest belt of the core zone."
+    },
+    {
+        id: "clouded-leopard",
+        name: "Clouded Leopard",
+        scientificName: "Neofelis nebulosa",
+        status: "Vulnerable",
+        icon: "🐆",
+        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/Neofelis_nebulosa.jpg/800px-Neofelis_nebulosa.jpg",
+        description: "An elusive, tree-adapted big cat that ranges across Nokrek's dense forest cover, rarely seen but confirmed through camera-trap surveys."
+    },
+    {
+        id: "asian-elephant",
+        name: "Asian Elephant",
+        scientificName: "Elephas maximus",
+        status: "Endangered",
+        icon: "🐘",
+        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Elephant_safari_in_Kaziranga.jpg/800px-Elephant_safari_in_Kaziranga.jpg",
+        description: "Elephant herds move seasonally through the Garo Hills forest corridors surrounding the park's buffer zone."
+    },
+    {
+        id: "hoolock-gibbon",
+        name: "Hoolock Gibbon",
+        scientificName: "Hoolock hoolock",
+        status: "Endangered",
+        icon: "🐒",
+        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Golden_Langur_Manas.jpg/800px-Golden_Langur_Manas.jpg",
+        description: "India's only ape species, found in the reserve's evergreen canopy, known for its loud, far-carrying morning calls."
+    },
+    {
+        id: "marbled-cat",
+        name: "Marbled Cat",
+        scientificName: "Pardofelis marmorata",
+        status: "Near Threatened",
+        icon: "🐈",
+        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Flying_squirrel_in_tree.jpg/800px-Flying_squirrel_in_tree.jpg",
+        description: "A small, arboreal wild cat with a strikingly patterned coat, adapted to dense forest hunting in the park's mid-elevation zones."
+    }
+];
+
+const BIODIVERSITY_STATS = [
+    { label: "Wild Citrus Species Protected", value: "Multiple", icon: "🍊" },
+    { label: "Recorded Mammal Species", value: "40+", icon: "🐾" },
+    { label: "Forest Types", value: "3 Zones", icon: "🌳" },
+    { label: "Elevation Range", value: "Up to 1,412 m", icon: "⛰️" }
+];
+
+const MAP_HOTSPOTS = [
+    {
+        id: "spot-nokrek-entry",
+        name: "Park Entry & Buffer Zone",
+        category: "gate",
+        x: 20,
+        y: 60,
+        description: "Main approach through community-managed buffer forest surrounding the core reserve."
+    },
+    {
+        id: "spot-citrus-sanctuary",
+        name: "Citrus Gene Sanctuary",
+        category: "citrus",
+        x: 42,
+        y: 45,
+        description: "Protected zone conserving wild Citrus indica and related citrus relatives in their native habitat."
+    },
+    {
+        id: "spot-nokrek-peak",
+        name: "Nokrek Peak (1,412 m)",
+        category: "peak",
+        x: 58,
+        y: 30,
+        description: "The highest point in the Garo Hills, capped in cool broadleaf forest — prime Red Panda habitat."
+    },
+    {
+        id: "spot-core-forest",
+        name: "Core Zone Forest Trail",
+        category: "forest",
+        x: 72,
+        y: 50,
+        description: "Dense subtropical broadleaf forest forming the strictly protected heart of the biosphere reserve."
+    }
+];
+
+const GALLERY_IMAGES = [
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/Red_Panda_%28Ailurus_fulgens%29.jpg/800px-Red_Panda_%28Ailurus_fulgens%29.jpg",
+        title: "Red Panda in the Canopy",
+        caption: "Nokrek protects one of the westernmost known Red Panda populations in Northeast India."
+    },
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/Neofelis_nebulosa.jpg/800px-Neofelis_nebulosa.jpg",
+        title: "Clouded Leopard on the Move",
+        caption: "A rarely-seen big cat adapted to Nokrek's dense forest cover."
+    },
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/39/Elephant_safari_in_Kaziranga.jpg/800px-Elephant_safari_in_Kaziranga.jpg",
+        title: "Elephant Corridor",
+        caption: "Seasonal elephant movement through the Garo Hills buffer forest."
+    },
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2b/Pushpawati_river_inside_the_Valley_of_Flowers_Uttarakhand_I.jpg/800px-Pushpawati_river_inside_the_Valley_of_Flowers_Uttarakhand_I.jpg",
+        title: "Garo Hills Forest Stream",
+        caption: "A cool forest stream winding through the reserve's broadleaf belt."
+    }
+];
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        NOKREK_INFO,
+        BIOSPHERE_OVERVIEW,
+        RED_PANDA_INFO,
+        WILD_CITRUS_INFO,
+        FOREST_ZONES,
+        NOKREK_WILDLIFE,
+        BIODIVERSITY_STATS,
+        MAP_HOTSPOTS,
+        GALLERY_IMAGES
+    };
+}

--- a/frontend/nokrek-national-park-explorer/nokrek.css
+++ b/frontend/nokrek-national-park-explorer/nokrek.css
@@ -1,0 +1,431 @@
+/* ==========================================================================
+   Nokrek National Park Explorer — Styling
+   Garo Hills Biosphere: forest green, citrus amber, panda rust
+   ========================================================================== */
+
+:root {
+    --nokrek-bg-dark: #0e1a14;
+    --nokrek-card-bg-dark: rgba(19, 40, 28, 0.78);
+    --nokrek-text-primary-dark: #f8fafc;
+    --nokrek-text-muted-dark: #94a3b8;
+    --nokrek-border-dark: rgba(255, 255, 255, 0.12);
+
+    --terai-amber: #d97706;
+    --sal-emerald: #15803d;
+    --wetland-azure: #0284c7;
+    --gold-bright: #fbbf24;
+    --panda-rust: #c2410c;
+    --card-shadow: 0 10px 30px -5px rgba(0, 0, 0, 0.55);
+
+    --font-heading: 'Playfair Display', Georgia, serif;
+    --font-body: 'Outfit', 'Inter', system-ui, sans-serif;
+}
+
+body.light-theme {
+    --nokrek-bg-dark: #f0fdf4;
+    --nokrek-card-bg-dark: rgba(255, 255, 255, 0.88);
+    --nokrek-text-primary-dark: #14532d;
+    --nokrek-text-muted-dark: #334155;
+    --nokrek-border-dark: rgba(21, 128, 61, 0.15);
+    --card-shadow: 0 10px 25px -5px rgba(217, 119, 6, 0.12);
+}
+
+.nokrek-main {
+    background-color: var(--nokrek-bg-dark);
+    color: var(--nokrek-text-primary-dark);
+    font-family: var(--font-body);
+    min-height: 100vh;
+    overflow-x: hidden;
+}
+
+.section-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+}
+
+.glass-card {
+    background: var(--nokrek-card-bg-dark);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid var(--nokrek-border-dark);
+    border-radius: 16px;
+    box-shadow: var(--card-shadow);
+    transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+}
+
+.glass-card:hover {
+    border-color: rgba(217, 119, 6, 0.4);
+}
+
+.nokrek-hero {
+    position: relative;
+    padding: 8rem 1.5rem 5rem;
+    text-align: center;
+    background: linear-gradient(180deg, rgba(14, 26, 20, 0.82) 0%, rgba(14, 26, 20, 0.96) 100%),
+                url("https://upload.wikimedia.org/wikipedia/commons/thumb/1/12/Red_Panda_%28Ailurus_fulgens%29.jpg/1280px-Red_Panda_%28Ailurus_fulgens%29.jpg") center/cover no-repeat;
+    overflow: hidden;
+}
+
+.hero-badges-row {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+}
+
+.hero-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.4rem 1rem;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+}
+
+.pill-unesco {
+    background: rgba(2, 132, 199, 0.2);
+    color: #38bdf8;
+    border: 1px solid rgba(2, 132, 199, 0.4);
+}
+
+.pill-panda {
+    background: rgba(194, 65, 12, 0.2);
+    color: #fb923c;
+    border: 1px solid rgba(194, 65, 12, 0.4);
+}
+
+.pill-state {
+    background: rgba(21, 128, 61, 0.2);
+    color: #4ade80;
+    border: 1px solid rgba(21, 128, 61, 0.4);
+}
+
+.nokrek-hero h1 {
+    font-family: var(--font-heading);
+    font-size: clamp(2.5rem, 5vw, 4.2rem);
+    font-weight: 700;
+    line-height: 1.15;
+    margin-bottom: 1rem;
+    color: #ffffff;
+}
+
+.nokrek-hero h1 span {
+    background: linear-gradient(135deg, #fbbf24 0%, #15803d 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.hero-subtitle {
+    max-width: 780px;
+    margin: 0 auto 2.5rem;
+    font-size: 1.15rem;
+    line-height: 1.7;
+    color: #cbd5e1;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.stat-card {
+    padding: 1.2rem;
+    text-align: center;
+    min-width: 0;
+    overflow: hidden;
+}
+.stat-icon {
+    font-size: 1.8rem;
+    margin-bottom: 0.3rem;
+}
+
+.stat-value {
+    font-size: 1.8rem;
+    font-weight: 800;
+    color: var(--gold-bright);
+    display: block;
+}
+
+.stat-label {
+    font-size: 0.85rem;
+    color: var(--nokrek-text-muted-dark);
+}
+
+.section-header {
+    text-align: center;
+    margin-bottom: 3rem;
+}
+
+.section-badge {
+    display: inline-block;
+    padding: 0.3rem 0.8rem;
+    background: rgba(217, 119, 6, 0.15);
+    color: var(--gold-bright);
+    border-radius: 999px;
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    margin-bottom: 0.6rem;
+}
+
+.section-header h2 {
+    font-family: var(--font-heading);
+    font-size: clamp(2rem, 3.5vw, 2.8rem);
+    margin-bottom: 0.8rem;
+}
+
+.section-subtitle {
+    max-width: 680px;
+    margin: 0 auto;
+    color: var(--nokrek-text-muted-dark);
+    font-size: 1.05rem;
+    line-height: 1.6;
+}
+
+.ecosystem-section {
+    padding: 5rem 0;
+}
+
+.ecosystem-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.8rem;
+}
+
+.eco-card {
+    padding: 2rem;
+}
+
+.eco-card h3 {
+    font-family: var(--font-heading);
+    font-size: 1.35rem;
+    color: var(--gold-bright);
+    margin-bottom: 0.8rem;
+}
+
+.eco-card p {
+    font-size: 0.92rem;
+    color: var(--nokrek-text-muted-dark);
+    line-height: 1.65;
+}
+
+.conservation-section {
+    padding: 5rem 0;
+    background: rgba(217, 119, 6, 0.03);
+    border-top: 1px solid var(--nokrek-border-dark);
+    border-bottom: 1px solid var(--nokrek-border-dark);
+}
+
+.conservation-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+}
+
+@media (max-width: 868px) {
+    .conservation-grid { grid-template-columns: 1fr; }
+}
+
+.conserve-card { padding: 2rem; }
+
+.safari-section {
+    padding: 5rem 0;
+}
+
+.ecosystem-grid > div[style] {
+    overflow: hidden;
+}
+
+.map-section {
+    padding: 5rem 0;
+    background: rgba(2, 132, 199, 0.02);
+}
+
+.map-card-wrapper {
+    position: relative;
+    border-radius: 20px;
+    overflow: hidden;
+    padding: 2rem;
+}
+
+.map-svg-container {
+    position: relative;
+    width: 100%;
+    height: 480px;
+    background: radial-gradient(circle at 50% 50%, #173225 0%, #0f1c15 100%);
+    border-radius: 16px;
+    border: 1px solid var(--nokrek-border-dark);
+    overflow: hidden;
+}
+
+.park-map-svg {
+    width: 100%;
+    height: 100%;
+}
+
+.map-hotspot-pin {
+    position: absolute;
+    transform: translate(-50%, -50%);
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    background: var(--terai-amber);
+    color: #fff;
+    display: grid;
+    place-items: center;
+    font-size: 0.95rem;
+    cursor: pointer;
+    transition: transform 0.25s ease, background-color 0.25s ease;
+    box-shadow: 0 0 14px rgba(217, 119, 6, 0.6);
+    border: 2px solid #ffffff;
+}
+
+.map-hotspot-pin:hover {
+    transform: translate(-50%, -50%) scale(1.25);
+    background: var(--wetland-azure);
+}
+
+.map-info-popup {
+    position: absolute;
+    bottom: 2rem;
+    left: 2rem;
+    right: 2rem;
+    max-width: 450px;
+    padding: 1.2rem 1.5rem;
+    border-radius: 12px;
+    background: rgba(14, 26, 20, 0.95);
+    backdrop-filter: blur(16px);
+    border: 1px solid var(--terai-amber);
+    box-shadow: 0 15px 30px rgba(0,0,0,0.6);
+    z-index: 10;
+}
+
+.map-info-popup h4 {
+    font-family: var(--font-heading);
+    font-size: 1.15rem;
+    color: var(--gold-bright);
+    margin-bottom: 0.4rem;
+}
+
+.map-info-popup p {
+    font-size: 0.88rem;
+    color: #cbd5e1;
+    line-height: 1.5;
+}
+
+.gallery-section { padding: 5rem 0; }
+
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.gallery-item {
+    height: 220px;
+    border-radius: 14px;
+    overflow: hidden;
+    position: relative;
+    cursor: pointer;
+}
+
+.gallery-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.4s ease;
+}
+
+.gallery-item:hover .gallery-img { transform: scale(1.08); }
+
+.gallery-overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, transparent 50%, rgba(14, 26, 20, 0.9) 100%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+}
+
+.gallery-item:hover .gallery-overlay { opacity: 1; }
+
+.lightbox-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    background: rgba(0, 0, 0, 0.92);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+}
+
+.lightbox-modal.hidden { display: none; }
+
+.lightbox-content {
+    max-width: 900px;
+    width: 100%;
+    text-align: center;
+    position: relative;
+}
+
+.lightbox-img {
+    max-height: 75vh;
+    max-width: 100%;
+    border-radius: 12px;
+}
+
+.lightbox-close {
+    position: absolute;
+    top: -2.5rem;
+    right: 0;
+    background: transparent;
+    border: none;
+    color: #fff;
+    font-size: 2rem;
+    cursor: pointer;
+}
+
+.lightbox-caption {
+    margin-top: 1rem;
+    color: #cbd5e1;
+    font-size: 1rem;
+}
+
+.hidden { display: none !important; }
+
+.media-icon-box {
+    width: 100%;
+    height: 100%;
+    display: grid;
+    place-items: center;
+    font-size: 3.5rem;
+    background: linear-gradient(135deg, rgba(217,119,6,0.15), rgba(21,128,61,0.15));
+}
+
+.gallery-icon-box {
+    width: 100%;
+    height: 100%;
+    display: grid;
+    place-items: center;
+    font-size: 3rem;
+    background: linear-gradient(135deg, rgba(217,119,6,0.15), rgba(21,128,61,0.15));
+}
+
+.lightbox-icon {
+    font-size: 8rem;
+    line-height: 1;
+    margin-bottom: 1rem;
+}

--- a/frontend/nokrek-national-park-explorer/nokrek.css
+++ b/frontend/nokrek-national-park-explorer/nokrek.css
@@ -429,3 +429,15 @@ body.light-theme {
     line-height: 1;
     margin-bottom: 1rem;
 }
+.gallery-item {
+    border: none;
+    padding: 0;
+    font: inherit;
+    color: inherit;
+    text-align: left;
+}
+
+.gallery-item:focus-visible {
+    outline: 3px solid var(--gold-bright);
+    outline-offset: 2px;
+}

--- a/frontend/nokrek-national-park-explorer/nokrek.js
+++ b/frontend/nokrek-national-park-explorer/nokrek.js
@@ -1,0 +1,229 @@
+/**
+ * Nokrek National Park Explorer — Interactive Logic
+ */
+
+(function () {
+    'use strict';
+
+    document.addEventListener('DOMContentLoaded', function () {
+        initTheme();
+        renderQuickStats();
+        renderBiosphereOverview();
+        renderForestZones();
+        renderRedPandaAndCitrus();
+        renderWildlifeGrid();
+        renderBiodiversityStats();
+        renderInteractiveMap();
+        renderGalleryGrid();
+        bindEvents();
+    });
+
+    function initTheme() {
+        var savedTheme = localStorage.getItem('theme') || 'dark';
+        if (savedTheme === 'light') {
+            document.body.classList.add('light-theme');
+        }
+    }
+
+    function bindEvents() {
+        var themeBtn = document.getElementById('theme-toggle');
+        if (themeBtn) {
+            themeBtn.addEventListener('click', function () {
+                document.body.classList.toggle('light-theme');
+                var isLight = document.body.classList.contains('light-theme');
+                localStorage.setItem('theme', isLight ? 'light' : 'dark');
+            });
+        }
+
+        var lbClose = document.getElementById('lightbox-close');
+        if (lbClose) lbClose.addEventListener('click', closeLightbox);
+
+        var lbModal = document.getElementById('lightbox-modal');
+        if (lbModal) {
+            lbModal.addEventListener('click', function (e) {
+                if (e.target === lbModal) closeLightbox();
+            });
+        }
+
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape') closeLightbox();
+        });
+    }
+
+    function renderQuickStats() {
+        var container = document.getElementById('stats-grid');
+        if (!container || typeof NOKREK_INFO === 'undefined') return;
+
+        var html = '';
+        NOKREK_INFO.quickStats.forEach(function (st) {
+            html +=
+                '<div class="stat-card glass-card">' +
+                '<div class="stat-icon">' + st.icon + '</div>' +
+                '<span class="stat-value">' + st.value + '</span>' +
+                '<span class="stat-label">' + st.label + '</span>' +
+                '</div>';
+        });
+        container.innerHTML = html;
+    }
+
+    function renderBiosphereOverview() {
+        var el = document.getElementById('biosphere-overview-text');
+        if (!el || typeof BIOSPHERE_OVERVIEW === 'undefined') return;
+        el.textContent = BIOSPHERE_OVERVIEW.overview + ' ' + BIOSPHERE_OVERVIEW.zoning;
+    }
+
+    function renderForestZones() {
+        var container = document.getElementById('forest-zones-grid');
+        if (!container || typeof FOREST_ZONES === 'undefined') return;
+
+        var html = '';
+        FOREST_ZONES.forEach(function (zone) {
+            html +=
+                '<div class="eco-card glass-card">' +
+                '<h3>' + zone.title + '</h3>' +
+                '<p>' + zone.description + '</p>' +
+                '</div>';
+        });
+        container.innerHTML = html;
+    }
+
+    function renderRedPandaAndCitrus() {
+        var pandaEl = document.getElementById('red-panda-text');
+        if (pandaEl && typeof RED_PANDA_INFO !== 'undefined') {
+            pandaEl.textContent = RED_PANDA_INFO.significance + ' ' + RED_PANDA_INFO.adaptation;
+        }
+
+        var citrusEl = document.getElementById('wild-citrus-text');
+        if (citrusEl && typeof WILD_CITRUS_INFO !== 'undefined') {
+            citrusEl.textContent = WILD_CITRUS_INFO.overview + ' ' + WILD_CITRUS_INFO.conservation;
+        }
+    }
+
+    function renderWildlifeGrid() {
+        var container = document.getElementById('wildlife-grid');
+        if (!container || typeof NOKREK_WILDLIFE === 'undefined') return;
+
+        var html = '';
+        NOKREK_WILDLIFE.forEach(function (w) {
+            html +=
+                '<div class="glass-card" style="overflow:hidden; display:flex; flex-direction:column;">' +
+                '<div style="height:190px; position:relative; overflow:hidden;">' +
+                '<div class="media-icon-box">' + w.icon + '</div>' +
+                '<span style="position:absolute; top:0.8rem; right:0.8rem; padding:0.3rem 0.7rem; border-radius:999px; font-size:0.75rem; font-weight:700; background:rgba(217,119,6,0.9); color:#fff;">' + w.status + '</span>' +
+                '</div>' +
+                '<div style="padding:1.5rem; display:flex; flex-direction:column; flex-grow:1;">' +
+                '<h3 style="font-family:var(--font-heading); font-size:1.3rem; margin-bottom:0.2rem;">' + w.name + '</h3>' +
+                '<div style="font-style:italic; font-size:0.85rem; color:var(--gold-bright); margin-bottom:0.8rem;">' + w.scientificName + '</div>' +
+                '<p style="font-size:0.9rem; color:var(--nokrek-text-muted-dark); line-height:1.55;">' + w.description + '</p>' +
+                '</div>' +
+                '</div>';
+        });
+        container.innerHTML = html;
+    }
+
+    function renderBiodiversityStats() {
+        var container = document.getElementById('biodiversity-grid');
+        if (!container || typeof BIODIVERSITY_STATS === 'undefined') return;
+
+        var html = '';
+        BIODIVERSITY_STATS.forEach(function (st) {
+            html +=
+                '<div class="stat-card glass-card">' +
+                '<div class="stat-icon">' + st.icon + '</div>' +
+                '<span class="stat-value">' + st.value + '</span>' +
+                '<span class="stat-label">' + st.label + '</span>' +
+                '</div>';
+        });
+        container.innerHTML = html;
+    }
+
+    function renderInteractiveMap() {
+        var container = document.getElementById('map-hotspots-layer');
+        var infoPopup = document.getElementById('map-info-popup');
+        if (!container || typeof MAP_HOTSPOTS === 'undefined') return;
+
+        var iconFor = function (category) {
+            if (category === 'gate') return '🚪';
+            if (category === 'citrus') return '🍊';
+            if (category === 'peak') return '⛰️';
+            return '🌲';
+        };
+
+        var html = '';
+        MAP_HOTSPOTS.forEach(function (spot) {
+            html +=
+                '<button type="button" class="map-hotspot-pin" style="left:' + spot.x + '%; top:' + spot.y + '%;" data-spot-id="' + spot.id + '" aria-label="' + spot.name + '">' +
+                iconFor(spot.category) +
+                '</button>';
+        });
+        container.innerHTML = html;
+
+        container.querySelectorAll('.map-hotspot-pin').forEach(function (pin) {
+            pin.addEventListener('click', function () {
+                var spot = MAP_HOTSPOTS.find(function (s) { return s.id === pin.dataset.spotId; });
+                if (spot && infoPopup) {
+                    infoPopup.innerHTML =
+                        '<h4>' + spot.name + '</h4>' +
+                        '<p>' + spot.description + '</p>';
+                    infoPopup.classList.remove('hidden');
+                }
+            });
+        });
+    }
+    function galleryIconFor(title) {
+    var t = title.toLowerCase();
+    if (t.indexOf('panda') !== -1) return '🐼';
+    if (t.indexOf('leopard') !== -1) return '🐆';
+    if (t.indexOf('elephant') !== -1) return '🐘';
+    if (t.indexOf('stream') !== -1 || t.indexOf('river') !== -1) return '💧';
+    return '🌳';
+}
+    function renderGalleryGrid() {
+        var container = document.getElementById('gallery-grid');
+        if (!container || typeof GALLERY_IMAGES === 'undefined') return;
+
+        var html = '';
+        GALLERY_IMAGES.forEach(function (img, idx) {
+            html +=
+                '<div class="gallery-item" data-idx="' + idx + '">' +
+                '<div class="gallery-icon-box">' + galleryIconFor(img.title) + '</div>' +
+                '<div class="gallery-overlay">' +
+                '<h4 style="color:#fff;">' + img.title + '</h4>' +
+                '<p style="color:#cbd5e1; font-size:0.82rem;">' + img.caption + '</p>' +
+                '</div>' +
+                '</div>';
+        });
+        container.innerHTML = html;
+
+        container.querySelectorAll('.gallery-item').forEach(function (item) {
+            item.addEventListener('click', function () {
+                openLightbox(parseInt(item.dataset.idx, 10));
+            });
+        });
+    }
+
+    function openLightbox(idx) {
+    if (typeof GALLERY_IMAGES === 'undefined' || !GALLERY_IMAGES[idx]) return;
+    var modal = document.getElementById('lightbox-modal');
+    var imgEl = document.getElementById('lightbox-img');
+    var capEl = document.getElementById('lightbox-caption');
+    if (!modal || !imgEl || !capEl) return;
+
+    imgEl.style.display = 'none';
+    var iconEl = document.getElementById('lightbox-icon');
+    if (!iconEl) {
+        iconEl = document.createElement('div');
+        iconEl.id = 'lightbox-icon';
+        iconEl.className = 'lightbox-icon';
+        imgEl.parentNode.insertBefore(iconEl, imgEl);
+    }
+    iconEl.textContent = galleryIconFor(GALLERY_IMAGES[idx].title);
+    capEl.textContent = GALLERY_IMAGES[idx].title + ' — ' + GALLERY_IMAGES[idx].caption;
+    modal.classList.remove('hidden');
+}
+
+    function closeLightbox() {
+        var modal = document.getElementById('lightbox-modal');
+        if (modal) modal.classList.add('hidden');
+    }
+})();

--- a/frontend/nokrek-national-park-explorer/nokrek.js
+++ b/frontend/nokrek-national-park-explorer/nokrek.js
@@ -185,13 +185,13 @@
         var html = '';
         GALLERY_IMAGES.forEach(function (img, idx) {
             html +=
-                '<div class="gallery-item" data-idx="' + idx + '">' +
+                '<button type="button" class="gallery-item" data-idx="' + idx + '">' +
                 '<div class="gallery-icon-box">' + galleryIconFor(img.title) + '</div>' +
                 '<div class="gallery-overlay">' +
                 '<h4 style="color:#fff;">' + img.title + '</h4>' +
                 '<p style="color:#cbd5e1; font-size:0.82rem;">' + img.caption + '</p>' +
                 '</div>' +
-                '</div>';
+                '</button>';
         });
         container.innerHTML = html;
 


### PR DESCRIPTION
Closes #934

## Changes
- Added dedicated Nokrek National Park Explorer page with:
  - UNESCO Biosphere Reserve overview
  - Red Panda & Wild Citrus (Citrus indica) conservation spotlight
  - Forest zones breakdown
  - Wildlife grid (5 species)
  - Biodiversity stats
  - Interactive SVG map with clickable hotspots
  - Photo gallery with lightbox
- Integrated Nokrek card into National Parks Explorer landing page
- Fixed asset path issues (relative → absolute paths)
- Replaced broken external image URLs with icon-based visuals

## Screenshots
<img width="1440" height="852" alt="Screenshot 2026-07-31 134731" src="https://github.com/user-attachments/assets/f4f0e822-15eb-46c7-b0f0-0a3a941148ca" />
<img width="1440" height="852" alt="Screenshot 2026-07-31 134739" src="https://github.com/user-attachments/assets/88f659ff-1eeb-49ee-8781-a712a2c15b0b" />
<img width="1440" height="852" alt="Screenshot 2026-07-31 135056" src="https://github.com/user-attachments/assets/8a0d3e6a-160d-446f-b48b-02156920cfc2" />
<img width="1440" height="852" alt="Screenshot 2026-07-31 134751" src="https://github.com/user-attachments/assets/6fd0cf90-0dbc-4ba5-8a85-7bbffef36203" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Nokrek National Park Explorer experience.
  * Added Nokrek National Park to the national parks directory and Meghalaya state listings.
  * Added information on UNESCO status, wildlife, biodiversity, forest zones, conservation, and wild citrus.
  * Added interactive map hotspots, responsive layouts, theme switching, photo gallery, and image lightbox viewing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->