### PR TITLE
feat: Create Nanda Devi National Park Explorer (#828)

### DIFF
--- a/frontend/national-parks-explorer/data.js
+++ b/frontend/national-parks-explorer/data.js
@@ -795,6 +795,26 @@ entryFee: '₹50 (Indian), ₹300 (Foreign)',
         entryFee: '₹250 (Indian), ₹1500 (Foreign)',
         image: 'https://commons.wikimedia.org/wiki/Special:FilePath/Amazing%20Landscape%20%40Satpura%20Tiger%20Reserve.jpg?width=960',
         explorerUrl: '../satpura-national-park-explorer/index.html'
+    },
+    {
+        id: 'nanda-devi',
+        name: 'Nanda Devi National Park',
+        state: 'Uttarakhand',
+        stateId: 'uk',
+        established: 1982,
+        area: 630.33,
+        areaUnit: 'km²',
+        type: 'National Park',
+        isTigerReserve: false,
+        isUNESCO: true,
+        description: 'Dominated by the majestic Nanda Devi Peak, this pristine wilderness is a recognized UNESCO World Heritage Site. It is celebrated for its breathtaking Alpine Meadows, rich Trekking History, and strict Conservation efforts that protect vulnerable Himalayan Wildlife and Rare Flora.',
+        keyFauna: ['Snow Leopard', 'Himalayan Musk Deer', 'Himalayan Black Bear', 'Blue Sheep', 'Himalayan Tahr'],
+        keyFlora: ['Bhojpatra', 'Rhododendron', 'Brahma Kamal', 'Rare Flora', 'Alpine Meadows'],
+        coordinates: { lat: 30.41, lng: 79.84 },
+        climate: 'Alpine',
+        bestTime: 'May to October',
+        entryFee: '₹2500 (Indian), ₹2500 (Foreign)',
+        image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/d/d2/Mt._Nanda_Devi.jpg/960px-Mt._Nanda_Devi.jpg'
     }
 ];
 const TIGER_RESERVES = NATIONAL_PARKS.filter(p => p.isTigerReserve);


### PR DESCRIPTION
## Description

This PR adds **Nanda Devi National Park** to the National Parks Explorer by extending the existing data-driven dataset. Since the explorer dynamically renders park cards, map markers, gallery items, and park detail modals from the `NATIONAL_PARKS` array, no changes to the rendering logic were required.

### Changes Made

- Added a new **Nanda Devi National Park** entry to the `NATIONAL_PARKS` dataset.
- Included information covering:
  - Nanda Devi Peak
  - UNESCO World Heritage Site
  - Alpine Meadows
  - Himalayan Wildlife
  - Rare Flora
  - Trekking History
  - Conservation
- Added:
  - Accurate geographic coordinates
  - Area
  - Climate
  - Best visiting season
  - Entry fee
  - Public Wikimedia Commons image
- Set `isUNESCO: true`.
- Preserved the existing dataset schema and property order.
- Added a unique park ID (`nanda-devi`).

### Impact

Because the explorer is fully data-driven, the new park is automatically integrated into:

- ✅ National Parks landing page
- ✅ Interactive map
- ✅ Image gallery
- ✅ Park details modal

No HTML, CSS, routing, or rendering logic was modified.

## Validation

- `npm run lint` could not be executed because no lint script exists.
- Verified JavaScript syntax using:

```bash
node -c frontend/national-parks-explorer/data.js
```

### Verified

- Valid JavaScript syntax
- Unique park ID
- Existing schema preserved
- No duplicate entries
- No rendering logic changes

## Related Issue

Closes #828