### PR TITLE
feat: Add Balpakram National Park Explorer (Issue #931)

### DIFF
--- a/frontend/balpakram-national-park-explorer/balpakram-data.js
+++ b/frontend/balpakram-national-park-explorer/balpakram-data.js
@@ -1,0 +1,130 @@
+/**
+ * Balpakram National Park Explorer Dataset
+ * Comprehensive data covering History, Garo Mythology & Legends, Plateau Landscape,
+ * Wildlife, Rare Plants, Waterfalls, Interactive Map Hotspots, and Photo Gallery.
+ */
+
+const BALPAKRAM_DATA = {
+    id: 'balpakram',
+    name: 'Balpakram National Park',
+    location: 'South Garo Hills District, Meghalaya',
+    established: 1987,
+    totalArea: '220 km²',
+    altitude: '300m – 910m',
+    coordinates: { lat: 25.25, lng: 90.87 },
+
+    quickStats: [
+        { label: 'Total Area', value: '220 km²', icon: '🏞️' },
+        { label: 'Established', value: '1987', icon: '📜' },
+        { label: 'Altitude Range', value: '300m–910m', icon: '⛰️' },
+        { label: 'Bird Species', value: '300+', icon: '🦅' }
+    ],
+
+    history: {
+        title: 'History & Establishment',
+        description: "Notified as a protected reserve in the mid-1980s and formally declared a National Park in 1987, Balpakram sits in the remote South Garo Hills close to the Indo-Bangladesh border. Its western boundary adjoins the Siju Bird Sanctuary along the banks of the Simsang River, together forming one of Meghalaya's most significant conservation corridors.",
+        facts: [
+            'Declared a National Park in 1987 at an altitude of nearly 3,000 ft.',
+            'Adjoins Siju Bird Sanctuary along the Simsang River to the west.',
+            'Administered from the DFO office in Baghmara, the South Garo Hills headquarters.',
+            "Remains largely undeveloped, preserving one of India's richest biodiversity pockets."
+        ]
+    },
+
+    mythology: {
+        title: 'Land of Perpetual Winds: Myths & Legends',
+        description: 'In Garo mythology, "Balpakram" translates to the land of the perpetual wind. The Garo tribe regards the plateau as the resting place of departed souls, and generations of folklore have layered the park with spirits, guardians, and sacred landmarks.',
+        legends: [
+            { name: 'Resting Place of Souls', icon: '🌬️', status: 'Garo Belief', desc: 'The Garo people believe Balpakram is where the spirits of the dead journey after leaving the mortal world, making the plateau one of the community\'s most sacred sites.' },
+            { name: 'The Mandeburung', icon: '👣', status: 'Folklore Spirit', desc: 'Local folklore speaks of the "mandeburung", a legendary jungle spirit said to roam the deep forests, echoing tales of the yeti or bigfoot across cultures.' },
+            { name: 'Boldak Matchu Karam', icon: '🦶', status: 'Sacred Landmark', desc: 'A rock formation believed by the Garo to be a fossilised human footprint, regarded as a mark left by ancestral spirits upon the land.' },
+            { name: 'Chidimak Lake', icon: '🌊', status: 'Sacred Site', desc: 'A small sacred lake within the park held in reverence by the Garo community, tied to local ritual and spiritual significance.' },
+            { name: 'Wangala Festival Connection', icon: '🥁', status: 'Living Tradition', desc: "The Garo's annual Wangala harvest festival, honouring the spirits believed to inhabit Balpakram, is celebrated with traditional drums, dance, and rituals." }
+        ]
+    },
+
+    landscape: {
+        title: 'Plateau, Gorges & Geology',
+        description: 'Balpakram\'s terrain shifts dramatically from sunlit table-top plateaus to shadowy gorges and limestone caves, earning it comparisons to the Grand Canyon. Windswept cliffs tower over the Simsang River valley, framing some of Meghalaya\'s most striking panoramas.',
+        features: [
+            { name: 'Balpakram Plateau & Gorge', icon: '🏜️', status: 'Signature Landform', desc: 'A dramatic tableland cut by a deep forested canyon, often compared to the Grand Canyon for its scale and rugged beauty.' },
+            { name: 'Limestone Caves & Rock Formations', icon: '🕳️', status: 'Geological Feature', desc: 'Numerous caves and karst formations dot the park, including passages linked to the wider Siju cave system nearby.' },
+            { name: 'Simsang River Valley', icon: '🏞️', status: 'Scenic Viewpoint', desc: 'Steep cliffs overlook the winding Simsang River valley, one of the most photographed viewpoints in the park.' },
+            { name: 'Elevation Gradient', icon: '⛰️', status: '300m – 910m', desc: 'Terrain rises from lowland river valleys to high plateaus, creating a transition of subtropical, grassland, and bamboo forest zones.' }
+        ]
+    },
+
+    wildlife: [
+        { name: 'Red Panda (Ailurus fulgens)', status: 'Endangered', icon: '🐼', desc: "One of the world's most elusive small mammals, found in Balpakram's higher forested elevations alongside its stronghold at neighbouring Nokrek." },
+        { name: 'Bengal Tiger (Panthera tigris)', status: 'Flagship Predator', icon: '🐅', desc: "Along with the Asian elephant, the tiger is one of Balpakram's flagship species, roaming its dense forests and grasslands." },
+        { name: 'Asian Elephant (Elephas maximus)', status: 'Flagship Species', icon: '🐘', desc: "Herds move seasonally through the park's forests and valleys, particularly visible during the winter months." },
+        { name: 'Clouded Leopard (Neofelis nebulosa)', status: 'Vulnerable', icon: '🐆', desc: "An elusive, arboreal wild cat recorded through camera-trap surveys across Balpakram's dense canopy." },
+        { name: 'Hoolock Gibbon (Hoolock hoolock)', status: "India's Only Ape", icon: '🐒', desc: "The only ape species native to India, swinging through Balpakram's treetops and calling at dawn across the forest." },
+        { name: 'Wild Water Buffalo', status: 'Endangered', icon: '🐃', desc: 'One of the rarest large mammals in the park, found along river valleys and grassland edges.' },
+        { name: 'Marbled Cat & Asian Golden Cat', status: 'Rare Felids', icon: '🐈', desc: "Two secretive small wild cats recorded in camera-trap surveys, reflecting the park's status as a felid biodiversity hotspot." },
+        { name: 'Great Indian Hornbill', status: 'Avian Icon', icon: '🦅', desc: 'Balpakram supports over 300 bird species, with the Great Hornbill among its most striking residents.' }
+    ],
+
+    flora: [
+        { name: 'Pitcher Plant (Nepenthes khasiana)', status: "India's Only Nepenthes", icon: '🪴', desc: 'An insectivorous rarity endemic to the Garo, Khasi, and Jaintia Hills, and the only native pitcher plant species found in India.' },
+        { name: 'Sundew (Drosera spp.)', status: 'Carnivorous Plant', icon: '🌿', desc: "Delicate carnivorous plants that trap insects on sticky, dew-covered leaves, thriving in the park's damp grassland patches." },
+        { name: 'Wild Orchids', status: 'Endemic Diversity', icon: '🌸', desc: "A rich variety of epiphytic and terrestrial orchids flourish across Balpakram's subtropical and evergreen forest zones." },
+        { name: 'Medicinal Herbs', status: 'Traditional Use', icon: '🍃', desc: "Numerous herbs used in traditional Garo medicine grow wild across the park's grasslands and forest understorey." }
+    ],
+
+    waterfalls: {
+        title: 'Rivers & Waterfalls',
+        description: 'The Simsang and Mahadeo rivers cut through Balpakram, feeding cascades such as Rongdong Falls that are at their most spectacular during the monsoon season, when the plateau\'s cliffs come alive with rushing water.',
+        highlights: [
+            'Rongdong Falls — a scenic monsoon-season cascade fed by the Simsang River.',
+            "Simsang River — the region's lifeline, forming deep valleys and multiple smaller falls.",
+            "Mahadeo River — a tributary adding to the park's network of waterfalls and streams.",
+            'Best viewed June–September, when monsoon rains are at their peak.'
+        ]
+    },
+
+    mapHotspots: [
+        { id: 'gate', name: 'Baghmara Entrance & DFO Office', x: 150, y: 480, desc: 'Permit checkpoint and starting point for most visits, located in the South Garo Hills headquarters town.' },
+        { id: 'plateau', name: 'Balpakram Plateau Viewpoint', x: 460, y: 180, desc: 'Table-top plateau offering panoramic views often compared to the Grand Canyon.' },
+        { id: 'gorge', name: 'Simsang River Gorge', x: 650, y: 320, desc: 'Dramatic cliffside overlook of the winding Simsang River valley below.' },
+        { id: 'lake', name: 'Chidimak Lake', x: 320, y: 380, desc: 'A small sacred lake revered by the Garo community, tied to local mythology.' },
+        { id: 'falls', name: 'Rongdong Falls', x: 780, y: 460, desc: 'Monsoon-season waterfall cascading from the Simsang River, a highlight for seasonal visitors.' }
+    ],
+
+    gallery: [
+        {
+            emoji: '🐼',
+            title: 'Red Panda',
+            caption: "Red Panda resting in Balpakram's dense subtropical forest canopy."
+        },
+        {
+            emoji: '🐆',
+            title: 'Clouded Leopard',
+            caption: "Clouded Leopard, one of Balpakram's most elusive resident wild cats."
+        },
+        {
+            emoji: '🐒',
+            title: 'Hoolock Gibbon',
+            caption: "Hoolock Gibbon, India's only ape species, swinging through the Garo Hills canopy."
+        },
+        {
+            emoji: '🪴',
+            title: 'Pitcher Plant',
+            caption: "Nepenthes khasiana, India's only native pitcher plant, endemic to the Garo Hills region."
+        },
+        {
+            emoji: '🏜️',
+            title: 'Balpakram Plateau',
+            caption: 'The table-top plateau and gorge, often compared to the Grand Canyon of the Garo Hills.'
+        },
+        {
+            emoji: '💦',
+            title: 'Rongdong Falls',
+            caption: 'Rongdong Falls cascading from the Simsang River during the monsoon season.'
+        }
+    ]
+};
+
+if (typeof module !== 'undefined') {
+    module.exports = { BALPAKRAM_DATA };
+}

--- a/frontend/balpakram-national-park-explorer/balpakram.css
+++ b/frontend/balpakram-national-park-explorer/balpakram.css
@@ -1,0 +1,364 @@
+/* Balpakram National Park Explorer Styles */
+
+:root {
+    --balpakram-bg-dark: #100a1c;
+    --balpakram-card-bg-dark: rgba(45, 28, 66, 0.78);
+    --balpakram-text-primary-dark: #f8fafc;
+    --balpakram-text-muted-dark: #d8c7f0;
+    --balpakram-border-dark: rgba(255, 255, 255, 0.12);
+    --balpakram-emerald: #10b981;
+    --balpakram-mist: #a78bfa;
+    --balpakram-gold: #ffb01f;
+    --balpakram-saffron: #ff6f3c;
+    --balpakram-wind: #38bdf8;
+}
+
+body.light-theme {
+    --balpakram-bg-dark: #f5f3ff;
+    --balpakram-card-bg-dark: rgba(255, 255, 255, 0.92);
+    --balpakram-text-primary-dark: #3b0764;
+    --balpakram-text-muted-dark: #6b21a8;
+    --balpakram-border-dark: rgba(139, 92, 246, 0.18);
+}
+
+.balpakram-main {
+    background-color: var(--balpakram-bg-dark);
+    color: var(--balpakram-text-primary-dark);
+    min-height: 100vh;
+    font-family: 'Outfit', sans-serif;
+}
+
+/* Glass card styling */
+.glass-card {
+    background: var(--balpakram-card-bg-dark);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid var(--balpakram-border-dark);
+    border-radius: 18px;
+    padding: 1.6rem;
+}
+
+/* Hero Section */
+.balpakram-hero {
+    padding: 6rem 1.5rem 3.5rem;
+    text-align: center;
+    background: radial-gradient(circle at 50% 20%, rgba(167, 139, 250, 0.22), transparent 70%);
+}
+
+.hero-badges-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.8rem;
+    flex-wrap: wrap;
+    margin-bottom: 1rem;
+}
+
+.hero-pill {
+    font-size: 0.85rem;
+    font-weight: 600;
+    padding: 0.35rem 0.9rem;
+    border-radius: 50px;
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid var(--balpakram-border-dark);
+}
+
+.balpakram-hero h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2.8rem;
+    font-weight: 800;
+    margin-bottom: 1rem;
+}
+
+.balpakram-hero h1 span {
+    color: var(--balpakram-gold);
+}
+
+.hero-subtitle {
+    max-width: 740px;
+    margin: 0 auto 2rem;
+    color: var(--balpakram-text-muted-dark);
+    font-size: 1.1rem;
+    line-height: 1.65;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1.2rem;
+    max-width: 900px;
+    margin: 2rem auto 0;
+}
+
+.stat-box {
+    background: var(--balpakram-card-bg-dark);
+    border: 1px solid var(--balpakram-border-dark);
+    padding: 1.2rem;
+    border-radius: 14px;
+    text-align: center;
+}
+
+.stat-number {
+    font-size: 2rem;
+    font-weight: 800;
+    color: var(--balpakram-gold);
+}
+
+.stat-label {
+    font-size: 0.88rem;
+    color: var(--balpakram-text-muted-dark);
+    margin-top: 0.3rem;
+}
+
+/* Ecosystem & Card Sections */
+.ecosystem-section {
+    padding: 3rem 1.5rem;
+}
+
+.section-container {
+    max-width: 1150px;
+    margin: 0 auto;
+}
+
+.section-header {
+    text-align: center;
+    margin-bottom: 2.5rem;
+}
+
+.section-badge {
+    display: inline-block;
+    font-size: 0.82rem;
+    font-weight: 700;
+    padding: 0.3rem 0.8rem;
+    border-radius: 20px;
+    background: rgba(167, 139, 250, 0.18);
+    color: #c4b5fd;
+    margin-bottom: 0.6rem;
+    text-transform: uppercase;
+}
+
+.section-header h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2.2rem;
+    font-weight: 700;
+    margin-bottom: 0.6rem;
+}
+
+.section-subtitle {
+    max-width: 680px;
+    margin: 0 auto;
+    color: var(--balpakram-text-muted-dark);
+    font-size: 1rem;
+}
+
+.ecosystem-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 1.6rem;
+}
+
+.fauna-card {
+    transition: transform 0.25s ease, border-color 0.25s ease;
+}
+
+.fauna-card:hover {
+    transform: translateY(-4px);
+    border-color: var(--balpakram-mist);
+}
+
+.fauna-card-header {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 0.8rem;
+}
+
+.fauna-icon {
+    font-size: 2.2rem;
+}
+
+.fauna-card h3 {
+    font-size: 1.2rem;
+    font-weight: 700;
+}
+
+.fauna-status {
+    font-size: 0.78rem;
+    color: var(--balpakram-gold);
+    font-weight: 600;
+}
+
+.fauna-card p {
+    font-size: 0.9rem;
+    color: var(--balpakram-text-muted-dark);
+    line-height: 1.55;
+}
+
+/* Fact lists (History & Waterfalls) */
+.fact-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.fact-list li {
+    font-size: 0.9rem;
+    color: var(--balpakram-text-primary-dark);
+    padding: 0.7rem 1rem;
+    border-radius: 10px;
+    background: rgba(167, 139, 250, 0.1);
+    border-left: 3px solid var(--balpakram-mist);
+    line-height: 1.5;
+}
+
+/* Map Section */
+.map-card-wrapper {
+    position: relative;
+    padding: 1rem;
+    overflow: hidden;
+}
+
+.park-map-svg {
+    width: 100%;
+    height: auto;
+    border-radius: 12px;
+    background: #14091f;
+}
+
+.map-pin-btn {
+    position: absolute;
+    transform: translate(-50%, -50%);
+    background: var(--balpakram-gold);
+    color: #000;
+    font-size: 0.8rem;
+    font-weight: 800;
+    padding: 0.3rem 0.7rem;
+    border-radius: 20px;
+    border: 2px solid #fff;
+    cursor: pointer;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+    transition: transform 0.2s;
+}
+
+.map-pin-btn:hover {
+    transform: translate(-50%, -50%) scale(1.15);
+    background: var(--balpakram-saffron);
+    color: #fff;
+}
+
+.map-info-popup {
+    margin-top: 1rem;
+    padding: 1rem;
+    border-radius: 12px;
+    background: rgba(0, 0, 0, 0.4);
+    border: 1px solid var(--balpakram-gold);
+}
+
+.map-info-popup.hidden {
+    display: none;
+}
+
+/* Gallery Section */
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 1.2rem;
+}
+
+.gallery-item {
+    border-radius: 14px;
+    overflow: hidden;
+    cursor: pointer;
+    border: 1px solid var(--balpakram-border-dark);
+    transition: transform 0.25s ease;
+}
+
+.gallery-item:hover {
+    transform: scale(1.03);
+}
+
+.gallery-emoji-box {
+    width: 100%;
+    height: 180px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 4.2rem;
+    background: linear-gradient(160deg, rgba(167, 139, 250, 0.22), rgba(56, 189, 248, 0.14));
+}
+
+.gallery-caption {
+    padding: 0.8rem;
+    font-size: 0.82rem;
+    color: var(--balpakram-text-muted-dark);
+    background: var(--balpakram-card-bg-dark);
+}
+
+/* Lightbox Modal */
+.lightbox-modal {
+    position: fixed;
+    top: 0; left: 0; right: 0; bottom: 0;
+    z-index: 9999;
+    background: rgba(0, 0, 0, 0.85);
+    backdrop-filter: blur(8px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem;
+}
+
+.lightbox-modal.hidden {
+    display: none;
+}
+
+.lightbox-content {
+    max-width: 800px;
+    width: 100%;
+    position: relative;
+    text-align: center;
+}
+
+.lightbox-close {
+    position: absolute;
+    top: -2.5rem;
+    right: 0;
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 2.5rem;
+    cursor: pointer;
+}
+
+.lightbox-emoji-display {
+    width: 100%;
+    max-height: 60vh;
+    min-height: 260px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 8rem;
+    border-radius: 12px;
+    border: 2px solid var(--balpakram-gold);
+    background: linear-gradient(160deg, rgba(167, 139, 250, 0.25), rgba(56, 189, 248, 0.15));
+}
+
+.lightbox-caption-title {
+    margin-top: 1rem;
+    color: var(--balpakram-text-primary-dark);
+    font-size: 1.3rem;
+    font-weight: 700;
+    font-family: 'Playfair Display', serif;
+}
+
+.lightbox-caption-text {
+    margin-top: 0.4rem;
+    color: var(--balpakram-gold);
+    font-size: 1rem;
+    font-weight: 600;
+}
+
+@media (max-width: 768px) {
+    .balpakram-hero h1 { font-size: 2.2rem; }
+}

--- a/frontend/balpakram-national-park-explorer/balpakram.js
+++ b/frontend/balpakram-national-park-explorer/balpakram.js
@@ -1,0 +1,183 @@
+/**
+ * Balpakram National Park Explorer Application Logic
+ */
+
+if (typeof window !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', () => {
+        if (typeof BALPAKRAM_DATA === 'undefined') return;
+
+        const statsGrid = document.getElementById('stats-grid');
+        const historyContent = document.getElementById('history-content');
+        const legendsGrid = document.getElementById('legends-grid');
+        const landscapeContent = document.getElementById('landscape-content');
+        const landscapeGrid = document.getElementById('landscape-grid');
+        const faunaGrid = document.getElementById('fauna-grid');
+        const floraGrid = document.getElementById('flora-grid');
+        const waterfallsContent = document.getElementById('waterfalls-content');
+        const mapHotspotsLayer = document.getElementById('map-hotspots-layer');
+        const mapInfoPopup = document.getElementById('map-info-popup');
+        const galleryGrid = document.getElementById('gallery-grid');
+        const lightboxModal = document.getElementById('lightbox-modal');
+        const lightboxEmoji = document.getElementById('lightbox-emoji');
+        const lightboxCaption = document.getElementById('lightbox-caption');
+        const lightboxClose = document.getElementById('lightbox-close');
+
+        // Reusable card-grid renderer (used for legends, landscape features, fauna, flora)
+        function renderCardGrid(container, items) {
+            if (!container || !items) return;
+            container.innerHTML = items.map(item => `
+                <div class="fauna-card glass-card">
+                    <div class="fauna-card-header">
+                        <div class="fauna-icon">${item.icon || '🌿'}</div>
+                        <div>
+                            <h3>${item.name}</h3>
+                            ${item.status ? `<span class="fauna-status">${item.status}</span>` : ''}
+                        </div>
+                    </div>
+                    <p>${item.desc}</p>
+                </div>
+            `).join('');
+        }
+
+        // Render Stats
+        if (statsGrid && BALPAKRAM_DATA.quickStats) {
+            statsGrid.innerHTML = BALPAKRAM_DATA.quickStats.map(s => `
+                <div class="stat-box">
+                    <div style="font-size: 1.8rem; margin-bottom: 0.2rem;">${s.icon}</div>
+                    <div class="stat-number">${s.value}</div>
+                    <div class="stat-label">${s.label}</div>
+                </div>
+            `).join('');
+        }
+
+        // Render History
+        if (historyContent && BALPAKRAM_DATA.history) {
+            const h = BALPAKRAM_DATA.history;
+            historyContent.innerHTML = `
+                <h3 style="font-family: 'Playfair Display', serif; font-size: 1.5rem; color: var(--balpakram-gold); margin-bottom: 0.8rem;">
+                    ${h.title}
+                </h3>
+                <p style="color: var(--balpakram-text-muted-dark); line-height: 1.7; margin-bottom: 1.2rem;">
+                    ${h.description}
+                </p>
+                <ul class="fact-list">
+                    ${h.facts.map(f => `<li>${f}</li>`).join('')}
+                </ul>
+            `;
+        }
+
+        // Render Mythology & Legends
+        if (legendsGrid && BALPAKRAM_DATA.mythology) {
+            renderCardGrid(legendsGrid, BALPAKRAM_DATA.mythology.legends);
+        }
+
+        // Render Landscape
+        if (landscapeContent && BALPAKRAM_DATA.landscape) {
+            landscapeContent.innerHTML = `<p>${BALPAKRAM_DATA.landscape.description}</p>`;
+        }
+        if (landscapeGrid && BALPAKRAM_DATA.landscape) {
+            renderCardGrid(landscapeGrid, BALPAKRAM_DATA.landscape.features);
+        }
+
+        // Render Wildlife
+        if (faunaGrid && BALPAKRAM_DATA.wildlife) {
+            renderCardGrid(faunaGrid, BALPAKRAM_DATA.wildlife);
+        }
+
+        // Render Rare Plants
+        if (floraGrid && BALPAKRAM_DATA.flora) {
+            renderCardGrid(floraGrid, BALPAKRAM_DATA.flora);
+        }
+
+        // Render Waterfalls
+        if (waterfallsContent && BALPAKRAM_DATA.waterfalls) {
+            const w = BALPAKRAM_DATA.waterfalls;
+            waterfallsContent.innerHTML = `
+                <h3 style="font-family: 'Playfair Display', serif; font-size: 1.5rem; color: var(--balpakram-gold); margin-bottom: 0.8rem;">
+                    ${w.title}
+                </h3>
+                <p style="color: var(--balpakram-text-muted-dark); line-height: 1.7; margin-bottom: 1.2rem;">
+                    ${w.description}
+                </p>
+                <ul class="fact-list">
+                    ${w.highlights.map(f => `<li>${f}</li>`).join('')}
+                </ul>
+            `;
+        }
+
+        // Render Map Hotspots
+        if (mapHotspotsLayer && BALPAKRAM_DATA.mapHotspots) {
+            mapHotspotsLayer.innerHTML = BALPAKRAM_DATA.mapHotspots.map(h => `
+                <button type="button" class="map-pin-btn" style="left: ${(h.x/1000)*100}%; top: ${(h.y/600)*100}%;" data-id="${h.id}">
+                    📍 ${h.name}
+                </button>
+            `).join('');
+
+            mapHotspotsLayer.addEventListener('click', (e) => {
+                const pin = e.target.closest('.map-pin-btn');
+                if (pin && mapInfoPopup) {
+                    const id = pin.getAttribute('data-id');
+                    const hObj = BALPAKRAM_DATA.mapHotspots.find(h => h.id === id);
+                    if (hObj) {
+                        mapInfoPopup.innerHTML = `
+                            <h4 style="font-size: 1.1rem; color: var(--balpakram-gold); margin-bottom: 0.3rem;">📍 ${hObj.name}</h4>
+                            <p style="font-size: 0.9rem; color: var(--balpakram-text-muted-dark);">${hObj.desc}</p>
+                        `;
+                        mapInfoPopup.classList.remove('hidden');
+                    }
+                }
+            });
+        }
+
+        // Render Gallery (emoji-based visual cards)
+        if (galleryGrid && BALPAKRAM_DATA.gallery) {
+            galleryGrid.innerHTML = BALPAKRAM_DATA.gallery.map(g => `
+                <div class="gallery-item" data-emoji="${g.emoji}" data-title="${g.title}" data-caption="${g.caption}" tabindex="0" role="button" aria-label="${g.caption}">
+                    <div class="gallery-emoji-box">${g.emoji}</div>
+                    <div class="gallery-caption">${g.caption}</div>
+                </div>
+            `).join('');
+
+            document.querySelectorAll('.gallery-item').forEach(item => {
+                const openLightbox = () => {
+                    const emoji = item.getAttribute('data-emoji');
+                    const title = item.getAttribute('data-title');
+                    const cap = item.getAttribute('data-caption');
+                    if (lightboxEmoji && lightboxCaption && lightboxModal) {
+                        lightboxEmoji.textContent = emoji;
+                        lightboxCaption.innerHTML = `
+                            <div class="lightbox-caption-title">${title}</div>
+                            <div class="lightbox-caption-text">${cap}</div>
+                        `;
+                        lightboxModal.classList.remove('hidden');
+                    }
+                };
+                item.addEventListener('click', openLightbox);
+                item.addEventListener('keydown', (e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        openLightbox();
+                    }
+                });
+            });
+        }
+
+        if (lightboxClose) {
+            lightboxClose.addEventListener('click', () => {
+                if (lightboxModal) lightboxModal.classList.add('hidden');
+            });
+        }
+
+        if (lightboxModal) {
+            lightboxModal.addEventListener('click', (e) => {
+                if (e.target === lightboxModal) lightboxModal.classList.add('hidden');
+            });
+        }
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'Escape' && lightboxModal && !lightboxModal.classList.contains('hidden')) {
+                lightboxModal.classList.add('hidden');
+            }
+        });
+    });
+}

