### PR TITLE
feat: add nanda lake explorer

### DIFF
--- a/frontend/Nanda-lake-explorer/index.html
+++ b/frontend/Nanda-lake-explorer/index.html
@@ -1,0 +1,238 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    document.body.classList.add('light-theme');
+                }
+            })();
+        </script>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Explore Nanda Lake in Cacora, Goa — Goa's first and only Ramsar Site, a freshwater marsh known for its water lilies, migratory birds, and aquatic biodiversity."
+        />
+        <title>Nanda Lake Explorer | Incredible India</title>
+
+        <!-- Google Fonts -->
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+            rel="stylesheet"
+        />
+
+        <!-- Stylesheets -->
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="style.css" />
+
+        <!-- Open Graph -->
+        <meta property="og:title" content="Nanda Lake Explorer | Incredible India" />
+        <meta
+            property="og:description"
+            content="Interactive explorer on Nanda Lake, Goa — freshwater lake ecosystem, Ramsar site status, aquatic plants, bird species, conservation, biodiversity, interactive map, and photo gallery."
+        />
+        <meta property="og:type" content="website" />
+    </head>
+
+    <body class="nanda-lake-main">
+        <!-- Site Navbar -->
+        <header class="navbar scrolled" id="navbar">
+            <div class="nav-container">
+                <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </button>
+                <nav class="nav-menu" id="nav-menu">
+                    <a href="../../index.html#home" class="nav-link">Home</a>
+                    <a href="../wetlands/index.html" class="nav-link">Wetlands Hub</a>
+                    <a href="../chilika-lake/index.html" class="nav-link">Chilika Lake</a>
+                    <a href="../kolleru-lake/index.html" class="nav-link">Kolleru Lake</a>
+                    <a href="index.html" class="nav-link active" style="color: var(--saffron)">Nanda Lake</a>
+                    <button
+                        id="theme-toggle"
+                        class="btn-theme-toggle"
+                        aria-label="Toggle Dark/Light Mode"
+                        title="Toggle Light Mode"
+                    >
+                        ☀️
+                    </button>
+                </nav>
+            </div>
+        </header>
+
+        <main>
+            <!-- Hero Section -->
+            <section class="nanda-lake-hero">
+                <div class="section-container">
+                    <div class="hero-badges-row">
+                        <span class="hero-pill pill-ramsar">🪷 Goa's First Ramsar Site</span>
+                        <span class="hero-pill pill-lily">🌸 Famed for its Water Lilies</span>
+                        <span class="hero-pill pill-marsh">💧 42 ha Freshwater Marsh</span>
+                    </div>
+                    <h1>Nanda Lake <span>Explorer</span></h1>
+                    <p class="hero-subtitle">
+                        Discover Goa's first and only Ramsar Site — a freshwater marsh beside the Zuari River in
+                        Cacora, where a simple sluice gate turns marshland into open water, water lilies bloom
+                        across the surface, and migratory birds pass through every winter.
+                    </p>
+
+                    <!-- Quick Stats Bar -->
+                    <div id="stats-grid" class="stats-grid">
+                        <!-- Populated dynamically -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Freshwater Lake Section -->
+            <section class="lake-section" id="freshwater-lake">
+                <div class="section-container">
+                    <div class="info-card">
+                        <span class="section-tag">A LAKE ON A SLUICE GATE</span>
+                        <h2 id="lake-title"></h2>
+                        <p id="lake-content"></p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Ramsar Site Section -->
+            <section class="ramsar-section" id="ramsar">
+                <div class="section-container">
+                    <div class="info-card highlight-card">
+                        <span class="section-tag">GLOBAL RECOGNITION</span>
+                        <h2 id="ramsar-title"></h2>
+                        <p id="ramsar-content"></p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Aquatic Plants Section -->
+            <section class="plants-section" id="aquatic-plants">
+                <div class="section-container">
+                    <div class="info-card">
+                        <span class="section-tag">A GREEN, BLOOMING SURFACE</span>
+                        <h2 id="plants-title"></h2>
+                        <p id="plants-content"></p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Bird Species Section -->
+            <section class="birds-section" id="bird-species">
+                <div class="section-container">
+                    <div class="bird-card-feature">
+                        <div class="bird-feature-info">
+                            <span class="section-tag">MIGRATORY VISITORS</span>
+                            <h2 id="birds-title"></h2>
+                            <p id="birds-content"></p>
+                            <div class="facts-list" id="birds-facts">
+                                <!-- Populated dynamically -->
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Biodiversity Section -->
+            <section class="biodiversity-section" id="biodiversity">
+                <div class="section-container">
+                    <div class="info-card highlight-card">
+                        <span class="section-tag">BEYOND THE BIRDS</span>
+                        <h2 id="biodiversity-title"></h2>
+                        <p id="biodiversity-content"></p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Conservation Section -->
+            <section class="conservation-section" id="conservation">
+                <div class="section-container">
+                    <div class="info-card">
+                        <span class="section-tag">PEOPLE, POLICY & PROTECTION</span>
+                        <h2 id="conservation-title"></h2>
+                        <p id="conservation-content"></p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Interactive Map Section -->
+            <section class="map-section" id="interactive-map">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-tag">HOTSPOT EXPLORER</span>
+                        <h2>Interactive Nanda Lake Map & Destinations</h2>
+                        <p>Select key points around the lake and its surrounding villages.</p>
+                    </div>
+                    <div class="map-layout">
+                        <div class="map-list" id="hotspots-list">
+                            <!-- Populated dynamically -->
+                        </div>
+                        <div class="map-detail" id="hotspot-detail">
+                            <!-- Populated dynamically -->
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Photo Gallery Section -->
+            <section class="gallery-section" id="gallery">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-tag">MEDIA SHOTS</span>
+                        <h2>Image Gallery</h2>
+                        <p>Glimpse the lilies, waters, and birdlife of Nanda Lake.</p>
+                    </div>
+                    <div class="gallery-grid" id="gallery-grid">
+                        <!-- Populated dynamically -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Interesting Facts Section -->
+            <section class="facts-section" id="facts">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-tag">TRIVIA</span>
+                        <h2>Interesting Facts</h2>
+                    </div>
+                    <div class="facts-grid" id="facts-grid">
+                        <!-- Populated dynamically -->
+                    </div>
+                </div>
+            </section>
+        </main>
+
+        <!-- Footer -->
+        <footer class="footer">
+            <div class="section-container">
+                <div class="footer-content">
+                    <div class="footer-logo">
+                        <h3>Incredible India Explorer</h3>
+                        <p>Promoting eco-tourism, biodiversity awareness, and sustainable exploration across India.</p>
+                    </div>
+                    <div class="footer-links">
+                        <a href="../../index.html#home">Home</a>
+                        <a href="../wetlands/index.html">Wetlands Hub</a>
+                        <a href="../chilika-lake/index.html">Chilika Lake</a>
+                        <a href="../kolleru-lake/index.html">Kolleru Lake</a>
+                    </div>
+                </div>
+                <div class="footer-bottom">
+                    <p>&copy; 2026 Incredible India Explorer. Open Source Educational Platform.</p>
+                </div>
+            </div>
+        </footer>
+
+        <!-- Scripts -->
+        <script type="module" src="script.js"></script>
+    </body>
+</html>

