### PR TITLE
feat:  create hirakud reservior  Wetland Explorer"

### DIFF
--- a/frontend/hirakud-reservoir-wetland-explorer/hirakud-data.js
+++ b/frontend/hirakud-reservoir-wetland-explorer/hirakud-data.js
@@ -1,0 +1,82 @@
+/**
+ * Hirakud Reservoir Wetland Explorer Dataset
+ * One of Asia's Largest Artificial Lakes & Ramsar Site #2494
+ */
+
+export const HIRAKUD_DATA = {
+    id: 'hirakud-reservoir-wetland-explorer',
+    name: 'Hirakud Reservoir Wetland Explorer',
+    subtitle: 'The Reservoir Behind the World\'s Longest Earthen Dam',
+    location: 'Sambalpur, Bargarh, Bolangir & Subarnapur Districts, Odisha',
+    ramsarSiteNo: 2494,
+    ramsarDeclared: 2021,
+    area: '743 km² (Full Reservoir Level)',
+    damLength: '25.8 km (including dykes)',
+    type: 'Man-made Reservoir on the Mahanadi River',
+    coordinates: { lat: 21.57, lng: 83.87 },
+
+    stats: [
+        { label: 'Reservoir Area', value: '743 km²', icon: '🌊' },
+        { label: 'Shoreline Length', value: '639 km', icon: '🏞️' },
+        { label: 'Bird Species Recorded', value: '130+', icon: '🦆' },
+        { label: 'Installed Hydropower', value: '347.5 MW', icon: '⚡' }
+    ],
+
+    reservoirHistory: {
+        title: 'India\'s First Post-Independence River Valley Project',
+        content: 'Before the dam, the Mahanadi River was known across Odisha as the "Sorrow of Odisha" for the floods it regularly sent through the delta. Governor Hawthorne Lewis laid the foundation stone in March 1946, and Jawaharlal Nehru poured the first batch of concrete two years later. Construction stretched through the early 1950s, and Nehru formally inaugurated the completed dam on 13 January 1957 — one of the first major multipurpose river valley projects taken up after independence. Filling the reservoir meant submerging the Padampur valley, along with more than 200 villages and a number of centuries-old temples. In the dry summer months of May and June, falling water levels still expose the spires of some of those temples, a reminder of what the valley looked like before the dam.'
+    },
+
+    ramsarSite: {
+        title: 'A Working Reservoir Recognised as a Wetland of International Importance',
+        content: 'Hirakud Reservoir was designated a Ramsar Site on 12 October 2021, part of a larger batch of Indian wetlands announced through 2021 and 2022. It is an unusual entry on the Ramsar list: unlike most designated wetlands, Hirakud is an actively engineered reservoir that still does the everyday work of flood control, irrigation, and power generation for a large part of western and coastal Odisha. Its listing recognises that decades of human engineering can still produce a wetland with real ecological value, supporting fish, birds, and other wildlife alongside its industrial role.'
+    },
+
+    waterManagement: {
+        title: 'Flood Control, Irrigation & Power in One System',
+        content: 'The Hirakud project regulates roughly 83,400 km² of the Mahanadi\'s catchment, holding back monsoon flows that once devastated the delta around Cuttack and Puri and releasing them in a controlled way through the Bargarh Main Canal, Sason Canal, and Sambalpur Canal. The reservoir irrigates well over 235,000 hectares of farmland across the Sambalpur, Bargarh, Bolangir, and Subarnapur districts, turning the region into one of western Odisha\'s main rice-growing belts. Two hydropower stations, Burla and Chiplima, together generate up to 347.5 MW of electricity. Because so many demands sit on the same water — farmers, industry, and power generation — allocation has occasionally become contentious, including a large protest by farmers over water diverted to industrial users. A renovation programme is now underway to convert ageing earthen canals to concrete, cutting seepage losses and improving water delivery to farms at the tail end of the system.'
+    },
+
+    birdlife: {
+        title: 'A Winter Stopover on the Reservoir',
+        subtitle: 'Over 130 recorded bird species, with roughly 20 of high conservation significance.',
+        content: 'Every winter, migratory waterfowl arrive at Hirakud\'s open water and shallows, feeding alongside the reservoir\'s resident bird population. Species commonly recorded include the common pochard, red-crested pochard, and great crested grebe, diving ducks and grebes that favour the reservoir\'s calmer stretches. The adjoining Debrigarh Wildlife Sanctuary, on the reservoir\'s northern shore, adds forested habitat that shelters birds and other wildlife moving in and out of the wetland edge.',
+        facts: [
+            'Around 20 to 25 waterbird species are regularly seen on the reservoir through the winter months.',
+            'Debrigarh Wildlife Sanctuary borders the reservoir and supports species that use both forest and open water habitats.',
+            'The reservoir\'s scale means birdwatching sites can vary considerably by season, as water levels rise and fall.'
+        ]
+    },
+
+    fisheries: {
+        title: 'A Livelihood for Thousands of Fishing Households',
+        content: 'Hirakud supports around 54 recorded species of fish, several of them of high economic value, alongside a smaller number classed as threatened or near-threatened. Fishing on the reservoir yields roughly 480 tonnes of fish annually and forms the economic backbone for close to 7,000 fisher households living around its shores. Balancing that fishery against water releases for irrigation and power is one of the reservoir\'s ongoing management challenges, since sudden drawdowns can affect both fish habitat and the safety of small fishing boats on open water.'
+    },
+
+    biodiversity: {
+        title: 'Beyond Fish and Flocks',
+        content: 'Hirakud\'s edges and islands host more than birds and fisheries. Cattle Island, a submerged hilltop near the reservoir\'s upper reaches, is home to a herd of feral cattle descended from animals left behind during the original resettlement of the valley in the 1950s — now wild, wary, and rarely caught. The surrounding forest tracts, including Debrigarh, support a wider mix of wildlife typical of dry deciduous Odisha forest, from deer to smaller mammals, drawn to the reservoir\'s permanent water source in an otherwise seasonally dry landscape.'
+    },
+
+    hotspots: [
+        { id: 'gandhi-minar', name: 'Gandhi Minar Viewpoint', lat: 21.58, lng: 83.87, desc: 'Observation tower on the dam\'s left bank offering sweeping views across the reservoir.' },
+        { id: 'jawahar-minar', name: 'Jawahar Minar Viewpoint', lat: 21.58, lng: 83.86, desc: 'Sister observation tower on the right bank, popular for sunset views over the dam.' },
+        { id: 'debrigarh', name: 'Debrigarh Wildlife Sanctuary', lat: 21.62, lng: 83.80, desc: 'Forested sanctuary bordering the reservoir\'s northern shore, rich in birdlife and deer.' },
+        { id: 'cattle-island', name: 'Cattle Island', lat: 21.75, lng: 84.10, desc: 'Remote hilltop island inhabited only by descendants of cattle left behind during resettlement.' },
+        { id: 'chiplima', name: 'Chiplima Power House', lat: 20.47, lng: 83.72, desc: 'Second hydropower station on the system, built where the Mahanadi drops over a natural fall.' }
+    ],
+
+    gallery: [
+        { title: 'Hirakud Dam Panorama', url: 'https://commons.wikimedia.org/wiki/Special:FilePath/Hirakud_Dam_Panorama.jpg', caption: 'Wide view across the main dam section spanning the Mahanadi River.' },
+        { title: 'Hirakud Reservoir', url: 'https://commons.wikimedia.org/wiki/Special:FilePath/Hirakud_Dam_Reservoir.jpg', caption: 'Open water of the reservoir stretching toward the horizon.' },
+        { title: 'Fisherman on the Reservoir', url: 'https://commons.wikimedia.org/wiki/Special:FilePath/Hirakud_fisherman2.jpg', caption: 'A local fisherman working the reservoir\'s waters, part of a livelihood shared by thousands.' },
+        { title: 'View of Hirakud', url: 'https://commons.wikimedia.org/wiki/Special:FilePath/View_of_Hirakud.jpg', caption: 'A broad view of the reservoir and its shoreline near Sambalpur.' }
+    ],
+
+    facts: [
+        'The Hirakud Dam and its dykes together stretch 25.8 km, making it the longest earthen dam in the world.',
+        'More than 200 villages, and the temples within them, were submerged when the reservoir was first filled — some resurface briefly each summer.',
+        'Cattle Island is home to a wild herd descended from cattle left behind during the original resettlement of the valley.',
+        'Hirakud is an unusual Ramsar site: a working reservoir that still supplies irrigation, flood control, and hydropower to this day.'
+    ]
+};

