### PR TITLE
feat: Create Himalayan Glaciers of India Explorer (#1246)

### DIFF
--- a/frontend/glaciers-explorer/data.js
+++ b/frontend/glaciers-explorer/data.js
@@ -1,0 +1,420 @@
+/* ==========================================================================
+   HIMALAYAN GLACIERS OF INDIA — DATASET
+   Figures for length, altitude and retreat are approximate. Published values
+   differ between studies depending on the measurement period and method, so
+   each glacier carries a `sourceNote` describing the basis of its numbers.
+   ========================================================================== */
+
+const GL_BASINS = [
+  { key: 'indus', name: 'Indus Basin', icon: '🏞️', desc: 'Glaciers of Ladakh, Zanskar, Lahaul-Spiti and Kashmir feeding the Indus and its tributaries — the Shyok, Nubra, Zanskar, Chenab and Jhelum.' },
+  { key: 'ganga', name: 'Ganga Basin', icon: '🕉️', desc: 'The Garhwal and Kumaon glaciers that give rise to the Bhagirathi, Alaknanda, Goriganga and Pindar — the headwaters of the Ganga.' },
+  { key: 'brahmaputra', name: 'Brahmaputra Basin', icon: '🌊', desc: 'Glaciers of Sikkim and Arunachal Pradesh feeding the Teesta, Subansiri and other Brahmaputra tributaries.' },
+];
+
+const GL_RANGES = [
+  { key: 'karakoram', name: 'Karakoram' },
+  { key: 'zanskar', name: 'Zanskar' },
+  { key: 'pirpanjal', name: 'Pir Panjal' },
+  { key: 'greathimalaya', name: 'Great Himalaya' },
+  { key: 'kumaon', name: 'Kumaon Himalaya' },
+  { key: 'sikkim', name: 'Sikkim Himalaya' },
+];
+
+/* Trend classes drive the colour coding on each glacier card. */
+const GL_TRENDS = {
+  rapid: { label: 'Rapid retreat', tone: 'bad', desc: 'Losing ground quickly by Himalayan standards — commonly cited at roughly 15 m per year or more.' },
+  moderate: { label: 'Moderate retreat', tone: 'warn', desc: 'Retreating steadily, in the broad range of about 5 to 15 m per year.' },
+  stable: { label: 'Relatively stable', tone: 'good', desc: 'Little net change, or behaviour complicated by debris cover and the Karakoram anomaly.' },
+};
+
+const GLACIERS = [
+  {
+    name: 'Siachen Glacier',
+    icon: '🏔️',
+    state: 'Ladakh',
+    range: 'karakoram',
+    basin: 'indus',
+    lengthKm: 76,
+    altitude: '3,620 – 5,753 m',
+    river: 'Nubra → Shyok → Indus',
+    trend: 'stable',
+    retreatMPerYear: 4,
+    tagline: 'Among the longest glaciers outside the polar regions',
+    desc: 'Siachen runs roughly 76 km through the eastern Karakoram, making it one of the largest glaciers outside the polar regions and the largest in the Karakoram. Its meltwater forms the Nubra, which joins the Shyok and then the Indus.',
+    sourceNote: 'Karakoram glaciers have shown anomalously little mass loss compared with the central and eastern Himalaya — a pattern researchers call the Karakoram anomaly. Figures here should be read in that light.',
+    facts: [
+      'The glacier sits in one of the most heavily glaciated regions outside the poles.',
+      'Its heavy debris cover insulates the ice, slowing surface melt relative to clean-ice glaciers.',
+    ],
+  },
+  {
+    name: 'Gangotri Glacier',
+    icon: '🕉️',
+    state: 'Uttarakhand',
+    range: 'greathimalaya',
+    basin: 'ganga',
+    lengthKm: 30,
+    altitude: '4,000 – 7,000 m',
+    river: 'Bhagirathi → Ganga',
+    trend: 'rapid',
+    retreatMPerYear: 18,
+    tagline: 'The source of the Bhagirathi',
+    desc: 'One of the largest glaciers in the Indian Himalaya, Gangotri terminates at Gaumukh — literally "cow\'s mouth" — where the Bhagirathi emerges. The Bhagirathi joins the Alaknanda at Devprayag to become the Ganga.',
+    sourceNote: 'Twentieth-century averages are often cited near 18–20 m per year; several studies report the rate has slowed in recent decades. Treat the figure as an order-of-magnitude indication.',
+    facts: [
+      'Gaumukh, the snout, is a pilgrimage destination reached on foot from Gangotri town.',
+      'The glacier is fed by several tributary glaciers including Raktvarn, Chaturangi and Kirti.',
+    ],
+  },
+  {
+    name: 'Zemu Glacier',
+    icon: '❄️',
+    state: 'Sikkim',
+    range: 'sikkim',
+    basin: 'brahmaputra',
+    lengthKm: 26,
+    altitude: '4,000 – 5,500 m',
+    river: 'Zemu Chu → Teesta → Brahmaputra',
+    trend: 'moderate',
+    retreatMPerYear: 12,
+    tagline: 'The largest glacier in the eastern Himalaya',
+    desc: 'Zemu drains the eastern flank of Kanchenjunga and is the largest glacier in the eastern Himalaya. Its meltwater forms the Zemu Chu, a headwater tributary of the Teesta.',
+    sourceNote: 'Access is difficult and monitoring is sparse; published retreat estimates vary considerably between studies.',
+    facts: [
+      'It lies within the Khangchendzonga Biosphere Reserve.',
+      'Early Kanchenjunga expeditions used the Zemu approach as their base route.',
+    ],
+  },
+  {
+    name: 'Bara Shigri Glacier',
+    icon: '🗻',
+    state: 'Himachal Pradesh',
+    range: 'greathimalaya',
+    basin: 'indus',
+    lengthKm: 28,
+    altitude: '4,000 – 6,000 m',
+    river: 'Chandra → Chenab → Indus',
+    trend: 'rapid',
+    retreatMPerYear: 22,
+    tagline: 'The largest glacier in Himachal Pradesh',
+    desc: 'Bara Shigri descends the Lahaul side of the Pir Panjal–Great Himalaya junction into the Chandra valley. It is the largest glacier in Himachal Pradesh and among the most studied in the western Himalaya.',
+    sourceNote: 'Retreat estimates come largely from repeat surveys of the Chandra basin; heavy debris cover on the lower tongue complicates snout measurement.',
+    facts: [
+      'Its name means "big glacier" in the local Lahauli usage.',
+      'It has been surveyed intermittently since the early twentieth century, giving an unusually long record.',
+    ],
+  },
+  {
+    name: 'Chhota Shigri Glacier',
+    icon: '🔬',
+    state: 'Himachal Pradesh',
+    range: 'pirpanjal',
+    basin: 'indus',
+    lengthKm: 9,
+    altitude: '4,050 – 6,263 m',
+    river: 'Chandra → Chenab → Indus',
+    trend: 'moderate',
+    retreatMPerYear: 7,
+    tagline: "India's benchmark glacier",
+    desc: 'Small, accessible and continuously monitored, Chhota Shigri has become the reference glacier for mass-balance research in the Indian Himalaya. Much of what is known about western Himalayan glacier behaviour comes from this one valley.',
+    sourceNote: 'Has one of the longest continuous mass-balance records in the Indian Himalaya, which is why its figures are relatively well constrained.',
+    facts: [
+      'Chosen as a benchmark because it is reachable from the Manali–Leh road.',
+      'Its record is used to calibrate estimates for glaciers that cannot be visited.',
+    ],
+  },
+  {
+    name: 'Drang-Drung Glacier',
+    icon: '🏔️',
+    state: 'Ladakh',
+    range: 'zanskar',
+    basin: 'indus',
+    lengthKm: 23,
+    altitude: '4,780 – 5,800 m',
+    river: 'Stod (Doda) → Zanskar → Indus',
+    trend: 'moderate',
+    retreatMPerYear: 9,
+    tagline: 'The great glacier of Zanskar',
+    desc: 'Visible directly from the Pensi La pass on the Kargil–Padum road, Drang-Drung is the largest glacier in the Zanskar range and the source of the Stod river, which becomes the Zanskar.',
+    sourceNote: 'One of the few large Indian glaciers observable from a motorable road, which has supported repeat photographic comparison over decades.',
+    facts: [
+      'Pensi La, at about 4,400 m, gives one of the clearest roadside glacier views in India.',
+      'The Zanskar river it feeds is the route of the winter Chadar trek.',
+    ],
+  },
+  {
+    name: 'Pindari Glacier',
+    icon: '🥾',
+    state: 'Uttarakhand',
+    range: 'kumaon',
+    basin: 'ganga',
+    lengthKm: 5,
+    altitude: '3,600 – 4,300 m',
+    river: 'Pindar → Alaknanda → Ganga',
+    trend: 'moderate',
+    retreatMPerYear: 10,
+    tagline: 'The most trekked glacier in India',
+    desc: 'Pindari sits below Nanda Devi and Nanda Kot in the Kumaon Himalaya, feeding the Pindar river. Its accessibility has made it the introduction to Himalayan glaciers for generations of Indian trekkers.',
+    sourceNote: 'Long observational record thanks to trekking access; snout position has been photographed repeatedly since the colonial period.',
+    facts: [
+      'The trail from Loharkhet to Zero Point is one of the oldest documented trekking routes in Kumaon.',
+      'The Pindar joins the Alaknanda at Karnaprayag, one of the Panch Prayag confluences.',
+    ],
+  },
+  {
+    name: 'Milam Glacier',
+    icon: '🧊',
+    state: 'Uttarakhand',
+    range: 'kumaon',
+    basin: 'ganga',
+    lengthKm: 16,
+    altitude: '3,870 – 5,500 m',
+    river: 'Goriganga → Kali → Ganga system',
+    trend: 'rapid',
+    retreatMPerYear: 15,
+    tagline: 'Source of the Goriganga',
+    desc: 'One of the largest glaciers in Kumaon, Milam lies on the eastern slopes of Nanda Devi. The Goriganga rises from its snout and flows south past the old trading village of Milam.',
+    sourceNote: 'Snout retreat estimated from survey comparisons spanning the twentieth century; year-to-year variability is high.',
+    facts: [
+      'Milam village was a major stop on the trans-Himalayan trade route to Tibet before 1962.',
+      'The glacier is approached through the Johar valley, historically home to Bhotiya trading communities.',
+    ],
+  },
+  {
+    name: 'Kolahoi Glacier',
+    icon: '⚠️',
+    state: 'Jammu & Kashmir',
+    range: 'pirpanjal',
+    basin: 'indus',
+    lengthKm: 5,
+    altitude: '4,000 – 5,425 m',
+    river: 'Lidder → Jhelum → Indus',
+    trend: 'rapid',
+    retreatMPerYear: 20,
+    tagline: "Kashmir's shrinking water tower",
+    desc: 'Kolahoi feeds the Lidder, which supplies irrigation and drinking water across the Kashmir valley. It has lost a substantial share of its area over recent decades, making it one of the most-cited examples of Himalayan glacier loss.',
+    sourceNote: 'Several remote-sensing studies report a large fractional area loss since the mid-twentieth century; exact percentages vary by study boundary and period.',
+    facts: [
+      'Its meltwater sustains the Lidder valley through the dry late-summer months.',
+      'The glacier has fragmented into separate ice bodies as it has thinned.',
+    ],
+  },
+  {
+    name: 'Dokriani Glacier',
+    icon: '📡',
+    state: 'Uttarakhand',
+    range: 'greathimalaya',
+    basin: 'ganga',
+    lengthKm: 6,
+    altitude: '3,800 – 6,000 m',
+    river: 'Din Gad → Bhagirathi → Ganga',
+    trend: 'rapid',
+    retreatMPerYear: 16,
+    tagline: 'A long-running field laboratory',
+    desc: 'Small but intensively studied, Dokriani in the Bhagirathi basin has supported field campaigns for decades, providing some of the better-constrained glacier hydrology data in the Garhwal Himalaya.',
+    sourceNote: 'Retreat and discharge data come from sustained field monitoring rather than one-off surveys, making this glacier unusually well documented.',
+    facts: [
+      'Discharge measurements here inform runoff models for the whole Bhagirathi basin.',
+      'It is reached from Bhukki via the Din Gad valley.',
+    ],
+  },
+  {
+    name: 'Satopanth Glacier',
+    icon: '🏔️',
+    state: 'Uttarakhand',
+    range: 'greathimalaya',
+    basin: 'ganga',
+    lengthKm: 13,
+    altitude: '3,870 – 5,000 m',
+    river: 'Alaknanda → Ganga',
+    trend: 'moderate',
+    retreatMPerYear: 11,
+    tagline: 'One of the two sources of the Alaknanda',
+    desc: 'Satopanth and its neighbour Bhagirath Kharak both terminate near Badrinath, and together their meltwater forms the Alaknanda — the Ganga headstream that meets the Bhagirathi at Devprayag.',
+    sourceNote: 'Estimates derived from repeat snout surveys in the Alaknanda basin; the two adjacent glaciers are sometimes reported together.',
+    facts: [
+      'Satopanth Tal, a glacial lake nearby, is tied to local pilgrimage tradition.',
+      'The glacier lies within the Nanda Devi Biosphere Reserve buffer zone.',
+    ],
+  },
+  {
+    name: 'Machoi Glacier',
+    icon: '🛣️',
+    state: 'Jammu & Kashmir',
+    range: 'greathimalaya',
+    basin: 'indus',
+    lengthKm: 9,
+    altitude: '4,000 – 5,200 m',
+    river: 'Sindh → Jhelum → Indus',
+    trend: 'moderate',
+    retreatMPerYear: 8,
+    tagline: 'Above the Zoji La',
+    desc: 'Machoi lies close to the Zoji La pass on the Srinagar–Leh road, feeding the Sindh river that flows through the Kashmir valley to join the Jhelum.',
+    sourceNote: 'Monitored mainly through satellite imagery; ground observation is limited by terrain and access restrictions.',
+    facts: [
+      'Zoji La, at about 3,500 m, is the key winter chokepoint on the Srinagar–Leh highway.',
+      'The Sindh valley below is one of Kashmir\'s main agricultural corridors.',
+    ],
+  },
+  {
+    name: 'Rimo Glacier',
+    icon: '🧭',
+    state: 'Ladakh',
+    range: 'karakoram',
+    basin: 'indus',
+    lengthKm: 40,
+    altitude: '4,000 – 5,900 m',
+    river: 'Shyok → Indus',
+    trend: 'stable',
+    retreatMPerYear: 3,
+    tagline: 'Draining into the Shyok',
+    desc: 'Rimo is one of the major Karakoram glacier systems on the Indian side, sitting near the Karakoram Pass and draining north-east towards the Shyok.',
+    sourceNote: 'Like other Karakoram glaciers, Rimo shows less mass loss than central Himalayan glaciers — part of the same regional anomaly.',
+    facts: [
+      'It lies close to the historic trade route over the Karakoram Pass to Central Asia.',
+      'The surrounding Rimo peaks were first climbed only in the 1980s.',
+    ],
+  },
+  {
+    name: 'Parkachik Glacier',
+    icon: '❄️',
+    state: 'Ladakh',
+    range: 'zanskar',
+    basin: 'indus',
+    lengthKm: 14,
+    altitude: '3,700 – 5,600 m',
+    river: 'Suru → Indus',
+    trend: 'moderate',
+    retreatMPerYear: 10,
+    tagline: 'Descending into the Suru valley',
+    desc: 'Flowing off the Nun-Kun massif, Parkachik descends almost to the floor of the Suru valley, making it one of the most easily observed large glaciers in Ladakh.',
+    sourceNote: 'Roadside visibility from the Kargil–Padum route has supported repeat photographic and satellite comparison.',
+    facts: [
+      'The Nun-Kun massif above it holds two of the highest peaks in the Zanskar range.',
+      'Its snout is unusually low for a Ladakh glacier, reaching close to the valley floor.',
+    ],
+  },
+];
+
+/* Glacier anatomy ---------------------------------------------------------- */
+const GL_ANATOMY = [
+  { term: 'Accumulation zone', icon: '🌨️', desc: 'The upper part of the glacier where more snow falls each year than melts. Snow compacts into firn and then into glacial ice under its own weight.' },
+  { term: 'Equilibrium line altitude (ELA)', icon: '📏', desc: 'The elevation at which accumulation exactly balances melt over a year. When the ELA rises, the glacier is losing mass — it is the single most telling number about a glacier\'s health.' },
+  { term: 'Ablation zone', icon: '💧', desc: 'The lower part, where annual loss to melting, evaporation and calving exceeds snowfall. This is where most meltwater is generated.' },
+  { term: 'Snout (terminus)', icon: '🔽', desc: 'The downstream end of the glacier, where meltwater emerges. Snout position is the classic field measurement of advance or retreat.' },
+  { term: 'Moraine', icon: '🪨', desc: 'Rock and sediment carried and deposited by ice. Lateral moraines form at the glacier\'s sides, medial moraines where two glaciers merge, and terminal moraines mark its furthest extent.' },
+  { term: 'Crevasse', icon: '🕳️', desc: 'A deep fracture opening where the ice is stretched — over a steepening bed, around a bend, or where the flow accelerates.' },
+  { term: 'Serac', icon: '🧊', desc: 'A tower or block of ice left standing between intersecting crevasses, typically in an icefall. Seracs collapse without warning.' },
+  { term: 'Debris cover', icon: '⛰️', desc: 'A layer of rock on the ice surface. A thick cover insulates the ice and slows melt, which is why some heavily covered glaciers appear more stable than they are.' },
+  { term: 'Proglacial lake', icon: '🏞️', desc: 'A lake that forms at the snout, usually dammed behind a terminal moraine. These lakes grow as glaciers retreat and are the source of GLOF risk.' },
+  { term: 'Bergschrund', icon: '↕️', desc: 'The crevasse separating moving glacier ice from the stationary ice and rock of the headwall above it.' },
+];
+
+/* GLOF case studies -------------------------------------------------------- */
+const GL_GLOF = [
+  {
+    name: 'Chamoli disaster',
+    year: '2021',
+    place: 'Rishiganga valley, Uttarakhand',
+    icon: '⚠️',
+    desc: 'In February 2021 a large rock-and-ice mass detached from the Ronti peak area and descended into the Rishiganga and Dhauliganga valleys as a debris flow. It destroyed the Rishiganga hydropower project and inundated the Tapovan-Vishnugad tunnel, killing around 200 people.',
+    lesson: 'The trigger was not a lake burst but a rock-ice avalanche — a reminder that high-mountain hazards include failures of frozen bedrock, not just glacial lakes.',
+  },
+  {
+    name: 'South Lhonak Lake GLOF',
+    year: '2023',
+    place: 'North Sikkim',
+    icon: '🌊',
+    desc: 'In October 2023 the moraine-dammed South Lhonak Lake burst, sending a flood surge down the Teesta. It destroyed the Chungthang dam of the Teesta-III project and caused severe damage and loss of life far downstream.',
+    lesson: 'South Lhonak had been identified as high-risk and partially siphoned beforehand. Identifying a dangerous lake is not the same as being ready for it to fail.',
+  },
+  {
+    name: 'Kedarnath floods',
+    year: '2013',
+    place: 'Mandakini valley, Uttarakhand',
+    icon: '🌧️',
+    desc: 'Extreme rainfall combined with the breach of Chorabari Lake above Kedarnath produced a devastating flood through the Mandakini valley, with very heavy loss of life among pilgrims and residents.',
+    lesson: 'Glacial-lake failure combined with extreme rainfall is far more destructive than either alone — a compound hazard that is becoming more likely.',
+  },
+  {
+    name: 'Gohna Tal breach',
+    year: '1894 & 1970',
+    place: 'Birahi Ganga, Uttarakhand',
+    icon: '📜',
+    desc: 'A landslide dammed the Birahi Ganga in 1894, forming Gohna Tal. Its controlled release was anticipated and downstream settlements were evacuated in advance; the lake breached again in 1970.',
+    lesson: 'The earliest documented example in the Indian Himalaya of forecasting an outburst and evacuating ahead of it — early warning is not a new idea here.',
+  },
+];
+
+/* Monitoring institutions -------------------------------------------------- */
+const GL_MONITORING = [
+  { title: 'Wadia Institute of Himalayan Geology', org: 'Dehradun', icon: '🔬', desc: 'The principal institution for Himalayan glaciology in India, running long-term mass-balance and snout monitoring programmes on benchmark glaciers.' },
+  { title: 'Himansh research station', org: 'Chandra basin, Spiti', icon: '🏠', desc: 'A high-altitude station established in the Chandra basin to support year-round glaciological fieldwork in Himachal Pradesh.' },
+  { title: 'ISRO / NRSC glacier inventory', org: 'Department of Space', icon: '🛰️', desc: 'Satellite-based inventories mapping glacier extent, glacial lakes and change over time across the Indian Himalayan river basins.' },
+  { title: 'Geological Survey of India', org: 'GSI', icon: '📐', desc: 'Has carried out glacier surveys and snout monitoring since the colonial period, providing some of the longest baselines available.' },
+  { title: 'National Institute of Hydrology', org: 'Roorkee', icon: '💧', desc: 'Studies glacier-fed runoff and its contribution to Himalayan river discharge, which is the link between ice loss and downstream water supply.' },
+  { title: 'NMSHE', org: 'Dept. of Science & Technology', icon: '🏛️', desc: 'The National Mission for Sustaining the Himalayan Ecosystem coordinates research and capacity building on the Himalayan cryosphere across institutions.' },
+];
+
+/* Climate impact ----------------------------------------------------------- */
+const GL_IMPACTS = [
+  { title: 'Peak water, then decline', icon: '📉', desc: 'Retreating glaciers first release more meltwater, then less. Basins that pass this peak face falling dry-season flow with no way to reverse it.', severity: 'Critical' },
+  { title: 'Growing glacial lakes', icon: '🏞️', desc: 'Retreat leaves meltwater ponded behind unstable moraine dams. The number and area of these lakes in the Indian Himalaya has been rising.', severity: 'Critical' },
+  { title: 'Dry-season water supply', icon: '🚰', desc: 'Glacier melt matters most exactly when rainfall is absent — late summer and pre-monsoon — so its loss hits the driest part of the year hardest.', severity: 'High' },
+  { title: 'Black carbon deposition', icon: '🏭', desc: 'Soot settling on snow darkens the surface, absorbs more sunlight and accelerates melt independently of air temperature.', severity: 'High' },
+  { title: 'Hydropower exposure', icon: '⚡', desc: 'Run-of-river projects are built in exactly the valleys where debris flows and outburst floods travel, as both Chamoli and Chungthang demonstrated.', severity: 'Critical' },
+  { title: 'Slope destabilisation', icon: '⛰️', desc: 'As glaciers thin, valley walls they once buttressed are left unsupported, and thawing permafrost weakens frozen bedrock above.', severity: 'High' },
+];
+
+/* Timeline ----------------------------------------------------------------- */
+const GL_TIMELINE = [
+  { year: '1780s–1850s', title: 'First European surveys', desc: 'Survey of India parties begin mapping Himalayan ice, producing the earliest positional records of several glacier snouts.' },
+  { year: '1894', title: 'Gohna Tal anticipated', desc: 'A landslide-dammed lake on the Birahi Ganga is expected to burst; downstream settlements are evacuated in advance — an early success in hazard forecasting.' },
+  { year: '1906–1935', title: 'Systematic snout monitoring', desc: 'The Geological Survey of India establishes repeat measurement of glacier termini, creating baselines still used for comparison today.' },
+  { year: '1970s', title: 'Modern glaciology begins', desc: 'Indian institutions start structured mass-balance programmes, moving beyond snout position to measure how much ice is actually gained and lost.' },
+  { year: '1980s–1990s', title: 'Satellites change the picture', desc: 'Remote sensing makes it possible to inventory thousands of glaciers that no field party could reach, revealing the scale of change.' },
+  { year: '2013', title: 'Kedarnath', desc: 'The Mandakini valley disaster puts glacial-lake and extreme-rainfall compound hazards at the centre of Indian disaster planning.' },
+  { year: '2016', title: 'Himansh station opens', desc: 'A dedicated high-altitude research base in the Chandra basin allows sustained fieldwork through more of the year.' },
+  { year: '2021', title: 'Chamoli', desc: 'The Rishiganga rock-ice avalanche shows that high-mountain hazard is not limited to lake bursts, and that hydropower siting is directly exposed.' },
+  { year: '2023', title: 'South Lhonak', desc: 'A lake already identified as dangerous bursts in Sikkim, destroying a major dam and demonstrating the gap between risk assessment and readiness.' },
+];
+
+/* Facts -------------------------------------------------------------------- */
+const GL_FACTS = [
+  'The Himalaya, Karakoram and neighbouring ranges are sometimes called the Third Pole, holding more freshwater ice than anywhere outside the Arctic and Antarctic.',
+  'Gangotri Glacier ends at Gaumukh, "cow\'s mouth" — the point where the Bhagirathi emerges from the ice.',
+  'Karakoram glaciers have shown anomalously little mass loss compared with the central Himalaya, a pattern researchers call the Karakoram anomaly.',
+  'A thick layer of rock debris insulates ice, so some debris-covered glaciers melt more slowly than clean-ice ones at the same altitude.',
+  'The equilibrium line altitude — where yearly accumulation equals yearly melt — is the single most informative measurement of a glacier\'s health.',
+  'Chhota Shigri in Himachal Pradesh is India\'s benchmark glacier, chosen partly because it can be reached from the Manali–Leh road.',
+  'Glacier meltwater matters most in the dry pre-monsoon months, when there is little rain to substitute for it.',
+  'Retreating glaciers leave lakes dammed by loose moraine — the material most likely to fail and cause an outburst flood.',
+  'Black carbon settling on snow darkens the surface and speeds melting even without any rise in air temperature.',
+  'Drang-Drung in Zanskar is one of the few large Indian glaciers clearly visible from a motorable road, at the Pensi La pass.',
+];
+
+/* Quiz --------------------------------------------------------------------- */
+const GL_QUIZ = [
+  { q: 'Which glacier is the source of the Bhagirathi river?', options: ['Zemu', 'Gangotri', 'Siachen', 'Pindari'], answer: 1, explain: 'The Bhagirathi emerges at Gaumukh, the snout of the Gangotri Glacier.' },
+  { q: 'The Himalayan region is often nicknamed the…', options: ['Third Pole', 'Ice Belt', 'Fourth Continent', 'White Plateau'], answer: 0, explain: 'It holds more freshwater ice than anywhere outside the polar regions, hence "Third Pole".' },
+  { q: 'What does GLOF stand for?', options: ['Glacial Land Overflow Formation', 'Glacial Lake Outburst Flood', 'Global Land Ocean Flux', 'Glacier Loss Observation Framework'], answer: 1, explain: 'A GLOF is a Glacial Lake Outburst Flood — the sudden release of water from a glacial lake.' },
+  { q: 'Which glacier is India\'s benchmark for mass-balance monitoring?', options: ['Bara Shigri', 'Chhota Shigri', 'Milam', 'Rimo'], answer: 1, explain: 'Chhota Shigri has one of the longest continuous mass-balance records in the Indian Himalaya.' },
+  { q: 'The 2023 GLOF that destroyed the Chungthang dam came from which lake?', options: ['Chorabari', 'Gohna Tal', 'South Lhonak', 'Satopanth Tal'], answer: 2, explain: 'South Lhonak Lake in North Sikkim burst in October 2023, sending a surge down the Teesta.' },
+  { q: 'Zemu Glacier drains into which river system?', options: ['Indus', 'Ganga', 'Brahmaputra', 'Narmada'], answer: 2, explain: 'Zemu feeds the Teesta, a tributary of the Brahmaputra.' },
+  { q: 'The equilibrium line altitude marks the elevation where…', options: ['The glacier is thickest', 'Accumulation equals ablation', 'Crevasses stop forming', 'The snout begins'], answer: 1, explain: 'At the ELA, annual snow gain exactly balances annual loss.' },
+  { q: 'A thick debris cover on a glacier generally…', options: ['Speeds up melting', 'Slows down melting', 'Has no effect', 'Causes the glacier to advance'], answer: 1, explain: 'Thick debris insulates the ice underneath, slowing surface melt.' },
+  { q: 'Siachen Glacier drains into which river?', options: ['Sutlej', 'Nubra, then Shyok and the Indus', 'Beas', 'Teesta'], answer: 1, explain: 'Siachen meltwater forms the Nubra, which joins the Shyok and then the Indus.' },
+  { q: 'Which term describes a lake formed at the snout of a retreating glacier?', options: ['Oxbow lake', 'Proglacial lake', 'Crater lake', 'Playa'], answer: 1, explain: 'A proglacial lake forms at the terminus, often dammed behind loose terminal moraine.' },
+];
+
+/* Gallery ------------------------------------------------------------------ */
+const GL_GALLERY = [
+  { icon: '🕉️', title: 'Gaumukh', caption: 'The snout of Gangotri Glacier, where the Bhagirathi emerges' },
+  { icon: '🏔️', title: 'Siachen', caption: 'The eastern Karakoram, Ladakh' },
+  { icon: '❄️', title: 'Zemu', caption: 'Draining the eastern flank of Kanchenjunga, Sikkim' },
+  { icon: '🛣️', title: 'Pensi La View', caption: 'Drang-Drung Glacier seen from the Kargil–Padum road, Zanskar' },
+  { icon: '🔬', title: 'Chhota Shigri', caption: 'Mass-balance stakes on India\'s benchmark glacier, Himachal Pradesh' },
+  { icon: '🏞️', title: 'Proglacial Lake', caption: 'Meltwater ponded behind a terminal moraine' },
+  { icon: '🥾', title: 'Pindari Trail', caption: 'The approach to Zero Point, Kumaon Himalaya' },
+  { icon: '🪨', title: 'Debris-Covered Ice', caption: 'Rock cover insulating the lower tongue of a Lahaul glacier' },
+];

--- a/frontend/glaciers-explorer/index.html
+++ b/frontend/glaciers-explorer/index.html
@@ -1,0 +1,283 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <script>(function(){const t=localStorage.getItem('theme')||'dark';if(t==='light')document.body.classList.add('light-theme')})();</script>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Explore the Himalayan glaciers of India — Siachen, Gangotri, Zemu, Bara Shigri and more — with basin and range filters, retreat comparisons, glacier anatomy, GLOF case studies and monitoring institutions." />
+  <title>Himalayan Glaciers of India Explorer | Incredible India</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="../../styles.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="navbar scrolled" id="navbar">
+    <div class="nav-container">
+      <a href="../../index.html#home" class="nav-logo" id="nav-logo"><span class="saffron">Incredible</span> <span class="gold">India</span> <span class="green">Explorer</span></a>
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false"><span class="bar"></span><span class="bar"></span><span class="bar"></span></button>
+      <nav class="nav-menu" id="nav-menu">
+        <a href="../../index.html#home" class="nav-link">Home</a>
+        <a href="../../index.html#map" class="nav-link">Interactive Map</a>
+        <a href="index.html" class="nav-link active" style="color:var(--gl-ice)">Glaciers</a>
+        <div class="nav-dropdown">
+          <button class="nav-link dropdown-toggle" id="link-explore-more">Explore More ▾</button>
+          <div class="dropdown-menu">
+            <a href="../mountains/index.html" class="dropdown-item">Mountains</a>
+            <a href="../mountain-ranges/index.html" class="dropdown-item">Mountain Ranges</a>
+            <a href="../geological-wonders/index.html" class="dropdown-item">Geological Wonders</a>
+            <a href="../river/river.html" class="dropdown-item">Rivers</a>
+            <a href="../wetlands/index.html" class="dropdown-item">Wetlands</a>
+          </div>
+        </div>
+        <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">☀️</button>
+      </nav>
+    </div>
+  </header>
+
+  <main class="gl-page">
+    <!-- ================= HERO ================= -->
+    <section class="hero-section">
+      <div class="hero-bg"></div>
+      <div class="hero-content">
+        <span class="hero-badge">🧊 The Third Pole</span>
+        <h1>Himalayan Glaciers <span>of India</span></h1>
+        <p>The ice above the Himalaya is the reason the Ganga, the Indus and the Brahmaputra flow in the dry months. It is also retreating. This explorer covers fourteen of India's major glaciers — where they are, what they feed, how fast they are changing, and what happens downstream when they fail.</p>
+        <div class="hero-stats">
+          <div class="hero-stat"><span class="number" id="stat-glaciers">14</span><span class="label">Glaciers Profiled</span></div>
+          <div class="hero-stat"><span class="number" id="stat-basins">3</span><span class="label">River Basins</span></div>
+          <div class="hero-stat"><span class="number" id="stat-longest">76</span><span class="label">Longest (km)</span></div>
+          <div class="hero-stat"><span class="number" id="stat-rapid">5</span><span class="label">In Rapid Retreat</span></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ================= OVERVIEW ================= -->
+    <section class="section-container" id="overview">
+      <div class="section-header">
+        <span class="section-badge">Why It Matters</span>
+        <h2>The Water Towers of Asia</h2>
+        <p class="section-subtitle">Glaciers are not just scenery at the top of a catchment. They are a stored buffer that releases water exactly when rainfall does not.</p>
+      </div>
+      <div class="content-section glass-card">
+        <div class="content-text">
+          <p>A glacier is a reservoir with a very slow release valve. Snow that fell decades or centuries ago is compressed into ice, carried downhill, and melts at the bottom. The useful part is the <strong>timing</strong>: the melt peaks in late spring and summer, in the months before the monsoon arrives, when rivers would otherwise be at their lowest.</p>
+          <p>That is why glacier loss is a water-security problem and not only a climate statistic. The <strong>Indus</strong> depends heavily on snow and glacier melt. The <strong>Ganga</strong> and <strong>Brahmaputra</strong> get proportionally more of their volume from the monsoon, but glacier melt still carries their headwaters through the dry season, and it is the headwater reaches where hydropower and mountain settlements sit.</p>
+          <p>There is a counter-intuitive middle stage. As a glacier retreats it first releases <em>more</em> water, not less, because there is more exposed ice melting. Basins cross a point sometimes called <strong>peak water</strong>, after which flow declines permanently. Some Himalayan basins are believed to be near or past that point.</p>
+          <ul>
+            <li>Melt is concentrated in the pre-monsoon and summer months, when rainfall is scarce</li>
+            <li>The Indus basin is the most glacier-dependent of the three</li>
+            <li>Retreat produces more water first, then permanently less</li>
+            <li>Retreat also leaves unstable lakes behind — the hazard grows as the resource shrinks</li>
+          </ul>
+        </div>
+        <div class="side-note">
+          <div class="big-icon">📐</div>
+          <h3>A Note on the Numbers</h3>
+          <p>Retreat rates on this page are approximate. Published values for the same glacier differ depending on the measurement period, the method, and where exactly the snout is defined — debris-covered tongues are especially hard to measure. Each glacier card carries a note on the basis of its figures. Treat them as indicative of scale, not as precise measurements.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- ================= BASINS ================= -->
+    <section class="section-container" id="basins">
+      <div class="section-header">
+        <span class="section-badge">Drainage</span>
+        <h2>Three Basins, One Range</h2>
+        <p class="section-subtitle">Every Indian Himalayan glacier ultimately drains into one of three great river systems.</p>
+      </div>
+      <div class="basin-grid" id="basin-grid"><!-- populated by script.js --></div>
+    </section>
+
+    <!-- ================= EXPLORER ================= -->
+    <section class="section-container" id="explorer">
+      <div class="section-header">
+        <span class="section-badge">Browse</span>
+        <h2>The Glaciers</h2>
+        <p class="section-subtitle">Filter by basin, mountain range or retreat trend. Open any card for altitude range, river fed, and the caveats on its measurements.</p>
+      </div>
+
+      <div class="filter-bar glass-card">
+        <div class="search-row">
+          <label class="sr-only" for="gl-search">Search glaciers</label>
+          <input type="search" id="gl-search" class="gl-search" placeholder="Search a glacier, state, range or river…" autocomplete="off" />
+          <button type="button" id="reset-filters" class="btn-reset">Reset</button>
+        </div>
+        <div class="filter-row">
+          <span class="filter-label">Basin</span>
+          <div class="chip-group" id="basin-chips" role="group" aria-label="Filter by river basin"><!-- populated by script.js --></div>
+        </div>
+        <div class="filter-row">
+          <span class="filter-label">Range</span>
+          <div class="chip-group" id="range-chips" role="group" aria-label="Filter by mountain range"><!-- populated by script.js --></div>
+        </div>
+        <div class="filter-row">
+          <span class="filter-label">Trend</span>
+          <div class="chip-group" id="trend-chips" role="group" aria-label="Filter by retreat trend"><!-- populated by script.js --></div>
+        </div>
+        <div class="filter-row sort-row">
+          <span class="filter-label">Sort by</span>
+          <div class="chip-group" id="sort-chips" role="group" aria-label="Sort glaciers">
+            <button type="button" class="chip active" data-filter="sort" data-value="name">Name</button>
+            <button type="button" class="chip" data-filter="sort" data-value="length">Length</button>
+            <button type="button" class="chip" data-filter="sort" data-value="retreat">Retreat rate</button>
+          </div>
+        </div>
+        <p class="result-count" id="result-count" aria-live="polite"></p>
+      </div>
+
+      <div class="glacier-grid" id="glacier-grid"><!-- populated by script.js --></div>
+      <div class="empty-state" id="empty-state" hidden>
+        <div class="big-icon">🔍</div>
+        <h3>No glaciers match those filters</h3>
+        <p>Try widening the basin or clearing the search box.</p>
+      </div>
+    </section>
+
+    <!-- ================= RETREAT COMPARISON ================= -->
+    <section class="section-container" id="retreat">
+      <div class="section-header">
+        <span class="section-badge">Comparison</span>
+        <h2>Approximate Retreat Rates</h2>
+        <p class="section-subtitle">Indicative snout retreat in metres per year. Bars are for comparison between glaciers, not precise measurements.</p>
+      </div>
+      <div class="chart-panel glass-card">
+        <div class="bar-chart" id="retreat-chart"><!-- populated by script.js --></div>
+        <p class="chart-caveat">⚠️ Published retreat figures vary between studies depending on the period observed, the survey method, and how the snout of a debris-covered glacier is defined. Karakoram glaciers in particular behave differently from the central and eastern Himalaya.</p>
+      </div>
+    </section>
+
+    <!-- ================= ANATOMY ================= -->
+    <section class="section-container" id="anatomy">
+      <div class="section-header">
+        <span class="section-badge">How a Glacier Works</span>
+        <h2>Glacier Anatomy</h2>
+        <p class="section-subtitle">Ten terms that make every other section on this page readable.</p>
+      </div>
+      <div class="anatomy-grid" id="anatomy-grid"><!-- populated by script.js --></div>
+    </section>
+
+    <!-- ================= GLOF ================= -->
+    <section class="section-container" id="glof">
+      <div class="section-header">
+        <span class="section-badge">Hazard</span>
+        <h2>Glacial Lake Outburst Floods</h2>
+        <p class="section-subtitle">When a moraine dam fails, the water above it arrives downstream in minutes. Four Indian case studies, and what each one taught.</p>
+      </div>
+      <div class="glof-grid" id="glof-grid"><!-- populated by script.js --></div>
+    </section>
+
+    <!-- ================= CLIMATE IMPACT ================= -->
+    <section class="section-container" id="impacts">
+      <div class="section-header">
+        <span class="section-badge">Consequences</span>
+        <h2>Climate Change Impact</h2>
+        <p class="section-subtitle">Six ways glacier loss propagates into water supply, hazard and infrastructure.</p>
+      </div>
+      <div class="info-grid" id="impacts-grid"><!-- populated by script.js --></div>
+    </section>
+
+    <!-- ================= MONITORING ================= -->
+    <section class="section-container" id="monitoring">
+      <div class="section-header">
+        <span class="section-badge">Who Watches the Ice</span>
+        <h2>Monitoring &amp; Research</h2>
+        <p class="section-subtitle">The institutions producing India's glacier data, from field stakes to satellite inventories.</p>
+      </div>
+      <div class="info-grid" id="monitoring-grid"><!-- populated by script.js --></div>
+    </section>
+
+    <!-- ================= TIMELINE ================= -->
+    <section class="section-container" id="timeline">
+      <div class="section-header">
+        <span class="section-badge">History</span>
+        <h2>Two Centuries of Observation</h2>
+        <p class="section-subtitle">From the first Survey of India measurements to the disasters that reshaped Indian hazard policy.</p>
+      </div>
+      <div class="timeline" id="gl-timeline"><!-- populated by script.js --></div>
+    </section>
+
+    <!-- ================= QUIZ ================= -->
+    <section class="section-container" id="quiz">
+      <div class="section-header">
+        <span class="section-badge">Test Yourself</span>
+        <h2>Glaciers Quiz</h2>
+        <p class="section-subtitle">Ten questions on Himalayan ice.</p>
+      </div>
+      <div class="quiz-section glass-card" id="quiz-section"><!-- populated by script.js --></div>
+    </section>
+
+    <!-- ================= GALLERY ================= -->
+    <section class="section-container" id="gallery">
+      <div class="section-header">
+        <span class="section-badge">Visual Journey</span>
+        <h2>Gallery</h2>
+        <p class="section-subtitle">Snouts, moraines and the roads that pass beneath them.</p>
+      </div>
+      <div class="gallery-grid" id="gallery-grid"><!-- populated by script.js --></div>
+    </section>
+
+    <!-- ================= FACTS ================= -->
+    <section class="section-container" id="facts">
+      <div class="section-header">
+        <span class="section-badge">Did You Know?</span>
+        <h2>Interesting Facts</h2>
+        <p class="section-subtitle">Ten things about Himalayan glaciers worth remembering.</p>
+      </div>
+      <div class="facts-grid" id="facts-grid"><!-- populated by script.js --></div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-container">
+      <div class="footer-section">
+        <h3>Incredible India Explorer</h3>
+        <p>An interactive digital guide to the geography, climate and natural heritage of India.</p>
+      </div>
+      <div class="footer-links">
+        <h3>Quick Navigation</h3>
+        <ul>
+          <li><a href="../../index.html#home">Home</a></li>
+          <li><a href="../mountains/index.html">Mountains</a></li>
+          <li><a href="../river/river.html">Rivers</a></li>
+          <li><a href="../geological-wonders/index.html">Geological Wonders</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-credits footer-credits-center">
+      <p>&copy; 2026 Incredible India Explorer. Created with Vanilla HTML, CSS &amp; JavaScript.</p>
+    </div>
+  </footer>
+
+  <!-- Glacier detail modal -->
+  <div class="gl-modal" id="gl-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" hidden>
+    <div class="gl-modal-backdrop" id="modal-backdrop"></div>
+    <div class="gl-modal-card" role="document">
+      <button class="gl-modal-close" id="modal-close" aria-label="Close details">&times;</button>
+      <div class="gl-modal-head">
+        <span class="gl-modal-icon" id="modal-icon">🏔️</span>
+        <div>
+          <h3 id="modal-title">Glacier</h3>
+          <p class="gl-modal-tagline" id="modal-tagline"></p>
+        </div>
+      </div>
+      <div class="gl-modal-meta" id="modal-meta"></div>
+      <p class="gl-modal-desc" id="modal-desc"></p>
+
+      <h4 class="gl-modal-subhead">Key Figures</h4>
+      <dl class="spec-list" id="modal-specs"></dl>
+
+      <h4 class="gl-modal-subhead">Notes</h4>
+      <ul class="note-list" id="modal-facts"></ul>
+
+      <p class="gl-modal-source" id="modal-source"></p>
+    </div>
+  </div>
+
+  <script src="../../app.js" defer></script>
+  <script src="data.js" defer></script>
+  <script src="script.js" defer></script>
+  <script type="module" src="../../auth.js"></script>
+</body>
+</html>

--- a/frontend/glaciers-explorer/script.js
+++ b/frontend/glaciers-explorer/script.js
@@ -1,0 +1,517 @@
+/* ==========================================================================
+   HIMALAYAN GLACIERS OF INDIA EXPLORER — INTERACTION LAYER
+   Vanilla JS, no dependencies. Everything renders from data.js.
+   ========================================================================== */
+
+(function () {
+  'use strict';
+
+  var filters = { search: '', basin: 'all', range: 'all', trend: 'all', sort: 'name' };
+  var quizState = { current: 0, score: 0, answered: false };
+  var lastFocused = null;
+
+  document.addEventListener('DOMContentLoaded', function () {
+    if (typeof GLACIERS === 'undefined') {
+      console.error('glaciers-explorer: data.js failed to load');
+      return;
+    }
+    renderHeroStats();
+    renderBasins();
+    renderChips('basin-chips', 'basin', GL_BASINS.map(function (b) {
+      return { value: b.key, label: b.name, icon: b.icon };
+    }));
+    renderChips('range-chips', 'range', GL_RANGES.map(function (r) {
+      return { value: r.key, label: r.name, icon: '' };
+    }));
+    renderChips('trend-chips', 'trend', Object.keys(GL_TRENDS).map(function (key) {
+      return { value: key, label: GL_TRENDS[key].label, icon: '' };
+    }));
+    bindSortChips();
+    renderGlaciers();
+    renderRetreatChart();
+    renderAnatomy();
+    renderGlof();
+    renderInfoGrid('impacts-grid', GL_IMPACTS);
+    renderInfoGrid('monitoring-grid', GL_MONITORING.map(function (item) {
+      return { title: item.title, icon: item.icon, desc: item.desc, tag: item.org };
+    }));
+    renderTimeline();
+    renderQuiz();
+    renderGallery();
+    renderFacts();
+    bindSearch();
+    bindModal();
+    revealVisible();
+  });
+
+  /* ---------------------------------------------------------------- utils */
+
+  function escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function lookupName(list, key) {
+    for (var i = 0; i < list.length; i++) {
+      if (list[i].key === key) return list[i].name;
+    }
+    return key;
+  }
+
+  function setText(id, value) {
+    var el = document.getElementById(id);
+    if (el) el.textContent = value;
+  }
+
+  /* ------------------------------------------------------------ hero stats */
+
+  function renderHeroStats() {
+    var longest = GLACIERS.reduce(function (acc, g) { return Math.max(acc, g.lengthKm); }, 0);
+    var rapid = GLACIERS.filter(function (g) { return g.trend === 'rapid'; }).length;
+
+    setText('stat-glaciers', GLACIERS.length);
+    setText('stat-basins', GL_BASINS.length);
+    setText('stat-longest', longest);
+    setText('stat-rapid', rapid);
+  }
+
+  /* ---------------------------------------------------------------- basins */
+
+  function renderBasins() {
+    var grid = document.getElementById('basin-grid');
+    if (!grid) return;
+    grid.innerHTML = GL_BASINS.map(function (basin) {
+      var members = GLACIERS.filter(function (g) { return g.basin === basin.key; });
+      return '<button type="button" class="basin-card animate-on-scroll" data-jump="' + escapeHtml(basin.key) + '">' +
+        '<div class="icon">' + basin.icon + '</div>' +
+        '<h3>' + escapeHtml(basin.name) + '</h3>' +
+        '<p>' + escapeHtml(basin.desc) + '</p>' +
+        '<span class="tag">' + members.length + ' glacier' + (members.length === 1 ? '' : 's') + ' featured</span>' +
+        '</button>';
+    }).join('');
+
+    grid.addEventListener('click', function (event) {
+      var card = event.target.closest('[data-jump]');
+      if (!card) return;
+      filters.basin = card.getAttribute('data-jump');
+      syncChips();
+      renderGlaciers();
+      var explorer = document.getElementById('explorer');
+      if (explorer) explorer.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  }
+
+  /* ----------------------------------------------------------------- chips */
+
+  function renderChips(containerId, filterKey, items) {
+    var group = document.getElementById(containerId);
+    if (!group) return;
+    var html = '<button type="button" class="chip active" data-filter="' + filterKey + '" data-value="all">All</button>';
+    html += items.map(function (item) {
+      var icon = item.icon ? item.icon + ' ' : '';
+      return '<button type="button" class="chip" data-filter="' + filterKey + '" data-value="' +
+        escapeHtml(item.value) + '">' + icon + escapeHtml(item.label) + '</button>';
+    }).join('');
+    group.innerHTML = html;
+    group.addEventListener('click', onChipClick);
+  }
+
+  function bindSortChips() {
+    var group = document.getElementById('sort-chips');
+    if (group) group.addEventListener('click', onChipClick);
+  }
+
+  function onChipClick(event) {
+    var chip = event.target.closest('.chip');
+    if (!chip) return;
+    filters[chip.getAttribute('data-filter')] = chip.getAttribute('data-value');
+    syncChips();
+    renderGlaciers();
+  }
+
+  function syncChips() {
+    ['basin', 'range', 'trend', 'sort'].forEach(function (key) {
+      var chips = document.querySelectorAll('[data-filter="' + key + '"]');
+      Array.prototype.forEach.call(chips, function (chip) {
+        chip.classList.toggle('active', chip.getAttribute('data-value') === filters[key]);
+      });
+    });
+  }
+
+  function bindSearch() {
+    var input = document.getElementById('gl-search');
+    var reset = document.getElementById('reset-filters');
+    if (input) {
+      input.addEventListener('input', function () {
+        filters.search = input.value.trim().toLowerCase();
+        renderGlaciers();
+      });
+    }
+    if (reset) {
+      reset.addEventListener('click', function () {
+        filters = { search: '', basin: 'all', range: 'all', trend: 'all', sort: 'name' };
+        if (input) input.value = '';
+        syncChips();
+        renderGlaciers();
+      });
+    }
+  }
+
+  /* ----------------------------------------------------------------- cards */
+
+  function matchesFilters(glacier) {
+    if (filters.basin !== 'all' && glacier.basin !== filters.basin) return false;
+    if (filters.range !== 'all' && glacier.range !== filters.range) return false;
+    if (filters.trend !== 'all' && glacier.trend !== filters.trend) return false;
+    if (!filters.search) return true;
+    var haystack = [glacier.name, glacier.state, glacier.river, glacier.tagline, glacier.desc,
+      lookupName(GL_RANGES, glacier.range), lookupName(GL_BASINS, glacier.basin)]
+      .join(' ')
+      .toLowerCase();
+    return haystack.indexOf(filters.search) !== -1;
+  }
+
+  function sortGlaciers(list) {
+    var sorted = list.slice();
+    if (filters.sort === 'length') {
+      sorted.sort(function (a, b) { return b.lengthKm - a.lengthKm; });
+    } else if (filters.sort === 'retreat') {
+      sorted.sort(function (a, b) { return b.retreatMPerYear - a.retreatMPerYear; });
+    } else {
+      sorted.sort(function (a, b) { return a.name.localeCompare(b.name); });
+    }
+    return sorted;
+  }
+
+  function renderGlaciers() {
+    var grid = document.getElementById('glacier-grid');
+    var empty = document.getElementById('empty-state');
+    var counter = document.getElementById('result-count');
+    if (!grid) return;
+
+    var matches = sortGlaciers(GLACIERS.filter(matchesFilters));
+
+    if (counter) {
+      counter.textContent = matches.length === GLACIERS.length
+        ? 'Showing all ' + GLACIERS.length + ' glaciers'
+        : 'Showing ' + matches.length + ' of ' + GLACIERS.length + ' glaciers';
+    }
+    if (empty) empty.hidden = matches.length !== 0;
+
+    grid.innerHTML = matches.map(function (glacier) {
+      var trend = GL_TRENDS[glacier.trend];
+      return '<article class="glacier-card animate-on-scroll" tabindex="0" role="button" ' +
+          'data-name="' + escapeHtml(glacier.name) + '" ' +
+          'aria-label="View details for ' + escapeHtml(glacier.name) + '">' +
+        '<div class="glacier-head">' +
+          '<span class="glacier-icon" aria-hidden="true">' + glacier.icon + '</span>' +
+          '<span class="trend-badge trend-' + trend.tone + '">' + escapeHtml(trend.label) + '</span>' +
+        '</div>' +
+        '<h3>' + escapeHtml(glacier.name) + '</h3>' +
+        '<p class="glacier-tagline">' + escapeHtml(glacier.tagline) + '</p>' +
+        '<div class="quick-specs">' +
+          '<span><strong>' + glacier.lengthKm + ' km</strong>length</span>' +
+          '<span><strong>~' + glacier.retreatMPerYear + ' m/yr</strong>retreat</span>' +
+        '</div>' +
+        '<p class="glacier-desc">' + escapeHtml(glacier.desc) + '</p>' +
+        '<div class="glacier-meta">' +
+          '<span class="pill pill-state">📍 ' + escapeHtml(glacier.state) + '</span>' +
+          '<span class="pill pill-basin">' + escapeHtml(lookupName(GL_BASINS, glacier.basin)) + '</span>' +
+          '<span class="pill pill-range">' + escapeHtml(lookupName(GL_RANGES, glacier.range)) + '</span>' +
+        '</div>' +
+        '<span class="glacier-cta">View full profile →</span>' +
+        '</article>';
+    }).join('');
+
+    revealVisible();
+  }
+
+  /* ---------------------------------------------------------------- charts */
+
+  function renderRetreatChart() {
+    var container = document.getElementById('retreat-chart');
+    if (!container) return;
+
+    var rows = GLACIERS.slice().sort(function (a, b) {
+      return b.retreatMPerYear - a.retreatMPerYear;
+    });
+    var max = rows.reduce(function (acc, g) { return Math.max(acc, g.retreatMPerYear); }, 0) || 1;
+
+    container.innerHTML = rows.map(function (glacier) {
+      var pct = Math.round((glacier.retreatMPerYear / max) * 100);
+      var tone = GL_TRENDS[glacier.trend].tone;
+      return '<div class="bar-row">' +
+        '<span class="bar-label">' + escapeHtml(glacier.name) + '</span>' +
+        '<span class="bar-track"><span class="bar-fill fill-' + tone + '" style="width:' + pct + '%"></span></span>' +
+        '<span class="bar-value">~' + glacier.retreatMPerYear + ' m</span>' +
+        '</div>';
+    }).join('');
+  }
+
+  /* --------------------------------------------------------------- anatomy */
+
+  function renderAnatomy() {
+    var grid = document.getElementById('anatomy-grid');
+    if (!grid) return;
+    grid.innerHTML = GL_ANATOMY.map(function (item) {
+      return '<div class="anatomy-card animate-on-scroll">' +
+        '<div class="anatomy-icon">' + item.icon + '</div>' +
+        '<h3>' + escapeHtml(item.term) + '</h3>' +
+        '<p>' + escapeHtml(item.desc) + '</p>' +
+        '</div>';
+    }).join('');
+  }
+
+  /* ------------------------------------------------------------------ glof */
+
+  function renderGlof() {
+    var grid = document.getElementById('glof-grid');
+    if (!grid) return;
+    grid.innerHTML = GL_GLOF.map(function (event) {
+      return '<article class="glof-card animate-on-scroll">' +
+        '<div class="glof-head">' +
+          '<span class="glof-icon">' + event.icon + '</span>' +
+          '<div>' +
+            '<h3>' + escapeHtml(event.name) + '</h3>' +
+            '<p class="glof-place">' + escapeHtml(event.year) + ' · ' + escapeHtml(event.place) + '</p>' +
+          '</div>' +
+        '</div>' +
+        '<p class="glof-desc">' + escapeHtml(event.desc) + '</p>' +
+        '<p class="glof-lesson"><strong>What it showed:</strong> ' + escapeHtml(event.lesson) + '</p>' +
+        '</article>';
+    }).join('');
+  }
+
+  /* ---------------------------------------------------- info, facts, media */
+
+  function renderInfoGrid(containerId, items) {
+    var grid = document.getElementById(containerId);
+    if (!grid) return;
+    grid.innerHTML = items.map(function (item) {
+      var badge = '';
+      if (item.severity) {
+        badge = '<span class="severity severity-' + item.severity.toLowerCase() + '">' +
+          escapeHtml(item.severity) + '</span>';
+      } else if (item.tag) {
+        badge = '<span class="org-tag">' + escapeHtml(item.tag) + '</span>';
+      }
+      return '<div class="info-card animate-on-scroll">' +
+        '<div class="icon">' + item.icon + '</div>' +
+        '<h3>' + escapeHtml(item.title) + '</h3>' +
+        '<p>' + escapeHtml(item.desc) + '</p>' +
+        badge +
+        '</div>';
+    }).join('');
+  }
+
+  function renderTimeline() {
+    var timeline = document.getElementById('gl-timeline');
+    if (!timeline) return;
+    timeline.innerHTML = GL_TIMELINE.map(function (entry, index) {
+      return '<div class="timeline-item animate-on-scroll ' + (index % 2 === 0 ? 'left' : 'right') + '">' +
+        '<div class="timeline-dot" aria-hidden="true"></div>' +
+        '<div class="timeline-content">' +
+          '<span class="timeline-year">' + escapeHtml(entry.year) + '</span>' +
+          '<h3>' + escapeHtml(entry.title) + '</h3>' +
+          '<p>' + escapeHtml(entry.desc) + '</p>' +
+        '</div>' +
+        '</div>';
+    }).join('');
+  }
+
+  function renderGallery() {
+    var grid = document.getElementById('gallery-grid');
+    if (!grid) return;
+    grid.innerHTML = GL_GALLERY.map(function (item) {
+      return '<figure class="gallery-item animate-on-scroll">' +
+        '<div class="gallery-visual" aria-hidden="true">' + item.icon + '</div>' +
+        '<figcaption><strong>' + escapeHtml(item.title) + '</strong><span>' + escapeHtml(item.caption) + '</span></figcaption>' +
+        '</figure>';
+    }).join('');
+  }
+
+  function renderFacts() {
+    var grid = document.getElementById('facts-grid');
+    if (!grid) return;
+    grid.innerHTML = GL_FACTS.map(function (fact, index) {
+      return '<div class="fact-card animate-on-scroll">' +
+        '<span class="fact-number">' + (index + 1) + '</span>' +
+        '<p>' + escapeHtml(fact) + '</p>' +
+        '</div>';
+    }).join('');
+  }
+
+  /* ----------------------------------------------------------------- modal */
+
+  function bindModal() {
+    var grid = document.getElementById('glacier-grid');
+    var modal = document.getElementById('gl-modal');
+    if (!grid || !modal) return;
+
+    grid.addEventListener('click', function (event) {
+      var card = event.target.closest('.glacier-card');
+      if (card) openModal(card.getAttribute('data-name'));
+    });
+
+    grid.addEventListener('keydown', function (event) {
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      var card = event.target.closest('.glacier-card');
+      if (!card) return;
+      event.preventDefault();
+      openModal(card.getAttribute('data-name'));
+    });
+
+    var close = document.getElementById('modal-close');
+    var backdrop = document.getElementById('modal-backdrop');
+    if (close) close.addEventListener('click', closeModal);
+    if (backdrop) backdrop.addEventListener('click', closeModal);
+
+    document.addEventListener('keydown', function (event) {
+      if (event.key === 'Escape' && !modal.hidden) closeModal();
+    });
+  }
+
+  function openModal(name) {
+    var glacier = GLACIERS.filter(function (g) { return g.name === name; })[0];
+    var modal = document.getElementById('gl-modal');
+    if (!glacier || !modal) return;
+
+    lastFocused = document.activeElement;
+    var trend = GL_TRENDS[glacier.trend];
+
+    document.getElementById('modal-icon').textContent = glacier.icon;
+    document.getElementById('modal-title').textContent = glacier.name;
+    document.getElementById('modal-tagline').textContent = glacier.tagline;
+    document.getElementById('modal-desc').textContent = glacier.desc;
+    document.getElementById('modal-source').textContent = glacier.sourceNote;
+
+    document.getElementById('modal-meta').innerHTML =
+      '<span class="pill pill-state">📍 ' + escapeHtml(glacier.state) + '</span>' +
+      '<span class="pill pill-basin">' + escapeHtml(lookupName(GL_BASINS, glacier.basin)) + '</span>' +
+      '<span class="pill pill-range">' + escapeHtml(lookupName(GL_RANGES, glacier.range)) + '</span>' +
+      '<span class="trend-badge trend-' + trend.tone + '">' + escapeHtml(trend.label) + '</span>';
+
+    var specs = [
+      { label: 'Approximate length', value: glacier.lengthKm + ' km' },
+      { label: 'Altitude range', value: glacier.altitude },
+      { label: 'River fed', value: glacier.river },
+      { label: 'Mountain range', value: lookupName(GL_RANGES, glacier.range) },
+      { label: 'Indicative retreat', value: '~' + glacier.retreatMPerYear + ' m per year' },
+    ];
+    document.getElementById('modal-specs').innerHTML = specs.map(function (spec) {
+      return '<dt>' + escapeHtml(spec.label) + '</dt><dd>' + escapeHtml(spec.value) + '</dd>';
+    }).join('');
+
+    document.getElementById('modal-facts').innerHTML = glacier.facts.map(function (fact) {
+      return '<li>' + escapeHtml(fact) + '</li>';
+    }).join('');
+
+    modal.hidden = false;
+    document.body.classList.add('modal-open');
+    var close = document.getElementById('modal-close');
+    if (close) close.focus();
+  }
+
+  function closeModal() {
+    var modal = document.getElementById('gl-modal');
+    if (!modal) return;
+    modal.hidden = true;
+    document.body.classList.remove('modal-open');
+    if (lastFocused && typeof lastFocused.focus === 'function') lastFocused.focus();
+  }
+
+  /* ------------------------------------------------------------------ quiz */
+
+  function renderQuiz() {
+    var section = document.getElementById('quiz-section');
+    if (!section) return;
+
+    if (quizState.current >= GL_QUIZ.length) {
+      var pct = Math.round((quizState.score / GL_QUIZ.length) * 100);
+      var verdict = pct === 100 ? 'Perfect score — solid glaciology.'
+        : pct >= 75 ? 'Strong result. Worth revisiting the anatomy section.'
+        : pct >= 50 ? 'A reasonable start — the GLOF case studies are worth a re-read.'
+        : 'Try another pass through the overview and anatomy sections.';
+      section.innerHTML =
+        '<div class="quiz-result">' +
+          '<div class="quiz-score">' + quizState.score + ' / ' + GL_QUIZ.length + '</div>' +
+          '<p class="quiz-verdict">' + verdict + '</p>' +
+          '<button type="button" class="btn-quiz" id="quiz-restart">Try Again</button>' +
+        '</div>';
+      var restart = document.getElementById('quiz-restart');
+      if (restart) {
+        restart.addEventListener('click', function () {
+          quizState = { current: 0, score: 0, answered: false };
+          renderQuiz();
+        });
+      }
+      return;
+    }
+
+    var question = GL_QUIZ[quizState.current];
+    section.innerHTML =
+      '<div class="quiz-progress">Question ' + (quizState.current + 1) + ' of ' + GL_QUIZ.length +
+        '<span class="quiz-running-score">Score: ' + quizState.score + '</span></div>' +
+      '<h3 class="quiz-question">' + escapeHtml(question.q) + '</h3>' +
+      '<div class="quiz-options" id="quiz-options">' +
+        question.options.map(function (option, index) {
+          return '<button type="button" class="quiz-option" data-index="' + index + '">' +
+            escapeHtml(option) + '</button>';
+        }).join('') +
+      '</div>' +
+      '<div class="quiz-explain" id="quiz-explain" hidden></div>';
+
+    var options = document.getElementById('quiz-options');
+    options.addEventListener('click', function (event) {
+      var button = event.target.closest('.quiz-option');
+      if (!button || quizState.answered) return;
+      quizState.answered = true;
+
+      var chosen = parseInt(button.getAttribute('data-index'), 10);
+      var correct = question.answer;
+      if (chosen === correct) quizState.score++;
+
+      Array.prototype.forEach.call(options.querySelectorAll('.quiz-option'), function (opt, index) {
+        opt.disabled = true;
+        if (index === correct) opt.classList.add('correct');
+        else if (index === chosen) opt.classList.add('wrong');
+      });
+
+      var explain = document.getElementById('quiz-explain');
+      explain.hidden = false;
+      explain.innerHTML = '<p>' + escapeHtml(question.explain) + '</p>' +
+        '<button type="button" class="btn-quiz" id="quiz-next">' +
+        (quizState.current === GL_QUIZ.length - 1 ? 'See Result' : 'Next Question') + '</button>';
+
+      document.getElementById('quiz-next').addEventListener('click', function () {
+        quizState.current++;
+        quizState.answered = false;
+        renderQuiz();
+      });
+    });
+  }
+
+  /* ------------------------------------------------------------ animations */
+
+  function revealVisible() {
+    var targets = document.querySelectorAll('.animate-on-scroll:not(.animate-visible)');
+    if (!targets.length) return;
+    if (!('IntersectionObserver' in window)) {
+      Array.prototype.forEach.call(targets, function (el) { el.classList.add('animate-visible'); });
+      return;
+    }
+    var observer = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('animate-visible');
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.08, rootMargin: '0px 0px -40px 0px' });
+    Array.prototype.forEach.call(targets, function (el) { observer.observe(el); });
+  }
+})();

--- a/frontend/glaciers-explorer/style.css
+++ b/frontend/glaciers-explorer/style.css
@@ -1,0 +1,1279 @@
+/* ==========================================================================
+   HIMALAYAN GLACIERS OF INDIA EXPLORER — PAGE STYLES
+   Scoped under .gl-page with page-local custom properties.
+   ========================================================================== */
+
+:root {
+  --gl-ice: #38bdf8;
+  --gl-deep: #0369a1;
+  --gl-frost: #a5f3fc;
+  --gl-warn: #f59e0b;
+  --gl-alert: #ef4444;
+  --gl-good: #22c55e;
+  --gl-bg: linear-gradient(135deg, #030b16, #061524, #04101d);
+  --gl-card: rgba(12, 27, 45, 0.58);
+  --gl-border: rgba(255, 255, 255, 0.1);
+  --gl-text: #eaf4fb;
+  --gl-sub: rgba(234, 244, 251, 0.68);
+}
+
+.light-theme {
+  --gl-bg: linear-gradient(135deg, #f0f9ff, #ecfeff, #f8fafc);
+  --gl-card: rgba(255, 255, 255, 0.85);
+  --gl-border: rgba(3, 105, 161, 0.16);
+  --gl-text: #06212f;
+  --gl-sub: rgba(6, 33, 47, 0.68);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.gl-page {
+  background: var(--gl-bg);
+  color: var(--gl-text);
+  font-family: 'Outfit', sans-serif;
+  min-height: 100vh;
+  padding-top: 80px;
+  overflow-x: hidden;
+}
+
+body.modal-open {
+  overflow: hidden;
+}
+
+/* -------------------------------------------------------------- sections */
+
+.section-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 60px 20px;
+}
+
+.section-header {
+  text-align: center;
+  margin-bottom: 40px;
+}
+
+.section-badge {
+  display: inline-block;
+  background: linear-gradient(135deg, var(--gl-deep), var(--gl-ice));
+  color: #fff;
+  padding: 5px 16px;
+  border-radius: 20px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-bottom: 12px;
+}
+
+.section-header h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: 2.4rem;
+  font-weight: 700;
+  margin-bottom: 12px;
+  letter-spacing: -0.5px;
+}
+
+.section-subtitle {
+  color: var(--gl-sub);
+  font-size: 1.03rem;
+  max-width: 740px;
+  margin: 0 auto;
+  line-height: 1.65;
+}
+
+.glass-card {
+  background: var(--gl-card);
+  border: 1px solid var(--gl-border);
+  border-radius: 18px;
+  backdrop-filter: blur(10px);
+}
+
+/* ------------------------------------------------------------------ hero */
+
+.hero-section {
+  position: relative;
+  min-height: 64vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 90px 20px;
+  overflow: hidden;
+}
+
+.hero-bg {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 22% 20%, rgba(56, 189, 248, 0.28), transparent 55%),
+    radial-gradient(circle at 78% 74%, rgba(165, 243, 252, 0.18), transparent 55%),
+    linear-gradient(135deg, #030b16 0%, #08283f 50%, #030b16 100%);
+  z-index: 0;
+}
+
+.light-theme .hero-bg {
+  background:
+    radial-gradient(circle at 22% 20%, rgba(186, 230, 253, 0.7), transparent 55%),
+    radial-gradient(circle at 78% 74%, rgba(207, 250, 254, 0.7), transparent 55%),
+    linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 50%, #f0f9ff 100%);
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  max-width: 880px;
+}
+
+.hero-badge {
+  display: inline-block;
+  padding: 7px 18px;
+  border-radius: 30px;
+  background: rgba(56, 189, 248, 0.16);
+  border: 1px solid rgba(56, 189, 248, 0.42);
+  color: var(--gl-ice);
+  font-size: 0.84rem;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  margin-bottom: 20px;
+}
+
+.hero-content h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2.2rem, 5.5vw, 3.7rem);
+  font-weight: 800;
+  line-height: 1.12;
+  margin-bottom: 18px;
+}
+
+.hero-content h1 span {
+  background: linear-gradient(135deg, var(--gl-ice), var(--gl-frost));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  display: block;
+}
+
+.light-theme .hero-content h1 span {
+  background: linear-gradient(135deg, var(--gl-deep), var(--gl-ice));
+  -webkit-background-clip: text;
+  background-clip: text;
+}
+
+.hero-content > p {
+  color: var(--gl-sub);
+  font-size: 1.06rem;
+  line-height: 1.7;
+  max-width: 770px;
+  margin: 0 auto 34px;
+}
+
+.hero-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 18px;
+  max-width: 660px;
+  margin: 0 auto;
+}
+
+.hero-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px 10px;
+  border-radius: 14px;
+  background: var(--gl-card);
+  border: 1px solid var(--gl-border);
+}
+
+.hero-stat .number {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.7rem;
+  font-weight: 700;
+  color: var(--gl-ice);
+}
+
+.hero-stat .label {
+  font-size: 0.76rem;
+  color: var(--gl-sub);
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+/* --------------------------------------------------------- content block */
+
+.content-section {
+  display: grid;
+  grid-template-columns: 1.55fr 1fr;
+  gap: 30px;
+  padding: 34px;
+}
+
+.content-text p {
+  color: var(--gl-sub);
+  line-height: 1.78;
+  margin-bottom: 14px;
+}
+
+.content-text strong {
+  color: var(--gl-text);
+}
+
+.content-text em {
+  color: var(--gl-ice);
+  font-style: italic;
+}
+
+.content-text ul {
+  margin: 6px 0 0 18px;
+  color: var(--gl-sub);
+  line-height: 1.9;
+}
+
+.side-note {
+  background: rgba(245, 158, 11, 0.09);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-radius: 16px;
+  padding: 28px;
+  text-align: center;
+  align-self: start;
+}
+
+.side-note .big-icon,
+.empty-state .big-icon {
+  font-size: 3rem;
+  margin-bottom: 12px;
+}
+
+.side-note h3 {
+  font-size: 1.12rem;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+
+.side-note p {
+  color: var(--gl-sub);
+  line-height: 1.68;
+  font-size: 0.94rem;
+}
+
+/* ---------------------------------------------------------------- basins */
+
+.basin-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+}
+
+.basin-card {
+  background: var(--gl-card);
+  border: 1px solid var(--gl-border);
+  border-radius: 16px;
+  padding: 26px 22px;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: transform 0.25s ease, border-color 0.25s ease;
+}
+
+.basin-card:hover,
+.basin-card:focus-visible {
+  transform: translateY(-4px);
+  border-color: rgba(56, 189, 248, 0.55);
+  outline: none;
+}
+
+.basin-card .icon,
+.info-card .icon {
+  font-size: 2.2rem;
+  margin-bottom: 12px;
+  display: block;
+}
+
+.basin-card h3,
+.info-card h3 {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.basin-card p,
+.info-card p {
+  color: var(--gl-sub);
+  line-height: 1.65;
+  font-size: 0.92rem;
+}
+
+.basin-card .tag {
+  display: inline-block;
+  margin-top: 12px;
+  font-size: 0.76rem;
+  font-weight: 600;
+  color: var(--gl-ice);
+  background: rgba(56, 189, 248, 0.12);
+  border-radius: 20px;
+  padding: 4px 12px;
+}
+
+/* --------------------------------------------------------------- filters */
+
+.filter-bar {
+  padding: 22px;
+  margin-bottom: 28px;
+}
+
+.search-row {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.gl-search {
+  flex: 1;
+  padding: 12px 16px;
+  border-radius: 12px;
+  border: 1px solid var(--gl-border);
+  background: rgba(0, 0, 0, 0.22);
+  color: var(--gl-text);
+  font: inherit;
+}
+
+.light-theme .gl-search {
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.gl-search:focus {
+  outline: 2px solid var(--gl-ice);
+  outline-offset: 1px;
+}
+
+.btn-reset {
+  padding: 12px 20px;
+  border-radius: 12px;
+  border: 1px solid var(--gl-border);
+  background: transparent;
+  color: var(--gl-sub);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+
+.btn-reset:hover {
+  border-color: var(--gl-ice);
+  color: var(--gl-ice);
+}
+
+.filter-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  margin-bottom: 14px;
+  flex-wrap: wrap;
+}
+
+.sort-row {
+  padding-top: 12px;
+  border-top: 1px solid var(--gl-border);
+}
+
+.filter-label {
+  min-width: 96px;
+  padding-top: 7px;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  color: var(--gl-sub);
+}
+
+.chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  flex: 1;
+}
+
+.chip {
+  padding: 6px 14px;
+  border-radius: 20px;
+  border: 1px solid var(--gl-border);
+  background: transparent;
+  color: var(--gl-sub);
+  font: inherit;
+  font-size: 0.84rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.chip:hover {
+  border-color: var(--gl-ice);
+  color: var(--gl-ice);
+}
+
+.chip.active {
+  background: linear-gradient(135deg, var(--gl-deep), var(--gl-ice));
+  border-color: transparent;
+  color: #fff;
+  font-weight: 600;
+}
+
+.result-count {
+  margin-top: 6px;
+  font-size: 0.86rem;
+  color: var(--gl-sub);
+}
+
+/* --------------------------------------------------------- glacier cards */
+
+.glacier-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 20px;
+}
+
+.glacier-card {
+  display: flex;
+  flex-direction: column;
+  background: var(--gl-card);
+  border: 1px solid var(--gl-border);
+  border-radius: 16px;
+  padding: 22px;
+  cursor: pointer;
+  transition: transform 0.25s ease, border-color 0.25s ease, box-shadow 0.25s ease;
+}
+
+.glacier-card:hover,
+.glacier-card:focus-visible {
+  transform: translateY(-5px);
+  border-color: rgba(56, 189, 248, 0.55);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.3);
+  outline: none;
+}
+
+.glacier-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.glacier-icon {
+  font-size: 2.2rem;
+}
+
+.trend-badge {
+  font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.7px;
+  border-radius: 20px;
+  padding: 4px 11px;
+}
+
+.trend-good { background: rgba(34, 197, 94, 0.16);  color: #4ade80; }
+.trend-warn { background: rgba(245, 158, 11, 0.16); color: #fbbf24; }
+.trend-bad  { background: rgba(239, 68, 68, 0.16);  color: #f87171; }
+
+.glacier-card h3 {
+  font-size: 1.12rem;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.glacier-tagline {
+  font-size: 0.85rem;
+  font-style: italic;
+  color: var(--gl-ice);
+  margin-bottom: 12px;
+}
+
+.quick-specs {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.quick-specs span {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 9px 12px;
+  border-radius: 10px;
+  background: rgba(56, 189, 248, 0.08);
+  border: 1px solid rgba(56, 189, 248, 0.18);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+  color: var(--gl-sub);
+}
+
+.quick-specs strong {
+  font-size: 0.98rem;
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--gl-text);
+}
+
+.glacier-desc {
+  color: var(--gl-sub);
+  font-size: 0.9rem;
+  line-height: 1.62;
+  margin-bottom: 14px;
+  flex: 1;
+}
+
+.glacier-meta,
+.gl-modal-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-bottom: 14px;
+}
+
+.pill {
+  font-size: 0.74rem;
+  border-radius: 20px;
+  padding: 4px 11px;
+  border: 1px solid var(--gl-border);
+  color: var(--gl-sub);
+}
+
+.pill-state {
+  border-color: rgba(56, 189, 248, 0.38);
+  color: var(--gl-ice);
+  background: rgba(56, 189, 248, 0.1);
+}
+
+.light-theme .pill-state { color: #0369a1; }
+
+.pill-basin {
+  border-color: rgba(34, 197, 94, 0.35);
+  color: #4ade80;
+  background: rgba(34, 197, 94, 0.1);
+}
+
+.light-theme .pill-basin { color: #15803d; }
+
+.pill-range {
+  border-color: rgba(148, 163, 184, 0.4);
+  color: #94a3b8;
+  background: rgba(148, 163, 184, 0.1);
+}
+
+.glacier-cta {
+  font-size: 0.83rem;
+  font-weight: 600;
+  color: var(--gl-ice);
+}
+
+.empty-state {
+  text-align: center;
+  padding: 60px 20px;
+  color: var(--gl-sub);
+}
+
+.empty-state h3 {
+  font-size: 1.2rem;
+  color: var(--gl-text);
+  margin-bottom: 8px;
+}
+
+/* ----------------------------------------------------------------- chart */
+
+.chart-panel {
+  padding: 30px;
+}
+
+.bar-row {
+  display: grid;
+  grid-template-columns: 170px 1fr 72px;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.bar-label {
+  font-size: 0.86rem;
+  color: var(--gl-sub);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.bar-track {
+  height: 11px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.07);
+  overflow: hidden;
+}
+
+.light-theme .bar-track {
+  background: rgba(3, 105, 161, 0.12);
+}
+
+.bar-fill {
+  display: block;
+  height: 100%;
+  border-radius: 10px;
+  transition: width 0.6s cubic-bezier(0.165, 0.84, 0.44, 1);
+}
+
+.fill-good { background: linear-gradient(90deg, #16a34a, #4ade80); }
+.fill-warn { background: linear-gradient(90deg, #d97706, #fbbf24); }
+.fill-bad  { background: linear-gradient(90deg, #b91c1c, #f87171); }
+
+.bar-value {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--gl-sub);
+  text-align: right;
+}
+
+.chart-caveat {
+  margin-top: 20px;
+  padding: 14px 16px;
+  border-radius: 12px;
+  background: rgba(245, 158, 11, 0.1);
+  border-left: 3px solid var(--gl-warn);
+  color: var(--gl-sub);
+  font-size: 0.88rem;
+  line-height: 1.65;
+}
+
+/* --------------------------------------------------------------- anatomy */
+
+.anatomy-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(270px, 1fr));
+  gap: 18px;
+}
+
+.anatomy-card {
+  background: var(--gl-card);
+  border: 1px solid var(--gl-border);
+  border-top: 3px solid var(--gl-ice);
+  border-radius: 14px;
+  padding: 22px;
+  transition: transform 0.25s ease;
+}
+
+.anatomy-card:hover {
+  transform: translateY(-4px);
+}
+
+.anatomy-icon {
+  font-size: 1.9rem;
+  margin-bottom: 10px;
+}
+
+.anatomy-card h3 {
+  font-size: 1rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.anatomy-card p {
+  color: var(--gl-sub);
+  font-size: 0.89rem;
+  line-height: 1.64;
+}
+
+/* ------------------------------------------------------------------ glof */
+
+.glof-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+  gap: 20px;
+}
+
+.glof-card {
+  background: var(--gl-card);
+  border: 1px solid var(--gl-border);
+  border-left: 4px solid var(--gl-alert);
+  border-radius: 16px;
+  padding: 24px;
+}
+
+.glof-head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 14px;
+}
+
+.glof-icon {
+  font-size: 2.1rem;
+}
+
+.glof-card h3 {
+  font-size: 1.08rem;
+  font-weight: 700;
+  margin-bottom: 2px;
+}
+
+.glof-place {
+  font-size: 0.79rem;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  color: var(--gl-sub);
+}
+
+.glof-desc {
+  color: var(--gl-sub);
+  font-size: 0.92rem;
+  line-height: 1.7;
+  margin-bottom: 14px;
+}
+
+.glof-lesson {
+  padding: 13px 15px;
+  border-radius: 12px;
+  background: rgba(239, 68, 68, 0.09);
+  color: var(--gl-sub);
+  font-size: 0.89rem;
+  line-height: 1.65;
+}
+
+.glof-lesson strong {
+  color: var(--gl-text);
+}
+
+/* ---------------------------------------------------------- info + facts */
+
+.info-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+}
+
+.info-card {
+  background: var(--gl-card);
+  border: 1px solid var(--gl-border);
+  border-radius: 16px;
+  padding: 26px 22px;
+  transition: transform 0.25s ease, border-color 0.25s ease;
+}
+
+.info-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+.severity,
+.org-tag {
+  display: inline-block;
+  margin-top: 12px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  border-radius: 20px;
+  padding: 4px 12px;
+}
+
+.severity-critical { background: rgba(185, 28, 28, 0.18); color: #f87171; }
+.severity-high     { background: rgba(217, 119, 6, 0.16); color: #fbbf24; }
+.severity-moderate { background: rgba(56, 189, 248, 0.14); color: var(--gl-ice); }
+
+.org-tag {
+  background: rgba(56, 189, 248, 0.12);
+  color: var(--gl-ice);
+}
+
+.light-theme .org-tag { color: #0369a1; }
+
+.facts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.fact-card {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  background: var(--gl-card);
+  border: 1px solid var(--gl-border);
+  border-left: 3px solid var(--gl-ice);
+  border-radius: 14px;
+  padding: 18px 20px;
+}
+
+.fact-number {
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, var(--gl-deep), var(--gl-ice));
+  color: #fff;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.fact-card p {
+  color: var(--gl-sub);
+  line-height: 1.6;
+  font-size: 0.92rem;
+}
+
+/* -------------------------------------------------------------- timeline */
+
+.timeline {
+  position: relative;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 10px 0;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  transform: translateX(-50%);
+  background: linear-gradient(180deg, transparent, var(--gl-ice), transparent);
+}
+
+.timeline-item {
+  position: relative;
+  width: 50%;
+  padding: 0 34px 34px;
+}
+
+.timeline-item.left { left: 0; text-align: right; }
+.timeline-item.right { left: 50%; }
+
+.timeline-dot {
+  position: absolute;
+  top: 8px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--gl-ice);
+  box-shadow: 0 0 0 4px rgba(56, 189, 248, 0.22);
+}
+
+.timeline-item.left .timeline-dot { right: -7px; }
+.timeline-item.right .timeline-dot { left: -7px; }
+
+.timeline-content {
+  background: var(--gl-card);
+  border: 1px solid var(--gl-border);
+  border-radius: 14px;
+  padding: 20px;
+}
+
+.timeline-year {
+  display: inline-block;
+  font-family: 'Playfair Display', serif;
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--gl-ice);
+  margin-bottom: 6px;
+}
+
+.timeline-content h3 {
+  font-size: 1.04rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.timeline-content p {
+  color: var(--gl-sub);
+  line-height: 1.65;
+  font-size: 0.91rem;
+}
+
+/* --------------------------------------------------------------- gallery */
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 18px;
+}
+
+.gallery-item {
+  background: var(--gl-card);
+  border: 1px solid var(--gl-border);
+  border-radius: 16px;
+  overflow: hidden;
+  transition: transform 0.25s ease;
+}
+
+.gallery-item:hover { transform: translateY(-5px); }
+
+.gallery-visual {
+  height: 130px;
+  display: grid;
+  place-items: center;
+  font-size: 3.4rem;
+  background:
+    radial-gradient(circle at 30% 30%, rgba(56, 189, 248, 0.26), transparent 60%),
+    radial-gradient(circle at 70% 70%, rgba(165, 243, 252, 0.2), transparent 60%);
+}
+
+.gallery-item figcaption {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px 18px;
+}
+
+.gallery-item figcaption strong { font-size: 0.95rem; }
+
+.gallery-item figcaption span {
+  font-size: 0.83rem;
+  color: var(--gl-sub);
+  line-height: 1.5;
+}
+
+/* ------------------------------------------------------------------ quiz */
+
+.quiz-section {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 30px;
+}
+
+.quiz-progress {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: var(--gl-sub);
+  margin-bottom: 16px;
+}
+
+.quiz-running-score { color: var(--gl-ice); }
+
+.quiz-question {
+  font-size: 1.2rem;
+  font-weight: 700;
+  line-height: 1.5;
+  margin-bottom: 20px;
+}
+
+.quiz-options {
+  display: grid;
+  gap: 10px;
+}
+
+.quiz-option {
+  text-align: left;
+  padding: 14px 18px;
+  border-radius: 12px;
+  border: 1px solid var(--gl-border);
+  background: rgba(0, 0, 0, 0.2);
+  color: var(--gl-text);
+  font: inherit;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.light-theme .quiz-option { background: rgba(255, 255, 255, 0.65); }
+
+.quiz-option:hover:not(:disabled) {
+  border-color: var(--gl-ice);
+  transform: translateX(4px);
+}
+
+.quiz-option:disabled { cursor: default; }
+
+.quiz-option.correct {
+  border-color: var(--gl-good);
+  background: rgba(34, 197, 94, 0.16);
+}
+
+.quiz-option.wrong {
+  border-color: var(--gl-alert);
+  background: rgba(239, 68, 68, 0.16);
+}
+
+.quiz-explain {
+  margin-top: 18px;
+  padding: 16px 18px;
+  border-radius: 12px;
+  background: rgba(56, 189, 248, 0.09);
+  border-left: 3px solid var(--gl-ice);
+}
+
+.quiz-explain p {
+  color: var(--gl-sub);
+  line-height: 1.6;
+  margin-bottom: 14px;
+}
+
+.btn-quiz {
+  padding: 11px 26px;
+  border: none;
+  border-radius: 12px;
+  background: linear-gradient(135deg, var(--gl-deep), var(--gl-ice));
+  color: #fff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-quiz:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 24px rgba(56, 189, 248, 0.3);
+}
+
+.quiz-result {
+  text-align: center;
+  padding: 20px 0;
+}
+
+.quiz-score {
+  font-family: 'Playfair Display', serif;
+  font-size: 3rem;
+  font-weight: 800;
+  color: var(--gl-ice);
+  margin-bottom: 10px;
+}
+
+.quiz-verdict {
+  color: var(--gl-sub);
+  margin-bottom: 22px;
+}
+
+/* ----------------------------------------------------------------- modal */
+
+.gl-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+}
+
+.gl-modal[hidden] { display: none; }
+
+.gl-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  backdrop-filter: blur(4px);
+}
+
+.gl-modal-card {
+  position: relative;
+  z-index: 1;
+  width: min(620px, 100%);
+  max-height: 86vh;
+  overflow-y: auto;
+  background: var(--gl-card);
+  border: 1px solid var(--gl-border);
+  border-radius: 20px;
+  padding: 34px 30px;
+  backdrop-filter: blur(18px);
+  animation: gl-modal-in 0.25s cubic-bezier(0.165, 0.84, 0.44, 1);
+}
+
+.light-theme .gl-modal-card { background: #f8fdff; }
+
+@keyframes gl-modal-in {
+  from { opacity: 0; transform: translateY(18px) scale(0.97); }
+  to   { opacity: 1; transform: none; }
+}
+
+.gl-modal-close {
+  position: absolute;
+  top: 14px;
+  right: 18px;
+  background: none;
+  border: none;
+  font-size: 1.9rem;
+  line-height: 1;
+  color: var(--gl-sub);
+  cursor: pointer;
+}
+
+.gl-modal-close:hover { color: var(--gl-ice); }
+
+.gl-modal-head {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 16px;
+  padding-right: 30px;
+}
+
+.gl-modal-icon { font-size: 2.8rem; }
+
+.gl-modal-card h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.6rem;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.gl-modal-tagline {
+  font-style: italic;
+  color: var(--gl-ice);
+  font-size: 0.92rem;
+}
+
+.gl-modal-desc {
+  color: var(--gl-sub);
+  line-height: 1.75;
+}
+
+.gl-modal-subhead {
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--gl-ice);
+  margin: 24px 0 12px;
+}
+
+.spec-list {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px 18px;
+  font-size: 0.9rem;
+}
+
+.spec-list dt {
+  color: var(--gl-sub);
+  font-weight: 500;
+}
+
+.spec-list dd {
+  color: var(--gl-text);
+  font-weight: 600;
+}
+
+.note-list {
+  display: grid;
+  gap: 8px;
+  list-style: none;
+}
+
+.note-list li {
+  position: relative;
+  padding-left: 20px;
+  color: var(--gl-sub);
+  font-size: 0.9rem;
+  line-height: 1.65;
+}
+
+.note-list li::before {
+  content: '❄';
+  position: absolute;
+  left: 0;
+  color: var(--gl-ice);
+}
+
+.gl-modal-source {
+  margin-top: 22px;
+  padding: 14px 16px;
+  border-radius: 12px;
+  background: rgba(245, 158, 11, 0.09);
+  border-left: 3px solid var(--gl-warn);
+  color: var(--gl-sub);
+  font-size: 0.88rem;
+  line-height: 1.65;
+}
+
+/* ------------------------------------------------------------ animations */
+
+.animate-on-scroll {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 0.55s ease, transform 0.55s cubic-bezier(0.165, 0.84, 0.44, 1);
+}
+
+.animate-on-scroll.animate-visible {
+  opacity: 1;
+  transform: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-on-scroll,
+  .gl-modal-card,
+  .bar-fill {
+    animation: none !important;
+    transition: none !important;
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* ------------------------------------------------------------ responsive */
+
+@media (max-width: 900px) {
+  .content-section { grid-template-columns: 1fr; }
+
+  .timeline::before { left: 18px; }
+
+  .timeline-item,
+  .timeline-item.left,
+  .timeline-item.right {
+    width: 100%;
+    left: 0;
+    text-align: left;
+    padding: 0 0 30px 46px;
+  }
+
+  .timeline-item.left .timeline-dot,
+  .timeline-item.right .timeline-dot {
+    left: 11px;
+    right: auto;
+  }
+}
+
+@media (max-width: 640px) {
+  .section-container { padding: 44px 16px; }
+
+  .section-header h2 { font-size: 1.9rem; }
+
+  .search-row { flex-direction: column; }
+
+  .filter-label {
+    min-width: 100%;
+    padding-top: 0;
+  }
+
+  .bar-row { grid-template-columns: 118px 1fr 62px; }
+
+  .spec-list { grid-template-columns: 1fr; gap: 2px 0; }
+
+  .spec-list dd { margin-bottom: 10px; }
+
+  .quiz-section,
+  .chart-panel,
+  .content-section,
+  .gl-modal-card {
+    padding: 22px 18px;
+  }
+
+  .gl-modal-head {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+  }
+}

--- a/frontend/mountain-ranges/index.html
+++ b/frontend/mountain-ranges/index.html
@@ -51,6 +51,7 @@
                             <a href="../heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
                             <a href="../monuments/monuments.html" class="dropdown-item">Monuments</a>
                             <a href="../spiritual/spiritual.html" class="dropdown-item">Spiritual India</a>
+                            <a href="../glaciers-explorer/index.html" class="dropdown-item">Himalayan Glaciers</a>
                         </div>
                     </div>
                     <button

--- a/frontend/mountains/index.html
+++ b/frontend/mountains/index.html
@@ -55,6 +55,7 @@
                         <a class="dropdown-item" href="../personalities/personalities.html">Famous Personalities</a>
                         <a class="dropdown-item" href="../spiritual/spiritual.html">Spiritual India</a>
                         <a class="dropdown-item" href="../arts-crafts/arts-crafts.html">Arts &amp; Crafts</a>
+                        <a class="dropdown-item" href="../glaciers-explorer/index.html">Himalayan Glaciers</a>
                     </div>
                 </div>
                 <div class="nav-dropdown">


### PR DESCRIPTION
## Description

Closes #1246

Adds a new self-contained explorer module at `frontend/glaciers-explorer/` covering **India's Himalayan glaciers as a system** — the ice that keeps the Ganga, Indus and Brahmaputra flowing through the dry season, and what happens as it retreats.

The repo has detailed pages for individual Himalayan **peaks** (Nanda Devi, Kanchenjunga, Shivling, Kedarnath…) and for wetlands, but nothing on glaciers. This fills that gap.

## The fourteen glaciers

| Glacier | State | Basin | Length |
|---|---|---|---|
| Siachen | Ladakh | Indus | ~76 km |
| Rimo | Ladakh | Indus | ~40 km |
| Gangotri | Uttarakhand | Ganga | ~30 km |
| Bara Shigri | Himachal Pradesh | Indus | ~28 km |
| Zemu | Sikkim | Brahmaputra | ~26 km |
| Drang-Drung | Ladakh | Indus | ~23 km |
| Milam | Uttarakhand | Ganga | ~16 km |
| Parkachik | Ladakh | Indus | ~14 km |
| Satopanth | Uttarakhand | Ganga | ~13 km |
| Chhota Shigri | Himachal Pradesh | Indus | ~9 km |
| Machoi | Jammu & Kashmir | Indus | ~9 km |
| Dokriani | Uttarakhand | Ganga | ~6 km |
| Pindari | Uttarakhand | Ganga | ~5 km |
| Kolahoi | Jammu & Kashmir | Indus | ~5 km |

## What's included

- **Overview** — glaciers as slow-release reservoirs, why the *timing* of melt matters more than the volume, and the **peak water** problem (retreat produces more water first, then permanently less)
- **Three basins** — Indus, Ganga, Brahmaputra, each card jumping into the filtered browser
- **Explorer** — basin × range × trend filters, free-text search, and sorting by name / length / retreat rate
- **Retreat comparison chart** — colour-coded by trend class, with a prominent caveat
- **Glacier anatomy** — 10 terms: accumulation zone, ELA, ablation zone, snout, moraine, crevasse, serac, debris cover, proglacial lake, bergschrund
- **GLOF case studies** — Chamoli 2021, South Lhonak 2023, Kedarnath 2013, Gohna Tal 1894, each with a "what it showed" takeaway
- **Climate impact** — 6 consequences with severity ratings, including hydropower exposure and slope destabilisation
- **Monitoring & research** — WIHG Dehradun, Himansh station, ISRO/NRSC inventories, GSI, NIH Roorkee, NMSHE
- **Timeline** — 1780s Survey of India → 1894 Gohna Tal → 1970s mass-balance programmes → satellite era → Kedarnath → Chamoli → South Lhonak
- **Quiz, gallery, facts** — 10 questions, 8 gallery cards, 10 facts

## On the accuracy of the numbers

This is the part I want reviewers to look at most closely. Published retreat figures for the same glacier differ substantially between studies depending on the period measured, the method, and how the snout of a debris-covered glacier is defined. Rather than presenting single numbers as fact, the page:

1. Labels every retreat figure as **approximate** (`~18 m/yr`, never `18 m/yr`)
2. Carries a **caveat panel** directly under the comparison chart
3. Gives **every glacier its own `sourceNote`** in the detail modal describing the basis and limitations of its figures
4. Explicitly flags the **Karakoram anomaly** — Siachen and Rimo behave differently from central Himalayan glaciers, and the page says so rather than lumping them together

The bars are built for relative comparison, and the page says that in as many words.

## Files

```
frontend/glaciers-explorer/index.html    283 lines
frontend/glaciers-explorer/data.js       420 lines
frontend/glaciers-explorer/script.js     517 lines
frontend/glaciers-explorer/style.css   1,279 lines
                                      ─────────────
                                       2,499 lines
```

Plus two one-line navigation additions in `frontend/mountains/index.html` and `frontend/mountain-ranges/index.html`.

## Technical notes

- **Vanilla HTML/CSS/JS only**, no build step, no external libraries
- **All content in `data.js`** — hero counters (14 glaciers / 3 basins / longest 76 km / 5 in rapid retreat) are all computed from the dataset, not hardcoded
- **XSS-safe** — all interpolated values pass through `escapeHtml()`
- **Accessibility** — keyboard-operable cards, `aria-modal` dialog with Escape and focus restore, `aria-live` result count, `<dl>` for the spec list, `prefers-reduced-motion` honoured
- **Responsive** — timeline collapses to one rail below 900px; the spec list becomes single-column and chart labels narrow below 640px
- Scoped under `.gl-page` with page-local custom properties; dark and light themes both styled

## Testing

Verified with a **headless jsdom harness** that loads `index.html`, injects `data.js` and `script.js`, fires `DOMContentLoaded` with a stubbed `IntersectionObserver`, and asserts that every container the page claims to populate is non-empty with no `jsdomError` and no `console.error`:

```
PASS frontend/glaciers-explorer  (14 containers populated; stat-glaciers=14 stat-basins=3 stat-longest=76 stat-rapid=5)
```

Also verified:
- `node --check` passes on both JS files
- All internal navigation links added by this PR resolve to files that exist in the repo
- Filter, search and reset logic reviewed against the dataset; sort-chip state transitions traced

**Not verified:** I do not have a working browser in this environment, so the visual rendering — dark/light theming, responsive breakpoints, hover and focus states, and the modal animation — has **not** been checked in a real browser. Those are worth a look before merge.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
