### PR TITLE
fix(ci): make the accessibility gate a real check instead of a no-op

### DIFF
--- a/.github/workflows/accessibility-audit.yml
+++ b/.github/workflows/accessibility-audit.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   accessibility-check:
     runs-on: ubuntu-latest
@@ -18,19 +21,5 @@ jobs:
         with:
           node-version: 20
 
-      - name: Audit HTML Semantic Markup
-        run: |
-          echo "Auditing HTML files for accessibility compliance..."
-          node -e "
-            const fs = require('fs');
-            const files = ['index.html', 'monuments.html', 'heritage.html', 'culture.html'];
-            files.forEach(f => {
-              if (fs.existsSync(f)) {
-                const content = fs.readFileSync(f, 'utf8');
-                if (!content.includes('aria-label') && !content.includes('alt=')) {
-                  console.warn('Warning: Missing accessibility attributes in ' + f);
-                }
-              }
-            });
-            console.log('Accessibility audit passed cleanly.');
-          "
+      - name: Audit HTML accessibility
+        run: node scripts/accessibility-check.js

--- a/.github/workflows/legacy-ci-check-stub.yml
+++ b/.github/workflows/legacy-ci-check-stub.yml
@@ -1,7 +1,0 @@
-name: Legacy CI Check Stub
-on: push
-jobs:
-  stub:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Deprecated legacy check"

--- a/forts/mirjan-fort.html
+++ b/forts/mirjan-fort.html
@@ -49,7 +49,7 @@
 
     <main>
         <!-- Hero / Overview Section -->
-        <section class="hero-section" id="overview" aria-label="Mirjan Fort Overview">
+        <section class="hero-section" aria-label="Mirjan Fort Overview">
             <div class="hero-bg">
                 <img src="https://images.unsplash.com/photo-1582510003544-4d00b7f74220?w=1600&q=80"
                     alt="Panoramic view of Mirjan Fort laterite walls" class="hero-image">

--- a/frontend/Ai-trip-planner/Ai-trip-planner.html
+++ b/frontend/Ai-trip-planner/Ai-trip-planner.html
@@ -195,7 +195,7 @@
       <div class="search-box">
         <svg xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
         <input type="text" id="search-input" placeholder="Search destinations, states, or experiences…">
-        <button class="clear-btn" id="clear-search-btn">
+        <button class="clear-btn" id="clear-search-btn" aria-label="Clear search">
           <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
         </button>
       </div>
@@ -247,7 +247,7 @@
           </label>
         </div>
 
-        <button class="clear-link" id="clear-filters-btn"></button>
+        <button class="clear-link" id="clear-filters-btn" aria-label="Clear all filters"></button>
       </div>
 
       <!-- Main Results Display Area -->

--- a/frontend/travel-search/search-reccomendation-engine.html
+++ b/frontend/travel-search/search-reccomendation-engine.html
@@ -194,7 +194,7 @@
       <div class="search-box">
         <svg xmlns="http://www.w3.org/2000/svg" width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line></svg>
         <input type="text" id="search-input" placeholder="Search destinations, states, or experiences…">
-        <button class="clear-btn" id="clear-search-btn">
+        <button class="clear-btn" id="clear-search-btn" aria-label="Clear search">
           <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
         </button>
       </div>
@@ -246,7 +246,7 @@
           </label>
         </div>
 
-        <button class="clear-link" id="clear-filters-btn"></button>
+        <button class="clear-link" id="clear-filters-btn" aria-label="Clear all filters"></button>
       </div>
 
       <!-- Main Results Display Area -->

--- a/login.html
+++ b/login.html
@@ -398,7 +398,7 @@
 <body>
 
     <main class="auth-page" id="app-root">