--- a/frontend/hirakud-reservoir-wetland-explorer/index.html
+++ b/frontend/hirakud-reservoir-wetland-explorer/index.html
@@ -1,0 +1,241 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    document.body.classList.add('light-theme');
+                }
+            })();
+        </script>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Explore Hirakud Reservoir in Odisha — one of Asia's largest artificial lakes, a Ramsar Site, formed by the world's longest earthen dam, with rich birdlife, fisheries, and biodiversity."
+        />
+        <title>Hirakud Reservoir Wetland Explorer | Incredible India</title>
+
+        <!-- Google Fonts -->
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+            rel="stylesheet"
+        />
+
+        <!-- Stylesheets -->
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="style.css" />
+
+        <!-- Open Graph -->
+        <meta property="og:title" content="Hirakud Reservoir Wetland Explorer | Incredible India" />
+        <meta
+            property="og:description"
+            content="Interactive explorer on Hirakud Reservoir in Odisha — reservoir history, Ramsar site status, water management, birdlife, fisheries, biodiversity, interactive map, and photo gallery."
+        />
+        <meta property="og:type" content="website" />
+    </head>
+
+    <body class="hirakud-main">
+        <!-- Site Navbar -->
+        <header class="navbar scrolled" id="navbar">
+            <div class="nav-container">
+                <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </button>
+                <nav class="nav-menu" id="nav-menu">
+                    <a href="../../index.html#home" class="nav-link">Home</a>
+                    <a href="../wetlands/index.html" class="nav-link">Wetlands Hub</a>
+                    <a href="../chilika-lake/index.html" class="nav-link">Chilika Lake</a>
+                    <a href="../kolleru-lake/index.html" class="nav-link">Kolleru Lake</a>
+                    <a href="../loktak-lake/index.html" class="nav-link">Loktak Lake</a>
+                    <a href="index.html" class="nav-link active" style="color: var(--saffron)">Hirakud Reservoir</a>
+                    <button
+                        id="theme-toggle"
+                        class="btn-theme-toggle"
+                        aria-label="Toggle Dark/Light Mode"
+                        title="Toggle Light Mode"
+                    >
+                        ☀️
+                    </button>
+                </nav>
+            </div>
+        </header>
+
+        <main>
+            <!-- Hero Section -->
+            <section class="hirakud-hero">
+                <div class="section-container">
+                    <div class="hero-badges-row">
+                        <span class="hero-pill pill-ramsar">🪷 Ramsar Site #2494</span>
+                        <span class="hero-pill pill-dam">🏗️ World's Longest Earthen Dam</span>
+                        <span class="hero-pill pill-reservoir">🌊 743 km² Reservoir</span>
+                    </div>
+                    <h1>Hirakud <span>Reservoir</span> Wetland Explorer</h1>
+                    <p class="hero-subtitle">
+                        Discover one of Asia's largest artificial lakes, held back by the world's longest earthen
+                        dam on the Mahanadi River. Beyond irrigation and hydropower, Hirakud is a Ramsar-listed
+                        wetland supporting migratory birds, thousands of fishing families, and a scattering of
+                        submerged history.
+                    </p>
+
+                    <!-- Quick Stats Bar -->
+                    <div id="stats-grid" class="stats-grid">
+                        <!-- Populated dynamically -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Reservoir History Section -->
+            <section class="history-section" id="history">
+                <div class="section-container">
+                    <div class="info-card">
+                        <span class="section-tag">TAMING THE "SORROW OF ODISHA"</span>
+                        <h2 id="history-title"></h2>
+                        <p id="history-content"></p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Ramsar Site Section -->
+            <section class="ramsar-section" id="ramsar">
+                <div class="section-container">
+                    <div class="info-card highlight-card">
+                        <span class="section-tag">GLOBAL RECOGNITION</span>
+                        <h2 id="ramsar-title"></h2>
+                        <p id="ramsar-content"></p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Water Management Section -->
+            <section class="water-management-section" id="water-management">
+                <div class="section-container">
+                    <div class="info-card">
+                        <span class="section-tag">ENGINEERING THE MAHANADI</span>
+                        <h2 id="water-title"></h2>
+                        <p id="water-content"></p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Birdlife Section -->
+            <section class="birdlife-section" id="birdlife">
+                <div class="section-container">
+                    <div class="bird-card-feature">
+                        <div class="bird-feature-info">
+                            <span class="section-tag">WINTER VISITORS</span>
+                            <h2 id="birdlife-title"></h2>
+                            <p id="birdlife-content"></p>
+                            <div class="facts-list" id="birdlife-facts">
+                                <!-- Populated dynamically -->
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Fisheries Section -->
+            <section class="fisheries-section" id="fisheries">
+                <div class="section-container">
+                    <div class="info-card">
+                        <span class="section-tag">LIVELIHOODS ON THE WATER</span>
+                        <h2 id="fisheries-title"></h2>
+                        <p id="fisheries-content"></p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Biodiversity Section -->
+            <section class="biodiversity-section" id="biodiversity">
+                <div class="section-container">
+                    <div class="info-card highlight-card">
+                        <span class="section-tag">WILDLIFE OF THE RESERVOIR</span>
+                        <h2 id="biodiversity-title"></h2>
+                        <p id="biodiversity-content"></p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Interactive Map Section -->
+            <section class="map-section" id="interactive-map">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-tag">HOTSPOT EXPLORER</span>
+                        <h2>Interactive Hirakud Map & Destinations</h2>
+                        <p>Select key viewpoints, sanctuaries, and power stations around the reservoir.</p>
+                    </div>
+                    <div class="map-layout">
+                        <div class="map-list" id="hotspots-list">
+                            <!-- Populated dynamically -->
+                        </div>
+                        <div class="map-detail" id="hotspot-detail">
+                            <!-- Populated dynamically -->
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Photo Gallery Section -->
+            <section class="gallery-section" id="gallery">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-tag">MEDIA SHOTS</span>
+                        <h2>Image Gallery</h2>
+                        <p>Glimpse the dam, waters, and daily life around Hirakud Reservoir.</p>
+                    </div>
+                    <div class="gallery-grid" id="gallery-grid">
+                        <!-- Populated dynamically -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Interesting Facts Section -->
+            <section class="facts-section" id="facts">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-tag">TRIVIA</span>
+                        <h2>Interesting Facts</h2>
+                    </div>
+                    <div class="facts-grid" id="facts-grid">
+                        <!-- Populated dynamically -->
+                    </div>
+                </div>
+            </section>
+        </main>
+
+        <!-- Footer -->
+        <footer class="footer">
+            <div class="section-container">
+                <div class="footer-content">
+                    <div class="footer-logo">
+                        <h3>Incredible India Explorer</h3>
+                        <p>Promoting eco-tourism, biodiversity awareness, and sustainable exploration across India.</p>
+                    </div>
+                    <div class="footer-links">
+                        <a href="../../index.html#home">Home</a>
+                        <a href="../wetlands/index.html">Wetlands Hub</a>
+                        <a href="../chilika-lake/index.html">Chilika Lake</a>
+                        <a href="../kolleru-lake/index.html">Kolleru Lake</a>
+                        <a href="../loktak-lake/index.html">Loktak Lake</a>
+                    </div>
+                </div>
+                <div class="footer-bottom">
+                    <p>&copy; 2026 Incredible India Explorer. Open Source Educational Platform.</p>
+                </div>
+            </div>
+        </footer>
+
+        <!-- Scripts -->
+        <script type="module" src="script.js"></script>
+    </body>
+</html>

