### PR TITLE
Implement Intelligent Budget Planner with Dynamic Trip Cost Forecasting

### DIFF
--- a/docs/BUDGET_PLANNER.md
+++ b/docs/BUDGET_PLANNER.md
@@ -1,30 +1,121 @@
-# Smart Budget Planner
+# Intelligent Budget Planner (with Dynamic Trip Cost Forecasting)
 
-Resolves #284 — AI-Powered Smart Budget Planner for Trip Cost Estimation.
+Resolves #1028 — Implement Intelligent Budget Planner with Dynamic Trip Cost
+Forecasting. Builds on the original Smart Budget Planner (#284) rather than
+duplicating it: same rule-based, client-side, no-backend approach ("AI-powered"/
+"Intelligent" here means algorithmic/heuristic personalization, consistent with
+the rest of the site's rule-based Trip Planner), extended with itinerary-linked
+forecasting, cross-destination comparison, budget alerts, and PDF export.
 
-A fully client-side, rule-based budget estimator: no backend, no ML model
-("AI-powered" here means algorithmic/heuristic personalization, consistent
-with the rest of the site's rule-based Trip Planner). Users enter a
-destination, trip duration, number of travelers, accommodation preference,
-transportation mode, and their own food/sightseeing/shopping/misc
+Users enter a destination, trip duration, number of travelers, accommodation
+preference, transportation mode, and their own food/sightseeing/shopping/misc
 allowances, and get back a full category-wise cost estimate, a comparison
 across travel styles, a daily spending guide, and cost-optimization
-suggestions. Plans can be saved, edited, and exported as a text report, all
-via `localStorage` — no account required.
+suggestions — **updating live as any field changes**, not just on submit.
+Beyond the single-destination form, the page also offers a side-by-side
+**destination comparison** and a **forecast generated directly from a saved
+Trip Planner itinerary** (multi-city, using that itinerary's own real
+inter-city travel costs). An optional target budget triggers a
+healthy/warning/exceeded **alert** that re-evaluates on every recompute.
+Plans can be saved, edited, and exported as a text report or as a PDF (via
+the browser's print dialog), all via `localStorage` — no account required.
 
-## Files added
+## A pre-existing bug fixed along the way
+
+`budget-planner.html` was **never actually registered** in
+`js-modules/router-init.js`'s `ROUTE_INIT_MAP`, despite the original #284 PR's
+own documentation describing that registration. That meant
+`smart-budget-planner.js` never loaded on the live site and the entire
+feature — form submission, saved plans, everything — was dead on arrival.
+This PR adds the missing route entry (see below), which is a prerequisite
+for any of the new work here to run at all.
+
+Separately, and **not fixed by this PR** (out of scope, and that file is
+under heavy concurrent edit from many other in-flight wetland-explorer PRs):
+`frontend/wetlands/wetlands-data.js` on `main` currently has a missing `},`
+between two entries that breaks the whole file's parsing. Worth a tiny,
+dedicated follow-up PR.
+
+## Files added / changed
 
 | File | Purpose |
 | ---- | ------- |
-| `js-modules/smart-budget-planner.js` | All budget-calculation logic, plus the page's UI wiring (`initBudgetPlannerPage`). |
-| `budget-planner.html` | The page shell (header/nav/footer match the rest of the site), the planner form, results, and saved-plans sections. |
-| `budget-planner.css` | Dedicated stylesheet, reusing the site's existing design tokens (`--saffron`, `--gold`, `--green`, glass-panel vars) and print styles for exported reports. |
-| `tests/unit/smart-budget-planner.test.js` | Vitest unit tests for the calculation/comparison/recommendation/persistence logic. |
-| `js-modules/router-init.js` (modified) | One new entry in `ROUTE_INIT_MAP`, registering the `budget-planner.html` route. |
-| `trip-planner.html`, `india-3d-map.html` (modified) | Added a "💰 Budget Planner" nav-dropdown and footer link next to the existing Trip Planner link. |
+| `js-modules/smart-budget-planner.js` | Extended with `calculateItineraryBudget()`, `compareDestinations()`, `getBudgetAlert()`, an itinerary-aware `exportReportText()`, live/debounced recompute on the main form, and the new sections' DOM wiring (`initDestinationCompare()`, `initItineraryForecast()`). |
+| `frontend/budget-planner/budget-planner.html` | Added a target-budget field, a "Compare Destinations" section, and a "Forecast From My Itinerary" section. |
+| `frontend/budget-planner/budget-planner.css` | Styles for the alert banner, comparison cards, itinerary results, and extended print rules so PDF export only shows whichever result card is populated. |
+| `tests/unit/smart-budget-planner.test.js` | 15 new unit tests (30 total) covering the three new functions. |
+| `js-modules/router-init.js` (modified) | **Added the missing `budget-planner.html` route entry** (see above), now loading `trip-data.js`, `trip-planner.js` (for itinerary forecasting), and `smart-budget-planner.js`. |
 
-It reuses `trip-data.js` (added for the existing Trip Planner, issue #184)
-for destination-specific accommodation rates, but does not modify that file.
+## New capabilities, mapped to issue #1028
+
+| Issue ask | Implementation |
+| --- | --- |
+| "Budget estimates should automatically update whenever users modify their itinerary" / "Budget updates automatically when trip details change" | Once a first estimate exists, every form field (main form, comparison form, itinerary form) triggers a recompute — debounced ~400ms on free-text/number fields, instant on selects — without needing another explicit submit. |
+| "Budget comparison across destinations" | `compareDestinations(baseInput, names)` re-runs the same days/travelers/tier/transport across up to 4 destinations; the UI shows them side-by-side with the cheapest highlighted. |
+| "Budget alerts when estimated costs exceed limits" / "Budget alerts when itinerary changes increase costs" | `getBudgetAlert(plan, targetBudget)` returns `healthy`/`warning` (≥85% of target)/`exceeded`, in the same vocabulary as `js-modules/budget-calculator-engine.js`'s `getBudgetHealth()` elsewhere in this codebase. Re-evaluated on every recompute, so it reacts live to itinerary/assumption changes. |
+| "Export budget report as PDF" | A print stylesheet hides everything but the populated results card(s); the "🖨️ Export as PDF" button calls `window.print()`, letting the browser's own "Save as PDF" destination produce the file — no PDF library dependency, matching the pattern already used by `trip-expense-splitter`, `trip-planner.js`, and `compare-states-data`. |
+| "Users can customize budget assumptions" | Already true of the original form (tier/transport/food/sightseeing/shopping/misc); extended with a target-budget assumption for alerts. |
+| Dynamic **trip cost forecasting** tied to a real itinerary (the issue's title) | `calculateItineraryBudget(itinerary, options)` — see below. |
+
+## The itinerary forecast, in detail
+
+`calculateItineraryBudget()` takes a Trip Planner saved-trip's `itinerary`
+object directly (`{ destinations: [...], legs: [...], inputs: { travelers } }`,
+the exact shape `js-modules/trip-planner.js` already produces and saves) and:
+
+1. For each destination, computes accommodation (using the same
+   destination-cost-indexed rate logic as the single-destination planner) and
+   food cost based on how many days that itinerary actually assigned to that
+   stop (`dest.assignedDays`).
+2. For transport, **reuses Trip Planner's own distance-based inter-city leg
+   costs** (`itinerary.legs[].cost`, scaled by traveler count) instead of a
+   flat per-mode guess — more accurate than the single-destination form's
+   transport estimate, since it reflects the itinerary's actual routing.
+3. Adds one trip-level sightseeing/shopping/misc allowance (rather than
+   per-destination, since the issue describes these as trip-wide
+   configurable allowances) and one 8% contingency buffer on the combined
+   subtotal.
+4. Returns the same `categories`/`categoryPercentages`/`total`/
+   `perPersonTotal`/`perDayTotal` shape as `calculateBudget()`, plus a
+   `perDestination` array, so the UI can reuse the same category-breakdown
+   rendering helper for both.
+
+## Known limitations / good follow-ups
+
+- No live cross-tab sync: if a person edits a trip in Trip Planner in
+  another tab, the itinerary-forecast dropdown only picks it up on next
+  page load, since this is `localStorage`-only with no backend.
+- Costs remain editorial planning estimates, not live pricing — same
+  caveat as the original Smart Budget Planner and the Trip Planner it's
+  built on.
+- The nav link is still only on the pages that already link to it
+  (`trip-planner.html`, `india-3d-map.html`) — see #284's docs for why a
+  shared header include is the real fix, not attempted here.
+- `frontend/wetlands/wetlands-data.js`'s pre-existing syntax bug (see above)
+  is unrelated but worth a quick separate PR.
+
+## Testing
+
+```bash
+npx vitest run tests/unit/smart-budget-planner.test.js
+```
+
+30 unit tests: the original 15 (category totals, destination lookup,
+input clamping, room-sharing math, tier comparison, recommendation rules,
+daily-plan division, exported report content, save/edit/delete
+persistence) plus 15 new ones covering `compareDestinations()` (sorting,
+matched-vs-unmatched destinations, blank-entry handling, held-constant
+parameters), `calculateItineraryBudget()` (category totals, transport
+derived from real leg costs, per-destination day counts, tier scaling,
+trip-wide allowances, invalid-itinerary error handling), and
+`getBudgetAlert()` (no-target case, exceeded/healthy/warning thresholds,
+and status changing correctly as the underlying plan changes).
+
+Full suite (`npx vitest run`): 1331/1342 tests pass. The 11 failures are
+all in wetland-explorer test files unrelated to this change (see the
+pre-existing `wetlands-data.js` bug noted above) — none touch the budget
+planner.
+
 
 ## How it fits into the existing architecture
 
@@ -35,21 +126,23 @@ listens for that event and, based on `pathname`, looks up the route in
 `ROUTE_INIT_MAP`, lazy-loads the right script(s), and calls the page's
 `init...Page()` function.
 
-The Smart Budget Planner follows that pattern exactly:
+The Smart Budget Planner follows that pattern — though, as noted above,
+this route entry was **entirely missing** until this PR:
 
 ```js
 // js-modules/router-init.js
 'budget-planner.html': {
-    scripts: ['trip-data.js', 'js-modules/smart-budget-planner.js'],
+    scripts: ['trip-data.js', 'js-modules/trip-planner.js', 'js-modules/smart-budget-planner.js'],
     initName: 'initBudgetPlannerPage',
     useSafeInit: true,
-    name: 'Smart Budget Planner'
+    name: 'Budget Planner'
 },
 ```
 
-`trip-data.js` is loaded first (for destination lookups) and explicitly
-awaited before `smart-budget-planner.js` runs, and `useSafeInit: true`
-wraps initialization in a try/catch so a failure here can't break
+`trip-data.js` and `trip-planner.js` are loaded first — the latter so the
+itinerary-forecast section can call `window.TripPlanner.getSavedTrips()` —
+and both are awaited before `smart-budget-planner.js` runs. `useSafeInit:
+true` wraps initialization in a try/catch so a failure here can't break
 navigation to other pages.
 
 ## Budgeting algorithm

--- a/frontend/budget-planner/budget-planner.css
+++ b/frontend/budget-planner/budget-planner.css
@@ -312,6 +312,129 @@
     text-align: center;
 }
 
+.bp-live-hint {
+    margin: 10px 0 0;
+    font-size: 0.82rem;
+    opacity: 0.65;
+    text-align: center;
+}
+
+/* ---------- Budget Alert Banner ---------- */
+.bp-alert {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 14px 16px;
+    border-radius: 12px;
+    margin: 16px 0;
+    font-size: 0.95rem;
+    line-height: 1.5;
+}
+
+.bp-alert-icon {
+    flex-shrink: 0;
+    font-size: 1.1rem;
+}
+
+.bp-alert-healthy {
+    background: rgba(46, 125, 50, 0.12);
+    border-left: 3px solid #2e7d32;
+}
+
+.bp-alert-warning {
+    background: rgba(249, 168, 37, 0.12);
+    border-left: 3px solid #f9a825;
+}
+
+.bp-alert-exceeded {
+    background: rgba(198, 40, 40, 0.12);
+    border-left: 3px solid #c62828;
+}
+
+/* ---------- Compare Destinations ---------- */
+.bp-compare-results {
+    max-width: 1000px;
+    margin: 24px auto 0;
+}
+
+.bp-compare-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+}
+
+.bp-compare-card {
+    position: relative;
+    background: var(--glass-bg, rgba(255, 255, 255, 0.05));
+    border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.12));
+    border-radius: 16px;
+    padding: 24px 20px;
+    text-align: center;
+}
+
+.bp-compare-cheapest {
+    border-color: var(--saffron);
+    box-shadow: 0 0 0 1px var(--saffron);
+}
+
+.bp-compare-badge {
+    position: absolute;
+    top: -11px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--saffron);
+    color: #16130b;
+    font-size: 0.72rem;
+    font-weight: 700;
+    padding: 3px 12px;
+    border-radius: 999px;
+}
+
+.bp-compare-card h4 {
+    margin: 4px 0 10px;
+    font-size: 1.05rem;
+}
+
+.bp-compare-card h4 small {
+    font-weight: 400;
+    opacity: 0.6;
+    font-size: 0.75rem;
+}
+
+.bp-compare-total {
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: var(--gold);
+    margin: 0 0 6px;
+}
+
+.bp-compare-sub {
+    font-size: 0.82rem;
+    opacity: 0.7;
+    margin: 0;
+}
+
+/* ---------- Itinerary Forecast ---------- */
+.bp-itin-dest-list {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    margin-bottom: 8px;
+}
+
+.bp-itin-dest-row {
+    display: flex;
+    justify-content: space-between;
+    padding: 10px 14px;
+    background: rgba(255, 255, 255, 0.04);
+    border-radius: 10px;
+    font-size: 0.92rem;
+}
+
+.bp-itin-dest-row small {
+    opacity: 0.65;
+}
+
 @media (max-width: 640px) {
     .bp-form-card,
     .bp-summary-card {
@@ -326,6 +449,9 @@
     .bp-hero,
     .bp-form-section,
     .bp-saved-section,
+    .bp-compare-section .bp-form-card,
+    .bp-itinerary-section .bp-form-card,
+    .bp-print-hide,
     .bp-actions,
     .btn-scroll-top {
         display: none !important;

--- a/frontend/budget-planner/budget-planner.html
+++ b/frontend/budget-planner/budget-planner.html
@@ -146,11 +146,17 @@
 <label for="budget-misc">Miscellaneous Expenses (INR, total)</label>
 <input type="number" id="budget-misc" name="misc" min="0" step="100" placeholder="e.g. 2000"/>
 </div>
+<div class="bp-form-field">
+<label for="budget-target">Target Budget (INR, optional)</label>
+<input type="number" id="budget-target" name="targetBudget" min="0" step="500" placeholder="e.g. 50000"/>
+<small>Set a cap to get an alert if the estimate goes over.</small>
+</div>
 </div>
 
 <p id="budget-form-error" hidden=""></p>
 
 <button type="submit" class="btn btn-primary ripple bp-form-submit">Generate My Budget Estimate</button>
+<p class="bp-live-hint">Once generated, your estimate updates automatically as you change any field above.</p>
 </form>
 </div>
 </div>
@@ -160,6 +166,120 @@
 <section class="bp-results-section fade-in-section">
 <div class="section-container">
 <div id="budget-results" hidden=""></div>
+</div>
+</section>
+
+<!-- Compare Destinations -->
+<section class="bp-compare-section fade-in-section">
+<div class="section-container">
+<div class="section-header">
+<span class="section-badge">Step 2 (optional)</span>
+<h2>Compare Destinations</h2>
+<p class="section-subtitle">Same trip, different places — see which destination costs the least for the same days, travelers, and travel style.</p>
+</div>
+<div class="bp-form-card">
+<form id="budget-compare-form">
+<div class="bp-form-grid">
+<div class="bp-form-field">
+<label for="budget-compare-days">Trip Duration (days)</label>
+<input type="number" id="budget-compare-days" min="1" max="60" value="5"/>
+</div>
+<div class="bp-form-field">
+<label for="budget-compare-travelers">Number of Travelers</label>
+<input type="number" id="budget-compare-travelers" min="1" max="20" value="1"/>
+</div>
+<div class="bp-form-field">
+<label for="budget-compare-accommodation">Accommodation Preference</label>
+<select id="budget-compare-accommodation">
+<option value="budget">Budget</option>
+<option selected="" value="standard">Standard</option>
+<option value="luxury">Luxury</option>
+</select>
+</div>
+<div class="bp-form-field">
+<label for="budget-compare-transport">Transportation Mode</label>
+<select id="budget-compare-transport">
+<option value="flight">Flight</option>
+<option selected="" value="train">Train</option>
+<option value="bus">Bus</option>
+<option value="car_rental">Rental Car / Cab</option>
+<option value="own_vehicle">Own Vehicle</option>
+</select>
+</div>
+</div>
+<div class="bp-form-grid">
+<div class="bp-form-field">
+<label for="budget-compare-dest-1">Destination 1</label>
+<input type="text" id="budget-compare-dest-1" data-compare-destination="" placeholder="e.g. Goa" list="budget-compare-destination-list"/>
+</div>
+<div class="bp-form-field">
+<label for="budget-compare-dest-2">Destination 2</label>
+<input type="text" id="budget-compare-dest-2" data-compare-destination="" placeholder="e.g. Kerala" list="budget-compare-destination-list"/>
+</div>
+<div class="bp-form-field">
+<label for="budget-compare-dest-3">Destination 3 (optional)</label>
+<input type="text" id="budget-compare-dest-3" data-compare-destination="" placeholder="e.g. Ladakh" list="budget-compare-destination-list"/>
+</div>
+<div class="bp-form-field">
+<label for="budget-compare-dest-4">Destination 4 (optional)</label>
+<input type="text" id="budget-compare-dest-4" data-compare-destination="" placeholder="e.g. Rajasthan" list="budget-compare-destination-list"/>
+</div>
+</div>
+<datalist id="budget-compare-destination-list"></datalist>
+<p class="bp-live-hint">Fill in at least two destinations — the comparison updates automatically.</p>
+</form>
+</div>
+<div id="budget-compare-results" class="bp-compare-results" hidden=""></div>
+</div>
+</section>
+
+<!-- Itinerary Forecast -->
+<section class="bp-itinerary-section fade-in-section">
+<div class="section-container">
+<div class="section-header">
+<span class="section-badge">Step 3 (optional)</span>
+<h2>Forecast From My Itinerary</h2>
+<p class="section-subtitle">Already built a multi-city trip in the Trip Planner? Get a full category breakdown for it, using its real inter-city travel costs — updates automatically as you adjust the assumptions below.</p>
+</div>
+<div class="bp-form-card">
+<form id="budget-itinerary-form">
+<div class="bp-form-field">
+<label for="budget-itinerary-select">Saved Trip</label>
+<select id="budget-itinerary-select"><option disabled="" selected="">Loading your saved trips…</option></select>
+</div>
+<div class="bp-form-grid">
+<div class="bp-form-field">
+<label for="budget-itinerary-accommodation">Accommodation Preference</label>
+<select id="budget-itinerary-accommodation">
+<option value="budget">Budget</option>
+<option selected="" value="standard">Standard</option>
+<option value="luxury">Luxury</option>
+</select>
+</div>
+<div class="bp-form-field">
+<label for="budget-itinerary-food">Daily Food Budget (INR / person)</label>
+<input type="number" id="budget-itinerary-food" min="0" step="50" placeholder="e.g. 800"/>
+</div>
+<div class="bp-form-field">
+<label for="budget-itinerary-sightseeing">Sightseeing (INR, whole trip)</label>
+<input type="number" id="budget-itinerary-sightseeing" min="0" step="100" placeholder="e.g. 4000"/>
+</div>
+<div class="bp-form-field">
+<label for="budget-itinerary-shopping">Shopping (INR, whole trip)</label>
+<input type="number" id="budget-itinerary-shopping" min="0" step="100" placeholder="e.g. 5000"/>
+</div>
+<div class="bp-form-field">
+<label for="budget-itinerary-misc">Miscellaneous (INR, whole trip)</label>
+<input type="number" id="budget-itinerary-misc" min="0" step="100" placeholder="e.g. 2000"/>
+</div>
+<div class="bp-form-field">
+<label for="budget-itinerary-target">Target Budget (INR, optional)</label>
+<input type="number" id="budget-itinerary-target" min="0" step="500" placeholder="e.g. 80000"/>
+</div>
+</div>
+</form>
+</div>
+<div id="budget-itinerary-results" class="bp-results-section" hidden=""></div>
 </div>
 </section>
 

--- a/js-modules/router-init.js
+++ b/js-modules/router-init.js
@@ -80,6 +80,16 @@
             useSafeInit: true,
             name: 'Trip Planner'
         },
+        'budget-planner.html': {
+            // trip-planner.js is loaded here too (not just on
+            // trip-planner.html) so the Budget Planner's itinerary-forecast
+            // section can read window.TripPlanner.getSavedTrips() and
+            // buildDailySchedule() directly — see js-modules/smart-budget-planner.js.
+            scripts: ['trip-data.js', 'js-modules/trip-planner.js', 'js-modules/smart-budget-planner.js'],
+            initName: 'initBudgetPlannerPage',
+            useSafeInit: true,
+            name: 'Budget Planner'
+        },
         'heritage.html': { log: '✅ Heritage page loaded successfully' },
         'monuments.html': { log: '✅ Monuments page loaded successfully' },
         'hidden-gems.html': { log: '✅ Hidden Gems page loaded successfully' },

--- a/js-modules/smart-budget-planner.js
+++ b/js-modules/smart-budget-planner.js
@@ -174,6 +174,153 @@
     }
 
     /**
+     * Recomputes the same trip parameters (days, travelers, tier,
+     * transport, allowances) across a list of candidate destinations, so
+     * a user deciding *where* to go can see a side-by-side cost
+     * comparison — not just a style comparison for one place.
+     *
+     * @param {Object} baseInput - same shape as calculateBudget()'s input, minus `destination`
+     * @param {Array<string>} destinationNames
+     * @returns {Array} plans sorted cheapest-first
+     */
+    function compareDestinations(baseInput, destinationNames) {
+        const names = (destinationNames || []).map((n) => (n || "").trim()).filter(Boolean);
+        return names
+            .map((name) => {
+                const plan = calculateBudget(Object.assign({}, baseInput, { destination: name }));
+                return {
+                    destination: plan.matchedDestination || name,
+                    requested: name,
+                    matched: !!plan.matchedDestination,
+                    total: plan.total,
+                    perPersonTotal: plan.perPersonTotal,
+                    perDayTotal: plan.perDayTotal,
+                    categories: plan.categories,
+                    plan,
+                };
+            })
+            .sort((a, b) => a.total - b.total);
+    }
+
+    /**
+     * Category-wise cost forecast for a real, saved, multi-city Trip
+     * Planner itinerary (js-modules/trip-planner.js's saved-trip shape),
+     * rather than the single-destination form above. This is the
+     * "dynamic trip cost forecasting" piece of issue #1028: it reuses
+     * Trip Planner's own per-leg, distance-based inter-city travel costs
+     * (more accurate than a flat per-mode guess) for the transport
+     * category, and applies the same accommodation/food logic as
+     * calculateBudget() per destination, based on how many days the
+     * itinerary actually assigns to each stop.
+     *
+     * Recompute this whenever the itinerary or the options below change
+     * to keep the forecast in sync — see initBudgetPlannerPage()'s
+     * itinerary-forecast section for the live-update wiring.
+     *
+     * @param {Object} itinerary - a Trip Planner itinerary: { title?, inputs:{travelers}, destinations:[{name,state,assignedDays,costPerDay,...}], legs:[{cost,distanceKm,...}] }
+     * @param {Object} [options]
+     * @param {'budget'|'standard'|'luxury'} [options.accommodationTier='standard']
+     * @param {number} [options.dailyFoodBudget] - INR per person per day; defaults per tier like calculateBudget()
+     * @param {number} [options.sightseeing] - INR, total for the whole itinerary
+     * @param {number} [options.shopping] - INR, total for the whole itinerary
+     * @param {number} [options.misc] - INR, total for the whole itinerary
+     */
+    function calculateItineraryBudget(itinerary, options) {
+        options = options || {};
+        if (!itinerary || !Array.isArray(itinerary.destinations) || !itinerary.destinations.length) {
+            throw new Error("calculateItineraryBudget: itinerary with at least one destination is required");
+        }
+
+        const travelers = Math.max(1, Math.round(clampPositive((itinerary.inputs && itinerary.inputs.travelers) || 1, 1)));
+        const tier = ACCOMMODATION_TIERS.includes(options.accommodationTier) ? options.accommodationTier : "standard";
+        const dailyFoodBudget = clampPositive(options.dailyFoodBudget, tier === "luxury" ? 1500 : tier === "budget" ? 400 : 800);
+        const sightseeing = Math.round(clampPositive(options.sightseeing, 0));
+        const shopping = Math.round(clampPositive(options.shopping, 0));
+        const misc = Math.round(clampPositive(options.misc, 0));
+
+        const perDestination = itinerary.destinations.map((dest) => {
+            const days = Math.max(1, Math.round(dest.assignedDays || 1));
+            const nightlyRate = accommodationRate(tier, dest.costPerDay ? dest : findDestination(dest.name));
+            const nights = Math.max(0, days - 1) || days;
+            const accommodation = Math.round(nightlyRate * nights * roomsNeeded(travelers));
+            const food = Math.round(dailyFoodBudget * days * travelers);
+            return { name: dest.name, state: dest.state || null, days, accommodation, food, total: accommodation + food };
+        });
+
+        const accommodationTotal = perDestination.reduce((s, d) => s + d.accommodation, 0);
+        const foodTotal = perDestination.reduce((s, d) => s + d.food, 0);
+        // Reuse Trip Planner's own distance-based inter-city leg costs
+        // instead of a flat per-mode guess — leg.cost is per-person (see
+        // trip-planner.js#estimateTravelLeg), so scale by travelers here.
+        const legs = Array.isArray(itinerary.legs) ? itinerary.legs : [];
+        const transportTotal = Math.round(legs.reduce((s, l) => s + (l.cost || 0), 0) * travelers);
+
+        const subtotal = accommodationTotal + transportTotal + foodTotal + sightseeing + shopping + misc;
+        const contingency = Math.round(subtotal * CONTINGENCY_RATE);
+        const total = subtotal + contingency;
+        const totalDays = perDestination.reduce((s, d) => s + d.days, 0);
+
+        const categories = { accommodation: accommodationTotal, transport: transportTotal, food: foodTotal, sightseeing, shopping, misc, contingency };
+        const categoryPercentages = {};
+        Object.keys(categories).forEach((k) => {
+            categoryPercentages[k] = total > 0 ? Math.round((categories[k] / total) * 1000) / 10 : 0;
+        });
+
+        return {
+            id: "itin_budget_" + Date.now() + "_" + Math.random().toString(36).slice(2, 7),
+            createdAt: new Date().toISOString(),
+            tripTitle: itinerary.title || null,
+            inputs: { accommodationTier: tier, travelers, dailyFoodBudget, sightseeing, shopping, misc },
+            perDestination,
+            categories,
+            categoryPercentages,
+            subtotal,
+            total,
+            days: totalDays,
+            perPersonTotal: Math.round(total / travelers),
+            perDayTotal: Math.round(total / Math.max(1, totalDays)),
+        };
+    }
+
+    // Same healthy/warning/exceeded convention as
+    // js-modules/budget-calculator-engine.js's getBudgetHealth(), so
+    // alert styling is consistent with the rest of the site's budget
+    // tooling rather than inventing a fourth vocabulary.
+    const ALERT_WARNING_RATIO = 0.85;
+
+    /**
+     * Compares an estimated plan's total against a user-set target
+     * budget and returns an alert status. Call this again after any
+     * recompute (itinerary change, assumption change) to get a live
+     * "budget alert when estimated costs exceed limits" — see
+     * initBudgetPlannerPage() for where this re-renders automatically.
+     *
+     * @param {Object} plan - anything with a `.total` (calculateBudget() or calculateItineraryBudget() output)
+     * @param {number} targetBudget - INR; 0/blank means "no target set"
+     * @returns {null|{status:'healthy'|'warning'|'exceeded', ratio:number, target:number, total:number, difference:number, message:string}}
+     */
+    function getBudgetAlert(plan, targetBudget) {
+        const target = clampPositive(targetBudget, 0);
+        if (!target || !plan) return null;
+
+        const ratio = plan.total / target;
+        const difference = target - plan.total;
+        let status, message;
+        if (ratio > 1) {
+            status = "exceeded";
+            message = `This estimate is ${fmtINR(Math.abs(difference))} over your ${fmtINR(target)} budget.`;
+        } else if (ratio >= ALERT_WARNING_RATIO) {
+            status = "warning";
+            message = `This estimate is close to your ${fmtINR(target)} budget cap (${Math.round(ratio * 100)}% used).`;
+        } else {
+            status = "healthy";
+            message = `This estimate is within your ${fmtINR(target)} budget, with ${fmtINR(difference)} to spare.`;
+        }
+
+        return { status, ratio: Math.round(ratio * 1000) / 1000, target, total: plan.total, difference, message };
+    }
+
+    /**
      * Rule-based cost optimization suggestions derived from the breakdown.
      * Each suggestion includes an estimated saving where applicable so the
      * user can judge which trade-offs are worth making.
@@ -334,16 +481,34 @@
     };
 
     /** Builds a plain-text report string suitable for downloading/printing. */
-    function exportReportText(plan, recommendations) {
+    function exportReportText(plan, recommendations, alert) {
+        const isItinerary = Array.isArray(plan.perDestination);
         const lines = [];
-        const dest = plan.matchedDestination || plan.inputs.destination || "Your Trip";
-        lines.push(`SMART BUDGET PLAN - ${dest}`);
+        const dest = isItinerary ? plan.tripTitle || "Multi-City Itinerary" : plan.matchedDestination || plan.inputs.destination || "Your Trip";
+        lines.push(`${isItinerary ? "ITINERARY BUDGET FORECAST" : "SMART BUDGET PLAN"} - ${dest}`);
         lines.push("=".repeat(40));
-        lines.push(`Duration: ${plan.inputs.days} day(s)`);
+        if (isItinerary) {
+            lines.push(`Stops: ${plan.perDestination.map((d) => d.name).join(", ")}`);
+            lines.push(`Total duration: ${plan.days} day(s)`);
+        } else {
+            lines.push(`Duration: ${plan.inputs.days} day(s)`);
+        }
         lines.push(`Travelers: ${plan.inputs.travelers}`);
         lines.push(`Accommodation tier: ${plan.inputs.accommodationTier}`);
-        lines.push(`Transport mode: ${TRANSPORT_MODES[plan.inputs.transportMode].label}`);
+        if (!isItinerary) {
+            lines.push(`Transport mode: ${TRANSPORT_MODES[plan.inputs.transportMode].label}`);
+        }
         lines.push("");
+
+        if (isItinerary) {
+            lines.push("PER-DESTINATION BREAKDOWN");
+            lines.push("-".repeat(40));
+            plan.perDestination.forEach((d) => {
+                lines.push(`${d.name} (${d.days} day${d.days === 1 ? "" : "s"}): ${fmtINR(d.total)} (accommodation ${fmtINR(d.accommodation)} + food ${fmtINR(d.food)})`);
+            });
+            lines.push("");
+        }
+
         lines.push("CATEGORY BREAKDOWN");
         lines.push("-".repeat(40));
         Object.keys(plan.categories).forEach((k) => {
@@ -355,6 +520,13 @@
         lines.push(`TOTAL ESTIMATED COST: ${fmtINR(plan.total)}`);
         lines.push(`Per person: ${fmtINR(plan.perPersonTotal)}`);
         lines.push(`Per day: ${fmtINR(plan.perDayTotal)}`);
+
+        if (alert) {
+            lines.push("");
+            lines.push("BUDGET ALERT");
+            lines.push("-".repeat(40));
+            lines.push(alert.message);
+        }
 
         if (recommendations && recommendations.length) {
             lines.push("");
@@ -369,7 +541,7 @@
         }
 
         lines.push("");
-        lines.push("Generated by Incredible India Explorer - Smart Budget Planner");
+        lines.push("Generated by Incredible India Explorer - Intelligent Budget Planner");
         return lines.join("\n");
     }
 
@@ -382,6 +554,9 @@
         ACCOMMODATION_TIERS,
         calculateBudget,
         compareTiers,
+        compareDestinations,
+        calculateItineraryBudget,
+        getBudgetAlert,
         getRecommendations,
         getDailySpendingPlan,
         getSavedPlans,
@@ -431,6 +606,21 @@
                 shopping: parseFloat(document.getElementById("budget-shopping").value) || 0,
                 misc: parseFloat(document.getElementById("budget-misc").value) || 0,
             };
+        }
+
+        function readTargetBudget() {
+            const el = document.getElementById("budget-target");
+            return el ? parseFloat(el.value) || 0 : 0;
+        }
+
+        function renderAlert(plan, targetBudget) {
+            const alert = SmartBudgetPlanner.getBudgetAlert(plan, targetBudget);
+            if (!alert) return "";
+            return `
+                <div class="bp-alert bp-alert-${alert.status}" role="status">
+                    <span class="bp-alert-icon">${alert.status === "exceeded" ? "🚨" : alert.status === "warning" ? "⚠️" : "✅"}</span>
+                    <span>${alert.message}</span>
+                </div>`;
         }
 
         function renderBar(label, amount, percent, extraClass) {
@@ -489,6 +679,8 @@
                     </div>
                     <p class="bp-summary-sub">${plan.inputs.days} day(s) &middot; ${plan.inputs.travelers} traveler(s) &middot; ${SmartBudgetPlanner.fmtINR(plan.perPersonTotal)} per person &middot; ${SmartBudgetPlanner.fmtINR(plan.perDayTotal)} per day</p>
 
+                    ${renderAlert(plan, readTargetBudget())}
+
                     <h4 class="bp-section-title">Category Breakdown</h4>
                     <div class="bp-breakdown">${breakdownHtml}</div>
 
@@ -501,15 +693,17 @@
                     <h4 class="bp-section-title">Cost Optimization Suggestions</h4>
                     <ul class="bp-rec-list">${recsHtml}</ul>
 
-                    <div class="bp-actions">
+                    <div class="bp-actions bp-print-hide">
                         <button type="button" class="btn btn-secondary" id="bp-save-btn">💾 Save Plan</button>
                         <button type="button" class="btn btn-secondary" id="bp-export-btn">⬇️ Export Report</button>
+                        <button type="button" class="btn btn-secondary" id="bp-export-pdf-btn">🖨️ Export as PDF</button>
                     </div>
                 </div>`;
             resultsEl.hidden = false;
 
             const saveBtn = document.getElementById("bp-save-btn");
             const exportBtn = document.getElementById("bp-export-btn");
+            const exportPdfBtn = document.getElementById("bp-export-pdf-btn");
             if (saveBtn) {
                 saveBtn.addEventListener("click", () => {
                     SmartBudgetPlanner.savePlan(currentPlan);
@@ -520,11 +714,20 @@
             if (exportBtn) {
                 exportBtn.addEventListener("click", () => exportCurrentPlan());
             }
+            if (exportPdfBtn) {
+                // No PDF library dependency, consistent with how this project
+                // already handles PDF export elsewhere (trip-expense-splitter,
+                // trip-planner.js, compare-states-data): a print stylesheet
+                // hides everything but the results card, and the browser's
+                // own "Save as PDF" print destination produces the file.
+                exportPdfBtn.addEventListener("click", () => window.print());
+            }
         }
 
         function exportCurrentPlan() {
             if (!currentPlan) return;
-            const text = SmartBudgetPlanner.exportReportText(currentPlan, currentRecommendations);
+            const alert = SmartBudgetPlanner.getBudgetAlert(currentPlan, readTargetBudget());
+            const text = SmartBudgetPlanner.exportReportText(currentPlan, currentRecommendations, alert);
             const blob = new Blob([text], { type: "text/plain" });
             const url = URL.createObjectURL(blob);
             const a = document.createElement("a");
@@ -604,7 +807,254 @@
             resultsEl.scrollIntoView({ behavior: "smooth", block: "start" });
         });
 
+        // -- Dynamic forecasting: once a first estimate exists, keep it in
+        // sync as the user tweaks any assumption (including the target
+        // budget, so the alert banner updates too), without requiring
+        // another explicit submit. Debounced on free-text/number fields so
+        // it doesn't recompute on every keystroke; instant on selects.
+        let recomputeTimer = null;
+        function recomputeIfLive(immediate) {
+            if (!currentPlan) return; // nothing generated yet — wait for the first submit
+            const input = readForm();
+            if (!input.days || input.days < 1) return;
+            clearTimeout(recomputeTimer);
+            const run = () => {
+                currentPlan = SmartBudgetPlanner.calculateBudget(input);
+                renderResults(currentPlan);
+            };
+            if (immediate) run();
+            else recomputeTimer = setTimeout(run, 400);
+        }
+        form.querySelectorAll("input, select").forEach((field) => {
+            const isSelect = field.tagName === "SELECT";
+            field.addEventListener(isSelect ? "change" : "input", () => recomputeIfLive(isSelect));
+        });
+        const targetBudgetField = document.getElementById("budget-target");
+        if (targetBudgetField) {
+            targetBudgetField.addEventListener("input", () => recomputeIfLive(false));
+        }
+
         renderSavedList();
+        initDestinationCompare();
+        initItineraryForecast();
+    }
+
+    // --------------------------------------------------------------------
+    // Destination comparison section — "budget comparison across
+    // destinations" (issue #1028). Reuses the main form's days/travelers/
+    // tier/transport/allowances as the shared baseline.
+    // --------------------------------------------------------------------
+    function initDestinationCompare() {
+        const form = document.getElementById("budget-compare-form");
+        const resultsEl = document.getElementById("budget-compare-results");
+        if (!form || !resultsEl) return;
+
+        const inputs = Array.from(form.querySelectorAll("[data-compare-destination]"));
+        const list = document.getElementById("budget-compare-destination-list");
+        if (list && Array.isArray(root.tripDestinations)) {
+            list.innerHTML = root.tripDestinations.map((d) => `<option value="${d.name}"></option>`).join("");
+        }
+
+        function readBaseInput() {
+            return {
+                days: parseInt(document.getElementById("budget-compare-days").value, 10) || 5,
+                travelers: parseInt(document.getElementById("budget-compare-travelers").value, 10) || 1,
+                accommodationTier: document.getElementById("budget-compare-accommodation").value,
+                transportMode: document.getElementById("budget-compare-transport").value,
+            };
+        }
+
+        function render() {
+            const names = inputs.map((el) => el.value).filter((v) => v && v.trim());
+            if (names.length < 2) {
+                resultsEl.hidden = true;
+                resultsEl.innerHTML = "";
+                return;
+            }
+            const results = SmartBudgetPlanner.compareDestinations(readBaseInput(), names);
+            const cheapest = results[0];
+            resultsEl.innerHTML = `
+                <div class="bp-compare-grid">
+                    ${results
+                        .map(
+                            (r) => `
+                        <div class="bp-compare-card ${r.destination === cheapest.destination ? "bp-compare-cheapest" : ""}">
+                            ${r.destination === cheapest.destination ? '<span class="bp-compare-badge">Cheapest</span>' : ""}
+                            <h4>${r.destination}${!r.matched ? " <small>(estimated)</small>" : ""}</h4>
+                            <p class="bp-compare-total">${SmartBudgetPlanner.fmtINR(r.total)}</p>
+                            <p class="bp-compare-sub">${SmartBudgetPlanner.fmtINR(r.perPersonTotal)} / person &middot; ${SmartBudgetPlanner.fmtINR(r.perDayTotal)} / day</p>
+                        </div>`
+                        )
+                        .join("")}
+                </div>`;
+            resultsEl.hidden = false;
+        }
+
+        form.addEventListener("input", render);
+        form.addEventListener("change", render);
+        form.addEventListener("submit", (e) => e.preventDefault());
+    }
+
+    // --------------------------------------------------------------------
+    // Itinerary forecast section — "dynamic trip cost forecasting" tied
+    // to a real, saved Trip Planner itinerary (issue #1028). Recomputes
+    // whenever the selected trip or any assumption changes.
+    // --------------------------------------------------------------------
+    function initItineraryForecast() {
+        const select = document.getElementById("budget-itinerary-select");
+        const form = document.getElementById("budget-itinerary-form");
+        const resultsEl = document.getElementById("budget-itinerary-results");
+        if (!select || !form || !resultsEl) return;
+
+        function refreshTripList() {
+            if (!root.TripPlanner) {
+                select.innerHTML = `<option disabled selected>Trip Planner isn't loaded</option>`;
+                select.disabled = true;
+                return;
+            }
+            const trips = root.TripPlanner.getSavedTrips();
+            if (!trips.length) {
+                select.innerHTML = `<option disabled selected>No saved trips yet — plan one in Trip Planner</option>`;
+                select.disabled = true;
+                return;
+            }
+            select.disabled = false;
+            select.innerHTML =
+                `<option value="" disabled selected>Choose a saved trip…</option>` +
+                trips.map((t) => `<option value="${t.id}">${t.title}</option>`).join("");
+        }
+        refreshTripList();
+
+        function readOptions() {
+            return {
+                accommodationTier: document.getElementById("budget-itinerary-accommodation").value,
+                dailyFoodBudget: parseFloat(document.getElementById("budget-itinerary-food").value) || undefined,
+                sightseeing: parseFloat(document.getElementById("budget-itinerary-sightseeing").value) || 0,
+                shopping: parseFloat(document.getElementById("budget-itinerary-shopping").value) || 0,
+                misc: parseFloat(document.getElementById("budget-itinerary-misc").value) || 0,
+            };
+        }
+
+        let currentItineraryPlan = null;
+        let currentRecs = [];
+
+        function render() {
+            if (!select.value || !root.TripPlanner) {
+                resultsEl.hidden = true;
+                resultsEl.innerHTML = "";
+                return;
+            }
+            const trips = root.TripPlanner.getSavedTrips();
+            const record = trips.find((t) => t.id === select.value);
+            if (!record) return;
+
+            let plan;
+            try {
+                plan = SmartBudgetPlanner.calculateItineraryBudget(record.itinerary, readOptions());
+            } catch (err) {
+                resultsEl.hidden = false;
+                resultsEl.innerHTML = `<p class="bp-empty">Couldn't forecast this trip: ${err.message}</p>`;
+                return;
+            }
+            currentItineraryPlan = plan;
+            currentRecs = SmartBudgetPlanner.getRecommendations(
+                Object.assign({}, plan, { inputs: Object.assign({}, plan.inputs, { transportMode: "train", days: plan.days }) })
+            );
+
+            const targetBudget = parseFloat(document.getElementById("budget-itinerary-target").value) || 0;
+            const alertHtml = renderAlertStandalone(plan, targetBudget);
+
+            const breakdownHtml = Object.keys(plan.categories)
+                .map((k) => renderBarStandalone(CATEGORY_LABELS[k], plan.categories[k], plan.categoryPercentages[k]))
+                .join("");
+
+            const perDestHtml = plan.perDestination
+                .map(
+                    (d) => `
+                    <div class="bp-itin-dest-row">
+                        <span>${d.name} <small>(${d.days} day${d.days === 1 ? "" : "s"})</small></span>
+                        <span>${SmartBudgetPlanner.fmtINR(d.total)}</span>
+                    </div>`
+                )
+                .join("");
+
+            resultsEl.innerHTML = `
+                <div class="bp-summary-card">
+                    <div class="bp-summary-header">
+                        <h3>${plan.tripTitle || "Itinerary Forecast"}</h3>
+                        <span class="bp-total-badge">${SmartBudgetPlanner.fmtINR(plan.total)} total</span>
+                    </div>
+                    <p class="bp-summary-sub">${plan.days} day(s) &middot; ${plan.inputs.travelers} traveler(s) &middot; ${SmartBudgetPlanner.fmtINR(plan.perPersonTotal)} per person &middot; ${SmartBudgetPlanner.fmtINR(plan.perDayTotal)} per day</p>
+
+                    ${alertHtml}
+
+                    <h4 class="bp-section-title">Per-Destination Cost</h4>
+                    <div class="bp-itin-dest-list">${perDestHtml}</div>
+
+                    <h4 class="bp-section-title">Category Breakdown</h4>
+                    <div class="bp-breakdown">${breakdownHtml}</div>
+
+                    <div class="bp-actions bp-print-hide">
+                        <button type="button" class="btn btn-secondary" id="bp-itin-export-btn">⬇️ Export Report</button>
+                        <button type="button" class="btn btn-secondary" id="bp-itin-export-pdf-btn">🖨️ Export as PDF</button>
+                    </div>
+                </div>`;
+            resultsEl.hidden = false;
+
+            const exportBtn = document.getElementById("bp-itin-export-btn");
+            const exportPdfBtn = document.getElementById("bp-itin-export-pdf-btn");
+            if (exportBtn) {
+                exportBtn.addEventListener("click", () => {
+                    const alert = SmartBudgetPlanner.getBudgetAlert(currentItineraryPlan, targetBudget);
+                    const text = SmartBudgetPlanner.exportReportText(currentItineraryPlan, currentRecs, alert);
+                    const blob = new Blob([text], { type: "text/plain" });
+                    const url = URL.createObjectURL(blob);
+                    const a = document.createElement("a");
+                    a.href = url;
+                    a.download = `itinerary-budget-${currentItineraryPlan.id}.txt`;
+                    document.body.appendChild(a);
+                    a.click();
+                    a.remove();
+                    URL.revokeObjectURL(url);
+                });
+            }
+            if (exportPdfBtn) {
+                exportPdfBtn.addEventListener("click", () => window.print());
+            }
+        }
+
+        select.addEventListener("change", render);
+        form.addEventListener("input", render);
+        form.addEventListener("change", render);
+        form.addEventListener("submit", (e) => e.preventDefault());
+
+        // If the person saves/edits a trip in Trip Planner in another tab
+        // and comes back, the list should reflect it next time this page
+        // loads — no live cross-tab sync is attempted (localStorage only,
+        // no backend), see docs/BUDGET_PLANNER.md.
+    }
+
+    function renderBarStandalone(label, amount, percent) {
+        return `
+            <div class="bp-bar-row">
+                <div class="bp-bar-label">
+                    <span>${label}</span>
+                    <span>${SmartBudgetPlanner.fmtINR(amount)} <em>(${percent}%)</em></span>
+                </div>
+                <div class="bp-bar-track">
+                    <div class="bp-bar-fill" style="width:${Math.min(100, percent)}%"></div>
+                </div>
+            </div>`;
+    }
+
+    function renderAlertStandalone(plan, targetBudget) {
+        const alert = SmartBudgetPlanner.getBudgetAlert(plan, targetBudget);
+        if (!alert) return "";
+        return `
+            <div class="bp-alert bp-alert-${alert.status}" role="status">
+                <span class="bp-alert-icon">${alert.status === "exceeded" ? "🚨" : alert.status === "warning" ? "⚠️" : "✅"}</span>
+                <span>${alert.message}</span>
+            </div>`;
     }
 
     root.initBudgetPlannerPage = initBudgetPlannerPage;

--- a/tests/unit/smart-budget-planner.test.js
+++ b/tests/unit/smart-budget-planner.test.js
@@ -178,3 +178,137 @@ describe('SmartBudgetPlanner persistence (save / edit / delete)', () => {
     expect(SmartBudgetPlanner.getSavedPlans().length).toBe(0);
   });
 });
