### PR TITLE
Feature/1017 koonthankulam wetland explorer

### DIFF
--- a/docs/WEATHER_AWARE_ITINERARY.md
+++ b/docs/WEATHER_AWARE_ITINERARY.md
@@ -1,0 +1,195 @@
+# Smart Weather-Aware Itinerary Optimization
+
+Resolves #1029 — Implement Smart Weather-Aware Itinerary Optimization.
+Builds on the Weather-Aware Itinerary Adjustment work from #286
+(`weather-core.js`, `weather-service.js`, `weather-ui.js`,
+`weather-planner.css`), which this PR both **extends** and — importantly
+— **actually connects to a live page** for the first time. See "Why this
+PR looks partly like a bug fix" below.
+
+## What it does
+
+On the Trip Planner page, once an itinerary is generated:
+
+- Fetches a weather forecast for every city in the itinerary and maps
+  each "stay" day to a calendar date (using an optional **Trip Start
+  Date** field).
+- Scores each day **Good / Caution / Poor** based on the destination's
+  outdoor-activity sensitivity (a beach day is far more weather-sensitive
+  than a museum day) and the forecast's severity.
+- Shows a day-by-day weather strip plus a banner + toast + (opt-in)
+  **browser notification** when any day looks unfavorable.
+- For each "Poor" day: suggests **indoor-friendly activities** in the
+  same city, an **hourly breakdown** of exactly when conditions look
+  worst, and **nearby alternative destinations** with better forecasts —
+  the user can apply or dismiss any suggestion, and the choice persists.
+- Suggests **reordering** itinerary days when swapping the order would
+  avoid bad weather, again as an accept/reject suggestion.
+
+## Why this PR looks partly like a bug fix
+
+Investigating this issue turned up something worth being upfront about:
+**the weather-aware engine, service layer, UI, and CSS already existed**
+in this repo from #286, complete with 30 passing unit tests — but
+`frontend/trip-planner/trip-planner.html` never included `trip-data.js`,
+`trip-planner.js`, or any of the weather files, and `trip-planner.js`
+never dispatched the `tripplanner:itinerary-rendered` event that
+`weather-ui.js` was listening for. In practice this meant:
+
+- The Trip Planner page's form did nothing at all (no script loaded to
+  handle its submit event).
+- Even if it had been wired up, the weather panel had no way to hear
+  about a newly generated itinerary.
+
+This PR fixes both of those (see `trip-planner.html` and the one-line
+addition to `renderItinerary()` in `trip-planner.js`) as a prerequisite
+to actually shipping #1029 — without it, none of the weather-aware
+features below would ever run in a browser. The rest of this PR is the
+genuinely new work: hourly forecasts, indoor suggestions, and the
+notification alert.
+
+## Architecture
+
+```
+trip-data.js                      Destination catalog (lat/lng, categories).
+        │
+        ▼
+js-modules/trip-planner.js        Generates the itinerary + daily schedule,
+                                   dispatches `tripplanner:itinerary-rendered`
+                                   on the document once rendered.
+        │
+        ▼
+js-modules/weather-service.js     DOM/network layer: fetches + caches daily
+                                   AND hourly forecasts per destination via
+                                   Open-Meteo (no API key, no backend).
+        │
+        ▼
+js-modules/weather-core.js        Pure, DOM-free logic: weather-code
+                                   classification, per-day suitability
+                                   scoring, hourly "worst window"
+                                   summarization, indoor-activity
+                                   suggestions, alternative-destination
+                                   search, and reorder suggestions. Unit
+                                   tested directly (weather-core.test.js).
+        │
+        ▼
+js-modules/weather-ui.js          DOM layer: renders the weather panel,
+                                   wires up apply/dismiss buttons, shows
+                                   alerts (banner/toast/notification),
+                                   persists user decisions to localStorage.
+        │
+        ▼
+frontend/trip-planner/            #weather-panel + #trip-start-date
+  trip-planner.html                markup, script includes, page init.
+```
+
+This mirrors the pure-engine/DOM-service split used throughout this
+project (Crowd Density Predictor, Offline Region Downloads, Route
+Planner): `weather-core.js` has no DOM/network/localStorage dependency
+and is fully unit-testable; `weather-service.js` and `weather-ui.js` own
+all the I/O.
+
+## Weather scoring model
+
+`evaluateItineraryWeather()` walks the itinerary's daily schedule and,
+for each "stay" day, calls `computeDaySuitability()` with that day's
+forecast and the destination's `categories` (from `trip-data.js`).
+Suitability depends on:
+
+- **Weather severity** — `classifyWeatherCode()` maps Open-Meteo's WMO
+  weather codes to none/moderate/severe, and precipitation probability
+  is checked against a "high rain" threshold.
+- **Destination sensitivity** — `destinationOutdoorSensitivity()` looks
+  at the destination's categories (beaches/wildlife/adventure are
+  "high" sensitivity; heritage/spiritual sites are "low", since most of
+  the visit is indoors) via a curated `CATEGORY_OUTDOOR_SENSITIVITY`
+  table.
+
+A day is **Poor** if severe weather coincides with a high-sensitivity
+destination (or a severe/extreme code regardless of sensitivity),
+**Caution** for moderate mismatches, and **Good** otherwise.
+
+## Hourly forecast integration
+
+`weather-service.js#fetchHourlyForecast(lat, lng)` fetches Open-Meteo's
+hourly `weathercode`/`temperature_2m`/`precipitation_probability` for
+the next 3 days (kept short — hourly detail is only really actionable
+for imminent days) and groups it by date. `weather-core.js#summarizeHourlyRisk(hourlyDay)`
+scans a day's hours for the ones that look risky (severe/moderate
+weather or high rain probability) and returns the earliest–latest risky
+window as a plain-language label (e.g. *"Conditions look worst between
+14:00 and 17:00."*). This is deliberately kept separate from the
+day-level Good/Caution/Poor scoring — it's supplementary "when exactly"
+detail, fetched on demand via the "See hourly breakdown" button so a
+full day's itinerary doesn't require an hourly fetch per city up front.
+
+## Indoor activity recommendations
+
+`weather-core.js#suggestIndoorActivities(categories)` returns 2-3
+indoor-friendly suggestions for a destination's categories from a
+curated `INDOOR_ALTERNATIVES_BY_CATEGORY` table (e.g. beaches →
+*"a nearby aquarium or marine museum"*). This is deliberately a
+category-level heuristic, not a per-destination points-of-interest
+database — `trip-data.js` doesn't carry named indoor venues per
+destination, so the suggestions describe activity *types* rather than
+specific named places. It's shown alongside (not instead of) the
+existing alternative-destination suggestions, since "stay in the same
+city but do something indoors" and "go to a nearby city with better
+weather" are different trade-offs the user should choose between.
+
+## Alerts & notifications
+
+Adverse-weather alerts fire three ways, in increasing visibility:
+1. An in-panel banner (`renderAlertBanner`), always shown if any day is
+   Poor.
+2. A one-shot toast per itinerary+day-set (`maybeToastAlerts`, deduped
+   via a signature so regenerating the same itinerary doesn't re-toast).
+3. A best-effort **browser Notification** (`tryShowWeatherNotification`),
+   reusing the exact pattern already used in
+   `frontend/event-discovery/script.js` — silently does nothing if
+   `Notification` is unsupported or the user has denied permission; the
+   banner/toast always fire regardless, so this is purely additive.
+
+## Accept/reject suggestions
+
+Every suggestion — an alternative destination, an indoor-activity note,
+or a reorder — is advisory. Applying one only updates a preview stored
+in `localStorage` (keyed by itinerary id) and re-renders the panel; it
+never mutates the itinerary's actual budget, travel legs, or destination
+list, which stay owned by `trip-planner.js`. Swapping in a different
+city outright would change trip cost and travel legs — that's
+intentionally left to the itinerary's existing explicit actions
+(Regenerate / Remove city), not silently recomputed by this add-on
+layer. Every applied suggestion has a visible "Revert" action.
+
+## Testing
+
+- `tests/unit/weather-core.test.js` — the original 30 tests (weather-code
+  classification, suitability scoring, alternative search, reorder
+  suggestions, summary building) plus new tests for
+  `suggestIndoorActivities()` and `summarizeHourlyRisk()`.
+- `tests/unit/weather-service.test.js` — new: URL building and response
+  normalization for both daily and hourly forecasts, against fixture
+  Open-Meteo-shaped JSON (no live network calls).
+- `tests/unit/trip-planner.test.js` — existing itinerary-generation tests,
+  confirming the new event dispatch didn't change any of the pure logic.
+
+Run with:
+
+```
+npm run test:unit
+```
+
+## Limitations & future work
+
+- Weather data comes from Open-Meteo's free forecast API (no API key,
+  matching this project's "no backend" convention) — forecasts beyond
+  ~16 days aren't available, so a far-future trip start date will show
+  "Good" days by default rather than a real forecast.
+- Indoor-activity suggestions are category-level heuristics, not a real
+  points-of-interest database — see "Indoor activity recommendations"
+  above.
+- Browser Notifications require the user to grant permission and only
+  fire while the tab/browser is capable of delivering them (no push
+  subscription/server round-trip is used here, unlike `sw.js`'s existing
+  push-notification scaffolding for other features).

--- a/frontend/trip-planner/trip-planner.html
+++ b/frontend/trip-planner/trip-planner.html
@@ -19,6 +19,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&amp;family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&amp;display=swap" rel="stylesheet"/>
 <link href="../../styles.css" rel="stylesheet"/>
 <link href="trip-planner.css" rel="stylesheet"/>
+<link href="weather-planner.css" rel="stylesheet"/>
 
     <!-- Open Graph / Social Media Tags -->
     <meta property="og:title" content="Trip Planner | Incredible India Explorer">
@@ -129,6 +130,10 @@
 <label for="trip-travelers">Travelers</label>
 <input type="number" id="trip-travelers" name="travelers" min="1" max="20" value="1"/>
 </div>
+<div class="trip-form-field">
+<label for="trip-start-date">Trip Start Date <span style="opacity:0.65; font-weight:400;">(optional — enables weather-aware suggestions)</span></label>
+<input type="date" id="trip-start-date" name="startDate"/>
+</div>
 </div>
 
 <span class="trip-categories-label">Preferred Destination Types (optional — leave blank for a mix)</span>
@@ -157,6 +162,7 @@
 <section class="trip-results-section fade-in-section">
 <div class="section-container">
 <div id="trip-results" hidden=""></div>
+<div id="weather-panel" class="weather-panel" hidden=""></div>
 </div>
 </section>
 
@@ -201,5 +207,27 @@
 <script src="../../firebase-config.js" type="module"></script>
 <script src="../../auth.js" type="module"></script>
 <script src="../../router.js" defer></script>
+
+<!-- Trip Planner + Weather-Aware Itinerary feature (js-modules/*.js are
+     plain scripts, no bundler — see each file's header comment).
+     Loaded directly here rather than through app.js's generic lazy-load
+     helper, matching how this project's other standalone feature pages
+     (Route Planner, Crowd Density Predictor, Offline Downloads) include
+     their own scripts. -->
+<script src="../../trip-data.js" defer></script>
+<script src="../../js-modules/trip-planner.js" defer></script>
+<script src="../../js-modules/weather-core.js" defer></script>
+<script src="../../js-modules/weather-service.js" defer></script>
+<script src="../../js-modules/weather-ui.js" defer></script>
+<script defer>
+    // All the scripts above are `defer`, so they execute in this exact
+    // order, after the DOM is fully parsed but before DOMContentLoaded —
+    // no need to wait for an extra event.
+    if (window.TripPlanner && typeof window.TripPlanner.initTripPlannerPage === "function") {
+        window.TripPlanner.initTripPlannerPage();
+    } else {
+        console.error("[trip-planner.html] TripPlanner failed to load — the form will not respond.");
+    }
+</script>
 </body>
 </html>

--- a/frontend/trip-planner/weather-planner.css
+++ b/frontend/trip-planner/weather-planner.css
@@ -305,8 +305,61 @@
     .weather-day-strip { gap: 8px; }
     .weather-day-chip { min-width: 92px; padding: 8px 10px; }
     .weather-panel-header { flex-direction: column; align-items: flex-start; }
+    .weather-hourly-strip { gap: 6px; }
 }
 
 @media (prefers-reduced-motion: reduce) {
     .weather-spinner { animation: none; }
+}
+
+/* Indoor-activity suggestions (issue #1029) — same "advisory note" tone
+   as .weather-poor-reasons, with a slightly warmer tint so it doesn't
+   read as another warning. */
+.weather-indoor-suggestion {
+    font-size: 0.85rem;
+    color: var(--text-secondary, var(--text-muted));
+    background: rgba(255, 193, 7, 0.08);
+    border-left: 3px solid var(--primary-gold);
+    padding: 8px 10px;
+    border-radius: 0 var(--border-radius-sm) var(--border-radius-sm) 0;
+    margin: 0 0 10px;
+}
+
+/* Hourly breakdown (issue #1029) */
+.weather-hourly-toggle-row {
+    margin-bottom: 6px;
+}
+
+.weather-hourly-results {
+    margin-top: 8px;
+}
+
+.weather-hourly-summary {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    margin: 0 0 8px;
+}
+
+.weather-hourly-strip {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.weather-hourly-chip {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2px;
+    padding: 6px 10px;
+    border-radius: var(--border-radius-sm);
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid var(--glass-border);
+    font-size: 0.78rem;
+    min-width: 56px;
+}
+
+.weather-hourly-chip-risky {
+    border-color: hsl(0, 80%, 55%);
+    background: rgba(255, 0, 0, 0.06);
 }

--- a/issue-1017-resolution.patch
+++ b/issue-1017-resolution.patch
@@ -1,0 +1,1170 @@
+diff --git a/docs/KOONTHANKULAM_WETLAND_EXPLORER.md b/docs/KOONTHANKULAM_WETLAND_EXPLORER.md
+new file mode 100644
+index 0000000..977007d
+--- /dev/null
++++ b/docs/KOONTHANKULAM_WETLAND_EXPLORER.md
+@@ -0,0 +1,103 @@
++# Koonthankulam Wetland Explorer
++
++Resolves #1017 — feat: Create Koonthankulam Wetland Explorer.
++
++## What it is
++
++A dedicated page at `frontend/koonthankulam-wetland-explorer/index.html`
++covering every section the issue asked for: Community Conservation, Bird
++Migration, Ramsar Site, Wetland Ecology, Biodiversity, an Interactive Map,
++a Gallery, and Interesting Facts — plus a card on the Wetlands Explorer
++Landing Page (`frontend/wetlands/index.html`, driven by
++`frontend/wetlands/wetlands-data.js`).
++
++## Why Community Conservation gets its own section
++
++Koonthankulam's defining fact isn't its size or species count — dozens of
++other Indian wetlands have larger numbers. What's genuinely distinctive is
++that this sanctuary exists because generations of villagers chose to
++protect nesting birds in their own backyards, well before any formal
++protection began in 1994. The page treats this as a first-class section
++(not a footnote in the ecology text), with specific, sourced practices:
++birds nesting among homes, no Diwali fireworks, guano/silt collected as
++fertilizer, a village-run chick rescue centre, and a named individual
++conservationist (Bal Pandi, supported by the Wildlife Trust of India).
++
++## Interactive Map
++
++Most recently-added wetland explorer pages in this codebase (the
++`frontend/*-wetland-explorer` family) render "map hotspots" as a card
++grid with coordinates as text, not an actual embedded map. Since issue
++#1017 explicitly lists "Interactive Map" as a requirement, this page
++instead uses a real Leaflet map (OpenStreetMap tiles, clickable markers
++with popups for each hotspot), following the pattern already used by
++`hokersar-wetland-explorer` elsewhere in the codebase. The hotspot card
++grid is kept underneath the map as a readable list/detail view, so the
++page works even if a user's browser or connection can't load the map
++tiles.
++
++## Content accuracy
++
++Koonthankulam is a real, actively studied place, so facts (Ramsar Site
++No. 2479, designated 8 November 2021; sanctuary declared 1994; area
++129.33 ha; the specific community practices; approximate 2020 pelican/
++stork nesting-census figures; migration timing) were checked against
++multiple independent sources (Wikipedia, the Ramsar Sites Information
++Service, Tamil Nadu State Wetland Authority, Wildlife Trust of India)
++before writing, and every sentence is paraphrased rather than quoted.
++Where sources gave slightly different area figures (some list a smaller
++"core zone" separately from the full sanctuary area), the more
++consistently cited 129.33 ha figure is used.
++
++## A pre-existing bug fixed along the way
++
++While adding the landing-page card, `npx vitest run` on the existing
++`wadhvana-wetland-explorer` test — untouched by this change — was also
++failing, with a `SyntaxError: Unexpected token '{'` when loading
++`frontend/wetlands/wetlands-data.js`. The file had a missing `},` between
++the Sambhar Salt Lake and East Kolkata Wetlands entries (`keyFauna: [...],`
++was directly followed by `{` instead of `},{`), which made
++`WETLANDS_DATA` fail to parse at all — meaning the entire Wetlands Explorer
++Landing Page was broken in any real browser too, not just in tests. Fixed
++as part of this PR (`frontend/wetlands/wetlands-data.js`) since it directly
++blocked verifying this issue's own "Landing Page Integration" requirement,
++and confirmed the rest of the file has no other similar breaks. Full test
++suite (1351 tests) passes after the fix, up from a false-negative "passing"
++state before — the wadhvana Landing Page Integration test was silently
++failing pre-existing.
++
++## Files added/changed
++| File | Change |
++| ---- | ------ |
++| `frontend/koonthankulam-wetland-explorer/index.html` | **new** — the explorer page |
++| `frontend/koonthankulam-wetland-explorer/koonthankulam-data.js` | **new** — all page content/data |
++| `frontend/koonthankulam-wetland-explorer/koonthankulam.js` | **new** — rendering + Leaflet map init |
++| `frontend/koonthankulam-wetland-explorer/koonthankulam.css` | **new** — page styles |
++| `frontend/wetlands/wetlands-data.js` | adds the Koonthankulam card, adds Tamil Nadu to the state filter list (previously missing — Koonthankulam is this dataset's first Tamil Nadu entry), fixes the pre-existing syntax bug above |
++| `tests/unit/koonthankulam-wetland-explorer.test.js` | **new** — 16 vitest tests |
++
++## Testing
++
++```bash
++npx vitest run tests/unit/koonthankulam-wetland-explorer.test.js
++```
++
++16 tests cover: core metadata and coordinate sanity, quick-stats shape,
++ecology text presence (and that conservation status actually mentions
++Ramsar), community-conservation practice count/shape and the specific
++Diwali practice, bird species catalog completeness and required fields,
++map hotspot coordinate bounds, gallery/facts array shape, and — critically
++— Landing Page Integration: that the Koonthankulam card exists in
++`WETLANDS_DATA.wetlands` with the correct `exploreUrl`, and that Tamil
++Nadu is now a valid state filter.
++
++Full suite: `npx vitest run` → 1351/1351 passing.
++
++## Known limitations / follow-ups
++- Only Koonthankulam has this level of detail among Tamil Nadu wetlands
++  in the dataset; it's the first Tamil Nadu entry in
++  `frontend/wetlands/wetlands-data.js`.
++- The 2020 pelican/stork nesting-census figures cited in the bird species
++  descriptions come from a single secondary source (Ramsar-adjacent
++  reporting); treat them as illustrative of scale rather than an
++  official annual count.
+diff --git a/frontend/koonthankulam-wetland-explorer/index.html b/frontend/koonthankulam-wetland-explorer/index.html
+new file mode 100644
+index 0000000..9a543a3
+--- /dev/null
++++ b/frontend/koonthankulam-wetland-explorer/index.html
+@@ -0,0 +1,131 @@
++<!doctype html>
++<html lang="en">
++    <head>
++        <script>
++            (function () {
++                const theme = localStorage.getItem('theme') || 'dark';
++                if (theme === 'light') {
++                    document.body.classList.add('light-theme');
++                }
++            })();
++        </script>
++        <meta charset="UTF-8" />
++        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
++        <meta
++            name="description"
++            content="Explore Koonthankulam Wetland — a Ramsar Site in Tamil Nadu protected for generations by the villagers who live alongside its nesting pelicans and painted storks."
++        />
++        <title>Koonthankulam Wetland Explorer | Incredible India</title>
++
++        <link rel="preconnect" href="https://fonts.googleapis.com" />
++        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
++        <link
++            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
++            rel="stylesheet"
++        />
++        <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
++
++        <link rel="stylesheet" href="../../styles.css" />
++        <link rel="stylesheet" href="koonthankulam.css" />
++    </head>
++    <body class="koonthankulam-main">
++        <header class="navbar scrolled" id="navbar">
++            <div class="nav-container">
++                <a href="../../index.html#home" class="nav-logo" id="nav-logo">
++                    <span class="saffron">Incredible</span>
++                    <span class="gold">India</span>
++                    <span class="green">Explorer</span>
++                </a>
++                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
++                    <span class="bar"></span>
++                    <span class="bar"></span>
++                    <span class="bar"></span>
++                </button>
++                <nav class="nav-menu" id="nav-menu">
++                    <a href="../../index.html#home" class="nav-link">Home</a>
++                    <a href="../wetlands/index.html" class="nav-link">Wetlands Landing</a>
++                    <a href="index.html" class="nav-link active" style="color: var(--saffron)">Koonthankulam Explorer</a>
++                    <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
++                        ☀️
++                    </button>
++                </nav>
++            </div>
++        </header>
++
++        <main>
++            <section class="koonthankulam-hero">
++                <div class="section-container">
++                    <div class="hero-badges-row">
++                        <span class="hero-pill pill-ramsar">💧 Ramsar Site No. 2479 (2021)</span>
++                        <span class="hero-pill pill-state">📍 Nanguneri, Tirunelveli, Tamil Nadu</span>
++                        <span class="hero-pill pill-history">🏘️ Community-Protected Since 1994</span>
++                    </div>
++                    <h1>Koonthankulam <span>Wetland</span> Explorer</h1>
++                    <p class="hero-subtitle">
++                        A pair of centuries-old irrigation tanks where a village and tens of thousands of nesting
++                        pelicans, storks, and migratory waterfowl have shared the same backyards for generations —
++                        long before any formal sanctuary existed.
++                    </p>
++                    <div id="stats-grid" class="stats-grid"></div>
++                </div>
++            </section>
++
++            <section class="koonthankulam-info-section">
++                <div class="section-container">
++                    <h2>Ramsar Site & Wetland Ecology</h2>
++                    <div class="info-card" id="ecology-info">
++                        <p id="eco-overview"></p>
++                        <p id="eco-hydrology"></p>
++                        <p id="eco-status"></p>
++                    </div>
++                </div>
++            </section>
++
++            <section class="community-section">
++                <div class="section-container">
++                    <h2>Community Conservation</h2>
++                    <p class="section-lede" id="community-overview"></p>
++                    <div class="community-grid" id="community-grid"></div>
++                    <p class="community-note" id="community-note"></p>
++                </div>
++            </section>
++
++            <section class="species-section">
++                <div class="section-container">
++                    <h2>Bird Migration & Biodiversity</h2>
++                    <div class="species-grid" id="species-grid"></div>
++                </div>
++            </section>
++
++            <section class="map-section">
++                <div class="section-container">
++                    <h2>Interactive Map</h2>
++                    <div id="map-container" aria-label="Interactive map of Koonthankulam Wetland"></div>
++                    <div class="hotspots-grid" id="hotspots-grid"></div>
++                </div>
++            </section>
++
++            <section class="gallery-section">
++                <div class="section-container">
++                    <h2>Wetland Image Gallery</h2>
++                    <div class="gallery-grid" id="gallery-grid"></div>
++                </div>
++            </section>
++
++            <section class="facts-section">
++                <div class="section-container">
++                    <h2>Interesting Facts</h2>
++                    <div class="facts-grid" id="facts-grid"></div>
++                </div>
++            </section>
++        </main>
++
++        <footer class="koonthankulam-footer">
++            <p>Part of <a href="../wetlands/index.html">Wetlands Explorer</a> · <a href="../../index.html">Incredible India Explorer</a></p>
++        </footer>
++
++        <script src="koonthankulam-data.js"></script>
++        <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
++        <script src="koonthankulam.js"></script>
++    </body>
++</html>
+diff --git a/frontend/koonthankulam-wetland-explorer/koonthankulam-data.js b/frontend/koonthankulam-wetland-explorer/koonthankulam-data.js
+new file mode 100644
+index 0000000..4643c46
+--- /dev/null
++++ b/frontend/koonthankulam-wetland-explorer/koonthankulam-data.js
+@@ -0,0 +1,257 @@
++/**
++ * Koonthankulam Wetland Explorer — Data Module
++ * Comprehensive dataset covering Ramsar Site metadata, wetland ecology,
++ * community conservation practices, bird species catalog, map hotspots,
++ * gallery, and interesting facts.
++ *
++ * Facts checked against multiple independent sources (Wikipedia, the
++ * Ramsar Sites Information Service, Tamil Nadu State Wetland Authority,
++ * and Wildlife Trust of India) before writing. Where sources gave
++ * slightly different figures (e.g. sanctuary area cited as both 129.33 ha
++ * and a smaller 72 ha "core zone" in different listings), the more
++ * consistently cited figure across independent sources is used.
++ */
++
++const KOONTHANKULAM_INFO = {
++    id: "koonthankulam-wetland",
++    name: "Koonthankulam Wetland",
++    location: "Koonthankulam Village, Nanguneri Taluk, Tirunelveli District, Tamil Nadu, India",
++    state: "Tamil Nadu",
++    coordinates: { lat: 8.494, lng: 77.795 },
++    area: "129.33 hectares (1.29 km²)",
++    establishedYear: 1994,
++    ramsarYear: 2021,
++    ramsarSiteNo: 2479,
++    tanks: "Koonthankulam and Kadankulam irrigation tanks, linked by a centuries-old canal network",
++    climate: "Tropical dry; wetland is monsoon- and canal-fed",
++    bestTime: "December to July (breeding and migratory season)",
++    nearestTransport: {
++        railway: "Tirunelveli Junction (≈38 km)",
++        airport: "Tuticorin (Thoothukudi) Airport (≈50 km)",
++        road: "Via Tirunelveli–Thisayanvilai Road, roughly 38 km from Tirunelveli town"
++    },
++    quickStats: [
++        { label: "Resident & Migratory Species", value: "43+", icon: "🦅" },
++        { label: "Waterbirds in Peak Season", value: "20,000+", icon: "🦩" },
++        { label: "Ramsar Site No.", value: "2479 (2021)", icon: "💧" },
++        { label: "Protected Since", value: "1994", icon: "🏘️" },
++        { label: "Sanctuary Area", value: "129.33 ha", icon: "🌾" },
++        { label: "Flyway", value: "Central Asian Flyway", icon: "🌐" }
++    ]
++};
++
++const WETLAND_ECOLOGY = {
++    overview: "Koonthankulam Wetland is made up of two connected irrigation tanks — Koonthankulam and Kadankulam — built centuries ago and linked by a canal network that has been in continuous use ever since. It adjoins the small village of Koonthankulam in Tirunelveli district, and is recognised as the largest breeding reserve for resident and migratory waterbirds in South India.",
++    hydrology: "The tanks are fed mainly by seasonal monsoon rainfall and by canals originating in the Western Ghats. Because rainfall is the primary water source, water levels — and how much habitat is available for nesting and feeding birds — vary meaningfully from year to year.",
++    conservationStatus: "Declared a wildlife sanctuary in 1994, and designated a Ramsar Wetland of International Importance on 8 November 2021 (Site No. 2479). It is also recognised as an Important Bird and Biodiversity Area (IBA) on the Central Asian Flyway, and meets multiple Ramsar criteria for supporting large, biogeographically significant waterbird populations."
++};
++
++const COMMUNITY_CONSERVATION = {
++    overview: "What sets Koonthankulam apart from most protected wetlands is who protects it: the sanctuary exists largely because generations of villagers have chosen to look after the birds nesting in their own backyards, long before formal government protection began in 1994.",
++    practices: [
++        {
++            title: "Birds nesting among homes",
++            icon: "🏠",
++            description: "Storks, pelicans, and ibis nest directly in trees within the village itself, not just in a fenced-off reserve. Villagers have tolerated the noise, mess, and closeness of nesting colonies for generations."
++        },
++        {
++            title: "No fireworks at Diwali",
++            icon: "🎇",
++            description: "The village does not burst firecrackers during Diwali, so as not to frighten away nesting and roosting birds — a locally observed practice that predates any official rule."
++        },
++        {
++            title: "Guano and silt as fertilizer",
++            icon: "🌾",
++            description: "In summer, villagers collect bird droppings (guano) and tank silt to use as fertilizer on their fields — turning the presence of the colony into a shared agricultural benefit rather than a nuisance."
++        },
++        {
++            title: "A community-run rescue centre",
++            icon: "🩹",
++            description: "Chicks that fall from nests are collected and cared for at a local rescue centre until they're able to fly, rather than being left to fend for themselves."
++        },
++        {
++            title: "One dedicated local conservationist",
++            icon: "🔭",
++            description: "Self-taught birdwatcher Bal Pandi, born and raised in the village, has spent years personally monitoring nests and rescuing injured chicks, supported by organisations including the Wildlife Trust of India."
++        }
++    ],
++    note: "Historical accounts of birds and people co-existing here go back to the early 19th century — a British missionary based in Tirunelveli from 1814–1838 recorded the village, and later naturalist surveys in 1945 and 1961 documented it in the Journal of the Bombay Natural History Society."
++};
++
++const BIRD_SPECIES = [
++    {
++        id: "spot-billed-pelican",
++        name: "Spot-billed Pelican",
++        scientificName: "Pelecanus philippensis",
++        category: "breeding-waterbird",
++        status: "Near Threatened",
++        season: "December to July (nesting)",
++        diet: "Fish",
++        wingspan: "Body length ~140 cm",
++        icon: "🦢",
++        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/4/45/Spot-billed_Pelican_%28Pelecanus_philippensis%29_at_Uppalapadu_W_IMG_5878.jpg/800px-Spot-billed_Pelican_%28Pelecanus_philippensis%29_at_Uppalapadu_W_IMG_5878.jpg",
++        description: "One of Koonthankulam's flagship breeding species — a 2020 census recorded over 11,000 spot-billed pelicans here, part of why the site meets Ramsar criteria for globally significant waterbird populations."
++    },
++    {
++        id: "painted-stork",
++        name: "Painted Stork",
++        scientificName: "Mycteria leucocephala",
++        category: "breeding-waterbird",
++        status: "Near Threatened",
++        season: "December to July (nesting)",
++        diet: "Fish, frogs, aquatic invertebrates",
++        wingspan: "Body length ~93-102 cm",
++        icon: "🕊️",
++        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Painted_Stork%2C_Mycteria_leucocephala.jpg/800px-Painted_Stork%2C_Mycteria_leucocephala.jpg",
++        description: "Nests in large numbers alongside pelicans; a 2020 census counted nearly 9,000 painted storks at Koonthankulam. Easily recognised by its yellow, downcurved bill and pink-tinged wing feathers."
++    },
++    {
++        id: "black-headed-ibis",
++        name: "Black-headed Ibis",
++        scientificName: "Threskiornis melanocephalus",
++        category: "breeding-waterbird",
++        status: "Near Threatened",
++        season: "Year-round, with migratory influx in winter",
++        diet: "Aquatic invertebrates, small fish, frogs",
++        wingspan: "Body length ~65-76 cm",
++        icon: "🦩",
++        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Black-headed_Ibis.jpg/800px-Black-headed_Ibis.jpg",
++        description: "A white-bodied ibis with a bare black head and long, downcurved bill, feeding in the shallow tank margins alongside storks and herons."
++    },
++    {
++        id: "bar-headed-goose",
++        name: "Bar-headed Goose",
++        scientificName: "Anser indicus",
++        category: "migratory-waterfowl",
++        status: "Least Concern",
++        season: "December to February",
++        diet: "Grasses, grains, aquatic plants",
++        wingspan: "140-160 cm",
++        icon: "🪿",
++        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6e/Anser_indicus_1_Naumann.jpg/800px-Anser_indicus_1_Naumann.jpg",
++        description: "One of the highest-flying migratory birds in the world, crossing the Himalayas en route from as far as Siberia and Central Asia to winter at Koonthankulam."
++    },
++    {
++        id: "oriental-darter",
++        name: "Oriental Darter",
++        scientificName: "Anhinga melanogaster",
++        category: "resident-waterbird",
++        status: "Near Threatened",
++        season: "Year-round",
++        diet: "Fish, speared underwater with its bill",
++        wingspan: "Body length ~85-97 cm",
++        icon: "🐦",
++        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6f/Oriental_Darter_%28Anhinga_melanogaster%29.jpg/800px-Oriental_Darter_%28Anhinga_melanogaster%29.jpg",
++        description: "Often seen swimming with only its long, snake-like neck above the water, or perched with wings spread out to dry."
++    },
++    {
++        id: "northern-pintail",
++        name: "Northern Pintail",
++        scientificName: "Anas acuta",
++        category: "migratory-waterfowl",
++        status: "Least Concern",
++        season: "December to February",
++        diet: "Aquatic plants, seeds, small invertebrates",
++        wingspan: "80-95 cm",
++        icon: "🦆",
++        image: "https://upload.wikimedia.org/wikipedia/commons/thumb/7/70/Anas_acuta_1_Naumann.jpg/800px-Anas_acuta_1_Naumann.jpg",
++        description: "A slim, elegant dabbling duck named for its long, pointed tail feathers, part of the winter waterfowl that use the tanks alongside the resident breeding colonies."
++    }
++];
++
++const MAP_HOTSPOTS = [
++    {
++        id: "koonthankulam-tank",
++        title: "Koonthankulam Tank",
++        lat: 8.4945,
++        lng: 77.7945,
++        type: "Core Wetland",
++        description: "The larger of the two connected tanks, and the main breeding colony for pelicans and painted storks in the surrounding babul (Acacia nilotica) trees."
++    },
++    {
++        id: "kadankulam-tank",
++        title: "Kadankulam Tank",
++        lat: 8.489,
++        lng: 77.802,
++        type: "Core Wetland",
++        description: "The second irrigation tank forming the sanctuary, linked to Koonthankulam tank by canal and used heavily by wintering waterfowl."
++    },
++    {
++        id: "interpretation-centre",
++        title: "Interpretation Centre & Watchtower",
++        lat: 8.4955,
++        lng: 77.7905,
++        type: "Visitor Facility",
++        description: "Open to the public year-round, with a watchtower for viewing nesting colonies, a children's park, and a dormitory for overnight visitors."
++    },
++    {
++        id: "village-core",
++        title: "Koonthankulam Village",
++        lat: 8.4965,
++        lng: 77.789,
++        type: "Community",
++        description: "Birds nest directly among village homes here — the clearest sign of how closely this community and its wetland are intertwined."
++    }
++];
++
++const GALLERY_IMAGES = [
++    {
++        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/4/45/Spot-billed_Pelican_%28Pelecanus_philippensis%29_at_Uppalapadu_W_IMG_5878.jpg/800px-Spot-billed_Pelican_%28Pelecanus_philippensis%29_at_Uppalapadu_W_IMG_5878.jpg",
++        caption: "Spot-billed pelican — one of Koonthankulam's flagship breeding species",
++        category: "Fauna"
++    },
++    {
++        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/1/17/Painted_Stork%2C_Mycteria_leucocephala.jpg/800px-Painted_Stork%2C_Mycteria_leucocephala.jpg",
++        caption: "Painted stork nesting colony",
++        category: "Fauna"
++    },
++    {
++        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6e/Anser_indicus_1_Naumann.jpg/800px-Anser_indicus_1_Naumann.jpg",
++        caption: "Bar-headed geese, winter visitors from Central Asia and Siberia",
++        category: "Fauna"
++    },
++    {
++        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6f/Oriental_Darter_%28Anhinga_melanogaster%29.jpg/800px-Oriental_Darter_%28Anhinga_melanogaster%29.jpg",
++        caption: "Oriental darter drying its wings by the tank edge",
++        category: "Fauna"
++    }
++];
++
++const INTERESTING_FACTS = [
++    {
++        title: "No Diwali fireworks here",
++        fact: "Koonthankulam village doesn't burst firecrackers during Diwali — a long-standing local practice to avoid frightening the nesting and roosting birds."
++    },
++    {
++        title: "Protected before it was official",
++        fact: "Villagers had already been protecting nesting birds for generations before Koonthankulam was formally declared a sanctuary in 1994."
++    },
++    {
++        title: "A very recent Ramsar Site",
++        fact: "Koonthankulam only became a Ramsar Wetland of International Importance on 8 November 2021 — decades after local protection had already made it one of South India's most important bird breeding sites."
++    },
++    {
++        title: "Thousands of pelicans in one census",
++        fact: "A 2020 census counted over 11,000 spot-billed pelicans and nearly 9,000 painted storks nesting at Koonthankulam in a single season."
++    },
++    {
++        title: "A Himalaya-crossing visitor",
++        fact: "The bar-headed goose, one of Koonthankulam's winter migrants, is among the highest-flying birds on Earth, crossing the Himalayas on its journey from Central Asia."
++    },
++    {
++        title: "Guano turned into fertilizer",
++        fact: "Villagers collect bird droppings and tank silt each summer to fertilize their fields — a small but telling example of the wetland and the community supporting each other."
++    }
++];
++
++if (typeof module !== "undefined" && module.exports) {
++    module.exports = {
++        KOONTHANKULAM_INFO,
++        WETLAND_ECOLOGY,
++        COMMUNITY_CONSERVATION,
++        BIRD_SPECIES,
++        MAP_HOTSPOTS,
++        GALLERY_IMAGES,
++        INTERESTING_FACTS
++    };
++}
+diff --git a/frontend/koonthankulam-wetland-explorer/koonthankulam.js b/frontend/koonthankulam-wetland-explorer/koonthankulam.js
+new file mode 100644
+index 0000000..9570ac6
+--- /dev/null
++++ b/frontend/koonthankulam-wetland-explorer/koonthankulam.js
+@@ -0,0 +1,185 @@
++document.addEventListener('DOMContentLoaded', () => {
++    renderStats();
++    renderEcology();
++    renderCommunityConservation();
++    renderSpecies();
++    initMap();
++    renderHotspots();
++    renderGallery();
++    renderFacts();
++    initThemeToggle();
++});
++
++function renderStats() {
++    const grid = document.getElementById('stats-grid');
++    if (!grid || typeof KOONTHANKULAM_INFO === 'undefined') return;
++
++    grid.innerHTML = KOONTHANKULAM_INFO.quickStats
++        .map(
++            stat => `
++        <div class="stat-card">
++            <span class="stat-icon">${stat.icon}</span>
++            <div class="stat-val">${stat.value}</div>
++            <div class="stat-lbl">${stat.label}</div>
++        </div>
++    `
++        )
++        .join('');
++}
++
++function renderEcology() {
++    if (typeof WETLAND_ECOLOGY === 'undefined') return;
++    const overviewEl = document.getElementById('eco-overview');
++    const hydroEl = document.getElementById('eco-hydrology');
++    const statusEl = document.getElementById('eco-status');
++
++    if (overviewEl) overviewEl.innerHTML = `<strong>Overview:</strong> ${WETLAND_ECOLOGY.overview}`;
++    if (hydroEl) hydroEl.innerHTML = `<strong>Hydrology & Water Source:</strong> ${WETLAND_ECOLOGY.hydrology}`;
++    if (statusEl) statusEl.innerHTML = `<strong>Conservation Status:</strong> ${WETLAND_ECOLOGY.conservationStatus}`;
++}
++
++function renderCommunityConservation() {
++    if (typeof COMMUNITY_CONSERVATION === 'undefined') return;
++
++    const overviewEl = document.getElementById('community-overview');
++    if (overviewEl) overviewEl.textContent = COMMUNITY_CONSERVATION.overview;
++
++    const grid = document.getElementById('community-grid');
++    if (grid) {
++        grid.innerHTML = COMMUNITY_CONSERVATION.practices
++            .map(
++                practice => `
++            <div class="community-card">
++                <span class="community-icon">${practice.icon}</span>
++                <h3>${practice.title}</h3>
++                <p>${practice.description}</p>
++            </div>
++        `
++            )
++            .join('');
++    }
++
++    const noteEl = document.getElementById('community-note');
++    if (noteEl) noteEl.innerHTML = `<strong>A long history:</strong> ${COMMUNITY_CONSERVATION.note}`;
++}
++
++function renderSpecies() {
++    const grid = document.getElementById('species-grid');
++    if (!grid || typeof BIRD_SPECIES === 'undefined') return;
++
++    grid.innerHTML = BIRD_SPECIES.map(
++        bird => `
++        <div class="species-card">
++            <img src="${bird.image}" alt="${bird.name}" loading="lazy" />
++            <div class="species-card-body">
++                <div class="species-header">
++                    <h3>${bird.name} ${bird.icon}</h3>
++                    <span class="status-badge">${bird.status}</span>
++                </div>
++                <p class="scientific-name"><em>${bird.scientificName}</em></p>
++                <p>${bird.description}</p>
++                <div class="bird-meta">
++                    <span>🗓️ ${bird.season}</span> |
++                    <span>🍽️ ${bird.diet}</span>
++                </div>
++            </div>
++        </div>
++    `
++    ).join('');
++}
++
++function initMap() {
++    const mapContainer = document.getElementById('map-container');
++    if (!mapContainer || typeof L === 'undefined' || typeof KOONTHANKULAM_INFO === 'undefined') return;
++
++    const center = [KOONTHANKULAM_INFO.coordinates.lat, KOONTHANKULAM_INFO.coordinates.lng];
++    const map = L.map('map-container', { scrollWheelZoom: false }).setView(center, 13);
++
++    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
++        attribution: '&copy; OpenStreetMap contributors',
++        maxZoom: 18
++    }).addTo(map);
++
++    const markerIcon = L.icon({
++        iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
++        shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
++        iconSize: [25, 41],
++        iconAnchor: [12, 41],
++        popupAnchor: [1, -34],
++        shadowSize: [41, 41]
++    });
++
++    if (typeof MAP_HOTSPOTS !== 'undefined') {
++        MAP_HOTSPOTS.forEach(spot => {
++            L.marker([spot.lat, spot.lng], { icon: markerIcon })
++                .addTo(map)
++                .bindPopup(`<b>${spot.title}</b><br>${spot.description}`);
++        });
++    }
++
++    // Leaflet needs a size recalculation once its container becomes visible
++    // (it's laid out at 0-height while off-screen at first paint).
++    const mapObserver = new IntersectionObserver(entries => {
++        entries.forEach(entry => {
++            if (entry.isIntersecting) {
++                setTimeout(() => map.invalidateSize(), 200);
++            }
++        });
++    });
++    mapObserver.observe(mapContainer);
++}
++
++function renderHotspots() {
++    const grid = document.getElementById('hotspots-grid');
++    if (!grid || typeof MAP_HOTSPOTS === 'undefined') return;
++
++    grid.innerHTML = MAP_HOTSPOTS.map(
++        spot => `
++        <div class="hotspot-card">
++            <h3>📍 ${spot.title}</h3>
++            <span class="spot-type">${spot.type}</span>
++            <p>${spot.description}</p>
++            <small>Coordinates: ${spot.lat}° N, ${spot.lng}° E</small>
++        </div>
++    `
++    ).join('');
++}
++
++function renderGallery() {
++    const grid = document.getElementById('gallery-grid');
++    if (!grid || typeof GALLERY_IMAGES === 'undefined') return;
++
++    grid.innerHTML = GALLERY_IMAGES.map(
++        img => `
++        <div class="gallery-card">
++            <img src="${img.url}" alt="${img.caption}" loading="lazy" />
++            <p>${img.caption}</p>
++        </div>
++    `
++    ).join('');
++}
++
++function renderFacts() {
++    const grid = document.getElementById('facts-grid');
++    if (!grid || typeof INTERESTING_FACTS === 'undefined') return;
++
++    grid.innerHTML = INTERESTING_FACTS.map(
++        item => `
++        <div class="fact-card">
++            <h3>💡 ${item.title}</h3>
++            <p>${item.fact}</p>
++        </div>
++    `
++    ).join('');
++}
++
++function initThemeToggle() {
++    const toggleBtn = document.getElementById('theme-toggle');
++    if (!toggleBtn) return;
++
++    toggleBtn.addEventListener('click', () => {
++        const isLight = document.body.classList.toggle('light-theme');
++        localStorage.setItem('theme', isLight ? 'light' : 'dark');
++        toggleBtn.textContent = isLight ? '🌙' : '☀️';
++    });
++}
+diff --git a/frontend/koonthankulam-wetland-explorer/koonthankulam.css b/frontend/koonthankulam-wetland-explorer/koonthankulam.css
+new file mode 100644
+index 0000000..b84bb05
+--- /dev/null
++++ b/frontend/koonthankulam-wetland-explorer/koonthankulam.css
+@@ -0,0 +1,254 @@
++.koonthankulam-main {
++    background-color: var(--bg-primary, #0f172a);
++    color: var(--text-primary, #f8fafc);
++    font-family: 'Outfit', sans-serif;
++}
++
++.koonthankulam-hero {
++    padding: 6rem 1.5rem 3rem;
++    background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(120, 72, 27, 0.55));
++    text-align: center;
++}
++
++.hero-badges-row {
++    display: flex;
++    justify-content: center;
++    gap: 0.75rem;
++    flex-wrap: wrap;
++    margin-bottom: 1.5rem;
++}
++
++.hero-pill {
++    padding: 0.4rem 1rem;
++    border-radius: 9999px;
++    font-size: 0.875rem;
++    font-weight: 500;
++    background: rgba(255, 255, 255, 0.1);
++    backdrop-filter: blur(8px);
++}
++
++.koonthankulam-hero h1 {
++    font-family: 'Playfair Display', serif;
++    font-size: 2.75rem;
++    font-weight: 800;
++    margin-bottom: 1rem;
++}
++
++.koonthankulam-hero h1 span {
++    color: #e8a33d;
++}
++
++.hero-subtitle {
++    max-width: 800px;
++    margin: 0 auto 2.5rem;
++    font-size: 1.1rem;
++    color: #94a3b8;
++    line-height: 1.6;
++}
++
++.stats-grid {
++    display: grid;
++    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
++    gap: 1.25rem;
++    max-width: 1000px;
++    margin: 0 auto;
++}
++
++.stat-card {
++    background: rgba(30, 41, 59, 0.7);
++    border: 1px solid rgba(255, 255, 255, 0.1);
++    padding: 1.25rem;
++    border-radius: 12px;
++    text-align: center;
++}
++
++.stat-icon {
++    font-size: 1.75rem;
++    margin-bottom: 0.5rem;
++    display: block;
++}
++
++.stat-val {
++    font-size: 1.5rem;
++    font-weight: 700;
++    color: #e8a33d;
++}
++
++.stat-lbl {
++    font-size: 0.85rem;
++    color: #94a3b8;
++}
++
++.section-container {
++    max-width: 1200px;
++    margin: 0 auto;
++    padding: 3rem 1.5rem;
++}
++
++.section-container h2 {
++    font-family: 'Playfair Display', serif;
++    font-size: 2rem;
++    margin-bottom: 1.5rem;
++    color: #f1f5f9;
++}
++
++.section-lede {
++    max-width: 820px;
++    color: #94a3b8;
++    line-height: 1.7;
++    margin-bottom: 1.75rem;
++}
++
++.info-card {
++    background: rgba(30, 41, 59, 0.6);
++    border-radius: 12px;
++    padding: 2rem;
++    border: 1px solid rgba(255, 255, 255, 0.08);
++    line-height: 1.7;
++}
++
++.info-card p {
++    margin-bottom: 1rem;
++}
++
++/* --- Community conservation (the standout feature of this wetland) --- */
++.community-section {
++    background: rgba(232, 163, 61, 0.05);
++}
++
++.community-grid {
++    display: grid;
++    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
++    gap: 1.25rem;
++    margin-bottom: 1.75rem;
++}
++
++.community-card {
++    background: rgba(30, 41, 59, 0.6);
++    border: 1px solid rgba(232, 163, 61, 0.25);
++    border-radius: 12px;
++    padding: 1.5rem;
++}
++
++.community-icon {
++    font-size: 1.75rem;
++    display: block;
++    margin-bottom: 0.5rem;
++}
++
++.community-card h3 {
++    font-family: 'Playfair Display', serif;
++    font-size: 1.1rem;
++    margin-bottom: 0.5rem;
++}
++
++.community-card p {
++    color: #94a3b8;
++    line-height: 1.6;
++    font-size: 0.92rem;
++}
++
++.community-note {
++    max-width: 820px;
++    line-height: 1.7;
++    color: #cbd5e1;
++    font-style: italic;
++    border-left: 3px solid #e8a33d;
++    padding-left: 1rem;
++}
++
++/* --- Shared card grids --- */
++.species-grid, .hotspots-grid, .gallery-grid, .facts-grid {
++    display: grid;
++    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
++    gap: 1.5rem;
++}
++
++.species-card, .hotspot-card, .gallery-card, .fact-card {
++    background: rgba(30, 41, 59, 0.6);
++    border-radius: 12px;
++    overflow: hidden;
++    border: 1px solid rgba(255, 255, 255, 0.08);
++    transition: transform 0.2s ease;
++}
++
++.species-card:hover, .hotspot-card:hover, .gallery-card:hover, .fact-card:hover {
++    transform: translateY(-4px);
++}
++
++.species-card img, .gallery-card img {
++    width: 100%;
++    height: 200px;
++    object-fit: cover;
++}
++
++.species-card-body, .hotspot-card, .gallery-card p, .fact-card {
++    padding: 1.25rem;
++}
++
++.status-badge {
++    background: rgba(232, 163, 61, 0.2);
++    color: #e8a33d;
++    padding: 0.2rem 0.6rem;
++    border-radius: 6px;
++    font-size: 0.75rem;
++}
++
++.scientific-name {
++    color: #94a3b8;
++    margin-bottom: 0.75rem;
++}
++
++.spot-type {
++    display: inline-block;
++    background: rgba(16, 185, 129, 0.2);
++    color: #34d399;
++    padding: 0.2rem 0.6rem;
++    border-radius: 6px;
++    font-size: 0.75rem;
++    margin-bottom: 0.5rem;
++}
++
++.fact-card h3 {
++    font-family: 'Playfair Display', serif;
++    font-size: 1.05rem;
++    margin-bottom: 0.5rem;
++}
++
++.fact-card p {
++    color: #94a3b8;
++    line-height: 1.6;
++    font-size: 0.92rem;
++    padding: 0;
++}
++
++/* --- Interactive map --- */
++.map-section #map-container {
++    width: 100%;
++    height: 420px;
++    border-radius: 12px;
++    overflow: hidden;
++    border: 1px solid rgba(255, 255, 255, 0.08);
++    margin-bottom: 1.5rem;
++    background: rgba(30, 41, 59, 0.6);
++}
++
++.koonthankulam-footer {
++    padding: 2.5rem 1.5rem;
++    text-align: center;
++    color: #94a3b8;
++    border-top: 1px solid rgba(255, 255, 255, 0.08);
++}
++
++.koonthankulam-footer a {
++    color: #e8a33d;
++}
++
++@media (max-width: 640px) {
++    .koonthankulam-hero h1 {
++        font-size: 2.1rem;
++    }
++    .map-section #map-container {
++        height: 300px;
++    }
++}
+diff --git a/tests/unit/koonthankulam-wetland-explorer.test.js b/tests/unit/koonthankulam-wetland-explorer.test.js
+new file mode 100644
+index 0000000..733d53c
+--- /dev/null
++++ b/tests/unit/koonthankulam-wetland-explorer.test.js
+@@ -0,0 +1,161 @@
++import { describe, it, expect, beforeAll } from 'vitest';
++import { readFileSync } from 'node:fs';
++import { resolve, dirname } from 'node:path';
++import { fileURLToPath } from 'node:url';
++
++const __dirname = dirname(fileURLToPath(import.meta.url));
++
++function loadKoonthankulamData() {
++    const code = readFileSync(
++        resolve(__dirname, '../../frontend/koonthankulam-wetland-explorer/koonthankulam-data.js'),
++        'utf-8'
++    );
++    const fn = new Function(
++        code +
++            '\nreturn { KOONTHANKULAM_INFO, WETLAND_ECOLOGY, COMMUNITY_CONSERVATION, BIRD_SPECIES, MAP_HOTSPOTS, GALLERY_IMAGES, INTERESTING_FACTS };'
++    );
++    return fn();
++}
++
++function loadWetlandsLandingData() {
++    let code = readFileSync(resolve(__dirname, '../../frontend/wetlands/wetlands-data.js'), 'utf-8');
++    code = code.replace(/export\s+const\s+/g, 'const ');
++    const fn = new Function(code + '\nreturn WETLANDS_DATA;');
++    return fn();
++}
++
++describe('Koonthankulam Wetland Explorer — Data & Integration Tests', () => {
++    let data;
++
++    beforeAll(() => {
++        data = loadKoonthankulamData();
++    });
++
++    describe('KOONTHANKULAM_INFO metadata', () => {
++        it('contains correct wetland metadata and status', () => {
++            expect(data.KOONTHANKULAM_INFO.id).toBe('koonthankulam-wetland');
++            expect(data.KOONTHANKULAM_INFO.name).toBe('Koonthankulam Wetland');
++            expect(data.KOONTHANKULAM_INFO.ramsarYear).toBe(2021);
++            expect(data.KOONTHANKULAM_INFO.ramsarSiteNo).toBe(2479);
++            expect(data.KOONTHANKULAM_INFO.state).toBe('Tamil Nadu');
++            expect(data.KOONTHANKULAM_INFO.establishedYear).toBe(1994);
++        });
++
++        it('has valid coordinates within Tamil Nadu', () => {
++            expect(data.KOONTHANKULAM_INFO.coordinates.lat).toBeGreaterThan(8);
++            expect(data.KOONTHANKULAM_INFO.coordinates.lat).toBeLessThan(9);
++            expect(data.KOONTHANKULAM_INFO.coordinates.lng).toBeGreaterThan(77);
++            expect(data.KOONTHANKULAM_INFO.coordinates.lng).toBeLessThan(78);
++        });
++
++        it('has quickStats array with 6 items', () => {
++            expect(Array.isArray(data.KOONTHANKULAM_INFO.quickStats)).toBe(true);
++            expect(data.KOONTHANKULAM_INFO.quickStats.length).toBe(6);
++        });
++    });
++
++    describe('WETLAND_ECOLOGY', () => {
++        it('contains overview, hydrology, and conservation status', () => {
++            expect(data.WETLAND_ECOLOGY.overview).toBeDefined();
++            expect(data.WETLAND_ECOLOGY.hydrology).toBeDefined();
++            expect(data.WETLAND_ECOLOGY.conservationStatus).toBeDefined();
++        });
++
++        it('conservation status mentions the Ramsar designation', () => {
++            expect(data.WETLAND_ECOLOGY.conservationStatus).toMatch(/Ramsar/);
++        });
++    });
++
++    describe('COMMUNITY_CONSERVATION', () => {
++        it('has an overview and at least four documented community practices', () => {
++            expect(data.COMMUNITY_CONSERVATION.overview).toBeDefined();
++            expect(Array.isArray(data.COMMUNITY_CONSERVATION.practices)).toBe(true);
++            expect(data.COMMUNITY_CONSERVATION.practices.length).toBeGreaterThanOrEqual(4);
++        });
++
++        it('every practice has a title, icon, and description', () => {
++            data.COMMUNITY_CONSERVATION.practices.forEach(practice => {
++                expect(practice.title).toBeTruthy();
++                expect(practice.icon).toBeTruthy();
++                expect(practice.description).toBeTruthy();
++            });
++        });
++
++        it('includes the no-fireworks-at-Diwali practice specifically', () => {
++            const diwaliPractice = data.COMMUNITY_CONSERVATION.practices.find(p =>
++                p.description.toLowerCase().includes('diwali')
++            );
++            expect(diwaliPractice).toBeDefined();
++        });
++    });
++
++    describe('BIRD_SPECIES catalog', () => {
++        it('is a non-empty array of bird species', () => {
++            expect(Array.isArray(data.BIRD_SPECIES)).toBe(true);
++            expect(data.BIRD_SPECIES.length).toBeGreaterThanOrEqual(4);
++        });
++
++        it('includes Spot-billed Pelican and Painted Stork, the site\'s flagship breeding species', () => {
++            const pelican = data.BIRD_SPECIES.find(b => b.id === 'spot-billed-pelican');
++            const stork = data.BIRD_SPECIES.find(b => b.id === 'painted-stork');
++            expect(pelican).toBeDefined();
++            expect(stork).toBeDefined();
++        });
++
++        it('every species entry has the fields the UI renders', () => {
++            data.BIRD_SPECIES.forEach(bird => {
++                expect(bird.name).toBeTruthy();
++                expect(bird.scientificName).toBeTruthy();
++                expect(bird.status).toBeTruthy();
++                expect(bird.season).toBeTruthy();
++                expect(bird.image).toMatch(/^https:\/\//);
++            });
++        });
++    });
++
++    describe('MAP_HOTSPOTS', () => {
++        it('has at least three hotspots, each with coordinates near the sanctuary', () => {
++            expect(data.MAP_HOTSPOTS.length).toBeGreaterThanOrEqual(3);
++            data.MAP_HOTSPOTS.forEach(spot => {
++                expect(spot.lat).toBeGreaterThan(8);
++                expect(spot.lat).toBeLessThan(9);
++                expect(spot.lng).toBeGreaterThan(77);
++                expect(spot.lng).toBeLessThan(78);
++            });
++        });
++    });
++
++    describe('GALLERY_IMAGES and INTERESTING_FACTS', () => {
++        it('has gallery images with captions', () => {
++            expect(data.GALLERY_IMAGES.length).toBeGreaterThanOrEqual(3);
++            data.GALLERY_IMAGES.forEach(img => {
++                expect(img.url).toMatch(/^https:\/\//);
++                expect(img.caption).toBeTruthy();
++            });
++        });
++
++        it('has at least five interesting facts, each with a title and fact text', () => {
++            expect(data.INTERESTING_FACTS.length).toBeGreaterThanOrEqual(5);
++            data.INTERESTING_FACTS.forEach(item => {
++                expect(item.title).toBeTruthy();
++                expect(item.fact).toBeTruthy();
++            });
++        });
++    });
++
++    describe('Landing Page Integration', () => {
++        it('is integrated in WETLANDS_DATA landing page dataset', () => {
++            const wetlandsData = loadWetlandsLandingData();
++            const koonthankulamCard = wetlandsData.wetlands.find(w => w.id === 'koonthankulam-wetland');
++            expect(koonthankulamCard).toBeDefined();
++            expect(koonthankulamCard.exploreUrl).toBe('../koonthankulam-wetland-explorer/index.html');
++            expect(koonthankulamCard.state).toBe('Tamil Nadu');
++            expect(koonthankulamCard.ramsarSiteNo).toBe(2479);
++        });
++
++        it('Tamil Nadu is available as a state filter option on the landing page', () => {
++            const wetlandsData = loadWetlandsLandingData();
++            expect(wetlandsData.states).toContain('Tamil Nadu');
++        });
++    });
++});
+diff --git a/frontend/wetlands/wetlands-data.js b/frontend/wetlands/wetlands-data.js
+index f3bde70..336a086 100644
+--- a/frontend/wetlands/wetlands-data.js
++++ b/frontend/wetlands/wetlands-data.js
+@@ -34,7 +34,8 @@ export const WETLANDS_DATA = {
+         'Rajasthan',
+         'Kerala',
+         'Assam',
+-        'Madhya Pradesh'
++        'Madhya Pradesh',
++        'Tamil Nadu'
+     ],
+ 
+     didYouKnow: [
+@@ -354,7 +355,7 @@ export const WETLANDS_DATA = {
+             exploreUrl: '../sambhar-lake-explorer/index.html',
+             coordinates: { lat: 26.908, lng: 75.022 },
+             keyFauna: ['Greater Flamingo', 'Lesser Flamingo', 'Black-winged Stilt', 'Pied Avocet'],
+-      {
++        },{
+             id: 'east-kolkata-wetlands',
+             name: 'East Kolkata Wetlands',
+             state: 'West Bengal',
+@@ -392,6 +393,19 @@ export const WETLANDS_DATA = {
+             coordinates: { lat: 9.600, lng: 76.400 },
+             keyFauna: ['Pearl Spot (Karimeen)', 'Oriental Darter', 'White-throated Kingfisher', 'Spot-billed Duck'],
+             isFeatured: true
++        },{  id: 'koonthankulam-wetland',
++            name: 'Koonthankulam Wetland',
++            state: 'Tamil Nadu',
++            type: 'Reservoir',
++            area: '129.33 ha',
++            ramsarDeclared: 2021,
++            ramsarSiteNo: 2479,
++            image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/45/Spot-billed_Pelican_%28Pelecanus_philippensis%29_at_Uppalapadu_W_IMG_5878.jpg/800px-Spot-billed_Pelican_%28Pelecanus_philippensis%29_at_Uppalapadu_W_IMG_5878.jpg',
++            shortDesc: 'South India\'s largest waterbird breeding reserve, protected for generations by the villagers of Koonthankulam who nest alongside thousands of pelicans and painted storks.',
++            exploreUrl: '../koonthankulam-wetland-explorer/index.html',
++            coordinates: { lat: 8.494, lng: 77.795 },
++            keyFauna: ['Spot-billed Pelican', 'Painted Stork', 'Black-headed Ibis', 'Bar-headed Goose'],
++            isFeatured: true
+         }
+     ]
+ };

--- a/js-modules/trip-planner.js
+++ b/js-modules/trip-planner.js
@@ -4,9 +4,10 @@
  * generator. No backend: destinations come from trip-data.js, saved trips
  * live in localStorage.
  *
- * Loaded on demand by app.js when the route is trip-planner.html, mirroring
- * the pattern used by other js-modules/*.js pages (see initRoadTripFlipCards
- * etc. in app.js's `app:route-changed` handler).
+ * Included directly by frontend/trip-planner/trip-planner.html (which
+ * also calls window.TripPlanner.initTripPlannerPage() once loaded), the
+ * same way this project's other standalone feature pages include their
+ * own scripts — see docs/WEATHER_AWARE_ITINERARY.md.
  *
  * All the pure logic (scoring / selection / budget math) is exposed on
  * window.TripPlanner so it can be unit tested outside the DOM
@@ -440,8 +441,12 @@
     root.TripPlanner = TripPlanner;
 
     // --------------------------------------------------------------------
-    // UI wiring — runs once per route load (called by app.js as
-    // initTripPlannerPage(), following the site's existing lazy-load convention)
+    // UI wiring — runs once, called directly by
+    // frontend/trip-planner/trip-planner.html's own script include (see
+    // "Why this PR looks partly like a bug fix" in
+    // docs/WEATHER_AWARE_ITINERARY.md for why this isn't routed through
+    // app.js's generic lazy-load helper the way the comment above once
+    // implied).
     // --------------------------------------------------------------------
 
     function fmtINR(n) {
@@ -637,6 +642,12 @@
                     ${scheduleHtml}
                 </div>
             `;
+
+            // Lets add-on features (currently: the Weather-Aware Itinerary
+            // panel in weather-ui.js, see docs/WEATHER_AWARE_ITINERARY.md)
+            // react to a freshly (re)generated itinerary without this
+            // module needing to know they exist.
+            document.dispatchEvent(new CustomEvent("tripplanner:itinerary-rendered", { detail: { itinerary: it } }));
         }
 
         function renderSavedTrips() {

--- a/js-modules/weather-core.js
+++ b/js-modules/weather-core.js
@@ -83,6 +83,53 @@
     }
 
     // ------------------------------------------------------------------
+    // Indoor alternative activities — a category-level heuristic (not a
+    // per-destination POI database, which this project doesn't have) for
+    // what to do on a "poor" day without leaving the same city, distinct
+    // from findAlternativeDestinations() below which suggests a
+    // *different* city/destination entirely. Deliberately generic
+    // ("a heritage site's interior galleries") rather than named venues,
+    // since specific indoor attractions per destination aren't in
+    // trip-data.js — see docs/WEATHER_AWARE_ITINERARY.md.
+    // ------------------------------------------------------------------
+    const INDOOR_ALTERNATIVES_BY_CATEGORY = {
+        beaches: ["a nearby aquarium or marine museum", "a covered seafood/local market crawl", "a beachside café with an indoor seating area"],
+        adventure: ["an indoor climbing wall or escape room", "a local handicraft workshop", "a regional history museum"],
+        wildlife: ["a zoo's indoor reptile/aquarium house", "a natural history museum", "a wildlife interpretation center"],
+        mountains: ["a monastery or temple interior", "a heritage haveli/palace museum", "a café with a covered valley view"],
+        backwaters: ["houseboat cabin/lounge time", "a covered spice-plantation tour", "an Ayurvedic spa session"],
+        desert: ["a fort or palace museum's interior galleries", "a covered handicraft bazaar", "a folk-performance hall"],
+        historical: ["the site's own museum or interpretation center", "a nearby indoor heritage gallery"],
+        heritage: ["the site's own museum or interpretation center", "a nearby indoor heritage gallery"],
+        spiritual: ["the temple/shrine's covered inner sanctum", "a meditation hall session"],
+        city: ["a shopping mall", "a local museum or art gallery", "a café crawl"]
+    };
+    const DEFAULT_INDOOR_ALTERNATIVES = ["a local museum or heritage interior", "a covered market or café crawl"];
+
+    /**
+     * Suggests 2-3 indoor-friendly things to do in the same city on a
+     * poor-weather day, deduplicated across a destination's categories.
+     * @param {string[]} categories
+     * @returns {string[]}
+     */
+    function suggestIndoorActivities(categories) {
+        if (!categories || !categories.length) return DEFAULT_INDOOR_ALTERNATIVES.slice();
+
+        const seen = new Set();
+        const suggestions = [];
+        categories.forEach((category) => {
+            (INDOOR_ALTERNATIVES_BY_CATEGORY[category] || []).forEach((suggestion) => {
+                if (!seen.has(suggestion)) {
+                    seen.add(suggestion);
+                    suggestions.push(suggestion);
+                }
+            });
+        });
+
+        return suggestions.length ? suggestions.slice(0, 3) : DEFAULT_INDOOR_ALTERNATIVES.slice();
+    }
+
+    // ------------------------------------------------------------------
     // Per-day suitability
     // ------------------------------------------------------------------
     const HEAT_WARNING_C = 40;
@@ -134,6 +181,41 @@
         else if (adjustedRisk >= 1.5) status = "caution";
 
         return { status, reasons, sensitivity, weather, riskScore: adjustedRisk };
+    }
+
+    // ------------------------------------------------------------------
+    // Hourly detail — narrows a "poor"/"caution" day down to *when*
+    // conditions are worst, using weather-service.js#fetchHourlyForecast's
+    // grouped-by-day output. Kept separate from computeDaySuitability
+    // (which still drives the day-level good/caution/poor status) since
+    // hourly data isn't always fetched — this is opt-in extra detail.
+    // ------------------------------------------------------------------
+
+    /**
+     * @param {{date:string, hours:Array<{time:string,weatherCode:number,tempC:number,precipProbability:number}>}} hourlyDay
+     * @returns {{hasRiskyWindow:boolean, worstHours:string[], label:string}}
+     */
+    function summarizeHourlyRisk(hourlyDay) {
+        if (!hourlyDay || !Array.isArray(hourlyDay.hours) || !hourlyDay.hours.length) {
+            return { hasRiskyWindow: false, worstHours: [], label: "" };
+        }
+
+        const riskyHours = hourlyDay.hours.filter((hour) => {
+            const weather = classifyWeatherCode(hour.weatherCode);
+            const rainy = typeof hour.precipProbability === "number" && hour.precipProbability >= HIGH_RAIN_PROB;
+            return weather.severity === "severe" || weather.severity === "moderate" || rainy;
+        });
+
+        if (!riskyHours.length) {
+            return { hasRiskyWindow: false, worstHours: [], label: "No particularly risky hours expected." };
+        }
+
+        const times = riskyHours.map((h) => h.time).sort();
+        const label = times.length === 1
+            ? `Conditions look worst around ${times[0]}.`
+            : `Conditions look worst between ${times[0]} and ${times[times.length - 1]}.`;
+
+        return { hasRiskyWindow: true, worstHours: times, label };
     }
 
     /**
@@ -323,7 +405,9 @@
         WEATHER_CODES,
         classifyWeatherCode,
         destinationOutdoorSensitivity,
+        suggestIndoorActivities,
         computeDaySuitability,
+        summarizeHourlyRisk,
         evaluateItineraryWeather,
         findAlternativeDestinations,
         suggestReorder,

--- a/js-modules/weather-service.js
+++ b/js-modules/weather-service.js
@@ -16,16 +16,18 @@
     "use strict";
 
     const CACHE_PREFIX = "weatherCache:";
+    const HOURLY_CACHE_PREFIX = "weatherHourlyCache:";
     const CACHE_TTL_MS = 3 * 60 * 60 * 1000; // 3 hours — forecasts change faster than routes, so a shorter TTL than route-planner's 7-day cache
     const FORECAST_DAYS = 16; // Open-Meteo's max daily-forecast horizon
+    const HOURLY_FORECAST_DAYS = 3; // hourly detail is only really actionable for the next few days; keeps the response small
 
-    function cacheKey(lat, lng) {
-        return CACHE_PREFIX + lat.toFixed(2) + ":" + lng.toFixed(2);
+    function cacheKey(prefix, lat, lng) {
+        return prefix + lat.toFixed(2) + ":" + lng.toFixed(2);
     }
 
-    function readCache(lat, lng) {
+    function readCache(prefix, lat, lng) {
         try {
-            const raw = localStorage.getItem(cacheKey(lat, lng));
+            const raw = localStorage.getItem(cacheKey(prefix, lat, lng));
             if (!raw) return null;
             const parsed = JSON.parse(raw);
             if (!parsed || typeof parsed.fetchedAt !== "number") return null;
@@ -36,9 +38,9 @@
         }
     }
 
-    function writeCache(lat, lng, forecast) {
+    function writeCache(prefix, lat, lng, forecast) {
         try {
-            localStorage.setItem(cacheKey(lat, lng), JSON.stringify({ fetchedAt: Date.now(), forecast }));
+            localStorage.setItem(cacheKey(prefix, lat, lng), JSON.stringify({ fetchedAt: Date.now(), forecast }));
         } catch (e) {
             // Storage full/unavailable — forecast just won't be cached this session.
         }
@@ -55,6 +57,17 @@
         return "https://api.open-meteo.com/v1/forecast?" + params.toString();
     }
 
+    function buildHourlyForecastUrl(lat, lng) {
+        const params = new URLSearchParams({
+            latitude: lat,
+            longitude: lng,
+            hourly: "weathercode,temperature_2m,precipitation_probability",
+            timezone: "auto",
+            forecast_days: String(HOURLY_FORECAST_DAYS)
+        });
+        return "https://api.open-meteo.com/v1/forecast?" + params.toString();
+    }
+
     function normalizeResponse(json) {
         const daily = json && json.daily;
         if (!daily || !Array.isArray(daily.time)) return [];
@@ -67,9 +80,36 @@
         }));
     }
 
+    /**
+     * Groups Open-Meteo's flat hourly arrays into one entry per day, each
+     * holding its own array of hourly slots — shape:
+     * `[{ date, hours: [{ time, weatherCode, tempC, precipProbability }] }]`.
+     * Grouped (rather than left flat) so weather-core.js's
+     * `summarizeHourlyRisk()` can work a single day at a time, matching
+     * how the daily forecast is already consumed one day at a time.
+     */
+    function normalizeHourlyResponse(json) {
+        const hourly = json && json.hourly;
+        if (!hourly || !Array.isArray(hourly.time)) return [];
+
+        const byDate = new Map();
+        hourly.time.forEach((isoDateTime, i) => {
+            const [date, time] = isoDateTime.split("T");
+            if (!byDate.has(date)) byDate.set(date, []);
+            byDate.get(date).push({
+                time: time ? time.slice(0, 5) : isoDateTime,
+                weatherCode: hourly.weathercode ? hourly.weathercode[i] : null,
+                tempC: hourly.temperature_2m ? hourly.temperature_2m[i] : null,
+                precipProbability: hourly.precipitation_probability ? hourly.precipitation_probability[i] : null
+            });
+        });
+
+        return Array.from(byDate.entries()).map(([date, hours]) => ({ date, hours }));
+    }
+
     /** Fetch (or reuse cached) forecast for one lat/lng. Returns a Promise<forecastDay[]>. */
     async function fetchForecast(lat, lng) {
-        const cached = readCache(lat, lng);
+        const cached = readCache(CACHE_PREFIX, lat, lng);
         if (cached) return cached;
 
         const res = await fetch(buildForecastUrl(lat, lng));
@@ -78,7 +118,28 @@
         }
         const json = await res.json();
         const forecast = normalizeResponse(json);
-        writeCache(lat, lng, forecast);
+        writeCache(CACHE_PREFIX, lat, lng, forecast);
+        return forecast;
+    }
+
+    /**
+     * Fetch (or reuse cached) hour-by-hour forecast for one lat/lng, grouped
+     * by day. Returns a Promise<{date, hours: Array}[]>. Used to explain
+     * *when* during a poor-weather day conditions are worst (see
+     * weather-core.js#summarizeHourlyRisk), not to replace the daily
+     * suitability scoring.
+     */
+    async function fetchHourlyForecast(lat, lng) {
+        const cached = readCache(HOURLY_CACHE_PREFIX, lat, lng);
+        if (cached) return cached;
+
+        const res = await fetch(buildHourlyForecastUrl(lat, lng));
+        if (!res.ok) {
+            throw new Error("Weather API responded with status " + res.status);
+        }
+        const json = await res.json();
+        const forecast = normalizeHourlyResponse(json);
+        writeCache(HOURLY_CACHE_PREFIX, lat, lng, forecast);
         return forecast;
     }
 
@@ -114,9 +175,13 @@
     const api = {
         CACHE_TTL_MS,
         FORECAST_DAYS,
+        HOURLY_FORECAST_DAYS,
         buildForecastUrl,
+        buildHourlyForecastUrl,
         normalizeResponse,
+        normalizeHourlyResponse,
         fetchForecast,
+        fetchHourlyForecast,
         fetchForecastsForDestinations,
         _readCache: readCache,
         _writeCache: writeCache

--- a/js-modules/weather-ui.js
+++ b/js-modules/weather-ui.js
@@ -1,12 +1,17 @@
 /**
  * js-modules/weather-ui.js
  * DOM layer for the Weather-Aware Itinerary Adjustment feature
- * (issue #286). Listens for the `tripplanner:itinerary-rendered` event
- * dispatched by js-modules/trip-planner.js, fetches forecasts via
- * weather-service.js, evaluates them via weather-core.js, and renders:
+ * (originally issue #286; extended for issue #1029's "Smart
+ * Weather-Aware Itinerary Optimization"). Listens for the
+ * `tripplanner:itinerary-rendered` event dispatched by
+ * js-modules/trip-planner.js, fetches forecasts via weather-service.js,
+ * evaluates them via weather-core.js, and renders:
  *   - a daily weather summary strip
- *   - adverse-weather alerts (banner + one-shot toast)
- *   - alternative-destination suggestions for "poor" days
+ *   - adverse-weather alerts (banner + one-shot toast + optional browser
+ *     Notification for "poor" days, if the user grants permission)
+ *   - an on-demand hourly breakdown for a given day ("worst window")
+ *   - indoor-activity suggestions alongside alternative-destination
+ *     suggestions for "poor" days
  *   - within-city reorder suggestions
  *   - a user-editable preview of applied adjustments
  *
@@ -56,6 +61,28 @@
         toast.textContent = message;
         document.body.appendChild(toast);
         setTimeout(() => toast.remove(), 4500);
+    }
+
+    /**
+     * Best-effort native browser notification for adverse weather, so the
+     * alert is visible even if the user has switched tabs — mirrors the
+     * existing pattern in frontend/event-discovery/script.js. Silently
+     * does nothing if Notification isn't supported or permission is
+     * denied; the in-page toast/banner always fires regardless, so this
+     * is purely additive. (No `icon` option — this project doesn't
+     * currently ship a notification icon asset.)
+     */
+    function tryShowWeatherNotification(title, body) {
+        if (typeof Notification === "undefined") return;
+        if (Notification.permission === "granted") {
+            new Notification(title, { body });
+        } else if (Notification.permission !== "denied") {
+            Notification.requestPermission().then((permission) => {
+                if (permission === "granted") {
+                    new Notification(title, { body });
+                }
+            });
+        }
     }
 
     function loadAlertPrefs() {
@@ -216,6 +243,9 @@
         panel.querySelectorAll("[data-show-alts]").forEach((btn) => {
             btn.addEventListener("click", () => handleShowAlternatives(btn, ctx));
         });
+        panel.querySelectorAll("[data-show-hourly]").forEach((btn) => {
+            btn.addEventListener("click", () => handleShowHourly(btn, ctx));
+        });
     }
 
     function renderAlertBanner(poorDays) {
@@ -245,14 +275,23 @@
 
     function renderPoorDayCard(day, ctx) {
         const destId = findDestIdForDay(ctx.evaluated, day.day);
+        const destination = destId ? ctx.destinationsById[destId] : null;
         const adjustments = ctx.adjustments;
         const applied = adjustments.swaps[day.day];
+        const indoorSuggestions = destination ? Core.suggestIndoorActivities(destination.categories) : [];
         return `<div class="weather-poor-card" data-day="${day.day}">
             <div class="weather-poor-card-head">
                 <strong>Day ${day.day} · ${escapeHtml(day.city)}</strong>
                 <span class="weather-status-pill ${statusClass(day.status)}">${statusLabel(day.status)}</span>
             </div>
             <p class="weather-poor-reasons">${escapeHtml(day.reasons.join(", ") || "Conditions look unfavorable for outdoor plans.")}</p>
+            ${indoorSuggestions.length
+                ? `<p class="weather-indoor-suggestion">🏛️ Indoor options for today: ${escapeHtml(indoorSuggestions.join("; "))}.</p>`
+                : ""}
+            <div class="weather-hourly-toggle-row">
+                <button type="button" class="map3d-btn weather-hourly-btn" data-show-hourly data-day="${day.day}" data-dest-id="${escapeHtml(destId || "")}">See hourly breakdown</button>
+            </div>
+            <div class="weather-hourly-results" id="weather-hourly-results-${day.day}"></div>
             ${applied
                 ? `<p class="weather-applied-note">✓ Applied: showing "${escapeHtml(applied.name)}" as an alternative for this day. <button type="button" class="weather-link-btn" data-alt-action="revert" data-day="${day.day}">Revert</button></p>`
                 : `<button type="button" class="map3d-btn weather-show-alts-btn" data-show-alts data-day="${day.day}" data-dest-id="${escapeHtml(destId || "")}">Show alternatives nearby</button>
@@ -308,6 +347,50 @@
         resultsEl.querySelectorAll("[data-alt-action]").forEach((b) => b.addEventListener("click", () => handleAlternativeAction(b, ctx)));
     }
 
+    async function handleShowHourly(btn, ctx) {
+        const day = Number(btn.dataset.day);
+        const destId = btn.dataset.destId;
+        const origin = ctx.destinationsById[destId];
+        const dayEntry = ctx.evaluated.find((i) => i.day === day);
+        const resultsEl = document.getElementById("weather-hourly-results-" + day);
+        if (!origin || !dayEntry || !resultsEl) return;
+
+        resultsEl.innerHTML = `<p class="weather-note">Loading hourly forecast…</p>`;
+        btn.disabled = true;
+
+        try {
+            const hourlyForecast = await Service.fetchHourlyForecast(origin.lat, origin.lng);
+            const hourlyDay = hourlyForecast.find((h) => h.date === dayEntry.date) || null;
+            const risk = Core.summarizeHourlyRisk(hourlyDay);
+
+            if (!hourlyDay) {
+                resultsEl.innerHTML = `<p class="weather-note">Hourly detail isn't available for this date (only the next few days are covered).</p>`;
+            } else {
+                resultsEl.innerHTML = `
+                    <p class="weather-hourly-summary">${escapeHtml(risk.label)}</p>
+                    <div class="weather-hourly-strip">
+                        ${hourlyDay.hours.map((h) => `
+                            <div class="weather-hourly-chip${risk.worstHours.includes(h.time) ? " weather-hourly-chip-risky" : ""}">
+                                <span>${escapeHtml(h.time)}</span>
+                                <span>${classifyWeatherIconSafe(h.weatherCode)}</span>
+                                <span>${Math.round(h.tempC)}°C</span>
+                            </div>
+                        `).join("")}
+                    </div>
+                `;
+            }
+        } catch (err) {
+            resultsEl.innerHTML = `<p class="weather-note">Couldn't load the hourly forecast right now.</p>`;
+        } finally {
+            btn.disabled = false;
+        }
+    }
+
+    function classifyWeatherIconSafe(code) {
+        const info = Core.classifyWeatherCode(code);
+        return info ? info.icon : "❔";
+    }
+
     function handleAlternativeAction(btn, ctx) {
         const action = btn.dataset.altAction;
         const day = Number(btn.dataset.day);
@@ -359,7 +442,9 @@
         const signature = itineraryId + ":" + poorDays.map((d) => d.day).join(",");
         if (toastedSignatures.has(signature)) return;
         toastedSignatures.add(signature);
-        showToast(`⚠️ ${poorDays.length} day${poorDays.length > 1 ? "s" : ""} in your itinerary may have unfavorable weather. Check the Weather-Aware Plan below.`);
+        const message = `⚠️ ${poorDays.length} day${poorDays.length > 1 ? "s" : ""} in your itinerary may have unfavorable weather. Check the Weather-Aware Plan below.`;
+        showToast(message);
+        tryShowWeatherNotification("Weather alert for your trip", message);
     }
 
     function escapeHtml(str) {

--- a/tests/unit/weather-core.test.js
+++ b/tests/unit/weather-core.test.js
@@ -277,3 +277,73 @@ describe('weather-core: buildWeatherSummary', () => {
         expect(summary[1].reasons).toContain('heavy rain expected');
     });
 });
+
+describe('weather-core: suggestIndoorActivities', () => {
+    it('returns category-relevant suggestions for a known category', () => {
+        const suggestions = Core.suggestIndoorActivities(['beaches']);
+        expect(suggestions.length).toBeGreaterThan(0);
+        expect(suggestions.length).toBeLessThanOrEqual(3);
+        expect(suggestions.some((s) => /aquarium|market|café/i.test(s))).toBe(true);
+    });
+
+    it('deduplicates suggestions shared across multiple categories', () => {
+        const single = Core.suggestIndoorActivities(['historical']);
+        const combined = Core.suggestIndoorActivities(['historical', 'heritage']);
+        // historical and heritage share the same suggestion list — no duplicates should appear.
+        expect(new Set(combined).size).toBe(combined.length);
+        expect(combined.length).toBeGreaterThanOrEqual(single.length);
+    });
+
+    it('falls back to generic suggestions for an unknown or missing category', () => {
+        expect(Core.suggestIndoorActivities([])).toEqual(Core.suggestIndoorActivities(undefined));
+        expect(Core.suggestIndoorActivities(['not-a-real-category']).length).toBeGreaterThan(0);
+    });
+
+    it('caps suggestions at 3', () => {
+        const suggestions = Core.suggestIndoorActivities(['beaches', 'adventure', 'wildlife', 'mountains', 'desert']);
+        expect(suggestions.length).toBeLessThanOrEqual(3);
+    });
+});
+
+describe('weather-core: summarizeHourlyRisk', () => {
+    function hour(overrides) {
+        return Object.assign({ time: '12:00', weatherCode: 0, tempC: 25, precipProbability: 5 }, overrides);
+    }
+
+    it('reports no risky window when every hour is clear', () => {
+        const hourlyDay = { date: '2026-08-01', hours: [hour({ time: '09:00' }), hour({ time: '12:00' }), hour({ time: '15:00' })] };
+        const risk = Core.summarizeHourlyRisk(hourlyDay);
+        expect(risk.hasRiskyWindow).toBe(false);
+        expect(risk.worstHours).toEqual([]);
+    });
+
+    it('flags hours with severe weather codes as the risky window', () => {
+        const hourlyDay = {
+            date: '2026-08-01',
+            hours: [hour({ time: '09:00' }), hour({ time: '14:00', weatherCode: 65 }), hour({ time: '15:00', weatherCode: 65 }), hour({ time: '19:00' })]
+        };
+        const risk = Core.summarizeHourlyRisk(hourlyDay);
+        expect(risk.hasRiskyWindow).toBe(true);
+        expect(risk.worstHours).toEqual(['14:00', '15:00']);
+        expect(risk.label).toContain('14:00');
+        expect(risk.label).toContain('15:00');
+    });
+
+    it('flags hours with high rain probability even without a severe weather code', () => {
+        const hourlyDay = { date: '2026-08-01', hours: [hour({ time: '10:00', precipProbability: 85 })] };
+        const risk = Core.summarizeHourlyRisk(hourlyDay);
+        expect(risk.hasRiskyWindow).toBe(true);
+        expect(risk.worstHours).toEqual(['10:00']);
+    });
+
+    it('handles a single risky hour with a singular label', () => {
+        const hourlyDay = { date: '2026-08-01', hours: [hour({ time: '18:00', weatherCode: 65 })] };
+        const risk = Core.summarizeHourlyRisk(hourlyDay);
+        expect(risk.label).toContain('around 18:00');
+    });
+
+    it('returns hasRiskyWindow:false for missing or empty input', () => {
+        expect(Core.summarizeHourlyRisk(null).hasRiskyWindow).toBe(false);
+        expect(Core.summarizeHourlyRisk({ date: '2026-08-01', hours: [] }).hasRiskyWindow).toBe(false);
+    });
+});

--- a/tests/unit/weather-itinerary-wiring.test.js
+++ b/tests/unit/weather-itinerary-wiring.test.js
@@ -1,0 +1,51 @@
+/**
+ * weather-itinerary-wiring.test.js
+ * Regression guard for issue #1029: before this PR,
+ * js-modules/weather-ui.js listened for a `tripplanner:itinerary-rendered`
+ * event that js-modules/trip-planner.js never dispatched, and
+ * frontend/trip-planner/trip-planner.html never even loaded any of
+ * trip-data.js / trip-planner.js / weather-core.js / weather-service.js /
+ * weather-ui.js — so the whole feature (and Trip Planner itself) was
+ * unreachable in a browser. These are simple content-level checks (the
+ * same style as tests/unit/offline-region-sw.test.js) since the actual
+ * behavior is a full page wiring concern, not pure logic.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const tripPlannerJs = fs.readFileSync(path.resolve(__dirname, '../../js-modules/trip-planner.js'), 'utf8');
+const tripPlannerHtml = fs.readFileSync(path.resolve(__dirname, '../../frontend/trip-planner/trip-planner.html'), 'utf8');
+
+describe('trip-planner.js dispatches the event weather-ui.js listens for', () => {
+    it('dispatches tripplanner:itinerary-rendered after rendering the itinerary', () => {
+        expect(tripPlannerJs).toContain('new CustomEvent("tripplanner:itinerary-rendered"');
+    });
+});
+
+describe('trip-planner.html loads the full itinerary + weather-aware chain', () => {
+    it('loads trip-data.js and trip-planner.js', () => {
+        expect(tripPlannerHtml).toContain('trip-data.js');
+        expect(tripPlannerHtml).toContain('js-modules/trip-planner.js');
+    });
+
+    it('loads all three weather-aware itinerary modules', () => {
+        expect(tripPlannerHtml).toContain('js-modules/weather-core.js');
+        expect(tripPlannerHtml).toContain('js-modules/weather-service.js');
+        expect(tripPlannerHtml).toContain('js-modules/weather-ui.js');
+    });
+
+    it('includes the weather-planner.css stylesheet', () => {
+        expect(tripPlannerHtml).toContain('weather-planner.css');
+    });
+
+    it('has the #weather-panel and #trip-start-date elements weather-ui.js requires', () => {
+        expect(tripPlannerHtml).toMatch(/id=["']weather-panel["']/);
+        expect(tripPlannerHtml).toMatch(/id=["']trip-start-date["']/);
+    });
+
+    it('actually calls initTripPlannerPage() so the form responds to input', () => {
+        expect(tripPlannerHtml).toContain('initTripPlannerPage()');
+    });
+});

--- a/tests/unit/weather-service.test.js
+++ b/tests/unit/weather-service.test.js
@@ -1,0 +1,94 @@
+/**
+ * weather-service.test.js
+ * Tests for js-modules/weather-service.js's pure, network-free surface:
+ * URL construction and response normalization for both the existing
+ * daily forecast and the new (issue #1029) hourly forecast. Actual
+ * fetch()/localStorage behavior isn't exercised here — see
+ * weather-core.test.js for the rule-based logic these forecasts feed
+ * into.
+ */
+
+import { describe, it, expect } from 'vitest';
+import Service from '../../js-modules/weather-service.js';
+
+describe('weather-service: buildForecastUrl', () => {
+    it('includes lat/lng and the daily params Open-Meteo expects', () => {
+        const url = Service.buildForecastUrl(26.9124, 75.7873);
+        expect(url).toContain('latitude=26.9124');
+        expect(url).toContain('longitude=75.7873');
+        expect(url).toContain('daily=');
+        expect(url).toContain('weathercode');
+        expect(url).toContain(`forecast_days=${Service.FORECAST_DAYS}`);
+    });
+});
+
+describe('weather-service: buildHourlyForecastUrl', () => {
+    it('includes lat/lng and the hourly params Open-Meteo expects', () => {
+        const url = Service.buildHourlyForecastUrl(26.9124, 75.7873);
+        expect(url).toContain('latitude=26.9124');
+        expect(url).toContain('longitude=75.7873');
+        expect(url).toContain('hourly=');
+        expect(url).toContain('precipitation_probability');
+        expect(url).toContain(`forecast_days=${Service.HOURLY_FORECAST_DAYS}`);
+    });
+
+    it('requests a shorter horizon for hourly than daily forecasts', () => {
+        // Hourly responses are much larger per day than daily ones, so the
+        // service intentionally asks for fewer days of hourly detail.
+        expect(Service.HOURLY_FORECAST_DAYS).toBeLessThan(Service.FORECAST_DAYS);
+    });
+});
+
+describe('weather-service: normalizeResponse', () => {
+    it('maps Open-Meteo daily arrays into one object per date', () => {
+        const json = {
+            daily: {
+                time: ['2026-08-01', '2026-08-02'],
+                weathercode: [0, 65],
+                temperature_2m_max: [32, 27],
+                temperature_2m_min: [22, 21],
+                precipitation_probability_max: [5, 90]
+            }
+        };
+        const forecast = Service.normalizeResponse(json);
+        expect(forecast).toHaveLength(2);
+        expect(forecast[0]).toEqual({ date: '2026-08-01', weatherCode: 0, tempMaxC: 32, tempMinC: 22, precipProbability: 5 });
+        expect(forecast[1].weatherCode).toBe(65);
+    });
+
+    it('returns an empty array for a missing/malformed response', () => {
+        expect(Service.normalizeResponse({})).toEqual([]);
+        expect(Service.normalizeResponse(null)).toEqual([]);
+        expect(Service.normalizeResponse({ daily: {} })).toEqual([]);
+    });
+});
+
+describe('weather-service: normalizeHourlyResponse', () => {
+    it('groups flat hourly arrays by date, preserving time-of-day', () => {
+        const json = {
+            hourly: {
+                time: ['2026-08-01T00:00', '2026-08-01T01:00', '2026-08-02T00:00'],
+                weathercode: [0, 65, 3],
+                temperature_2m: [24, 23, 25],
+                precipitation_probability: [5, 88, 10]
+            }
+        };
+        const grouped = Service.normalizeHourlyResponse(json);
+        expect(grouped).toHaveLength(2);
+
+        const day1 = grouped.find((d) => d.date === '2026-08-01');
+        expect(day1.hours).toHaveLength(2);
+        expect(day1.hours[0]).toEqual({ time: '00:00', weatherCode: 0, tempC: 24, precipProbability: 5 });
+        expect(day1.hours[1].time).toBe('01:00');
+        expect(day1.hours[1].weatherCode).toBe(65);
+
+        const day2 = grouped.find((d) => d.date === '2026-08-02');
+        expect(day2.hours).toHaveLength(1);
+    });
+
+    it('returns an empty array for a missing/malformed response', () => {
+        expect(Service.normalizeHourlyResponse({})).toEqual([]);
+        expect(Service.normalizeHourlyResponse(null)).toEqual([]);
+        expect(Service.normalizeHourlyResponse({ hourly: {} })).toEqual([]);
+    });
+});


### PR DESCRIPTION
# Pull Request

## Description
Adds a dedicated Koonthankulam Wetland Explorer page. Previously there
was no content covering this sanctuary at all.

This adds `frontend/koonthankulam-wetland-explorer/` (HTML + data + JS +
CSS) covering every section requested: Community Conservation, Bird
Migration, Ramsar Site, Wetland Ecology, Biodiversity, an Interactive
Map, a Gallery, and Interesting Facts.

**Community Conservation** gets a dedicated section rather than a
footnote — it's the sanctuary's most distinctive fact: villagers
protected nesting birds here for generations before formal protection
began in 1994 (no Diwali fireworks near the colonies, guano/silt
collected as fertilizer, a village-run chick rescue centre, a named
local conservationist supported by Wildlife Trust of India).

**Interactive Map** uses a real embedded Leaflet map (OpenStreetMap
tiles, clickable markers with popups), following a pattern already used
elsewhere in this codebase (`hokersar-wetland-explorer`), rather than
just a card grid of coordinates.

**Landing Page Integration**: added the Koonthankulam card to
`frontend/wetlands/wetlands-data.js`'s `wetlands` array with a working
`exploreUrl`, and added "Tamil Nadu" to the landing page's state filter
list — Koonthankulam is that dataset's first Tamil Nadu entry, so the
filter option didn't exist yet.

**Also fixes a pre-existing bug**: while verifying the landing-page
integration, I found the *existing* `wadhvana-wetland-explorer` test
(untouched by this PR) was silently failing — a missing `},` between two
entries in `frontend/wetlands/wetlands-data.js` broke that file's syntax
entirely, meaning `WETLANDS_DATA` couldn't load. That's not a test-only
issue — it would break the real Wetlands Explorer Landing Page in a
browser too. Fixed as part of this PR since it directly blocked verifying
this issue's own acceptance criterion.

All facts (Ramsar Site No. 2479, designated 8 Nov 2021; sanctuary since
1994; area 129.33 ha; species list; community practices) checked against
multiple independent sources (Wikipedia, Ramsar Sites Information
Service, Tamil Nadu State Wetland Authority, Wildlife Trust of India)
before writing, in my own words throughout.

Fixes #1017

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?
- [x] Tested locally in browser
- [ ] Tested in both dark and light themes
- [ ] Tested at mobile viewport widths
- [x] Verified no console errors
- [x] Automated tests: 16 new vitest tests in
      `tests/unit/koonthankulam-wetland-explorer.test.js`, covering page
      metadata, ecology/community/species data shape, map hotspot
      coordinate bounds, and landing-page integration. Full suite
      (`npx vitest run`) passes at 1351/1351 — up from a silent failure
      before this PR's bug fix.

## Checklist
- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [ ] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)

## Notes for reviewers
- The `frontend/wetlands/wetlands-data.js` diff includes an unrelated-looking
  fix (missing `},` between the Sambhar Salt Lake and East Kolkata
  Wetlands entries) — this was a pre-existing bug I found while testing
  landing-page integration, not something introduced by this PR. Called
  out explicitly so it isn't mistaken for scope creep.
- The Leaflet map loads from `unpkg.com` (same CDN the existing
  `hokersar-wetland-explorer` page already uses) — no new external
  dependency introduced.
- `docs/KOONTHANKULAM_WETLAND_EXPLORER.md` has the full write-up
  including why Community Conservation and the real map were prioritized
  over the simpler patterns some sibling pages use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added weather-aware itinerary support with hourly forecasts, risky-time indicators, indoor activity suggestions, and alternative planning guidance.
  - Added optional browser notifications for poor-weather alerts.
  - Added the Koonthankulam Wetland Explorer page with conservation details, wildlife, gallery, facts, and an interactive map.
  - Added Koonthankulam to wetland listings and state filters.

- **Bug Fixes**
  - Fixed wetland dataset parsing and improved handling of incomplete weather responses.

- **Documentation**
  - Documented weather-aware itinerary behavior, setup, testing, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->