--- a/frontend/hirakud-reservoir-wetland-explorer/script.js
+++ b/frontend/hirakud-reservoir-wetland-explorer/script.js
@@ -1,0 +1,178 @@
+import { HIRAKUD_DATA } from './hirakud-data.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+    initTheme();
+    initNavbar();
+    renderStats();
+    renderHistory();
+    renderRamsar();
+    renderWaterManagement();
+    renderBirdlife();
+    renderFisheries();
+    renderBiodiversity();
+    renderMapHotspots();
+    renderGallery();
+    renderFacts();
+});
+
+function initTheme() {
+    const themeToggleBtn = document.getElementById('theme-toggle');
+    if (!themeToggleBtn) return;
+
+    themeToggleBtn.addEventListener('click', () => {
+        document.body.classList.toggle('light-theme');
+        const isLight = document.body.classList.contains('light-theme');
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        themeToggleBtn.textContent = isLight ? '🌙' : '☀️';
+    });
+}
+
+function initNavbar() {
+    const menuToggle = document.getElementById('menu-toggle');
+    const navMenu = document.getElementById('nav-menu');
+    if (!menuToggle || !navMenu) return;
+
+    menuToggle.addEventListener('click', () => {
+        const isExpanded = menuToggle.getAttribute('aria-expanded') === 'true';
+        menuToggle.setAttribute('aria-expanded', !isExpanded);
+        navMenu.classList.toggle('active');
+    });
+}
+
+function renderStats() {
+    const container = document.getElementById('stats-grid');
+    if (!container || !HIRAKUD_DATA.stats) return;
+
+    container.innerHTML = HIRAKUD_DATA.stats
+        .map(
+            (stat) => `
+        <div class="stat-card">
+            <span class="stat-icon">${stat.icon}</span>
+            <div class="stat-value">${stat.value}</div>
+            <div class="stat-label">${stat.label}</div>
+        </div>
+    `
+        )
+        .join('');
+}
+
+function renderHistory() {
+    const title = document.getElementById('history-title');
+    const content = document.getElementById('history-content');
+    if (title) title.textContent = HIRAKUD_DATA.reservoirHistory.title;
+    if (content) content.textContent = HIRAKUD_DATA.reservoirHistory.content;
+}
+
+function renderRamsar() {
+    const title = document.getElementById('ramsar-title');
+    const content = document.getElementById('ramsar-content');
+    if (title) title.textContent = HIRAKUD_DATA.ramsarSite.title;
+    if (content) content.textContent = HIRAKUD_DATA.ramsarSite.content;
+}
+
+function renderWaterManagement() {
+    const title = document.getElementById('water-title');
+    const content = document.getElementById('water-content');
+    if (title) title.textContent = HIRAKUD_DATA.waterManagement.title;
+    if (content) content.textContent = HIRAKUD_DATA.waterManagement.content;
+}
+
+function renderBirdlife() {
+    const title = document.getElementById('birdlife-title');
+    const content = document.getElementById('birdlife-content');
+    const factsList = document.getElementById('birdlife-facts');
+
+    if (title) title.textContent = HIRAKUD_DATA.birdlife.title;
+    if (content) content.textContent = HIRAKUD_DATA.birdlife.content;
+
+    if (factsList && HIRAKUD_DATA.birdlife.facts) {
+        factsList.innerHTML = HIRAKUD_DATA.birdlife.facts
+            .map((f) => `<div class="fact-bullet">🦆 ${f}</div>`)
+            .join('');
+    }
+}
+
+function renderFisheries() {
+    const title = document.getElementById('fisheries-title');
+    const content = document.getElementById('fisheries-content');
+    if (title) title.textContent = HIRAKUD_DATA.fisheries.title;
+    if (content) content.textContent = HIRAKUD_DATA.fisheries.content;
+}
+
+function renderBiodiversity() {
+    const title = document.getElementById('biodiversity-title');
+    const content = document.getElementById('biodiversity-content');
+    if (title) title.textContent = HIRAKUD_DATA.biodiversity.title;
+    if (content) content.textContent = HIRAKUD_DATA.biodiversity.content;
+}
+
+function renderMapHotspots() {
+    const listContainer = document.getElementById('hotspots-list');
+    if (!listContainer || !HIRAKUD_DATA.hotspots) return;
+
+    listContainer.innerHTML = HIRAKUD_DATA.hotspots
+        .map(
+            (spot, index) => `
+        <button class="spot-btn ${index === 0 ? 'active' : ''}" data-id="${spot.id}">
+            <span class="spot-name">${spot.name}</span>
+        </button>
+    `
+        )
+        .join('');
+
+    showHotspotDetail(HIRAKUD_DATA.hotspots[0]);
+
+    listContainer.addEventListener('click', (e) => {
+        const btn = e.target.closest('.spot-btn');
+        if (!btn) return;
+
+        const id = btn.getAttribute('data-id');
+        const spot = HIRAKUD_DATA.hotspots.find((s) => s.id === id);
+
+        document.querySelectorAll('.spot-btn').forEach((b) => b.classList.remove('active'));
+        btn.classList.add('active');
+
+        if (spot) {
+            showHotspotDetail(spot);
+        }
+    });
+}
+
+function showHotspotDetail(spot) {
+    const detailContainer = document.getElementById('hotspot-detail');
+    if (!detailContainer) return;
+
+    detailContainer.innerHTML = `
+        <h3 style="margin: 0 0 0.5rem; color: #0ea5e9; font-size: 1.5rem;">${spot.name}</h3>
+        <p style="color: var(--hirakud-text-sub); line-height: 1.6; margin-bottom: 1.25rem;">${spot.desc}</p>
+        <div style="font-family: monospace; font-size: 0.85rem; color: #94a3b8; background: rgba(0,0,0,0.2); padding: 0.5rem 0.85rem; border-radius: 0.5rem;">Coordinates: ${spot.lat}° N, ${spot.lng}° E</div>
+    `;
+}
+
+function renderGallery() {
+    const container = document.getElementById('gallery-grid');
+    if (!container || !HIRAKUD_DATA.gallery) return;
+
+    container.innerHTML = HIRAKUD_DATA.gallery
+        .map(
+            (g) => `
+        <div class="gallery-card">
+            <img src="${g.url}" alt="${g.title}" loading="lazy" />
+            <div class="gallery-info">
+                <h4>${g.title}</h4>
+                <p>${g.caption}</p>
+            </div>
+        </div>
+    `
+        )
+        .join('');
+}
+
+function renderFacts() {
+    const container = document.getElementById('facts-grid');
+    if (!container || !HIRAKUD_DATA.facts) return;
+
+    container.innerHTML = HIRAKUD_DATA.facts
+        .map((f) => `<div class="trivia-box">💡 ${f}</div>`)
+        .join('');
+}