--- a/frontend/balpakram-national-park-explorer/index.html
+++ b/frontend/balpakram-national-park-explorer/index.html
@@ -1,0 +1,280 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    document.body.classList.add('light-theme');
+                }
+            })();
+        </script>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Explore Balpakram National Park in Meghalaya — the Garo 'Land of Perpetual Winds', a mystical plateau and gorge landscape with Red Pandas, Tigers, Hoolock Gibbons, rare pitcher plants, and monsoon waterfalls."
+        />
+        <title>Balpakram National Park Explorer | Incredible India</title>
+
+        <!-- Google Fonts -->
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+            rel="stylesheet"
+        />
+
+        <!-- Stylesheets -->
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="balpakram.css" />
+    </head>
+
+    <body class="balpakram-main">
+        <!-- Site Navbar -->
+        <header class="navbar scrolled" id="navbar">
+            <div class="nav-container">
+                <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </button>
+                <nav class="nav-menu" id="nav-menu">
+                    <a href="../../index.html#home" class="nav-link">Home</a>
+                    <a href="../national-parks-explorer/index.html" class="nav-link">National Parks</a>
+                    <a href="../wildlife/wildlife.html" class="nav-link">Wildlife</a>
+                    <a href="index.html" class="nav-link active" style="color: var(--saffron)">Balpakram Explorer</a>
+                    <button
+                        id="theme-toggle"
+                        class="btn-theme-toggle"
+                        aria-label="Toggle Dark/Light Mode"
+                        title="Toggle Light Mode"
+                    >
+                        ☀️
+                    </button>
+                </nav>
+            </div>
+        </header>
+
+        <main>
+            <!-- Hero Section -->
+            <section class="balpakram-hero">
+                <div class="section-container">
+                    <div class="hero-badges-row">
+                        <span class="hero-pill">📍 South Garo Hills, Meghalaya</span>
+                        <span class="hero-pill">🌬️ Land of Perpetual Winds</span>
+                        <span class="hero-pill">🏞️ 220 km² Plateau &amp; Gorge</span>
+                    </div>
+                    <h1>Balpakram <span>National Park</span> Explorer</h1>
+                    <p class="hero-subtitle">
+                        Step into a mystical wilderness in the South Garo Hills — a land the Garo people believe is home to
+                        departed souls and guardian spirits, shaped by windswept table-top plateaus, deep river gorges,
+                        limestone caves, rare wildlife, and carnivorous plants found nowhere else in India.
+                    </p>
+
+                    <!-- Quick Stats Grid -->
+                    <div id="stats-grid" class="stats-grid">
+                        <!-- Populated by balpakram.js -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- History Section -->
+            <section class="ecosystem-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Origins &amp; Protection</span>
+                        <h2>History &amp; Establishment</h2>
+                        <p class="section-subtitle">
+                            From a remote tribal wilderness to one of Meghalaya's most significant protected areas.
+                        </p>
+                    </div>
+
+                    <div id="history-content" class="glass-card">
+                        <!-- Populated by balpakram.js -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Mythology & Legends Section -->
+            <section class="ecosystem-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Garo Mythology</span>
+                        <h2>Land of Perpetual Winds: Myths &amp; Legends</h2>
+                        <p class="section-subtitle">
+                            Sacred beliefs and folklore that have shaped Balpakram's identity for generations.
+                        </p>
+                    </div>
+
+                    <div id="legends-grid" class="ecosystem-grid">
+                        <!-- Populated by balpakram.js -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Plateau Landscape Section -->
+            <section class="ecosystem-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Geography &amp; Geology</span>
+                        <h2>Plateau, Gorges &amp; Landscape</h2>
+                        <p class="section-subtitle">
+                            A dramatic canyon-and-plateau terrain often compared to the Grand Canyon of the Garo Hills.
+                        </p>
+                    </div>
+
+                    <div id="landscape-content" class="glass-card" style="margin-bottom: 2rem;">
+                        <!-- Populated by balpakram.js -->
+                    </div>
+
+                    <div id="landscape-grid" class="ecosystem-grid">
+                        <!-- Populated by balpakram.js -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Wildlife Section -->
+            <section class="ecosystem-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Rare Wildlife</span>
+                        <h2>Fauna &amp; Wildlife Protection</h2>
+                        <p class="section-subtitle">
+                            Balpakram protects Red Pandas, Tigers, Elephants, and India's only native ape species.
+                        </p>
+                    </div>
+
+                    <div id="fauna-grid" class="ecosystem-grid">
+                        <!-- Populated by balpakram.js -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Rare Plants Section -->
+            <section class="ecosystem-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Botanical Rarities</span>
+                        <h2>Rare &amp; Carnivorous Plants</h2>
+                        <p class="section-subtitle">
+                            Home to India's only native pitcher plant and other insect-trapping botanical rarities.
+                        </p>
+                    </div>
+
+                    <div id="flora-grid" class="ecosystem-grid">
+                        <!-- Populated by balpakram.js -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Waterfalls Section -->
+            <section class="ecosystem-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Rivers &amp; Cascades</span>
+                        <h2>Waterfalls of Balpakram</h2>
+                        <p class="section-subtitle">
+                            The Simsang and Mahadeo rivers feed monsoon-season cascades across the park.
+                        </p>
+                    </div>
+
+                    <div id="waterfalls-content" class="glass-card">
+                        <!-- Populated by balpakram.js -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Interactive Park Map Section -->
+            <section class="ecosystem-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Geography &amp; Hotspots</span>
+                        <h2>Interactive Map of Balpakram Reserve</h2>
+                        <p class="section-subtitle">
+                            Click on map pins to discover the Baghmara Gate, Plateau Viewpoint, Chidimak Lake, and Rongdong Falls.
+                        </p>
+                    </div>
+
+                    <div class="map-card-wrapper glass-card">
+                        <svg class="park-map-svg" viewBox="0 0 1000 600" xmlns="http://www.w3.org/2000/svg">
+                            <rect width="1000" height="600" fill="#14091f" />
+                            <path d="M60,120 Q480,40 940,160 L940,540 L60,540 Z" fill="#241238" stroke="rgba(167,139,250,0.3)" stroke-width="2"/>
+                            <!-- Simsang River Gorge -->
+                            <path d="M120,400 Q340,240 560,300 T900,260" fill="none" stroke="#38bdf8" stroke-width="18" opacity="0.75"/>
+                            <text x="330" y="250" fill="#7dd3fc" font-size="16" font-weight="bold" font-family="Outfit">Simsang River Gorge</text>
+                        </svg>
+
+                        <!-- Map Hotspots Layer -->
+                        <div id="map-hotspots-layer">
+                            <!-- Populated by balpakram.js -->
+                        </div>
+
+                        <!-- Info Popup -->
+                        <div id="map-info-popup" class="map-info-popup hidden">
+                            <!-- Populated by balpakram.js -->
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Gallery Section -->
+            <section class="ecosystem-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Visual Exploration</span>
+                        <h2>Balpakram Photo Gallery</h2>
+                        <p class="section-subtitle">
+                            Click any photo to view full-screen image with caption details.
+                        </p>
+                    </div>
+
+                    <div id="gallery-grid" class="gallery-grid">
+                        <!-- Populated by balpakram.js -->
+                    </div>
+                </div>
+            </section>
+        </main>
+
+        <!-- Lightbox Modal -->
+        <div id="lightbox-modal" class="lightbox-modal hidden" role="dialog" aria-modal="true" aria-label="Photo Lightbox">
+            <div class="lightbox-content">
+                <button type="button" id="lightbox-close" class="lightbox-close" aria-label="Close Lightbox">&times;</button>
+                <div id="lightbox-emoji" class="lightbox-emoji-display"></div>
+                <div id="lightbox-caption"></div>
+            </div>
+        </div>
+
+        <!-- Site Footer -->
+        <footer class="footer">
+            <div class="footer-container">
+                <div class="footer-brand">
+                    <h3>Incredible India Explorer</h3>
+                    <p>An interactive digital guide to the wildlife, ecosystems, and culture of India.</p>
+                </div>
+                <div class="footer-links">
+                    <h3>Quick Navigation</h3>
+                    <ul>
+                        <li><a href="../../index.html#home">Home</a></li>
+                        <li><a href="../national-parks-explorer/index.html">National Parks Explorer</a></li>
+                        <li><a href="../wildlife/wildlife.html">Wildlife</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-credits footer-credits-center">
+                <p>&copy; 2026 Incredible India Explorer. Balpakram National Park Explorer.</p>
+            </div>
+        </footer>
+
+        <!-- Scripts -->
+        <script src="../../app.js" defer></script>
+        <script src="balpakram-data.js" defer></script>
+        <script src="balpakram.js" defer></script>
+        <script type="module" src="../../auth.js"></script>
+    </body>
+</html>