--- a/frontend/Nanda-lake-explorer/nanda-lake-data.js
+++ b/frontend/Nanda-lake-explorer/nanda-lake-data.js
@@ -1,0 +1,80 @@
+/**
+ * Nanda Lake Explorer Dataset
+ * Goa's First and Only Ramsar Site
+ */
+
+export const NANDA_LAKE_DATA = {
+    id: 'nanda-lake-explorer',
+    name: 'Nanda Lake Explorer',
+    subtitle: 'Goa\'s First Ramsar Site & a Freshwater Marsh Beside the Zuari',
+    location: 'Cacora Village, Quepem Taluka, South Goa',
+    ramsarSiteNo: 2471,
+    ramsarDeclared: 2022,
+    area: '42 ha (0.42 km²)',
+    type: 'Intermittent Freshwater Marsh',
+    coordinates: { lat: 15.236, lng: 74.109 },
+
+    stats: [
+        { label: 'Wetland Area', value: '42 ha', icon: '🌊' },
+        { label: 'Ramsar Declared', value: '2022', icon: '🪷' },
+        { label: 'Notable Bird Species', value: '8+', icon: '🐦' },
+        { label: 'Goa\'s Ramsar Sites', value: '1 of 1', icon: '🏞️' }
+    ],
+
+    freshwaterLake: {
+        title: 'A Lake That Follows the Rhythm of a Sluice Gate',
+        content: 'Nanda Lake sits beside a tributary of the Zuari River in Cacora village, Quepem taluka, and its character changes with the seasons in an unusual way. A sluice gate links the marsh to the adjoining river channel: when the gate is closed, water backs up and floods the marsh into something close to a proper lake; when it is open, the water drains and the site reverts to intermittent freshwater marshland, grasslands, and paddy-adjacent wet ground. That back-and-forth between "marsh" and "lake" is not an accident of engineering gone wrong, but a deliberate, decades-old local water-management practice, one that gives Nanda Lake a genuinely amphibious identity rather than a single fixed shoreline.'
+    },
+
+    ramsarSite: {
+        title: 'Goa\'s Only Wetland of International Importance',
+        content: 'Nanda Lake was designated a Ramsar Site on 8 June 2022, becoming the first, and so far only, Ramsar-recognised wetland in Goa. Covering just 42 hectares, it is a modest site by Ramsar standards, but the designation recognised how tightly the marsh is woven into the ecology of the Western Ghats foothills and into the daily water needs of the villages around it. Its listing came as part of a larger batch of ten new Indian wetlands announced that year, alongside sites such as Thane Creek in Maharashtra, taking India\'s total Ramsar count past 60.'
+    },
+
+    aquaticPlants: {
+        title: 'Water Lilies, Reeds, and a Green Surface',
+        content: 'Nanda Lake is known locally for its abundance of water lilies, which spread across the marsh surface during the wetter months and draw visitors during World Wetlands Day celebrations held at the site. Alongside the lilies, the wetland supports water hyacinth, lotus, and dense stands of reeds, plants that together shape the marsh into a mosaic of open water, floating vegetation, and reed beds. These plant communities do more than add scenery: they slow water flow, trap sediment, and create sheltered feeding and nesting conditions for the birds and amphibians that depend on the lake.'
+    },
+
+    birdSpecies: {
+        title: 'A Stop on the Central Asian Flyway',
+        subtitle: 'Migratory and resident waterbirds share the marsh\'s reeds and open water.',
+        content: 'Nanda Lake\'s official Ramsar listing names the black-headed ibis, common kingfisher, wire-tailed swallow, bronze-winged jacana, brahminy kite, intermediate egret, little cormorant, and lesser whistling duck among its notable bird species. Red-wattled lapwings are also regularly sighted along the marsh edges. As part of the Central Asian Flyway, the lake gives migratory waterbirds a reliable freshwater stopover in a state better known for its beaches than its wetlands, making it an easy site for birdwatchers to reach without leaving South Goa.',
+        facts: [
+            'The black-headed ibis and bronze-winged jacana are two of the more distinctive species regularly recorded here.',
+            'Nanda Lake lies on the Central Asian Flyway, a migratory route used by waterbirds across large parts of Asia.',
+            'World Wetlands Day is marked each February with a public celebration at the lake in nearby Curchorem.'
+        ]
+    },
+
+    biodiversity: {
+        title: 'More Than Birds: Fish, Amphibians, and a Threatened Species',
+        content: 'Beneath the water lilies, Nanda Lake supports a mix of fish and invertebrates that sustain local fishing, along with amphibians and reptiles suited to its seasonally flooded ground. Among the fish recorded here is Pethia setnai, a small barb species listed as threatened by the IUCN, underlining that even a compact 42-hectare marsh can hold conservation significance well beyond its size. The lake\'s combination of open water, reed beds, and adjoining coconut groves and paddy fields creates a layered habitat that few single ecosystems in Goa replicate.'
+    },
+
+    conservation: {
+        title: 'Balancing Ecology, Livelihoods, and Local Voices',
+        content: 'Nanda Lake\'s Ramsar recognition has not been free of friction. Local villagers, who depend on the lake for farming, fishing, and daily water use, have raised concerns that they were not adequately consulted before the designation, and debate has continued around plans for a research and observation centre at the site, with residents worried it could bring disruptive tourism or sideline their role as the lake\'s day-to-day stewards. On the ecological side, the Ramsar authorities list invasive non-native species, garbage and solid waste, and overfishing as active threats, and note that a formal management plan for the site has yet to be put in place — making Nanda Lake as much a live conservation conversation as a finished success story.'
+    },
+
+    hotspots: [
+        { id: 'sluice-gate', name: 'Nanda Lake Sluice Gate', lat: 15.238, lng: 74.108, desc: 'The control point where the lake\'s water level is regulated between marsh and open-water phases.' },
+        { id: 'cacora-village', name: 'Cacora Village Shoreline', lat: 15.236, lng: 74.109, desc: 'The village edge of the lake, where water lilies and reed beds are most visible.' },
+        { id: 'ravindra-bhavan', name: 'Ravindra Bhavan, Curchorem', lat: 15.256, lng: 74.106, desc: 'Venue for World Wetlands Day events celebrating the lake\'s designation and biodiversity.' },
+        { id: 'quepem-paddy-fields', name: 'Downstream Paddy Fields', lat: 15.230, lng: 74.107, desc: 'Rice paddies that rely on water released from the lake during the growing season.' }
+    ],
+
+    gallery: [
+        { title: 'Nanda Lake, Curchorem', url: 'https://commons.wikimedia.org/wiki/Special:FilePath/Nanda_Lake_Curchoten.jpg', caption: 'Wide view across Nanda Lake near Curchorem in South Goa.' },
+        { title: 'Nanda Lake, Cacora', url: 'https://commons.wikimedia.org/wiki/Special:FilePath/Nanda_Lake_Curchorem.jpg', caption: 'The marsh and open water of Nanda Lake, Goa\'s only Ramsar site.' },
+        { title: 'Sluice Gate, South Goa', url: 'https://commons.wikimedia.org/wiki/Special:FilePath/Sluice_Gate_in_Loutolim.jpg', caption: 'A South Goa sluice gate of the kind that regulates Nanda Lake\'s water level.' },
+        { title: 'Aquatic Birds, Goa Wetlands', url: 'https://commons.wikimedia.org/wiki/Special:FilePath/Aquatic_birds._in_Taleigao._Photo_by_JoeGoaUk.jpg', caption: 'Waterbirds typical of Goa\'s freshwater marsh habitats.' }
+    ],
+
+    facts: [
+        'Nanda Lake is Goa\'s first, and so far only, Ramsar-recognised Wetland of International Importance.',
+        'A sluice gate lets the local community switch the site between an open lake and a drained marsh, depending on the season.',
+        'The wetland is home to Pethia setnai, a small fish species classified as threatened by the IUCN.',
+        'At just 42 hectares, Nanda Lake is one of the smaller entries on India\'s Ramsar list, yet it sits on the Central Asian Flyway.'
+    ]
+};

