### PR TITLE
feat: Enrich Arjuna Award entry (Issue #1093)

### DIFF
--- a/js-modules/national-awards.js
+++ b/js-modules/national-awards.js
@@ -253,18 +253,24 @@ export const AWARD_ENCYCLOPEDIA = {
     categoryName: 'National Sports Award',
     rank: "Outstanding Performance in Sports",
     establishedYear: '1961',
-    eligibility: 'Awarded for consistent outstanding performance over 4 years at international level, combined with qualities of leadership, sportsmanship, and sense of discipline.',
-    history: 'Instituted in 1961 by the Ministry of Youth Affairs and Sports. Named after Arjuna, the archer hero from the Mahabharata.',
-    medalDesign: 'Bronze statuette of Arjuna with his bow, a formal scroll, and a cash prize of ₹15 lakh.',
+    eligibility: 'Awarded for consistent outstanding performance over the preceding 4 years at the international level, combined with qualities of leadership, sportsmanship, and sense of discipline. Covers Olympic and Asian Games disciplines (athletics, swimming, shooting, wrestling, boxing, badminton, hockey, cricket, etc.), indigenous games (Kabaddi, Kho-Kho, Mallakhamb), and Para-sports for differently-abled athletes. Selection follows a multi-stage process: sports-wise nominations are invited from National Sports Federations and State Governments, shortlisted candidates are evaluated by a Selection Committee constituted by the Ministry of Youth Affairs and Sports based on medals and rankings achieved, and final approval is granted by the Ministry.',
+    history: 'Instituted in 1961 by the Ministry of Youth Affairs and Sports as India\'s foundational sports honour, predating both the Khel Ratna (1991) and Dronacharya Award (1985). Named after Arjuna, the peerless archer-hero of the Mahabharata renowned for unwavering focus and mastery of his craft under the tutelage of Guru Dronacharya. The award was created to recognize sustained excellence and has since become the benchmark national recognition for India\'s top-performing athletes across dozens of sporting disciplines.',
+    medalDesign: 'Bronze statuette of Arjuna drawing his bow, mounted on a wooden base, accompanied by a formal citation scroll, ceremonial dress, and a cash prize of ₹15 lakh. Presented annually by the President of India at the National Sports Awards ceremony held at Rashtrapati Bhavan.',
     notableWinners: [
       { name: 'P. K. Banerjee', year: 1961, note: 'Football Legend (First Arjuna Batch)' },
       { name: 'Sunil Gavaskar', year: 1975, note: 'Cricket Master' },
+      { name: 'Prakash Padukone', year: 1972, note: 'Badminton All England Champion' },
+      { name: 'Kapil Dev', year: 1980, note: 'Cricket World Cup Winning Captain' },
       { name: 'P. V. Sindhu', year: 2013, note: 'Olympic Medallist Badminton' },
+      { name: 'Deepa Malik', year: 2011, note: 'Para-Athletics (First Para-athlete Padma Shri too)' },
+      { name: 'Manika Batra', year: 2018, note: 'Table Tennis Commonwealth Games Champion' },
       { name: 'Mohammed Shami', year: 2023, note: 'Cricket World Cup Fast Bowler' }
     ],
     interestingFacts: [
-      'P. K. Banerjee (Football) was among the first batch of Arjuna awardees in 1961.',
-      'Covers Olympic sports, indigenous games (like Kabaddi and Kho-Kho), and sports for differently-abled.'
+      'P. K. Banerjee (Football) was among the first batch of Arjuna awardees in 1961, alongside legends from athletics, wrestling, and swimming.',
+      'The Arjuna Award is India\'s oldest sports honour, established three decades before the Khel Ratna.',
+      'It covers the widest range of disciplines among all sports awards — from Olympic sports to indigenous games like Kabaddi and Kho-Kho, and Para-sports.',
+      'Several recipients, including P. V. Sindhu and Mary Kom, later went on to also receive the Khel Ratna after continued excellence.'
     ]
   },
   'dronacharya-award': {


### PR DESCRIPTION
## Summary
Enriches the existing Arjuna Award entry in the National Awards Explorer with comprehensive details as requested in the issue.

## Changes
- Expanded `eligibility` to describe sports covered (Olympic disciplines, indigenous games, Para-sports) and the selection process (federation nominations → committee shortlisting → Ministry approval)
- Expanded `history` with context on the award's origin as India's oldest sports honour (1961) and its namesake, Arjuna
- Expanded `notableWinners` from 4 to 8 recipients spanning 1961–2023, across football, cricket, badminton, and para-athletics
- Expanded `interestingFacts` from 2 to 4 facts

## Note
Consistent with the project's single combined "National Awards Explorer" page architecture (as established in PR #1263 for the Dronacharya Award), this PR enriches the existing `arjuna-award` entry in `js-modules/national-awards.js` rather than creating a separate dedicated page.

## Testing
- Verified via Live Server: card renders correctly under Sports Awards filter and search
- No new console errors

Closes #1093

<img width="1440" height="852" alt="Screenshot 2026-08-01 175001" src="https://github.com/user-attachments/assets/f186c67a-3f59-4632-a7df-f87f7a74442c" />
<img width="1440" height="852" alt="Screenshot 2026-08-01 175005" src="https://github.com/user-attachments/assets/e1abc2bd-b0d6-4797-a602-00bedbbaa4ac" />
