### PR TITLE
feat: Create Surinsar-Mansar Lakes Explorer (#983)

### DIFF
--- a/frontend/surinsar-mansar-lakes-explorer/index.html
+++ b/frontend/surinsar-mansar-lakes-explorer/index.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    document.body.classList.add('light-theme');
+                }
+            })();
+        </script>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Explore the Surinsar-Mansar Lakes — a twin-lake Ramsar Site in Jammu & Kashmir. Sacred freshwater lakes, unique wildlife, migratory birdlife, local legends, and an interactive map."
+        />
+        <meta property="og:title" content="Surinsar-Mansar Lakes Explorer | Incredible India" />
+        <meta
+            property="og:description"
+            content="Twin sacred freshwater lakes of Jammu & Kashmir — Ramsar Site No. 1573, a Wildlife Sanctuary with rare turtles, the freshwater medusa and wintering waterfowl."
+        />
+        <title>Surinsar-Mansar Lakes Explorer | Incredible India</title>
+
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+            rel="stylesheet"
+        />
+
+        <link
+            rel="stylesheet"
+            href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+            integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+            crossorigin=""
+        />
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="surinsar-mansar.css" />
+    </head>
+    <body class="sm-main">
+        <header class="navbar scrolled" id="navbar">
+            <div class="nav-container">
+                <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </button>
+                <nav class="nav-menu" id="nav-menu">
+                    <a href="../../index.html#home" class="nav-link">Home</a>
+                    <a href="../wetlands/index.html" class="nav-link">Wetlands Landing</a>
+                    <a href="../national-parks-explorer/index.html" class="nav-link">National Parks</a>
+                    <a href="index.html" class="nav-link active" style="color: var(--saffron)">Surinsar-Mansar Explorer</a>
+                    <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
+                        ☀️
+                    </button>
+                </nav>
+            </div>
+        </header>
+
+        <main>
+            <section class="sm-hero">
+                <div class="section-container">
+                    <div class="hero-badges-row">
+                        <span class="hero-pill pill-ramsar">💧 Ramsar Site No. 1573 (2005)</span>
+                        <span class="hero-pill pill-state">📍 Samba District, Jammu & Kashmir</span>
+                        <span class="hero-pill pill-history">🪞 Twin Sacred Freshwater Lakes</span>
+                    </div>
+                    <h1>Surinsar-Mansar <span>Lakes</span> Explorer</h1>
+                    <p class="hero-subtitle">
+                        Discover the twin sacred freshwater lakes of the Siwalik foothills — a composite Ramsar wetland and
+                        Wildlife Sanctuary cherished for its unique turtles, rare freshwater medusa, migratory birdlife and
+                        living mythology.
+                    </p>
+                    <div id="stats-grid" class="stats-grid"></div>
+                </div>
+            </section>
+
+            <section class="sm-section">
+                <div class="section-container">
+                    <h2>Twin Lake Ecosystem</h2>
+                    <div class="info-card">
+                        <p id="eco-overview"></p>
+                        <p id="eco-surinsar"></p>
+                        <p id="eco-mansar"></p>
+                        <p id="eco-hydrology"></p>
+                    </div>
+                </div>
+            </section>
+
+            <section class="sm-section">
+                <div class="section-container">
+                    <h2>Ramsar Site & Conservation</h2>
+                    <div class="info-card">
+                        <p id="ramsar-summary"></p>
+                        <div class="ramsar-lists">
+                            <div>
+                                <h4>Ramsar Criteria</h4>
+                                <ul id="ramsar-criteria"></ul>
+                            </div>
+                            <div>
+                                <h4>Key Threats</h4>
+                                <ul id="ramsar-threats"></ul>
+                            </div>
+                        </div>
+                        <p id="ramsar-conservation"></p>
+                    </div>
+                </div>
+            </section>
+
+            <section class="sm-section">
+                <div class="section-container">
+                    <h2>Religious Importance</h2>
+                    <div class="sm-grid" id="religious-grid"></div>
+                </div>
+            </section>
+
+            <section class="sm-section">
+                <div class="section-container">
+                    <h2>Wildlife & Aquatic Life</h2>
+                    <div class="species-grid" id="wildlife-grid"></div>
+                </div>
+            </section>
+
+            <section class="sm-section">
+                <div class="section-container">
+                    <h2>Birdlife & Migratory Waterfowl</h2>
+                    <div class="species-grid" id="birds-grid"></div>
+                </div>
+            </section>
+
+            <section class="sm-section">
+                <div class="section-container">
+                    <h2>Local Legends & Mythology</h2>
+                    <div class="sm-grid" id="legends-grid"></div>
+                </div>
+            </section>
+
+            <section class="sm-section">
+                <div class="section-container">
+                    <h2>Interactive Map</h2>
+                    <div id="map-container" class="sm-map"></div>
+                    <div class="hotspots-grid" id="hotspots-grid"></div>
+                </div>
+            </section>
+
+            <section class="sm-section">
+                <div class="section-container">
+                    <h2>Image Gallery</h2>
+                    <div class="gallery-grid" id="gallery-grid"></div>
+                </div>
+            </section>
+        </main>
+
+        <script
+            src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+            integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+            crossorigin=""
+        ></script>
+        <script src="surinsar-mansar-data.js"></script>
+        <script src="surinsar-mansar.js"></script>
+    </body>
+</html>