--- a/frontend/Nanda-lake-explorer/script.js
+++ b/frontend/Nanda-lake-explorer/script.js
@@ -1,0 +1,178 @@
+import { NANDA_LAKE_DATA } from './nanda-lake-data.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+    initTheme();
+    initNavbar();
+    renderStats();
+    renderFreshwaterLake();
+    renderRamsar();
+    renderAquaticPlants();
+    renderBirdSpecies();
+    renderBiodiversity();
+    renderConservation();
+    renderMapHotspots();
+    renderGallery();
+    renderFacts();
+});
+
+function initTheme() {
+    const themeToggleBtn = document.getElementById('theme-toggle');
+    if (!themeToggleBtn) return;
+
+    themeToggleBtn.addEventListener('click', () => {
+        document.body.classList.toggle('light-theme');
+        const isLight = document.body.classList.contains('light-theme');
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        themeToggleBtn.textContent = isLight ? '🌙' : '☀️';
+    });
+}
+
+function initNavbar() {
+    const menuToggle = document.getElementById('menu-toggle');
+    const navMenu = document.getElementById('nav-menu');
+    if (!menuToggle || !navMenu) return;
+
+    menuToggle.addEventListener('click', () => {
+        const isExpanded = menuToggle.getAttribute('aria-expanded') === 'true';
+        menuToggle.setAttribute('aria-expanded', !isExpanded);
+        navMenu.classList.toggle('active');
+    });
+}
+
+function renderStats() {
+    const container = document.getElementById('stats-grid');
+    if (!container || !NANDA_LAKE_DATA.stats) return;
+
+    container.innerHTML = NANDA_LAKE_DATA.stats
+        .map(
+            (stat) => `
+        <div class="stat-card">
+            <span class="stat-icon">${stat.icon}</span>
+            <div class="stat-value">${stat.value}</div>
+            <div class="stat-label">${stat.label}</div>
+        </div>
+    `
+        )
+        .join('');
+}
+
+function renderFreshwaterLake() {
+    const title = document.getElementById('lake-title');
+    const content = document.getElementById('lake-content');
+    if (title) title.textContent = NANDA_LAKE_DATA.freshwaterLake.title;
+    if (content) content.textContent = NANDA_LAKE_DATA.freshwaterLake.content;
+}
+
+function renderRamsar() {
+    const title = document.getElementById('ramsar-title');
+    const content = document.getElementById('ramsar-content');
+    if (title) title.textContent = NANDA_LAKE_DATA.ramsarSite.title;
+    if (content) content.textContent = NANDA_LAKE_DATA.ramsarSite.content;
+}
+
+function renderAquaticPlants() {
+    const title = document.getElementById('plants-title');
+    const content = document.getElementById('plants-content');
+    if (title) title.textContent = NANDA_LAKE_DATA.aquaticPlants.title;
+    if (content) content.textContent = NANDA_LAKE_DATA.aquaticPlants.content;
+}
+
+function renderBirdSpecies() {
+    const title = document.getElementById('birds-title');
+    const content = document.getElementById('birds-content');
+    const factsList = document.getElementById('birds-facts');
+
+    if (title) title.textContent = NANDA_LAKE_DATA.birdSpecies.title;
+    if (content) content.textContent = NANDA_LAKE_DATA.birdSpecies.content;
+
+    if (factsList && NANDA_LAKE_DATA.birdSpecies.facts) {
+        factsList.innerHTML = NANDA_LAKE_DATA.birdSpecies.facts
+            .map((f) => `<div class="fact-bullet">🐦 ${f}</div>`)
+            .join('');
+    }
+}
+
+function renderBiodiversity() {
+    const title = document.getElementById('biodiversity-title');
+    const content = document.getElementById('biodiversity-content');
+    if (title) title.textContent = NANDA_LAKE_DATA.biodiversity.title;
+    if (content) content.textContent = NANDA_LAKE_DATA.biodiversity.content;
+}
+
+function renderConservation() {
+    const title = document.getElementById('conservation-title');
+    const content = document.getElementById('conservation-content');
+    if (title) title.textContent = NANDA_LAKE_DATA.conservation.title;
+    if (content) content.textContent = NANDA_LAKE_DATA.conservation.content;
+}
+
+function renderMapHotspots() {
+    const listContainer = document.getElementById('hotspots-list');
+    if (!listContainer || !NANDA_LAKE_DATA.hotspots) return;
+
+    listContainer.innerHTML = NANDA_LAKE_DATA.hotspots
+        .map(
+            (spot, index) => `
+        <button class="spot-btn ${index === 0 ? 'active' : ''}" data-id="${spot.id}">
+            <span class="spot-name">${spot.name}</span>
+        </button>
+    `
+        )
+        .join('');
+
+    showHotspotDetail(NANDA_LAKE_DATA.hotspots[0]);
+
+    listContainer.addEventListener('click', (e) => {
+        const btn = e.target.closest('.spot-btn');
+        if (!btn) return;
+
+        const id = btn.getAttribute('data-id');
+        const spot = NANDA_LAKE_DATA.hotspots.find((s) => s.id === id);
+
+        document.querySelectorAll('.spot-btn').forEach((b) => b.classList.remove('active'));
+        btn.classList.add('active');
+
+        if (spot) {
+            showHotspotDetail(spot);
+        }
+    });
+}
+
+function showHotspotDetail(spot) {
+    const detailContainer = document.getElementById('hotspot-detail');
+    if (!detailContainer) return;
+
+    detailContainer.innerHTML = `
+        <h3 style="margin: 0 0 0.5rem; color: #ec4899; font-size: 1.5rem;">${spot.name}</h3>
+        <p style="color: var(--nanda-text-sub); line-height: 1.6; margin-bottom: 1.25rem;">${spot.desc}</p>
+        <div style="font-family: monospace; font-size: 0.85rem; color: #94a3b8; background: rgba(0,0,0,0.2); padding: 0.5rem 0.85rem; border-radius: 0.5rem;">Coordinates: ${spot.lat}° N, ${spot.lng}° E</div>
+    `;
+}
+
+function renderGallery() {
+    const container = document.getElementById('gallery-grid');
+    if (!container || !NANDA_LAKE_DATA.gallery) return;
+
+    container.innerHTML = NANDA_LAKE_DATA.gallery
+        .map(
+            (g) => `
+        <div class="gallery-card">
+            <img src="${g.url}" alt="${g.title}" loading="lazy" />
+            <div class="gallery-info">
+                <h4>${g.title}</h4>
+                <p>${g.caption}</p>
+            </div>
+        </div>
+    `
+        )
+        .join('');
+}
+
+function renderFacts() {
+    const container = document.getElementById('facts-grid');
+    if (!container || !NANDA_LAKE_DATA.facts) return;
+
+    container.innerHTML = NANDA_LAKE_DATA.facts
+        .map((f) => `<div class="trivia-box">💡 ${f}</div>`)
+        .join('');
+}

