### PR TITLE
feat: Create Sariska National Park Explorer (#834)

### DIFF
--- a/frontend/national-parks-explorer/data.js
+++ b/frontend/national-parks-explorer/data.js
@@ -795,6 +795,26 @@ entryFee: '₹50 (Indian), ₹300 (Foreign)',
         entryFee: '₹250 (Indian), ₹1500 (Foreign)',
         image: 'https://commons.wikimedia.org/wiki/Special:FilePath/Amazing%20Landscape%20%40Satpura%20Tiger%20Reserve.jpg?width=960',
         explorerUrl: '../satpura-national-park-explorer/index.html'
+    },
+    {
+        id: 'sariska',
+        name: 'Sariska National Park',
+        state: 'Rajasthan',
+        stateId: 'rj',
+        established: 1982,
+        area: 881,
+        areaUnit: 'km²',
+        type: 'Tiger Reserve',
+        isTigerReserve: true,
+        isUNESCO: false,
+        description: 'Set against the backdrop of the rugged Aravalli Hills, this Tiger Reserve is famous for its successful tiger relocation program. Visitors can explore diverse wildlife along well-marked Safari Routes, admire the scrub-thorn flora, and visit the historic Kankwari Fort located within the reserve.',
+        keyFauna: ['Bengal Tiger', 'Leopard', 'Jungle Cat', 'Golden Jackal', 'Chital'],
+        keyFlora: ['Dhok', 'Salai', 'Ber', 'Khair', 'Scrub-thorn Flora'],
+        coordinates: { lat: 27.31, lng: 76.43 },
+        climate: 'Semi-arid',
+        bestTime: 'October to March',
+        entryFee: '₹125 (Indian), ₹500 (Foreign)',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e5/Sariska_Tiger_Reserve%2C_Alwar.jpg/960px-Sariska_Tiger_Reserve%2C_Alwar.jpg'
     }
 ];
 const TIGER_RESERVES = NATIONAL_PARKS.filter(p => p.isTigerReserve);


### PR DESCRIPTION
## Description

This PR adds **Sariska National Park** to the National Parks Explorer by extending the existing data-driven dataset. Since the explorer dynamically renders park cards, interactive map markers, gallery items, and park detail modals from the `NATIONAL_PARKS` array, no changes to the rendering logic were required.

### Changes Made

- Added a new **Sariska National Park** entry to the `NATIONAL_PARKS` dataset.
- Included information covering:
  - Tiger Reserve
  - Aravalli Hills
  - Kankwari Fort
  - Wildlife
  - Safari Routes
  - Flora
- Added:
  - Geographic coordinates
  - Area
  - Climate
  - Best visiting season
  - Entry fee
  - Public Wikimedia Commons image
- Preserved the existing dataset schema and property order.
- Added a unique park ID (`sariska`).

### Impact

Because the explorer is fully data-driven, the new park is automatically integrated into:

- ✅ National Parks landing page
- ✅ Interactive map
- ✅ Image gallery
- ✅ Park details modal

No HTML, CSS, routing, or rendering logic was modified.

## Validation

- `npm run lint` could not be executed because no lint script exists.
- Verified JavaScript syntax using:

```bash
node -c frontend/national-parks-explorer/data.js
```

### Verified

- Valid JavaScript syntax
- Unique park ID
- Existing schema preserved
- No duplicate entries
- No rendering logic changes

## Related Issue

Closes #834