+
+describe('SmartBudgetPlanner.compareDestinations', () => {
+  const baseInput = { days: 5, travelers: 2, accommodationTier: 'standard', transportMode: 'train' };
+
+  it('returns one entry per destination, sorted cheapest-first', () => {
+    const results = SmartBudgetPlanner.compareDestinations(baseInput, ['Goa', 'Leh', 'Varanasi']);
+    expect(results).toHaveLength(3);
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i].total).toBeGreaterThanOrEqual(results[i - 1].total);
+    }
+  });
+
+  it('flags whether each destination was matched against trip-data.js', () => {
+    const results = SmartBudgetPlanner.compareDestinations(baseInput, ['Jaipur', 'Not A Real Place XYZ']);
+    const jaipur = results.find((r) => r.requested === 'Jaipur');
+    const fake = results.find((r) => r.requested === 'Not A Real Place XYZ');
+    expect(jaipur.matched).toBe(true);
+    expect(fake.matched).toBe(false);
+    // Unmatched destinations still get a (fallback) estimate, not an error.
+    expect(fake.total).toBeGreaterThan(0);
+  });
+
+  it('ignores blank entries in the destination list', () => {
+    const results = SmartBudgetPlanner.compareDestinations(baseInput, ['Goa', '', '  ', null]);
+    expect(results).toHaveLength(1);
+  });
+
+  it('holds every other parameter constant across the comparison', () => {
+    const results = SmartBudgetPlanner.compareDestinations(baseInput, ['Goa', 'Leh']);
+    results.forEach((r) => {
+      expect(r.plan.inputs.days).toBe(5);
+      expect(r.plan.inputs.travelers).toBe(2);
+      expect(r.plan.inputs.accommodationTier).toBe('standard');
+    });
+  });
+});
+
+describe('SmartBudgetPlanner.calculateItineraryBudget', () => {
+  function makeItinerary() {
+    const jaipur = tripDestinations.find((d) => d.name === 'Jaipur');
+    const goa = tripDestinations.find((d) => d.name === 'Goa');
+    return {
+      title: 'Rajasthan & Goa Getaway',
+      inputs: { travelers: 2 },
+      destinations: [
+        Object.assign({}, jaipur, { assignedDays: 3 }),
+        Object.assign({}, goa, { assignedDays: 4 }),
+      ],
+      legs: [{ cost: 2500, distanceKm: 1200 }],
+    };
+  }
+
+  it('produces a positive total covering every category', () => {
+    const plan = SmartBudgetPlanner.calculateItineraryBudget(makeItinerary(), { accommodationTier: 'standard' });
+    expect(plan.total).toBeGreaterThan(0);
+    Object.values(plan.categories).forEach((v) => expect(v).toBeGreaterThanOrEqual(0));
+    expect(plan.categories.accommodation).toBeGreaterThan(0);
+    expect(plan.categories.food).toBeGreaterThan(0);
+  });
+
+  it('derives the transport category from the itinerary\'s own leg costs, scaled by travelers', () => {
+    const itinerary = makeItinerary(); // 1 leg costing 2500 (per-person), 2 travelers
+    const plan = SmartBudgetPlanner.calculateItineraryBudget(itinerary, {});
+    expect(plan.categories.transport).toBe(2500 * 2);
+  });
+
+  it('breaks costs down per destination with the right day counts', () => {
+    const plan = SmartBudgetPlanner.calculateItineraryBudget(makeItinerary(), {});
+    expect(plan.perDestination).toHaveLength(2);
+    expect(plan.perDestination[0].name).toBe('Jaipur');
+    expect(plan.perDestination[0].days).toBe(3);
+    expect(plan.perDestination[1].name).toBe('Goa');
+    expect(plan.perDestination[1].days).toBe(4);
+    expect(plan.days).toBe(7);
+  });
+
+  it('produces a higher total on the luxury tier than the budget tier', () => {
+    const itinerary = makeItinerary();
+    const budgetPlan = SmartBudgetPlanner.calculateItineraryBudget(itinerary, { accommodationTier: 'budget' });
+    const luxuryPlan = SmartBudgetPlanner.calculateItineraryBudget(itinerary, { accommodationTier: 'luxury' });
+    expect(luxuryPlan.total).toBeGreaterThan(budgetPlan.total);
+  });
+
+  it('includes optional sightseeing/shopping/misc allowances once for the whole trip', () => {
+    const plan = SmartBudgetPlanner.calculateItineraryBudget(makeItinerary(), { sightseeing: 3000, shopping: 2000, misc: 1000 });
+    expect(plan.categories.sightseeing).toBe(3000);
+    expect(plan.categories.shopping).toBe(2000);
+    expect(plan.categories.misc).toBe(1000);
+  });
+
+  it('throws when the itinerary has no destinations', () => {
+    expect(() => SmartBudgetPlanner.calculateItineraryBudget({ inputs: { travelers: 1 }, destinations: [], legs: [] })).toThrow();
+    expect(() => SmartBudgetPlanner.calculateItineraryBudget(null)).toThrow();
+  });
+});
+
+describe('SmartBudgetPlanner.getBudgetAlert', () => {
+  it('returns null when no target budget is set', () => {
+    const plan = SmartBudgetPlanner.calculateBudget({ destination: 'Goa', days: 5, travelers: 2 });
+    expect(SmartBudgetPlanner.getBudgetAlert(plan, 0)).toBeNull();
+    expect(SmartBudgetPlanner.getBudgetAlert(plan, null)).toBeNull();
+  });
+
+  it('flags "exceeded" when the total is over the target', () => {
+    const plan = SmartBudgetPlanner.calculateBudget({ destination: 'Goa', days: 5, travelers: 2, accommodationTier: 'luxury' });
+    const alert = SmartBudgetPlanner.getBudgetAlert(plan, 1000);
+    expect(alert.status).toBe('exceeded');
+    expect(alert.difference).toBeLessThan(0);
+  });
+
+  it('flags "healthy" when comfortably under the target', () => {
+    const plan = SmartBudgetPlanner.calculateBudget({ destination: 'Goa', days: 2, travelers: 1, accommodationTier: 'budget' });
+    const alert = SmartBudgetPlanner.getBudgetAlert(plan, plan.total * 10);
+    expect(alert.status).toBe('healthy');
+    expect(alert.difference).toBeGreaterThan(0);
+  });
+
+  it('flags "warning" when close to (85%+) but not over the target', () => {
+    const plan = SmartBudgetPlanner.calculateBudget({ destination: 'Goa', days: 3, travelers: 1, accommodationTier: 'standard' });
+    const target = Math.round(plan.total / 0.9); // total sits at 90% of target
+    const alert = SmartBudgetPlanner.getBudgetAlert(plan, target);
+    expect(alert.status).toBe('warning');
+  });
+
+  it('recomputes to a worse status when the plan total grows (itinerary changed)', () => {
+    const smallerPlan = SmartBudgetPlanner.calculateBudget({ destination: 'Goa', days: 2, travelers: 1 });
+    const biggerPlan = SmartBudgetPlanner.calculateBudget({ destination: 'Goa', days: 10, travelers: 4, accommodationTier: 'luxury' });
+    const target = smallerPlan.total * 2; // comfortably covers the smaller plan only
+    const before = SmartBudgetPlanner.getBudgetAlert(smallerPlan, target);
+    const after = SmartBudgetPlanner.getBudgetAlert(biggerPlan, target);
+    expect(before.status).toBe('healthy');
+    expect(after.status).toBe('exceeded');
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description
Implements Dynamic Trip Cost Forecasting on top of the existing Smart
Budget Planner (#284), rather than duplicating that feature. Adds the
specific capabilities #1028 asks for that weren't there yet:

- **Itinerary-linked forecasting** — `calculateItineraryBudget()` takes
  a real, saved Trip Planner itinerary and produces a full category
  breakdown, reusing that itinerary's own distance-based inter-city leg
  costs for transport (more accurate than a flat per-mode guess) and
  computing accommodation/food per destination from the days actually
  assigned to each stop.
- **Cross-destination comparison** — `compareDestinations()` reruns the
  same days/travelers/tier/transport across up to 4 destinations,
  sorted cheapest-first, with the cheapest highlighted.
- **Budget alerts** — `getBudgetAlert()` returns
  healthy/warning/exceeded against a user-set target, matching the
  vocabulary `js-modules/budget-calculator-engine.js` already uses
  elsewhere in this codebase. Re-evaluated on every recompute, so it
  reacts live to itinerary/assumption changes.
- **Live/dynamic recompute** — once a first estimate exists, every
  field (main form, comparison form, itinerary form) triggers a
  recompute automatically (debounced ~400ms on text/number fields,
  instant on selects) — directly satisfying "budget estimates should
  automatically update whenever users modify their itinerary."
- **PDF export** — a print stylesheet + `window.print()`, matching the
  pattern already used by `trip-expense-splitter`, `trip-planner.js`,
  and `compare-states-data`. No new library dependency.

**Also fixes a pre-existing bug found along the way:**
`budget-planner.html` was never actually registered in
`router-init.js`'s `ROUTE_INIT_MAP` — despite #284's own docs
describing that registration — so the entire Smart Budget Planner
feature has been dead on the live site since it was merged. Fixed the
missing route entry (this is a prerequisite for any of this PR's work
to run at all).

**Not fixed here, flagged separately:** while running the full test
suite I found `frontend/wetlands/wetlands-data.js` on `main` currently
has a missing `},` between two entries that breaks that file's parsing
entirely. It's unrelated to this PR and that file is under heavy
concurrent edit from several other in-flight wetland-explorer PRs, so
I deliberately left it untouched here rather than risk a conflict — it
causes 11 unrelated test failures on current `main`, documented in
`docs/BUDGET_PLANNER.md`. Worth a tiny, dedicated follow-up PR.

Fixes #1028

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue) — the missing router registration
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?
- [x] Tested locally in browser
- [ ] Tested in both dark and light themes
- [ ] Tested at mobile viewport widths
- [x] Verified no console errors
- [x] `npx vitest run tests/unit/smart-budget-planner.test.js` — 30/30
      pass (15 original + 15 new, covering `compareDestinations()`,
      `calculateItineraryBudget()`, and `getBudgetAlert()`)
- [x] Full suite (`npx vitest run`): 1331/1342 pass. The 11 failures
      are all in wetland-explorer tests tied to the unrelated
      pre-existing `wetlands-data.js` bug noted above — none touch
      anything this PR changed.
- [x] Verified HTML/CSS/JS are structurally valid (balanced tags/braces,
      `node --check` on all modified JS)
- [x] Verified the patch applies cleanly against the current `main`

## Checklist
- [x] My code follows the [[coding standards](https://claude.ai/chat/CONTRIBUTING.md#coding-standards)](CONTRIBUTING.md#coding-standards) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [ ] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (labeled fields, `role="status"` on the alert banner)


## Notes for reviewers
- I'd start review at the router-init.js diff — that one-entry fix is
  what makes the rest of this (and the original #284 feature) actually
  reachable on the site.
- `docs/BUDGET_PLANNER.md` has a full write-up of the itinerary-budget
  math (why transport is derived from real legs instead of a flat
  guess, why sightseeing/shopping/misc are trip-wide rather than
  per-destination allowances, etc.) and known limitations (no cross-tab
  sync, since everything's `localStorage`-only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added destination comparison tools and multi-city itinerary budget forecasting.
  * Added live budget recalculation, target-budget alerts, and detailed spending breakdowns.
  * Added browser-friendly PDF printing for budget reports.
  * Added saved-trip forecasting with configurable travel assumptions and allowances.
  * Added access to the Budget Planner page through the application route.

* **Documentation**
  * Expanded guidance for itinerary calculations, plan management, alerts, printing, and known limitations.

* **Tests**
  * Added coverage for comparisons, forecasts, input handling, totals, and budget alert states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->