-        <a href="frontend/traditional-games/index.html" class="auth-topbar">
+        <a href="frontend/traditional-games/index.html" class="auth-topbar" aria-label="Incredible India Explorer">
             <!-- <span class="saffron">Incredible</span> <span class="gold">India</span> <span class="green">Explorer</span> -->
         </a>
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "vitest run",
     "test:unit": "vitest run tests/unit/",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "a11y": "node scripts/accessibility-check.js"
   },
   "devDependencies": {
     "jsdom": "^29.1.1",

--- a/scripts/accessibility-check.js
+++ b/scripts/accessibility-check.js
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/**
+ * Accessibility checker for the static HTML pages in this repo.
+ *
+ * Replaces the previous workflow-inlined script, which only looked at a
+ * hardcoded list of four files (three of which no longer exist) and could
+ * never exit non-zero.
+ *
+ * Usage:
+ *   node scripts/accessibility-check.js              # scan every page
+ *   node scripts/accessibility-check.js a.html b.html # scan specific pages
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const IGNORED_DIRS = new Set(['.git', 'node_modules', 'dist', 'coverage']);
+
+export function collectHtmlFiles(dir, found = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (IGNORED_DIRS.has(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) collectHtmlFiles(full, found);
+    else if (entry.name.endsWith('.html')) found.push(full);
+  }
+  return found;
+}
+
+/**
+ * Blank out comments and <script>/<style> bodies so their contents aren't parsed
+ * as markup. Newlines are preserved and every other character becomes a space, so
+ * offsets stay aligned with the original file and reported line numbers are correct.
+ */
+function stripNonMarkup(html) {
+  const blank = (match) => match.replace(/[^\n]/g, ' ');
+  return html
+    .replace(/<!--[\s\S]*?-->/g, blank)
+    .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, blank)
+    .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, blank);
+}
+
+function lineOf(content, index) {
+  return content.slice(0, index).split('\n').length;
+}
+
+export const RULES = [
+  {
+    id: 'img-alt',
+    describe: 'every <img> needs an alt attribute (use alt="" if decorative)',
+    run(html) {
+      const issues = [];
+      for (const m of html.matchAll(/<img\b[^>]*>/gi)) {
+        if (!/\salt\s*=/i.test(m[0])) {
+          issues.push({ line: lineOf(html, m.index), detail: m[0].slice(0, 80) });
+        }
+      }
+      return issues;
+    }
+  },
+  {
+    id: 'html-lang',
+    describe: '<html> needs a lang attribute so screen readers pick the right voice',
+    run(html) {
+      if (!/<html\b[^>]*\slang\s*=\s*["'][^"']+["']/i.test(html)) {
+        return [{ line: lineOf(html, Math.max(0, html.search(/<html/i))), detail: '<html> has no lang' }];
+      }
+      return [];
+    }
+  },
+  {
+    id: 'page-title',
+    describe: '<title> must be present and non-empty',
+    run(html) {
+      const m = html.match(/<title\b[^>]*>([\s\S]*?)<\/title>/i);
+      if (!m || !m[1].trim()) {
+        return [{ line: m ? lineOf(html, m.index) : 1, detail: 'missing or empty <title>' }];
+      }
+      return [];
+    }
+  },
+  {
+    id: 'duplicate-id',
+    describe: 'id attributes must be unique (aria references resolve to the first match)',
+    run(html) {
+      const issues = [];
+      const seen = new Map();
+      for (const m of html.matchAll(/\sid\s*=\s*["']([^"']+)["']/gi)) {
+        const id = m[1];
+        if (seen.has(id)) {
+          issues.push({ line: lineOf(html, m.index), detail: `id "${id}" also used on line ${seen.get(id)}` });
+        } else {
+          seen.set(id, lineOf(html, m.index));
+        }
+      }
+      return issues;
+    }
+  },
+  {
+    id: 'control-name',
+    describe: 'buttons and links need an accessible name (text, aria-label, or title)',
+    run(html) {
+      const issues = [];
+      const pattern = /<(button|a)\b([^>]*)>([\s\S]*?)<\/\1>/gi;
+      for (const m of html.matchAll(pattern)) {
+        const [full, tag, attrs, inner] = m;
+        if (/\saria-label\s*=\s*["']\s*\S/i.test(attrs)) continue;
+        if (/\saria-labelledby\s*=/i.test(attrs)) continue;
+        if (/\stitle\s*=\s*["']\s*\S/i.test(attrs)) continue;
+        if (/\saria-hidden\s*=\s*["']true["']/i.test(attrs)) continue;
+        // An <a> without href is not an interactive control.
+        if (tag.toLowerCase() === 'a' && !/\shref\s*=/i.test(attrs)) continue;
+        // Nested media with alt text supplies the name.
+        if (/<img\b[^>]*\salt\s*=\s*["']\s*\S/i.test(inner)) continue;
+        if (inner.replace(/<[^>]*>/g, '').trim()) continue;
+        issues.push({ line: lineOf(html, m.index), detail: full.slice(0, 80).replace(/\s+/g, ' ') });
+      }
+      return issues;
+    }
+  }
+];
+
+/**
+ * Run every rule over the given pages (defaults to the whole repo).
+ * Returns { totalScanned, violations: [{ file, line, rule, detail, describe }] }.
+ */
+export function auditAccessibility(files = collectHtmlFiles('.')) {
+  const violations = [];
+  for (const file of files) {
+    const markup = stripNonMarkup(fs.readFileSync(file, 'utf8'));
+    for (const rule of RULES) {
+      for (const issue of rule.run(markup)) {
+        violations.push({ file, line: issue.line, rule: rule.id, detail: issue.detail, describe: rule.describe });
+      }
+    }
+  }
+  return { totalScanned: files.length, violations };
+}
+
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isMain) {
+  const args = process.argv.slice(2).filter((a) => a.endsWith('.html'));
+  const files = args.length ? args.filter((f) => fs.existsSync(f)) : collectHtmlFiles('.');
+  const { totalScanned, violations } = auditAccessibility(files);
+
+  for (const v of violations) {
+    console.error(`${v.file}:${v.line}  [${v.rule}] ${v.detail}`);
+    console.error(`    ${v.describe}`);
+  }
+
+  console.log(`\nAccessibility check: scanned ${totalScanned} page(s), found ${violations.length} violation(s).`);
+
+  if (violations.length > 0) {
+    console.error('\nFix the violations above, or justify an exception in the PR description.');
+    process.exit(1);
+  }
+}

--- a/scripts/accessibility-check.js
+++ b/scripts/accessibility-check.js
@@ -141,7 +141,16 @@ const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv
 
 if (isMain) {
   const args = process.argv.slice(2).filter((a) => a.endsWith('.html'));
-  const files = args.length ? args.filter((f) => fs.existsSync(f)) : collectHtmlFiles('.');
+  const files = args.length ? args : collectHtmlFiles('.');
+
+  // A typo'd path would otherwise scan nothing and exit 0, reporting a clean bill
+  // of health for a file that was never read.
+  const missing = files.filter((f) => !fs.existsSync(f));
+  if (missing.length) {
+    console.error(`File(s) not found: ${missing.join(', ')}`);
+    process.exit(1);
+  }
+
   const { totalScanned, violations } = auditAccessibility(files);
 
   for (const v of violations) {

--- a/tests/unit/accessibility-check.test.js
+++ b/tests/unit/accessibility-check.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { RULES, auditAccessibility } from '../../scripts/accessibility-check.js';
+
+const rule = (id) => RULES.find((r) => r.id === id);
+const ids = (html, id) => rule(id).run(html).length;
+
+describe('accessibility-check rules', () => {
+  it('flags <img> without alt but accepts alt="" for decorative images', () => {
+    expect(ids('<img src="a.png">', 'img-alt')).toBe(1);
+    expect(ids('<img src="a.png" alt="">', 'img-alt')).toBe(0);
+    expect(ids('<img src="a.png" alt="Taj Mahal">', 'img-alt')).toBe(0);
+  });
+
+  it('flags a missing lang attribute on <html>', () => {
+    expect(ids('<html>', 'html-lang')).toBe(1);
+    expect(ids('<html lang="en">', 'html-lang')).toBe(0);
+  });
+
+  it('flags a missing or empty <title>', () => {
+    expect(ids('<head></head>', 'page-title')).toBe(1);
+    expect(ids('<title>   </title>', 'page-title')).toBe(1);
+    expect(ids('<title>Incredible India</title>', 'page-title')).toBe(0);
+  });
+
+  it('flags reused id attributes', () => {
+    expect(ids('<section id="overview"></section><div id="overview"></div>', 'duplicate-id')).toBe(1);
+    expect(ids('<section id="overview"></section><div id="history"></div>', 'duplicate-id')).toBe(0);
+  });
+
+  it('flags controls with no accessible name', () => {
+    expect(ids('<button></button>', 'control-name')).toBe(1);
+    expect(ids('<button><svg></svg></button>', 'control-name')).toBe(1);
+    expect(ids('<a href="/x"></a>', 'control-name')).toBe(1);
+
+    expect(ids('<button>Search</button>', 'control-name')).toBe(0);
+    expect(ids('<button aria-label="Clear search"><svg></svg></button>', 'control-name')).toBe(0);
+    expect(ids('<button aria-labelledby="lbl"></button>', 'control-name')).toBe(0);
+    expect(ids('<a href="/x"><img src="logo.png" alt="Home"></a>', 'control-name')).toBe(0);
+    // An anchor without href is a link target, not an interactive control.
+    expect(ids('<a name="top"></a>', 'control-name')).toBe(0);
+  });
+});
+
+describe('accessibility-check reporting', () => {
+  it('reports the line number from the original file, not the stripped one', () => {
+    const html = ['<html lang="en">', '<script>', 'let x = 1;', '</script>', '<img src="a.png">'].join('\n');
+    const [issue] = rule('img-alt').run(
+      html.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, (m) => m.replace(/[^\n]/g, ' '))
+    );
+    expect(issue.line).toBe(5);
+  });
+
+  it('ignores markup that only appears inside <script> or comments', () => {
+    const inScript = '<script>const t = `<button></button>`;</script>'.replace(
+      /<script\b[^>]*>[\s\S]*?<\/script>/gi,
+      (m) => m.replace(/[^\n]/g, ' ')
+    );
+    expect(rule('control-name').run(inScript)).toEqual([]);
+
+    const inComment = '<!-- <img src="old.png"> -->'.replace(/<!--[\s\S]*?-->/g, (m) =>
+      m.replace(/[^\n]/g, ' ')
+    );
+    expect(rule('img-alt').run(inComment)).toEqual([]);
+  });
+
+  it('finds no violations across the repository', () => {
+    const { totalScanned, violations } = auditAccessibility();
+    expect(totalScanned).toBeGreaterThan(0);
+    expect(violations).toEqual([]);
+  });
+});

--- a/tests/unit/accessibility-check.test.js
+++ b/tests/unit/accessibility-check.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
 import { RULES, auditAccessibility } from '../../scripts/accessibility-check.js';
 
 const rule = (id) => RULES.find((r) => r.id === id);
@@ -67,5 +68,33 @@ describe('accessibility-check reporting', () => {
     const { totalScanned, violations } = auditAccessibility();
     expect(totalScanned).toBeGreaterThan(0);
     expect(violations).toEqual([]);
+  });
+});
+
+describe('accessibility-check CLI', () => {
+  const run = (args) => {
+    try {
+      const stdout = execFileSync('node', ['scripts/accessibility-check.js', ...args], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe']
+      });
+      return { code: 0, output: stdout };
+    } catch (err) {
+      return { code: err.status, output: `${err.stdout || ''}${err.stderr || ''}` };
+    }
+  };
+
+  it('fails loudly when an explicitly named file does not exist', () => {
+    // Silently scanning nothing would report a clean bill of health for a file
+    // that was never read.
+    const { code, output } = run(['definitely-not-a-real-page.html']);
+    expect(code).toBe(1);
+    expect(output).toMatch(/not found/i);
+  });
+
+  it('scans an existing file that is passed explicitly', () => {
+    const { code, output } = run(['login.html']);
+    expect(code).toBe(0);
+    expect(output).toMatch(/scanned 1 page/);
   });
 });


### PR DESCRIPTION
Closes #1290

## Problem

The accessibility workflow reported success on every run while auditing almost nothing.

```js
const files = ['index.html', 'monuments.html', 'heritage.html', 'culture.html'];
files.forEach(f => {
  if (fs.existsSync(f)) {                  // silently skips the 3 that don't exist
    if (!content.includes('aria-label') && !content.includes('alt=')) {
      console.warn('Warning: ...');        // warns; never exits non-zero
    }
  }
});
console.log('Accessibility audit passed cleanly.');   // prints unconditionally
```

Three of those four files were moved into `frontend/` long ago, so the job audited **1 page out of 460**. Even for that one, the check was a substring test — a page with 200 images and a single `alt=` anywhere passed. And because it warned instead of failing, no PR could ever be blocked by it.

That is worse than having no check: the green tick told reviewers a page had been audited when it hadn't.

`legacy-ci-check-stub.yml` was a second no-op — self-labelled "Deprecated legacy check", running `echo` on every push.

## What this changes

**1. A real checker — `scripts/accessibility-check.js`**

Scans every HTML page in the repo and exits non-zero on violations. Five rules, each chosen because it's mechanically detectable and genuinely breaks assistive tech:

| Rule | Catches |
|---|---|
| `img-alt` | `<img>` with no `alt` (accepts `alt=""` for decorative images) |
| `html-lang` | `<html>` without `lang`, so screen readers pick the wrong voice |
| `page-title` | missing or whitespace-only `<title>` |
| `duplicate-id` | reused `id`s — `aria-labelledby`/`href="#x"` silently resolve to the first match |
| `control-name` | buttons/links with no accessible name |

Two details worth review:

- **Line numbers are accurate.** `<script>`/`<style>`/comment bodies are blanked out rather than deleted — every character becomes a space, newlines preserved — so offsets stay aligned with the original file. Deleting them would have made every reported line number wrong past the first script tag. (This was a genuine bug in my first draft, caught while verifying a reported line against the file.)
- **`control-name` avoids the obvious false positives.** It accepts `aria-label`, `aria-labelledby`, `title`, nested `<img alt="...">`, and skips `<a>` without `href` (a link target, not a control) and `aria-hidden="true"`.

**2. Fixes for the 6 violations it found**, so the gate starts green rather than landing pre-broken:

| File | Issue | Fix |
|---|---|---|
| `forts/mirjan-fort.html` | `id="overview"` on both the hero and the content section | dropped it from the hero — `#overview` in the TOC now resolves to the content section, matching every other TOC link |
| `frontend/Ai-trip-planner/Ai-trip-planner.html` | 2 icon-only/empty buttons | `aria-label` |
| `frontend/travel-search/search-reccomendation-engine.html` | same 2 buttons | `aria-label` |
| `login.html` | `<a class="auth-topbar">` whose only content is commented out | `aria-label` |

The `clear-filters-btn` case is worth noting: it's empty in markup and gets its text from `renderClearLink()` at runtime, so it has no accessible name until a filter is applied. A static `aria-label` fixes that without touching the JS.

**3. Removes `legacy-ci-check-stub.yml`** and adds `npm run a11y` so contributors can run the check locally.

## Verification

Deliberately reintroduced one violation and confirmed the gate actually fails — this is the property the old workflow lacked:

```
$ node scripts/accessibility-check.js; echo "EXIT: $?"
login.html:401  [control-name] <a href="frontend/traditional-games/index.html" class="auth-topbar">
    buttons and links need an accessible name (text, aria-label, or title)
EXIT: 1

$ # after restoring the fix
Accessibility check: scanned 460 page(s), found 0 violation(s).
EXIT: 0
```

**Test suite:** `tests/unit/accessibility-check.test.js` adds 8 tests. They assert each rule fires on bad markup *and* stays quiet on good markup, so the tests would catch the checker regressing into a no-op the way its predecessor did.

**No regressions.** I ran the full suite on `main` before my changes and on this branch:

| | Test files | Tests |
|---|---|---|
| `main` (baseline) | 16 failed, 153 passed | 3 failed, 1402 passed |
| this branch | 16 failed, **154** passed | 3 failed, **1410** passed |

Same failures both times — they're pre-existing (`national-awards.js` and several park explorers fail Vite's import analysis, unrelated to this PR). My 8 tests are the delta.

## Notes for reviewers

The rule set is deliberately conservative — only violations with near-zero false-positive rates, so the gate is trustworthy from day one. Contrast checking, focus order, and heading hierarchy are the obvious next additions, but those need a real DOM and a tolerance for noise, so they belong in a follow-up rather than here.

I kept the checker dependency-free and framework-free to match the existing `scripts/pr-health-checker.js` convention, and exported `auditAccessibility()` / `RULES` in the same style so it's unit-testable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved accessible names for search controls and navigation links.
  * Preserved clearer page navigation anchors.
  * Added automated checks for missing alternative text, language metadata, titles, duplicate IDs, and unnamed controls.

* **Chores**
  * Replaced the inline accessibility audit with a reusable checker.
  * Removed the deprecated legacy CI workflow.

* **Tests**
  * Added comprehensive automated coverage for accessibility rules and violation reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->