--- a/frontend/national-parks-explorer/data.js
+++ b/frontend/national-parks-explorer/data.js
@@ -560,6 +560,27 @@ const NATIONAL_PARKS = [
         image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/2a/Desert_vegetation_DSC0942.jpg/960px-Desert_vegetation_DSC0942.jpg'
     },
     {
+        id: 'balpakram',
+        name: 'Balpakram National Park',
+        state: 'Meghalaya',
+        stateId: 'ml',
+        established: 1987,
+        area: 220,
+        areaUnit: 'km²',
+        type: 'National Park',
+        isTigerReserve: false,
+        isUNESCO: false,
+        description: 'Known as the "Abode of Perpetual Winds," Balpakram sits atop the Garo Hills plateau near the Bangladesh border. Famous for its dramatic gorge — often compared to a mini Grand Canyon — limestone caves, and as one of the few confirmed habitats of the red panda in the region.',
+        keyFauna: ['Red Panda', 'Clouded Leopard', 'Asian Elephant', 'Hoolock Gibbon', 'Bengal Tiger', 'Great Hornbill'],
+        keyFlora: ['Pitcher Plant', 'Sundew (Drosera)', 'Bamboo Forest', 'Montane Grassland', 'Shola Forest'],
+        coordinates: { lat: 25.417, lng: 90.867 },
+        climate: 'Subtropical Highland',
+        bestTime: 'October to April',
+        entryFee: '₹50 (Indian), ₹300 (Foreign)',
+        image: 'https://commons.wikimedia.org/wiki/Special:FilePath/Matcha%20Nokpante%20(tiger%27s%20meeting%20place)%20in%20Balpakram%20National%20Park.jpg',
+        explorerUrl: '../balpakram-national-park-explorer/index.html'
+    },
+    {
         id: 'silent-valley',
         name: 'Silent Valley National Park',
         state: 'Kerala',
@@ -834,5 +855,6 @@ const STATES = [
     { id: 'as', name: 'Assam', region: 'northeast' },
     { id: 'wb', name: 'West Bengal', region: 'east' },
     { id: 'or', name: 'Odisha', region: 'east' },
-    { id: 'ar', name: 'Arunachal Pradesh', region: 'northeast' }
+    { id: 'ar', name: 'Arunachal Pradesh', region: 'northeast' },
+    { id: 'ml', name: 'Meghalaya', region: 'northeast' }
 ];


### PR DESCRIPTION
## Summary
Adds a new dedicated explorer page for Balpakram National Park (Meghalaya) and integrates it into the main National Parks Explorer landing page.

## Changes
- Created `frontend/balpakram-national-park-explorer/` with:
  - `index.html` — hero section, key stats, and photo gallery
  - `balpakram.css` — page-specific styling
  - `balpakram.js` — gallery/lightbox interactivity
  - `balpakram-data.js` — park facts, fauna, and flora data
- Replaced broken image URLs in the gallery with emoji-based visual cards (🐼 Red Panda, 🐆 Clouded Leopard, 🐒 Hoolock Gibbon, 🪴 Pitcher Plant, 🏜️ Plateau, 💦 Rongdong Falls) to avoid broken-image states
- Added Balpakram entry to `frontend/national-parks-explorer/data.js` (`NATIONAL_PARKS` array), linked via `explorerUrl`
- Added missing `Meghalaya` (`ml`) entry to the `STATES` array so the state filter works correctly

## Testing
- Verified Balpakram page loads with no new console errors (only pre-existing project-wide 404s: `router-init`, `seo-helper`, `toast-system`)
- Verified theme toggle behaves consistently with other explorer pages (pre-existing, unrelated issue)
- Verified search + state filter on the National Parks landing page correctly surface the Balpakram card

## Screenshots
<img width="1440" height="852" alt="Screenshot 2026-07-31 161417" src="https://github.com/user-attachments/assets/f4142871-19c8-43d7-b89d-287f0032cc40" />


Closes #931
<img width="1440" height="852" alt="Screenshot 2026-07-31 153733" src="https://github.com/user-attachments/assets/ad17d664-9d10-4c40-bd7b-02577f65fea7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Balpakram National Park Explorer page.
  * Added park history, mythology, landscapes, wildlife, flora, waterfalls, statistics, and gallery content.
  * Added interactive map hotspots with informational popups.
  * Added an image gallery with lightbox viewing and keyboard controls.
  * Added theme support, responsive layouts, and mobile-friendly navigation.
  * Added Balpakram National Park and Meghalaya to the national parks explorer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->