--- a/frontend/surinsar-mansar-lakes-explorer/surinsar-mansar-data.js
+++ b/frontend/surinsar-mansar-lakes-explorer/surinsar-mansar-data.js
@@ -1,0 +1,300 @@
+/**
+ * Surinsar-Mansar Lakes Explorer — Data Module
+ * Comprehensive dataset covering the twin Ramsar-designated freshwater lakes
+ * in Jammu & Kashmir — metadata, twin lake ecosystem, Ramsar details,
+ * religious importance, wildlife, birdlife, local legends, map hotspots
+ * and image gallery.
+ */
+
+const SM_INFO = {
+    id: "surinsar-mansar-lakes",
+    name: "Surinsar-Mansar Lakes",
+    location: "Samba District, Jammu & Kashmir, India",
+    state: "Jammu & Kashmir",
+    coordinates: { lat: 32.720, lng: 75.170 },
+    area: "350 ha (composite Ramsar site)",
+    ramsarYear: 2005,
+    ramsarSiteNo: 1573,
+    wetlandType: "Freshwater Composite Lake (Twin Lakes)",
+    designation: "Ramsar Site & Wildlife Sanctuary",
+    bestTime: "October to March",
+    quickStats: [
+        { label: "Ramsar Site No.", value: "1573", icon: "💧" },
+        { label: "Designated", value: "2005", icon: "🪷" },
+        { label: "Composite Area", value: "350 ha", icon: "🌊" },
+        { label: "Twin Lakes", value: "Mansar + Surinsar", icon: "🪞" },
+        { label: "Sanctuary Area", value: "3.5 km²", icon: "🏞️" },
+        { label: "CITES Species", value: "2 Turtles + Medusa", icon: "🐢" }
+    ]
+};
+
+const TWIN_LAKE_ECOSYSTEM = {
+    overview: "Surinsar and Mansar are twin freshwater lakes lying in the Siwalik foothills of Jammu, about 9 km apart, yet treated as a single composite wetland of exceptional ecological value. Despite sitting on high ground with no visible surface feeder channel, both lakes remain perennial, sustained by groundwater conditions and a small catchment.",
+    surinsarProfile: "Surinsar Lake is the smaller twin — an oval, rain-fed water body about 20 ha with a maximum depth of 24 m and a small central island. Its alkaline waters (pH 7.2–8.9) support a complete belt of varied aquatic vegetation along its banks. Mythology says it was born where Arjuna's son shot an arrow and a spring gushed forth.",
+    mansarProfile: "Mansar Lake is the larger twin — a semi-oval lake of about 329 ha, roughly 1.6 km long and 645 m wide, with a maximum depth of about 38 m and a water volume of 12.37 million m³. Fringed by forest-covered hills, it is rich in aquatic flora with 86 algal genera spanning 207 species in its shallow littoral zone.",
+    hydrology: "Surinsar is rain-fed with no permanent outlet, while Mansar is fed primarily by surface run-off and partially by mineralised water passing through surrounding paddy fields, with inflows rising sharply in the rainy season. Subterranean springs and artesian-like groundwater conditions keep both lakes perennial through the dry months."
+};
+
+const RAMSAR_DETAILS = {
+    summary: "Surinsar-Mansar Lakes were designated as a Ramsar Site of International Importance on 8 November 2005 (Ramsar Site No. 1573, 350 ha). The site also forms the core of the Surinsar-Mansar Wildlife Sanctuary (3.5 km²), established in 2005 under the Wildlife Protection Act, 1972.",
+    criteria: [
+        "Criterion 2 — Supports vulnerable and endangered species including the Indian Softshell Turtle and Indian Flapshell Turtle listed under CITES and the IUCN Red List.",
+        "Criterion 3 — Sustains unique biodiversity, notably the rare freshwater medusa Mansariella lacustris and rich macrophyte growth.",
+        "Criterion 4 — Provides an ideal breeding, nursery and wintering habitat for migratory waterfowl along the Central Asian Flyway."
+    ],
+    threats: [
+        "Rising tourist inflow and unplanned development around the lake shore",
+        "Agricultural runoff and siltation from the catchment",
+        "Bathing, ritual offerings and cremation activities at sacred sites",
+        "Introduction of common carp, altering native fish ecology"
+    ],
+    conservation: "Managed by the Jammu & Kashmir Wildlife Department under the Chief Wildlife Warden. Conservation efforts focus on awareness-raising, catchment protection, water quality monitoring and regulated eco-tourism."
+};
+
+const RELIGIOUS_IMPORTANCE = [
+    {
+        icon: "🐍",
+        title: "Sheshnag Temple",
+        description: "A temple dedicated to Sheshnag, the serpent king of Hindu mythology, stands on the banks of Mansar Lake. It is central to the lake's sanctity and a major destination for pilgrims in the Jammu region."
+    },
+    {
+        icon: "🛕",
+        title: "Sacred Shoreline Temples",
+        description: "Numerous temples line the lakes' shores. Pilgrims perform a ritual circumambulation (parikrama) of the lake, bathe in its waters, and offer prayers on occasions such as Maha Shivratri."
+    },
+    {
+        icon: "💍",
+        title: "Marriage & Rite-of-Passage Rituals",
+        description: "Newly married couples circumambulate the lake seeking marital harmony, and families bring infants for mundan (first hair-cut) ceremonies — living traditions that keep the sacred landscape active."
+    },
+    {
+        icon: "🎉",
+        title: "Annual Fair",
+        description: "A well-known annual fair is held by the lake, drawing devotees and visitors from across the region and blending religious observance with local cultural celebrations."
+    }
+];
+
+const WILDLIFE_SPECIES = [
+    {
+        id: "indian-flapshell-turtle",
+        name: "Indian Flapshell Turtle",
+        scientificName: "Lissemys punctata",
+        status: "CITES Appendix II",
+        category: "Reptile",
+        icon: "🐢",
+        description: "A soft-shelled freshwater turtle that shelters in the lake's muddy shallows; listed under CITES and valued in the site's turtle fauna."
+    },
+    {
+        id: "indian-softshell-turtle",
+        name: "Indian Softshell Turtle",
+        scientificName: "Aspideretes gangeticus",
+        status: "CITES Appendix I · IUCN Vulnerable",
+        category: "Reptile",
+        icon: "🐢",
+        description: "A large, vulnerable freshwater turtle whose presence in Mansar Lake contributed to the site's Ramsar Criterion 2 designation."
+    },
+    {
+        id: "mansariella-medusa",
+        name: "Freshwater Medusa",
+        scientificName: "Mansariella lacustris",
+        status: "Rare & Site-Endemic",
+        category: "Invertebrate",
+        icon: "🪼",
+        description: "An exceptionally rare freshwater jellyfish found in Mansar Lake — a biodiversity highlight unique among Indian wetlands."
+    },
+    {
+        id: "rohu",
+        name: "Rohu",
+        scientificName: "Labeo rohita",
+        status: "Common Lake Fish",
+        category: "Fish",
+        icon: "🐟",
+        description: "A major carp of the lake, accompanied by Puntius, Channa, Rasbora, Trichogaster and other native fish species; fishing is discouraged for religious reasons."
+    },
+    {
+        id: "siwalik-mammals",
+        name: "Siwalik Foothill Mammals",
+        scientificName: "Sanctuary Fauna",
+        status: "Wildlife Sanctuary",
+        category: "Mammal",
+        icon: "🦌",
+        description: "The surrounding sanctuary protects forested hills harbouring wild boar, Indian crested porcupine, rhesus macaque, jackal and, in the denser cover, the common leopard."
+    },
+    {
+        id: "macrophyte-flora",
+        name: "Aquatic Flora",
+        scientificName: "Nelumbo · Typha · Potamogeton",
+        status: "207 Algal Species",
+        category: "Flora",
+        icon: "🪷",
+        description: "Emergent cattails and reeds, floating lotus (Nelumbo nucifera) and submerged pondweeds create the nursery habitat that makes the composite lake so productive."
+    }
+];
+
+const BIRD_SPECIES = [
+    {
+        id: "common-coot",
+        name: "Common Coot",
+        scientificName: "Fulica atra",
+        status: "Winter Visitor",
+        season: "October–March",
+        count: "497 recorded (1989–90)",
+        icon: "🦆",
+        description: "The lake's most abundant wintering waterfowl, rafts of coots dot the open water of Mansar."
+    },
+    {
+        id: "common-moorhen",
+        name: "Common Moorhen",
+        scientificName: "Gallinula chloropus",
+        status: "Winter Visitor",
+        season: "October–March",
+        count: "114 recorded (1989–90)",
+        icon: "🦆",
+        description: "Slate-black rail with a red bill that picks its way through the reed fringes."
+    },
+    {
+        id: "black-necked-grebe",
+        name: "Black-necked Grebe",
+        scientificName: "Podiceps nigricollis",
+        status: "Winter Visitor",
+        season: "October–March",
+        count: "56 recorded (1989–90)",
+        icon: "🦆",
+        description: "A small diving grebe with elegant golden ear tufts that winters on the open lake."
+    },
+    {
+        id: "common-pochard",
+        name: "Common Pochard",
+        scientificName: "Aythya ferina",
+        status: "Winter Visitor",
+        season: "November–February",
+        count: "38 recorded (1989–90)",
+        icon: "🦆",
+        description: "Rusty-headed diving duck that joins the wintering flocks of the Central Asian Flyway."
+    },
+    {
+        id: "tufted-duck",
+        name: "Tufted Duck",
+        scientificName: "Aythya fuligula",
+        status: "Winter Visitor",
+        season: "November–February",
+        count: "26 recorded (1989–90)",
+        icon: "🦆",
+        description: "Black-and-white diving duck recognised by its distinctive crest."
+    },
+    {
+        id: "cormorant-herons",
+        name: "Cormorants & Herons",
+        scientificName: "Phalacrocorax · Ardea",
+        status: "Resident & Wintering",
+        season: "Year-round",
+        count: "Large Cormorant, Grey Heron, Night Heron",
+        icon: "🦢",
+        description: "Darters and cormorants fish the deep water while herons and egrets stalk the marshy margins."
+    }
+];
+
+const LOCAL_LEGENDS = [
+    {
+        icon: "🏹",
+        title: "The Arrow of Arjuna's Son",
+        description: "Legend holds that Arjuna's son shot a miraculous arrow into the ground at Mansar and a spring gushed forth, filling the basin that became Surinsar Lake — originally known as 'Surang Sar'."
+    },
+    {
+        icon: "🐍",
+        title: "Arjuna, Ulupi & Babar Vahan",
+        description: "Regional lore links the lakes to the Mahabharata. After the Kurukshetra war, during the Ashwamedha Yajna, Arjuna was slain by his own son Babar Vahan, born of the Naga princess Ulupi. To revive his father, Babar Vahan journeyed to the realm of Sheshnag for a magical jewel — the entrance to that underworld is associated with Surinsar Lake and the emergence point with Mansar Lake."
+    },
+    {
+        icon: "🏔️",
+        title: "Sanctity of Mansarovar",
+        description: "Mansar shares its name and veneration with the high-altitude Mansarovar (Manasarovar) of Tibet. Many devotees believe the lake carries the sanctity of Mansarovar, and a ritual dip here is considered highly meritorious."
+    },
+    {
+        icon: "🪞",
+        title: "The Twin-Born Lakes",
+        description: "Believed to originate from the Mahabharata period, the two lakes are regarded as inseparable twins — one composite sacred wetland whose fortunes and legends are told together in the folk memory of the Jammu region."
+    }
+];
+
+const MAP_HOTSPOTS = [
+    {
+        id: "mansar-lake",
+        title: "Mansar Lake",
+        lat: 32.696,
+        lng: 75.147,
+        type: "Ramsar Component Lake",
+        description: "The larger twin (~329 ha) — sacred lake, Sheshnag Temple and migratory waterfowl habitat."
+    },
+    {
+        id: "surinsar-lake",
+        title: "Surinsar Lake",
+        lat: 32.740,
+        lng: 75.165,
+        type: "Ramsar Component Lake",
+        description: "The smaller oval twin (~20 ha) with a central island, about 9 km from Mansar."
+    },
+    {
+        id: "sheshnag-temple",
+        title: "Sheshnag Temple",
+        lat: 32.693,
+        lng: 75.149,
+        type: "Sacred Site",
+        description: "Temple of the serpent king on the banks of Mansar Lake — a hub of pilgrimage and ritual."
+    },
+    {
+        id: "wildlife-sanctuary",
+        title: "Surinsar-Mansar Wildlife Sanctuary",
+        lat: 32.720,
+        lng: 75.170,
+        type: "Protected Area",
+        description: "3.5 km² sanctuary established in 2005 protecting the twin lakes and their forested catchment."
+    }
+];
+
+const GALLERY_IMAGES = [
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/2/28/Dr_harleen_Kaur_mansar_lake_near_udhampur.jpg",
+        caption: "Mansar Lake fringed by forest-covered hills",
+        category: "Lake"
+    },
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/8/82/Mansar_lake_footpath.png",
+        caption: "Footpath skirting the sacred lake",
+        category: "Lake"
+    },
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c7/Keoladeo_Ghana_Bird_Sanctuary.jpg/960px-Keoladeo_Ghana_Bird_Sanctuary.jpg",
+        caption: "Wetland habitat for wintering waterfowl",
+        category: "Wetland"
+    },
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f4/Chilika_Lake_Boat.jpg/960px-Chilika_Lake_Boat.jpg",
+        caption: "Freshwater lake ecosystem and boating",
+        category: "Lake"
+    },
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e1/Common_Pochard_male.jpg/800px-Common_Pochard_male.jpg",
+        caption: "Common Pochard — a wintering visitor",
+        category: "Birdlife"
+    },
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Loktak_lake_Manipur.jpg/960px-Loktak_lake_Manipur.jpg",
+        caption: "Lacustrine wetland with aquatic vegetation",
+        category: "Wetland"
+    }
+];
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        SM_INFO,
+        TWIN_LAKE_ECOSYSTEM,
+        RAMSAR_DETAILS,
+        RELIGIOUS_IMPORTANCE,
+        WILDLIFE_SPECIES,
+        BIRD_SPECIES,
+        LOCAL_LEGENDS,
+        MAP_HOTSPOTS,
+        GALLERY_IMAGES
+    };
+}