--- a/frontend/Nanda-lake-explorer/style.css
+++ b/frontend/Nanda-lake-explorer/style.css
@@ -1,0 +1,358 @@
+/* Nanda Lake Explorer Stylesheet */
+
+:root {
+    --nanda-primary: #0d9488;
+    --nanda-accent: #ec4899;
+    --nanda-dark-bg: #0a1a17;
+    --nanda-card-bg: rgba(14, 28, 25, 0.85);
+    --nanda-card-border: rgba(236, 72, 153, 0.2);
+    --nanda-text-main: #f0fdfa;
+    --nanda-text-sub: #9cb8b0;
+}
+
+body.light-theme {
+    --nanda-dark-bg: #f0fdfa;
+    --nanda-card-bg: rgba(255, 255, 255, 0.95);
+    --nanda-card-border: rgba(13, 148, 136, 0.2);
+    --nanda-text-main: #0c211d;
+    --nanda-text-sub: #48645d;
+}
+
+body.nanda-lake-main {
+    background-color: var(--nanda-dark-bg);
+    color: var(--nanda-text-main);
+    font-family: 'Outfit', sans-serif;
+    margin: 0;
+    padding: 0;
+    overflow-x: hidden;
+}
+
+.section-container {
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+}
+
+/* Header Navbar */
+.navbar {
+    background: rgba(10, 26, 23, 0.88);
+    backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--nanda-card-border);
+}
+body.light-theme .navbar {
+    background: rgba(240, 253, 250, 0.92);
+}
+
+/* Hero Section */
+.nanda-lake-hero {
+    padding: 8rem 0 4rem;
+    background: linear-gradient(180deg, rgba(236, 72, 153, 0.14) 0%, rgba(10, 26, 23, 0) 100%);
+    text-align: center;
+}
+
+.hero-badges-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+}
+
+.hero-pill {
+    padding: 0.4rem 1rem;
+    border-radius: 9999px;
+    font-size: 0.875rem;
+    font-weight: 600;
+    background: rgba(13, 148, 136, 0.15);
+    border: 1px solid var(--nanda-card-border);
+    color: #2dd4bf;
+}
+
+.nanda-lake-hero h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: clamp(2.5rem, 5vw, 4rem);
+    font-weight: 800;
+    margin: 0 0 1rem;
+}
+
+.nanda-lake-hero h1 span {
+    background: linear-gradient(135deg, #f472b6 0%, #0d9488 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.hero-subtitle {
+    max-width: 800px;
+    margin: 0 auto 3rem;
+    font-size: 1.15rem;
+    color: var(--nanda-text-sub);
+    line-height: 1.7;
+}
+
+/* Stats Grid */
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.25rem;
+    margin-top: 2rem;
+}
+
+.stat-card {
+    background: var(--nanda-card-bg);
+    border: 1px solid var(--nanda-card-border);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    text-align: center;
+    transition: transform 0.3s ease;
+}
+
+.stat-card:hover {
+    transform: translateY(-4px);
+    border-color: #2dd4bf;
+}
+
+.stat-icon {
+    font-size: 2rem;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.stat-value {
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: #2dd4bf;
+    margin-bottom: 0.25rem;
+}
+
+.stat-label {
+    font-size: 0.875rem;
+    color: var(--nanda-text-sub);
+}
+
+/* Section Header */
+.section-header {
+    text-align: center;
+    margin-bottom: 3rem;
+}
+
+.section-tag {
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    color: #0d9488;
+    text-transform: uppercase;
+    display: block;
+    margin-bottom: 0.5rem;
+}
+
+.section-header h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2.25rem;
+    margin: 0 0 0.75rem;
+}
+
+.section-header p {
+    color: var(--nanda-text-sub);
+    font-size: 1.05rem;
+    max-width: 650px;
+    margin: 0 auto;
+}
+
+/* Info Cards */
+.lake-section,
+.ramsar-section,
+.plants-section,
+.biodiversity-section,
+.conservation-section {
+    padding: 4rem 0;
+}
+
+.info-card {
+    background: var(--nanda-card-bg);
+    border: 1px solid var(--nanda-card-border);
+    border-radius: 1.25rem;
+    padding: 2.5rem;
+}
+
+.highlight-card {
+    background: linear-gradient(135deg, rgba(236, 72, 153, 0.1) 0%, rgba(14, 28, 25, 0.85) 100%);
+    border-color: rgba(244, 114, 182, 0.3);
+}
+
+.info-card h2,
+.info-card h3 {
+    font-family: 'Playfair Display', serif;
+    font-size: 1.8rem;
+    margin: 0.5rem 0 1rem;
+    color: #2dd4bf;
+}
+
+.info-card p {
+    color: var(--nanda-text-sub);
+    line-height: 1.8;
+    font-size: 1.05rem;
+    margin: 0;
+}
+
+/* Bird Species Section */
+.birds-section {
+    padding: 4rem 0;
+}
+
+.bird-card-feature {
+    background: var(--nanda-card-bg);
+    border: 1px solid var(--nanda-card-border);
+    border-radius: 1.5rem;
+    padding: 2.5rem;
+}
+
+.bird-feature-info h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2rem;
+    color: #2dd4bf;
+    margin: 0.5rem 0 1rem;
+}
+
+.facts-list {
+    margin-top: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.fact-bullet {
+    background: rgba(236, 72, 153, 0.1);
+    border-left: 3px solid #f472b6;
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    font-size: 0.95rem;
+    color: var(--nanda-text-sub);
+}
+
+/* Map Section */
+.map-section {
+    padding: 4rem 0;
+}
+
+.map-layout {
+    display: grid;
+    grid-template-columns: 1fr 1.2fr;
+    gap: 2rem;
+}
+
+.map-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+}
+
+.spot-btn {
+    background: var(--nanda-card-bg);
+    border: 1px solid var(--nanda-card-border);
+    padding: 1rem 1.25rem;
+    border-radius: 0.85rem;
+    text-align: left;
+    color: var(--nanda-text-main);
+    cursor: pointer;
+    transition: all 0.3s ease;
+}
+
+.spot-btn:hover,
+.spot-btn.active {
+    border-color: #f472b6;
+    background: rgba(236, 72, 153, 0.12);
+    transform: translateX(6px);
+}
+
+.spot-name {
+    font-weight: 700;
+    font-size: 1.05rem;
+    display: block;
+}
+
+.map-detail {
+    background: var(--nanda-card-bg);
+    border: 1px solid var(--nanda-card-border);
+    border-radius: 1.25rem;
+    padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+/* Gallery & Facts */
+.gallery-section,
+.facts-section {
+    padding: 4rem 0;
+}
+
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.gallery-card {
+    background: var(--nanda-card-bg);
+    border: 1px solid var(--nanda-card-border);
+    border-radius: 1rem;
+    overflow: hidden;
+}
+
+.gallery-card img {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+}
+
+.gallery-info {
+    padding: 1rem;
+}
+
+.gallery-info h4 {
+    margin: 0 0 0.35rem;
+    font-size: 1rem;
+}
+
+.gallery-info p {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--nanda-text-sub);
+}
+
+.facts-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.trivia-box {
+    background: var(--nanda-card-bg);
+    border: 1px solid var(--nanda-card-border);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    color: var(--nanda-text-sub);
+    line-height: 1.6;
+}
+
+@media (max-width: 900px) {
+    .map-layout {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    .bird-card-feature {
+        padding: 1.75rem;
+    }
+}
+
+@media (max-width: 640px) {
+    .info-card {
+        padding: 1.75rem;
+    }
+
+    .nanda-lake-hero {
+        padding: 7rem 0 3rem;
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description
Adds a new educational page for Nanda Lake, Goa's first and only Ramsar Site, a freshwater marsh beside the Zuari River known for its water lilies and migratory birdlife. The page follows the existing wetland-explorer pattern (index.html / style.css / script.js / nanda-lake-data.js) and covers Freshwater Lake ecosystem, Ramsar Site status, Aquatic Plants, Bird Species, Conservation, Biodiversity, an interactive hotspot map, and a photo gallery.

Fixes #997

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?
- [ ] Tested locally in browser
- [ ] Tested in both dark and light themes
- [ ] Tested at mobile viewport widths
- [ ] Verified no console errors

## Checklist
- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [ ] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)

## Screenshots (if applicable)
<img width="1920" height="1080" alt="Screenshot (1871)" src="https://github.com/user-attachments/assets/c4ffdb7f-f685-476f-8eab-2dcfafe7b0fa" />
<img width="1920" height="1080" alt="Screenshot (1872)" src="https://github.com/user-attachments/assets/d4adb1a9-456e-4ff0-b9b0-feded89a5656" />
<img width="1920" height="1080" alt="Screenshot (1873)" src="https://github.com/user-attachments/assets/bfb44e68-c6d7-4652-bf1b-7830778ae1df" />
<img width="1920" height="1080" alt="Screenshot (1874)" src="https://github.com/user-attachments/assets/992b64c9-8ba6-49f4-9a48-083e33eea01f" />