--- a/frontend/hirakud-reservoir-wetland-explorer/style.css
+++ b/frontend/hirakud-reservoir-wetland-explorer/style.css
@@ -1,0 +1,358 @@
+/* Hirakud Reservoir Wetland Explorer Stylesheet */
+
+:root {
+    --hirakud-primary: #0369a1;
+    --hirakud-accent: #0ea5e9;
+    --hirakud-dark-bg: #0a1620;
+    --hirakud-card-bg: rgba(15, 26, 38, 0.85);
+    --hirakud-card-border: rgba(14, 165, 233, 0.2);
+    --hirakud-text-main: #f0f9ff;
+    --hirakud-text-sub: #94a8b8;
+}
+
+body.light-theme {
+    --hirakud-dark-bg: #f0f9ff;
+    --hirakud-card-bg: rgba(255, 255, 255, 0.95);
+    --hirakud-card-border: rgba(3, 105, 161, 0.2);
+    --hirakud-text-main: #0c1a26;
+    --hirakud-text-sub: #47606f;
+}
+
+body.hirakud-main {
+    background-color: var(--hirakud-dark-bg);
+    color: var(--hirakud-text-main);
+    font-family: 'Outfit', sans-serif;
+    margin: 0;
+    padding: 0;
+    overflow-x: hidden;
+}
+
+.section-container {
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+}
+
+/* Header Navbar */
+.navbar {
+    background: rgba(10, 22, 32, 0.88);
+    backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--hirakud-card-border);
+}
+body.light-theme .navbar {
+    background: rgba(240, 249, 255, 0.92);
+}
+
+/* Hero Section */
+.hirakud-hero {
+    padding: 8rem 0 4rem;
+    background: linear-gradient(180deg, rgba(14, 165, 233, 0.18) 0%, rgba(10, 22, 32, 0) 100%);
+    text-align: center;
+}
+
+.hero-badges-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+}
+
+.hero-pill {
+    padding: 0.4rem 1rem;
+    border-radius: 9999px;
+    font-size: 0.875rem;
+    font-weight: 600;
+    background: rgba(14, 165, 233, 0.15);
+    border: 1px solid var(--hirakud-card-border);
+    color: #38bdf8;
+}
+
+.hirakud-hero h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: clamp(2.5rem, 5vw, 4rem);
+    font-weight: 800;
+    margin: 0 0 1rem;
+}
+
+.hirakud-hero h1 span {
+    background: linear-gradient(135deg, #38bdf8 0%, #0369a1 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.hero-subtitle {
+    max-width: 800px;
+    margin: 0 auto 3rem;
+    font-size: 1.15rem;
+    color: var(--hirakud-text-sub);
+    line-height: 1.7;
+}
+
+/* Stats Grid */
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.25rem;
+    margin-top: 2rem;
+}
+
+.stat-card {
+    background: var(--hirakud-card-bg);
+    border: 1px solid var(--hirakud-card-border);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    text-align: center;
+    transition: transform 0.3s ease;
+}
+
+.stat-card:hover {
+    transform: translateY(-4px);
+    border-color: #38bdf8;
+}
+
+.stat-icon {
+    font-size: 2rem;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.stat-value {
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: #38bdf8;
+    margin-bottom: 0.25rem;
+}
+
+.stat-label {
+    font-size: 0.875rem;
+    color: var(--hirakud-text-sub);
+}
+
+/* Section Header */
+.section-header {
+    text-align: center;
+    margin-bottom: 3rem;
+}
+
+.section-tag {
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    color: #0ea5e9;
+    text-transform: uppercase;
+    display: block;
+    margin-bottom: 0.5rem;
+}
+
+.section-header h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2.25rem;
+    margin: 0 0 0.75rem;
+}
+
+.section-header p {
+    color: var(--hirakud-text-sub);
+    font-size: 1.05rem;
+    max-width: 650px;
+    margin: 0 auto;
+}
+
+/* Info Cards */
+.history-section,
+.ramsar-section,
+.water-management-section,
+.fisheries-section,
+.biodiversity-section {
+    padding: 4rem 0;
+}
+
+.info-card {
+    background: var(--hirakud-card-bg);
+    border: 1px solid var(--hirakud-card-border);
+    border-radius: 1.25rem;
+    padding: 2.5rem;
+}
+
+.highlight-card {
+    background: linear-gradient(135deg, rgba(14, 165, 233, 0.12) 0%, rgba(15, 26, 38, 0.85) 100%);
+    border-color: rgba(56, 189, 248, 0.3);
+}
+
+.info-card h2,
+.info-card h3 {
+    font-family: 'Playfair Display', serif;
+    font-size: 1.8rem;
+    margin: 0.5rem 0 1rem;
+    color: #38bdf8;
+}
+
+.info-card p {
+    color: var(--hirakud-text-sub);
+    line-height: 1.8;
+    font-size: 1.05rem;
+    margin: 0;
+}
+
+/* Birdlife Section */
+.birdlife-section {
+    padding: 4rem 0;
+}
+
+.bird-card-feature {
+    background: var(--hirakud-card-bg);
+    border: 1px solid var(--hirakud-card-border);
+    border-radius: 1.5rem;
+    padding: 2.5rem;
+}
+
+.bird-feature-info h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2rem;
+    color: #38bdf8;
+    margin: 0.5rem 0 1rem;
+}
+
+.facts-list {
+    margin-top: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.fact-bullet {
+    background: rgba(14, 165, 233, 0.12);
+    border-left: 3px solid #38bdf8;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    font-size: 0.95rem;
+    color: var(--hirakud-text-sub);
+}
+
+/* Map Section */
+.map-section {
+    padding: 4rem 0;
+}
+
+.map-layout {
+    display: grid;
+    grid-template-columns: 1fr 1.2fr;
+    gap: 2rem;
+}
+
+.map-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+}
+
+.spot-btn {
+    background: var(--hirakud-card-bg);
+    border: 1px solid var(--hirakud-card-border);
+    padding: 1rem 1.25rem;
+    border-radius: 0.85rem;
+    text-align: left;
+    color: var(--hirakud-text-main);
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.spot-btn:hover,
+.spot-btn.active {
+    border-color: #38bdf8;
+    background: rgba(14, 165, 233, 0.15);
+    transform: translateX(6px);
+}
+
+.spot-name {
+    font-weight: 700;
+    font-size: 1.05rem;
+    display: block;
+}
+
+.map-detail {
+    background: var(--hirakud-card-bg);
+    border: 1px solid var(--hirakud-card-border);
+    border-radius: 1.25rem;
+    padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+/* Gallery & Facts */
+.gallery-section,
+.facts-section {
+    padding: 4rem 0;
+}
+
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.gallery-card {
+    background: var(--hirakud-card-bg);
+    border: 1px solid var(--hirakud-card-border);
+    border-radius: 1rem;
+    overflow: hidden;
+}
+
+.gallery-card img {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+}
+
+.gallery-info {
+    padding: 1rem;
+}
+
+.gallery-info h4 {
+    margin: 0 0 0.35rem;
+    font-size: 1rem;
+}
+
+.gallery-info p {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--hirakud-text-sub);
+}
+
+.facts-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.trivia-box {
+    background: var(--hirakud-card-bg);
+    border: 1px solid var(--hirakud-card-border);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    color: var(--hirakud-text-sub);
+    line-height: 1.6;
+}
+
+@media (max-width: 900px) {
+    .map-layout {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    .bird-card-feature {
+        padding: 1.75rem;
+    }
+}
+
+@media (max-width: 640px) {
+    .info-card {
+        padding: 1.75rem;
+    }
+
+    .hirakud-hero {
+        padding: 7rem 0 3rem;
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description
Adds a new educational page for Hirakud Reservoir, one of Asia's largest artificial lakes, formed by the world's longest earthen dam on the Mahanadi River in Odisha, and a Ramsar Site since 2021. 

Fixes #1000

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?
- [ ] Tested locally in browser
- [ ] Tested in both dark and light themes
- [ ] Tested at mobile viewport widths
- [ ] Verified no console errors

## Checklist
- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [ ] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)

## Screenshots (if applicable)
<img width="1920" height="1080" alt="Screenshot (1864)" src="https://github.com/user-attachments/assets/80428da7-8aae-45a2-8d29-7fc4322976de" />
<img width="1920" height="1080" alt="Screenshot (1865)" src="https://github.com/user-attachments/assets/04c99c3e-4c42-450e-b65d-62d93a92e207" />
<img width="1920" height="1080" alt="Screenshot (1866)" src="https://github.com/user-attachments/assets/5a76941b-e057-4d98-bad9-8223da59479e" />
<img width="1920" height="1080" alt="Screenshot (1867)" src="https://github.com/user-attachments/assets/2b0bb6e4-9d48-40e0-955b-78bd5dfa38f3" />