--- a/frontend/surinsar-mansar-lakes-explorer/surinsar-mansar.css
+++ b/frontend/surinsar-mansar-lakes-explorer/surinsar-mansar.css
@@ -1,0 +1,292 @@
+.sm-main {
+    background-color: var(--bg-primary, #0f172a);
+    color: var(--text-primary, #f8fafc);
+    font-family: 'Outfit', sans-serif;
+}
+
+.sm-hero {
+    padding: 6rem 1.5rem 3rem;
+    background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(5, 150, 105, 0.75));
+    text-align: center;
+}
+
+.hero-badges-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+}
+
+.hero-pill {
+    padding: 0.4rem 1rem;
+    border-radius: 9999px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(8px);
+}
+
+.sm-hero h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2.75rem;
+    font-weight: 800;
+    margin-bottom: 1rem;
+}
+
+.sm-hero h1 span {
+    color: #34d399;
+}
+
+.hero-subtitle {
+    max-width: 800px;
+    margin: 0 auto 2.5rem;
+    font-size: 1.1rem;
+    color: #94a3b8;
+    line-height: 1.6;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1.25rem;
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.stat-card {
+    background: rgba(30, 41, 59, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 1.25rem;
+    border-radius: 12px;
+    text-align: center;
+}
+
+.stat-icon {
+    font-size: 1.75rem;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.stat-val {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #34d399;
+}
+
+.stat-lbl {
+    font-size: 0.85rem;
+    color: #94a3b8;
+}
+
+.section-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem;
+}
+
+.section-container h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2rem;
+    margin-bottom: 1.5rem;
+    color: #f1f5f9;
+}
+
+.info-card {
+    background: rgba(30, 41, 59, 0.6);
+    border-radius: 12px;
+    padding: 2rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    line-height: 1.7;
+}
+
+.info-card p {
+    margin-bottom: 1rem;
+}
+
+.ramsar-lists {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+    margin: 1rem 0;
+}
+
+.ramsar-lists h4 {
+    color: #34d399;
+    margin-bottom: 0.75rem;
+}
+
+.ramsar-lists ul {
+    list-style: none;
+    padding: 0;
+}
+
+.ramsar-lists li {
+    padding: 0.5rem 0 0.5rem 1.4rem;
+    position: relative;
+    color: #cbd5e1;
+}
+
+.ramsar-lists li::before {
+    content: '💧';
+    position: absolute;
+    left: 0;
+    font-size: 0.8rem;
+}
+
+.sm-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.sm-card {
+    background: rgba(30, 41, 59, 0.6);
+    border-radius: 12px;
+    padding: 1.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    transition: transform 0.2s ease;
+}
+
+.sm-card:hover {
+    transform: translateY(-4px);
+}
+
+.sm-card-icon {
+    font-size: 2rem;
+    display: block;
+    margin-bottom: 0.75rem;
+}
+
+.sm-card h3 {
+    font-size: 1.1rem;
+    margin-bottom: 0.5rem;
+    color: #f1f5f9;
+}
+
+.sm-card p {
+    color: #94a3b8;
+    font-size: 0.95rem;
+    line-height: 1.6;
+}
+
+.species-grid,
+.hotspots-grid,
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.species-card,
+.hotspot-card,
+.gallery-card {
+    background: rgba(30, 41, 59, 0.6);
+    border-radius: 12px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    transition: transform 0.2s ease;
+}
+
+.species-card:hover,
+.hotspot-card:hover,
+.gallery-card:hover {
+    transform: translateY(-4px);
+}
+
+.species-card img,
+.gallery-card img {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+}
+
+.species-card-body,
+.hotspot-card,
+.gallery-card p {
+    padding: 1.25rem;
+}
+
+.status-badge {
+    background: rgba(16, 185, 129, 0.2);
+    color: #34d399;
+    padding: 0.2rem 0.6rem;
+    border-radius: 6px;
+    font-size: 0.75rem;
+}
+
+.scientific-name {
+    color: #94a3b8;
+    margin-bottom: 0.75rem;
+}
+
+.bird-meta {
+    margin-top: 0.75rem;
+    color: #94a3b8;
+    font-size: 0.85rem;
+}
+
+.spot-type {
+    display: inline-block;
+    background: rgba(16, 185, 129, 0.2);
+    color: #34d399;
+    padding: 0.2rem 0.6rem;
+    border-radius: 6px;
+    font-size: 0.75rem;
+    margin-bottom: 0.5rem;
+}
+
+.sm-map {
+    height: 500px;
+    width: 100%;
+    border-radius: 16px;
+    margin-bottom: 1.5rem;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+    border: 2px solid rgba(255, 255, 255, 0.1);
+    z-index: 1;
+}
+
+.light-theme .sm-main {
+    background-color: var(--bg-primary, #f8fafc);
+    color: var(--text-primary, #0f172a);
+}
+
+.light-theme .sm-hero {
+    background: linear-gradient(135deg, rgba(248, 250, 252, 0.95), rgba(110, 231, 183, 0.55));
+}
+
+.light-theme .sm-hero h1,
+.light-theme .section-container h2,
+.light-theme .sm-card h3 {
+    color: #0f172a;
+}
+
+.light-theme .hero-subtitle,
+.light-theme .sm-card p,
+.light-theme .scientific-name {
+    color: #475569;
+}
+
+.light-theme .stat-card,
+.light-theme .info-card,
+.light-theme .sm-card,
+.light-theme .species-card,
+.light-theme .hotspot-card,
+.light-theme .gallery-card {
+    background: rgba(255, 255, 255, 0.75);
+    border-color: rgba(15, 23, 42, 0.1);
+}
+
+.light-theme .stat-lbl,
+.light-theme .bird-meta {
+    color: #64748b;
+}
+
+.light-theme .ramsar-lists li {
+    color: #334155;
+}
+
+.light-theme .sm-map {
+    border-color: rgba(15, 23, 42, 0.1);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.1);
+}

--- a/frontend/surinsar-mansar-lakes-explorer/surinsar-mansar.js
+++ b/frontend/surinsar-mansar-lakes-explorer/surinsar-mansar.js
@@ -1,0 +1,192 @@
+document.addEventListener('DOMContentLoaded', () => {
+    renderStats();
+    renderEcosystem();
+    renderRamsar();
+    renderReligious();
+    renderWildlife();
+    renderBirds();
+    renderLegends();
+    renderHotspots();
+    initMap();
+    renderGallery();
+    initThemeToggle();
+});
+
+function renderStats() {
+    const grid = document.getElementById('stats-grid');
+    if (!grid || typeof SM_INFO === 'undefined') return;
+
+    grid.innerHTML = SM_INFO.quickStats
+        .map(
+            stat => `
+        <div class="stat-card">
+            <span class="stat-icon">${stat.icon}</span>
+            <div class="stat-val">${stat.value}</div>
+            <div class="stat-lbl">${stat.label}</div>
+        </div>
+    `
+        )
+        .join('');
+}
+
+function renderEcosystem() {
+    if (typeof TWIN_LAKE_ECOSYSTEM === 'undefined') return;
+    const overviewEl = document.getElementById('eco-overview');
+    const surinsarEl = document.getElementById('eco-surinsar');
+    const mansarEl = document.getElementById('eco-mansar');
+    const hydroEl = document.getElementById('eco-hydrology');
+
+    if (overviewEl) overviewEl.innerHTML = `<strong>Overview:</strong> ${TWIN_LAKE_ECOSYSTEM.overview}`;
+    if (surinsarEl) surinsarEl.innerHTML = `<strong>Surinsar Lake:</strong> ${TWIN_LAKE_ECOSYSTEM.surinsarProfile}`;
+    if (mansarEl) mansarEl.innerHTML = `<strong>Mansar Lake:</strong> ${TWIN_LAKE_ECOSYSTEM.mansarProfile}`;
+    if (hydroEl) hydroEl.innerHTML = `<strong>Hydrology & Water Source:</strong> ${TWIN_LAKE_ECOSYSTEM.hydrology}`;
+}
+
+function renderRamsar() {
+    if (typeof RAMSAR_DETAILS === 'undefined') return;
+    const summaryEl = document.getElementById('ramsar-summary');
+    const criteriaEl = document.getElementById('ramsar-criteria');
+    const threatsEl = document.getElementById('ramsar-threats');
+    const conservationEl = document.getElementById('ramsar-conservation');
+
+    if (summaryEl) summaryEl.textContent = RAMSAR_DETAILS.summary;
+    if (criteriaEl)
+        criteriaEl.innerHTML = RAMSAR_DETAILS.criteria.map(item => `<li>${item}</li>`).join('');
+    if (threatsEl)
+        threatsEl.innerHTML = RAMSAR_DETAILS.threats.map(item => `<li>${item}</li>`).join('');
+    if (conservationEl)
+        conservationEl.innerHTML = `<strong>Conservation & Management:</strong> ${RAMSAR_DETAILS.conservation}`;
+}
+
+function renderReligious() {
+    const grid = document.getElementById('religious-grid');
+    if (!grid || typeof RELIGIOUS_IMPORTANCE === 'undefined') return;
+
+    grid.innerHTML = RELIGIOUS_IMPORTANCE.map(
+        item => `
+        <div class="sm-card">
+            <span class="sm-card-icon">${item.icon}</span>
+            <h3>${item.title}</h3>
+            <p>${item.description}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function renderWildlife() {
+    const grid = document.getElementById('wildlife-grid');
+    if (!grid || typeof WILDLIFE_SPECIES === 'undefined') return;
+
+    grid.innerHTML = WILDLIFE_SPECIES.map(
+        sp => `
+        <div class="species-card">
+            <div class="species-card-body">
+                <div class="species-header">
+                    <h3>${sp.icon} ${sp.name}</h3>
+                    <span class="status-badge">${sp.status}</span>
+                </div>
+                <p class="scientific-name"><em>${sp.scientificName} · ${sp.category}</em></p>
+                <p>${sp.description}</p>
+            </div>
+        </div>
+    `
+    ).join('');
+}
+
+function renderBirds() {
+    const grid = document.getElementById('birds-grid');
+    if (!grid || typeof BIRD_SPECIES === 'undefined') return;
+
+    grid.innerHTML = BIRD_SPECIES.map(
+        sp => `
+        <div class="species-card">
+            <div class="species-card-body">
+                <div class="species-header">
+                    <h3>${sp.icon} ${sp.name}</h3>
+                    <span class="status-badge">${sp.status}</span>
+                </div>
+                <p class="scientific-name"><em>${sp.scientificName}</em></p>
+                <p>${sp.description}</p>
+                <div class="bird-meta">
+                    <span>🗓️ ${sp.season}</span> |
+                    <span>📊 ${sp.count}</span>
+                </div>
+            </div>
+        </div>
+    `
+    ).join('');
+}
+
+function renderLegends() {
+    const grid = document.getElementById('legends-grid');
+    if (!grid || typeof LOCAL_LEGENDS === 'undefined') return;
+
+    grid.innerHTML = LOCAL_LEGENDS.map(
+        item => `
+        <div class="sm-card legend-card">
+            <span class="sm-card-icon">${item.icon}</span>
+            <h3>${item.title}</h3>
+            <p>${item.description}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function renderHotspots() {
+    const grid = document.getElementById('hotspots-grid');
+    if (!grid || typeof MAP_HOTSPOTS === 'undefined') return;
+
+    grid.innerHTML = MAP_HOTSPOTS.map(
+        spot => `
+        <div class="hotspot-card">
+            <h3>📍 ${spot.title}</h3>
+            <span class="spot-type">${spot.type}</span>
+            <p>${spot.description}</p>
+            <small>Coordinates: ${spot.lat}° N, ${spot.lng}° E</small>
+        </div>
+    `
+    ).join('');
+}
+
+function initMap() {
+    const mapEl = document.getElementById('map-container');
+    if (!mapEl || typeof MAP_HOTSPOTS === 'undefined' || typeof L === 'undefined') return;
+
+    const map = L.map('map-container').setView([SM_INFO.coordinates.lat, SM_INFO.coordinates.lng], 11);
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 18,
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    }).addTo(map);
+
+    MAP_HOTSPOTS.forEach(spot => {
+        L.marker([spot.lat, spot.lng])
+            .addTo(map)
+            .bindPopup(`<strong>${spot.title}</strong><br/><em>${spot.type}</em><br/>${spot.description}`);
+    });
+}
+
+function renderGallery() {
+    const grid = document.getElementById('gallery-grid');
+    if (!grid || typeof GALLERY_IMAGES === 'undefined') return;
+
+    grid.innerHTML = GALLERY_IMAGES.map(
+        img => `
+        <div class="gallery-card">
+            <img src="${img.url}" alt="${img.caption}" loading="lazy" />
+            <p>${img.caption}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function initThemeToggle() {
+    const toggleBtn = document.getElementById('theme-toggle');
+    if (!toggleBtn) return;
+
+    toggleBtn.addEventListener('click', () => {
+        const isLight = document.body.classList.toggle('light-theme');
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        toggleBtn.textContent = isLight ? '🌙' : '☀️';
+    });
+}

--- a/frontend/wetlands/wetlands-data.js
+++ b/frontend/wetlands/wetlands-data.js
@@ -508,6 +508,21 @@ export const WETLANDS_DATA = {
             coordinates: { lat: 28.462, lng: 76.892 },
             keyFauna: ['Bar-headed Goose', 'Black-necked Stork', 'Spot-billed Pelican', 'Eurasian Wigeon'],
             isFeatured: true
+        },
+        {
+            id: 'surinsar-mansar-lakes',
+            name: 'Surinsar-Mansar Lakes',
+            state: 'Jammu & Kashmir',
+            type: 'Lake',
+            area: '350 ha',
+            ramsarDeclared: 2005,
+            ramsarSiteNo: 1573,
+            image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/2/28/Dr_harleen_Kaur_mansar_lake_near_udhampur.jpg/800px-Dr_harleen_Kaur_mansar_lake_near_udhampur.jpg',
+            shortDesc: 'Twin sacred freshwater lakes of the Siwalik foothills — Ramsar Site No. 1573 and a Wildlife Sanctuary sheltering rare turtles, the freshwater medusa and wintering waterfowl.',
+            exploreUrl: '../surinsar-mansar-lakes-explorer/index.html',
+            coordinates: { lat: 32.720, lng: 75.170 },
+            keyFauna: ['Indian Softshell Turtle', 'Indian Flapshell Turtle', 'Common Coot', 'Common Pochard'],
+            isFeatured: true
         }
     ]
 };

--- a/search-index.js
+++ b/search-index.js
@@ -1485,6 +1485,13 @@ window.indiaSearchIndex = [
     description: "Explore Tampara Lake in Ganjam, Odisha — Ramsar Site, freshwater coastal lagoon, fisheries, and eco-boating destination.",
     url: "frontend/tampara-lake-explorer/index.html"
   },
+  // --- Surinsar-Mansar Lakes Explorer ---
+  {
+    title: "Surinsar-Mansar Lakes Explorer",
+    category: "Wetlands & Ramsar Sites",
+    description: "Explore the Surinsar-Mansar Lakes in Jammu & Kashmir — twin sacred freshwater lakes, Ramsar Site No. 1573, Wildlife Sanctuary, rare turtles, freshwater medusa, birdlife, and local legends.",
+    url: "frontend/surinsar-mansar-lakes-explorer/index.html"
+  },
   // --- Keshopur-Miani Wetland Explorer ---
   {
     title: "Keshopur-Miani Wetland Explorer",

--- a/tests/unit/surinsar-mansar-lakes-explorer.test.js
+++ b/tests/unit/surinsar-mansar-lakes-explorer.test.js
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadSurinsarMansarData() {
+    const code = readFileSync(
+        resolve(__dirname, '../../frontend/surinsar-mansar-lakes-explorer/surinsar-mansar-data.js'),
+        'utf-8'
+    );
+    const fn = new Function(
+        code +
+            '\nreturn { SM_INFO, TWIN_LAKE_ECOSYSTEM, RAMSAR_DETAILS, RELIGIOUS_IMPORTANCE, WILDLIFE_SPECIES, BIRD_SPECIES, LOCAL_LEGENDS, MAP_HOTSPOTS, GALLERY_IMAGES };'
+    );
+    return fn();
+}
+
+function loadWetlandsLandingData() {
+    let code = readFileSync(
+        resolve(__dirname, '../../frontend/wetlands/wetlands-data.js'),
+        'utf-8'
+    );
+    code = code.replace(/export\s+const\s+/g, 'const ');
+    const fn = new Function(code + '\nreturn WETLANDS_DATA;');
+    return fn();
+}
+
+describe('Surinsar-Mansar Lakes Explorer — Data & Integration Tests', () => {
+    let data;
+
+    beforeAll(() => {
+        data = loadSurinsarMansarData();
+    });
+
+    describe('SM_INFO metadata', () => {
+        it('contains correct wetland metadata and Ramsar status', () => {
+            expect(data.SM_INFO.id).toBe('surinsar-mansar-lakes');
+            expect(data.SM_INFO.name).toBe('Surinsar-Mansar Lakes');
+            expect(data.SM_INFO.ramsarYear).toBe(2005);
+            expect(data.SM_INFO.ramsarSiteNo).toBe(1573);
+            expect(data.SM_INFO.state).toBe('Jammu & Kashmir');
+        });
+
+        it('has quickStats array with 6 items', () => {
+            expect(Array.isArray(data.SM_INFO.quickStats)).toBe(true);
+            expect(data.SM_INFO.quickStats.length).toBe(6);
+        });
+    });
+
+    describe('TWIN_LAKE_ECOSYSTEM', () => {
+        it('covers both lakes and hydrology', () => {
+            expect(data.TWIN_LAKE_ECOSYSTEM.overview).toBeDefined();
+            expect(data.TWIN_LAKE_ECOSYSTEM.surinsarProfile).toContain('Surinsar');
+            expect(data.TWIN_LAKE_ECOSYSTEM.mansarProfile).toContain('Mansar');
+            expect(data.TWIN_LAKE_ECOSYSTEM.hydrology).toBeDefined();
+        });
+    });
+
+    describe('RAMSAR_DETAILS', () => {
+        it('documents criteria and threats', () => {
+            expect(data.RAMSAR_DETAILS.summary).toContain('8 November 2005');
+            expect(Array.isArray(data.RAMSAR_DETAILS.criteria)).toBe(true);
+            expect(data.RAMSAR_DETAILS.criteria.length).toBeGreaterThanOrEqual(3);
+            expect(Array.isArray(data.RAMSAR_DETAILS.threats)).toBe(true);
+            expect(data.RAMSAR_DETAILS.conservation).toBeDefined();
+        });
+    });
+
+    describe('Species catalogs', () => {
+        it('wildlife covers the CITES-listed turtles and the medusa', () => {
+            const flap = data.WILDLIFE_SPECIES.find(s => s.id === 'indian-flapshell-turtle');
+            const soft = data.WILDLIFE_SPECIES.find(s => s.id === 'indian-softshell-turtle');
+            const medusa = data.WILDLIFE_SPECIES.find(s => s.id === 'mansariella-medusa');
+            expect(flap).toBeDefined();
+            expect(soft).toBeDefined();
+            expect(medusa).toBeDefined();
+        });
+
+        it('birdlife includes the key wintering waterfowl', () => {
+            const coot = data.BIRD_SPECIES.find(b => b.id === 'common-coot');
+            const pochard = data.BIRD_SPECIES.find(b => b.id === 'common-pochard');
+            const tufted = data.BIRD_SPECIES.find(b => b.id === 'tufted-duck');
+            expect(coot).toBeDefined();
+            expect(pochard).toBeDefined();
+            expect(tufted).toBeDefined();
+        });
+    });
+
+    describe('Mythology, map hotspots and gallery', () => {
+        it('includes local legends', () => {
+            expect(Array.isArray(data.LOCAL_LEGENDS)).toBe(true);
+            expect(data.LOCAL_LEGENDS.length).toBeGreaterThanOrEqual(3);
+        });
+
+        it('has map hotspots and gallery images', () => {
+            expect(Array.isArray(data.MAP_HOTSPOTS)).toBe(true);
+            expect(data.MAP_HOTSPOTS.length).toBeGreaterThanOrEqual(3);
+            expect(data.MAP_HOTSPOTS.find(s => s.id === 'mansar-lake')).toBeDefined();
+            expect(Array.isArray(data.GALLERY_IMAGES)).toBe(true);
+            expect(data.GALLERY_IMAGES.length).toBeGreaterThanOrEqual(4);
+        });
+    });
+
+    describe('Landing Page Integration', () => {
+        it('is integrated in WETLANDS_DATA landing page dataset', () => {
+            const wetlandsData = loadWetlandsLandingData();
+            const smCard = wetlandsData.wetlands.find(w => w.id === 'surinsar-mansar-lakes');
+            expect(smCard).toBeDefined();
+            expect(smCard.ramsarSiteNo).toBe(1573);
+            expect(smCard.state).toBe('Jammu & Kashmir');
+            expect(smCard.exploreUrl).toBe('../surinsar-mansar-lakes-explorer/index.html');
+        });
+    });
+});


### PR DESCRIPTION
## Overview
Closes #983

Adds a dedicated **Surinsar-Mansar Lakes Explorer** — an interactive page for the twin sacred freshwater lakes of the Siwalik foothills in Jammu & Kashmir (Ramsar Site No. 1573, designated 8 Nov 2005; part of the Surinsar-Mansar Wildlife Sanctuary).

## What's included
- **Twin Lake Ecosystem** — overview, Surinsar & Mansar profiles, hydrology (rain-fed Surinsar; surface run-off + paddy-field inflow to Mansar)
- **Ramsar Site & Conservation** — designation details, Ramsar Criteria 2/3/4, key threats, management
- **Religious Importance** — Sheshnag Temple, sacred shoreline temples, marriage/mundan rituals, annual fair
- **Wildlife & Aquatic Life** — Indian Flapshell Turtle (CITES II), Indian Softshell Turtle (CITES I/IUCN Vulnerable), rare freshwater medusa *Mansariella lacustris*, fish and sanctuary fauna
- **Birdlife & Migratory Waterfowl** — Common Coot, Moorhen, Black-necked Grebe, Common Pochard, Tufted Duck, cormorants & herons (with 1989–90 counts)
- **Local Legends & Mythology** — Arjuna–Babar Vahan–Sheshnag legend, the "Surang Sar" arrow spring, Mansarovar sanctity, twin-born lakes
- **Interactive Map** — Leaflet map with lake/sanctuary/temple hotspots
- **Image Gallery**

## Landing page integration
- Added Surinsar-Mansar card to the Wetlands of India Explorer (`frontend/wetlands/wetlands-data.js`)
- Added a search-index entry (`search-index.js`)

## Tests
- New `tests/unit/surinsar-mansar-lakes-explorer.test.js` (9 tests) — passes
- `wetlands-explorer`, `tampara-lake-explorer` and related wetland tests still pass

## Files
- `frontend/surinsar-mansar-lakes-explorer/` (index.html, surinsar-mansar-data.js, surinsar-mansar.css, surinsar-mansar.js)
- `frontend/wetlands/wetlands-data.js`
- `search-index.js`
- `tests/unit/surinsar-mansar-lakes-explorer.test.js`