### PR TITLE
fix(theme): move theme bootstrap below <body> so it stops throwing

### DIFF
--- a/ati-vishisht-seva-medal.html
+++ b/ati-vishisht-seva-medal.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore the Ati Vishisht Seva Medal (AVSM), awarded for distinguished service of an exceptional order in the Indian Armed Forces.">
@@ -36,6 +28,14 @@
     <link rel="stylesheet" href="ati-vishisht-seva-medal.css">
 </head>
 <body class="avsm-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/bharat-award.html
+++ b/bharat-award.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore the Bharat Award, the highest honour under the National Bravery Awards recognizing the most exceptional act of bravery by a child.">
@@ -35,6 +27,14 @@
     <link rel="stylesheet" href="bharat-award.css">
 </head>
 <body class="bha-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="index.html#home" class="nav-logo" id="nav-logo">

--- a/bhitarkanika-wetlands-explorer/bhitarkanika-wetlands-explorer.html
+++ b/bhitarkanika-wetlands-explorer/bhitarkanika-wetlands-explorer.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Bhitarkanika Wetlands Explorer - Explore India's magnificent mangrove paradise, famous for its giant saltwater crocodiles and rich estuarine biodiversity in Odisha." name="description"/>
@@ -42,6 +34,14 @@
     </script>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../index.html#home" class="nav-logo" id="nav-logo">

--- a/defence/armed-forces/index.html
+++ b/defence/armed-forces/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Explore the Indian Armed Forces — Army, Navy, Air Force, CDS, Commands, Ranks, Uniforms, and Equipment." name="description"/>
@@ -20,6 +12,14 @@
     <link href="styles.css" rel="stylesheet"/>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a class="nav-logo" href="../../index.html#home" id="nav-logo">

--- a/economy/rbi-governors/index.html
+++ b/economy/rbi-governors/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Explore the interactive timeline of the Governors of the Reserve Bank of India." name="description"/>
@@ -20,6 +12,14 @@
     <link href="styles.css" rel="stylesheet"/>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a class="nav-logo" href="../../index.html#home" id="nav-logo">

--- a/forts/bahu-fort.html
+++ b/forts/bahu-fort.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Bahu Fort - One of the oldest forts in Jammu, associated with the Bawe Wali Mata Temple.">
@@ -22,6 +14,14 @@
     <link rel="stylesheet" href="bahu-fort.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../index.html" class="nav-logo">

--- a/forts/bekal-sea-fort.html
+++ b/forts/bekal-sea-fort.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Bekal Sea Fort - One of India's finest coastal fortifications highlighting maritime heritage.">
@@ -22,6 +14,14 @@
     <link rel="stylesheet" href="bekal-sea-fort.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../index.html" class="nav-logo">

--- a/forts/chandragiri-fort.html
+++ b/forts/chandragiri-fort.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Chandragiri Fort - The last capital of the Vijayanagara Empire and a remarkable example of South Indian fort architecture.">
@@ -22,6 +14,14 @@
     <link rel="stylesheet" href="chandragiri-fort.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../index.html" class="nav-logo">

--- a/forts/devikot-fort.html
+++ b/forts/devikot-fort.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Devikot Fort - An important medieval fort associated with the early history of Bengal.">
@@ -22,6 +14,14 @@
     <link rel="stylesheet" href="devikot-fort.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../index.html" class="nav-logo">

--- a/forts/diu-fort.html
+++ b/forts/diu-fort.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Diu Fort - A magnificent Portuguese sea fort overlooking the Arabian Sea.">
@@ -22,6 +14,14 @@
     <link rel="stylesheet" href="diu-fort.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../index.html" class="nav-logo">

--- a/forts/mirjan-fort.html
+++ b/forts/mirjan-fort.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>
-        (function () {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
@@ -27,6 +19,14 @@
 </head>
 
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../index.html" class="nav-logo">

--- a/forts/murud-janjira-fort.html
+++ b/forts/murud-janjira-fort.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>
-        (function () {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
@@ -26,6 +18,14 @@
 </head>
 
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../index.html" class="nav-logo">

--- a/forts/panhala-fort.html
+++ b/forts/panhala-fort.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>
-        (function () {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
@@ -27,6 +19,14 @@
 </head>
 
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../index.html" class="nav-logo">

--- a/forts/raigad-fort.html
+++ b/forts/raigad-fort.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>
-        (function () {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
@@ -27,6 +19,14 @@
 </head>
 
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../index.html" class="nav-logo">

--- a/forts/rajmachi-fort.html
+++ b/forts/rajmachi-fort.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Rajmachi Fort - A twin-fort complex with immense strategic importance in the Western Ghats.">
@@ -22,6 +14,14 @@
     <link rel="stylesheet" href="rajmachi-fort.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../index.html" class="nav-logo">

--- a/forts/taragarh-fort.html
+++ b/forts/taragarh-fort.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Taragarh Fort - One of Rajasthan's oldest hill forts known for its strategic location and massive gateways.">
@@ -22,6 +14,14 @@
     <link rel="stylesheet" href="taragarh-fort.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../index.html" class="nav-logo">

--- a/forts/timeline-quiz-hub.html
+++ b/forts/timeline-quiz-hub.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Indian Forts Timeline & Interactive Quiz Hub - Explore India's forts through timelines, comparisons, and quizzes.">
@@ -22,6 +14,14 @@
     <link rel="stylesheet" href="timeline-quiz-hub.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../index.html" class="nav-logo">

--- a/forts/torna-fort.html
+++ b/forts/torna-fort.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>
-        (function () {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
@@ -27,6 +19,14 @@
 </head>
 
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../index.html" class="nav-logo">

--- a/frontend/Nanda-lake-explorer/index.html
+++ b/frontend/Nanda-lake-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -39,6 +31,14 @@
     </head>
 
     <body class="nanda-lake-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/about/about.html
+++ b/frontend/about/about.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Learn the story behind Incredible India Explorer — our mission, timeline, community, and technology stack. Discover how we're mapping India's heritage through open-source.">
@@ -44,6 +36,14 @@
 </head>
 
 <body data-page="about">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- ========== NAVBAR ========== -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/adventure/adventure.html
+++ b/frontend/adventure/adventure.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Adventure Tourism in Incredible India - Trekking, Rafting, Scuba and more.">
@@ -82,6 +74,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/adventure.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../traditional-games/index.html" class="nav-logo">

--- a/frontend/agatti-island-explorer/index.html
+++ b/frontend/agatti-island-explorer/index.html
@@ -1,12 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<script>
-  (function () {
-    const theme = localStorage.getItem('theme') || 'dark';
-    if (theme === 'light') document.body.classList.add('light-theme');
-  })();
-</script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Agatti Island Explorer | Incredible India Explorer</title>
@@ -231,6 +225,14 @@
 </style>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 <header class="navbar scrolled" id="navbar">
   <div class="nav-container">
     <a href="../../index.html#home" class="nav-logo">

--- a/frontend/aghanashini-estuary-explorer/index.html
+++ b/frontend/aghanashini-estuary-explorer/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>(function () { const t = localStorage.getItem('theme') || 'dark'; if (t === 'light') document.body.classList.add('light-theme') })();</script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description"
@@ -18,6 +17,14 @@
 </head>
 
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo"><span class="saffron">Incredible</span><span

--- a/frontend/amrita-devi-bishnoi-wildlife-protection-award-explorer/index.html
+++ b/frontend/amrita-devi-bishnoi-wildlife-protection-award-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Amrita Devi Bishnoi Wildlife Protection Award Explorer - Discover India's national honour recognizing exceptional courage and dedication in wildlife conservation and environmental protection. Learn about its history, inspiration, eligibility, selection process, awardees, and more.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="amrita-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/ancient-cities/ancient-cities.html
+++ b/frontend/ancient-cities/ancient-cities.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="India's Lost Cities & Ancient Civilizations Explorer - Discover Dholavira, Lothal, Pataliputra, Vijayanagara, Taxila, and Fatehpur Sikri with ancient maps, archaeological discoveries, excavation facts, and Before vs Today comparisons.">
@@ -24,6 +16,14 @@
 </head>
 
 <body class="ancient-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/ancient-mathematics-explorer/index.html
+++ b/frontend/ancient-mathematics-explorer/index.html
@@ -1,6 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ancient Indian Mathematics Explorer</title>
+    <link rel="stylesheet" href="../traditional-games/style.css">
+</head>
+<body>
     <script>
         (function() {
             const theme = localStorage.getItem('theme') || 'dark';
@@ -9,12 +15,6 @@
             }
         })();
     </script>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Ancient Indian Mathematics Explorer</title>
-    <link rel="stylesheet" href="../traditional-games/style.css">
-</head>
-<body>
     <div class="container">
         <header>
             <h1>Ancient Indian Mathematics Explorer</h1>

--- a/frontend/ansupa-lake-explorer/index.html
+++ b/frontend/ansupa-lake-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="ansupa.css" />
     </head>
     <body class="ansupa-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/architecture/architecture.html
+++ b/frontend/architecture/architecture.html
@@ -2,14 +2,6 @@
 
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="Explore important museums across India by city, state, and category." name="description"/>
@@ -41,6 +33,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/architecture.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 <header class="navbar scrolled" id="navbar">
 <div class="nav-container">
 <a class="nav-logo" href="../../index.html#home" id="nav-logo">

--- a/frontend/arts-crafts/arts-crafts.html
+++ b/frontend/arts-crafts/arts-crafts.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Arts, Crafts & Shopping - Discover the Handicraft Atlas and GI Tagged Products of India.">
@@ -397,6 +389,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/arts-crafts.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/ashtamudi-lake-explorer/index.html
+++ b/frontend/ashtamudi-lake-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="ashtamudi-lake.css" />
     </head>
     <body class="ashtamudi-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/astronomy/astronomy.html
+++ b/frontend/astronomy/astronomy.html
@@ -2,14 +2,6 @@
 
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="Explore India's astronomy heritage, observatories, milestones, and celestial traditions." name="description"/>
@@ -55,6 +47,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/astronomy.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 <header class="navbar scrolled" id="navbar"><div class="nav-container"><a class="nav-logo" href="../../index.html#home" id="nav-logo"><span class="saffron">Incredible</span> <span class="gold">India</span> <span class="green">Explorer</span></a><button aria-expanded="false" aria-label="Toggle Menu" class="menu-toggle" id="menu-toggle"><span class="bar"></span><span class="bar"></span><span class="bar"></span></button><nav class="nav-menu" id="nav-menu"><a class="nav-link" href="../../index.html#home">Home</a><a class="nav-link" href="../../index.html#map">Interactive Map</a><a class="nav-link" href="../cuisine/cuisine.html">Cuisine</a><a class="nav-link" href="../festivals/festivals.html">Festivals</a><a class="nav-link" href="../culture/culture.html">Culture</a><div class="nav-dropdown"><button class="nav-link dropdown-toggle" style="color:var(--saffron)">Explore More ▾</button><div class="dropdown-menu"><a class="dropdown-item" href="../travel/travel.html">Travel &amp; Destinations</a><a class="dropdown-item" href="../wildlife/wildlife.html">Nature &amp; Wildlife</a><a class="dropdown-item" href="../personalities/personalities.html">Famous Personalities</a><a class="dropdown-item" href="../spiritual/spiritual.html">Spiritual India</a><a class="dropdown-item" href="../arts-crafts/arts-crafts.html">Arts &amp; Crafts</a><a class="dropdown-item" href="../science/science.html">Science</a><a class="dropdown-item" href="astronomy.html" style="color:var(--saffron)">Astronomy Heritage</a></div></div><div class="nav-dropdown"><button class="nav-link dropdown-toggle">Learn &amp; Data ▾</button><div class="dropdown-menu"><a class="dropdown-item" href="../smart-cities/smart-cities.html">Smart Cities</a><a class="dropdown-item" href="../languages/languages.html">Languages of India</a><a class="dropdown-item" href="../data-india/data-india.html">Data &amp; Statistics</a><a class="dropdown-item" href="../learn/learn.html">Learn &amp; Quiz</a></div></div><button aria-label="Toggle Dark/Light Mode" class="btn-theme-toggle" id="theme-toggle" title="Toggle Light Mode">☀️</button><a class="nav-link" href="../premium/premium.html" style="color:var(--gold);font-weight:bold">★ Premium</a>
                 <a href="../../login.html" class="nav-link" id="link-login">Login</a><div class="journey-nav-search">
                     <input type="search" id="journey-search-input" class="journey-search-input" placeholder="Search all explorers…" aria-label="Search across all explorers" autocomplete="off">

--- a/frontend/awards-of-india-explorer/index.html
+++ b/frontend/awards-of-india-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Awards of India Explorer - Discover India's prestigious civilian, gallantry, sports, literature, science, and national recognition honours. Filter by category, explore timelines, and test your knowledge.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="awards-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/bangaram-island/bangaram-island.html
+++ b/frontend/bangaram-island/bangaram-island.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Bangaram Island — a coral atoll in Lakshadweep with a turquoise lagoon, vibrant marine biodiversity, scuba diving, eco-tourism and pristine beaches.">
@@ -46,6 +38,14 @@
 </head>
 
 <body class="bangaram-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/barren-island/barren-island.html
+++ b/frontend/barren-island/barren-island.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Barren Island — India's only confirmed active volcano. Eruption history, marine life, geological formation, wildlife, an interactive map and image gallery.">
@@ -46,6 +38,14 @@
 </head>
 
 <body class="barren-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/bazaars/bazaars.html
+++ b/frontend/bazaars/bazaars.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Explore historic Indian markets and bazaars with search, filters, specialties, history, and cultural details.">
@@ -40,6 +32,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/bazaars.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo">

--- a/frontend/beas-conservation-wetlands-explorer/index.html
+++ b/frontend/beas-conservation-wetlands-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -39,6 +31,14 @@
     </head>
 
     <body class="beas-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/bharat-ratna-explorer/index.html
+++ b/frontend/bharat-ratna-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Bharat Ratna Explorer - Explore India's highest civilian honour awarded for exceptional service in any field of human endeavour. History, medal design, selection process, recipients timeline, facts, FAQs, and image gallery.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="br-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/bharat-ratna-gallery/index.html
+++ b/frontend/bharat-ratna-gallery/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Bharat Ratna Interactive Gallery: Explore portraits, conferring years, national contributions, and biographies of all Bharat Ratna recipients from 1954 to 2024.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="br-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/bhoj-wetlands-explorer/index.html
+++ b/frontend/bhoj-wetlands-explorer/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>(function () { const t = localStorage.getItem('theme') || 'dark'; if (t === 'light') document.body.classList.add('light-theme') })();</script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description"
@@ -18,6 +17,14 @@
 </head>
 
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo"><span class="saffron">Incredible</span><span

--- a/frontend/biosphere-reserves/index.html
+++ b/frontend/biosphere-reserves/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="style.css" />
     </head>
     <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/bird-sanctuaries/index.html
+++ b/frontend/bird-sanctuaries/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="style.css" />
     </head>
     <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/border-explorer/border-explorer.html
+++ b/frontend/border-explorer/border-explorer.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="India's Border Explorer - Interactive hub exploring India's international borders with Pakistan, China, Nepal, Bhutan, Bangladesh, Myanmar, and Sri Lanka. Features border forces, checkpoints, border towns, and country comparison tools.">
@@ -24,6 +16,14 @@
 </head>
 
 <body class="border-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/border-neighbors-quiz/index.html
+++ b/frontend/border-neighbors-quiz/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Test your knowledge of Indian state borders in the Border Neighbors Quiz. Select all states sharing a land border with a given state and earn partial-credit points!">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="border-quiz-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/border-stories/border-stories.html
+++ b/frontend/border-stories/border-stories.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore every border shared between Indian states and discover unique cultures, dialects, foods, markets, rivers, and traditions found along those borders.">
@@ -24,6 +16,14 @@
 </head>
 
 <body class="border-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/bridges/bridges.html
+++ b/frontend/bridges/bridges.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore famous Indian bridges, cantilever structures, cable-stayed sea links, arch marvels, and ancient living root bridges with technical details and construction history.">
@@ -45,6 +37,14 @@
 </head>
 
 <body class="bridges-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/budget-planner/budget-planner.html
+++ b/frontend/budget-planner/budget-planner.html
@@ -2,14 +2,6 @@
 
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="Smart Budget Planner - Get an AI-powered, category-wise cost estimate for your India trip, with travel-style comparisons and money-saving tips." name="description"/>
@@ -21,6 +13,14 @@
 <link href="budget-planner.css" rel="stylesheet"/>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 <!-- Sticky Navigation Bar -->
 <header class="navbar scrolled" id="navbar">
 <div class="nav-container">

--- a/frontend/butterfly/butterfly.html
+++ b/frontend/butterfly/butterfly.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Explore butterfly species found across India with region filters, habitats, seasonal visibility, conservation notes, and interactive galleries.">
@@ -40,6 +32,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/butterfly.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo">

--- a/frontend/car-nicobar-island/car-nicobar-island.html
+++ b/frontend/car-nicobar-island/car-nicobar-island.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Car Nicobar — the most populated island in the Nicobar group, home to the Nicobarese people, coconut plantations, sandy beaches and a rich cultural history.">
@@ -46,6 +38,14 @@
 </head>
 
 <body class="car-nicobar-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/cave-art/cave-art.html
+++ b/frontend/cave-art/cave-art.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore India's ancient cave paintings, frescoes, murals, rock-cut sculptures, and artistic heritage across Ajanta, Ellora, Bhimbetka, and more.">
@@ -24,6 +16,14 @@
     <link rel="stylesheet" href="cave-art.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navigation Bar -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/caves/caves.html
+++ b/frontend/caves/caves.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta
@@ -50,6 +42,14 @@
 </head>
 
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/cbi-knowledge-center/index.html
+++ b/frontend/cbi-knowledge-center/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore the CBI Knowledge Center: Comprehensive guide to India's premier investigative agency - Central Bureau of Investigation, covering history, organization, legal powers, famous cases, and Interpol role.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="cbi-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/changabang/changabang.html
+++ b/frontend/changabang/changabang.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Changabang Mountain, a 6,864 m high peak in the Garhwal Himalayas of Uttarakhand. Discover facts, map locations, image gallery, and climb details.">
@@ -47,6 +39,14 @@
 </head>
 
 <body class="changabang-body-wrapper">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/changelog/changelog.html
+++ b/frontend/changelog/changelog.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
@@ -29,6 +21,14 @@
 </head>
 
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Sticky Navigation Bar -->
     <header class="navbar" id="navbar">
         <div class="nav-container">

--- a/frontend/chief-justices-timeline/index.html
+++ b/frontend/chief-justices-timeline/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -31,6 +23,14 @@
     </head>
 
     <body class="cji-timeline-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/chilika-lake/index.html
+++ b/frontend/chilika-lake/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -39,6 +31,14 @@
     </head>
 
     <body class="chilika-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/climate-zones/climate-zones.html
+++ b/frontend/climate-zones/climate-zones.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore India's diverse climate zones, rainfall distribution, and seasonal variations through an interactive visual map and detailed climate cards.">
@@ -45,6 +37,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/climate-zones.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Sticky Navigation Bar -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/coastal-india/coastal-india.html
+++ b/frontend/coastal-india/coastal-india.html
@@ -2,14 +2,6 @@
 
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="Explore famous beaches and coastal destinations across India by region, state, season, and nearby attractions." name="description"/>
@@ -402,6 +394,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/coastal-india.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 <header class="navbar scrolled" id="navbar">
 <div class="nav-container">
 <a class="nav-logo" href="../../index.html#home" id="nav-logo">

--- a/frontend/coin/coin.html
+++ b/frontend/coin/coin.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
@@ -49,6 +41,14 @@
 </head>
 
 <body class="coins-page-body" data-page="coins">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/community-guides/community-guides.html
+++ b/frontend/community-guides/community-guides.html
@@ -2,14 +2,6 @@
 
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="Browse community-written travel guides for destinations across India." name="description"/>
@@ -41,6 +33,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/community-guides.html">
 </head>
 <body data-page="guides">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 <!-- Sticky Navigation Bar -->
 <header class="navbar scrolled" id="navbar">
 <div class="nav-container">

--- a/frontend/community-guides/guide-editor.html
+++ b/frontend/community-guides/guide-editor.html
@@ -2,14 +2,6 @@
 
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="Write or edit a community travel guide for Incredible India Explorer." name="description"/>
@@ -55,6 +47,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/guide-editor.html">
 </head>
 <body data-page="editor">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 <!-- Sticky Navigation Bar -->
 <header class="navbar scrolled" id="navbar">
 <div class="nav-container">

--- a/frontend/community-guides/guide-moderation.html
+++ b/frontend/community-guides/guide-moderation.html
@@ -2,14 +2,6 @@
 
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="Moderation dashboard for reviewing and publishing community travel guides." name="description"/>
@@ -41,6 +33,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/guide-moderation.html">
 </head>
 <body data-page="moderation">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 <!-- Sticky Navigation Bar -->
 <header class="navbar scrolled" id="navbar">
 <div class="nav-container">

--- a/frontend/community/community.html
+++ b/frontend/community/community.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Meet the Incredible India Explorer open-source community — contributors, maintainers, showcase projects, and ways to get involved.">
@@ -44,6 +36,14 @@
 </head>
 
 <body data-page="community">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/constitution-amendments/constitution-amendments.html
+++ b/frontend/constitution-amendments/constitution-amendments.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Interactive explorer of all 106 Constitutional Amendments of India — timeline, search, decade filter, government tracking, and quiz.">
@@ -29,6 +21,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/constitution-amendments/constitution-amendments.html">
 </head>
 <body class="ca-page-body" data-page="constitution-amendments">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/constitution-makers/index.html
+++ b/frontend/constitution-makers/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Constituent Assembly Learning Hub: Interactive guide introducing members of the Constituent Assembly (Dr. B. R. Ambedkar, Dr. Rajendra Prasad, Nehru, Patel, Hansa Mehta), their roles, contributions, and drafting timeline.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="cm-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/constitution-timeline/index.html
+++ b/frontend/constitution-timeline/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore the interactive, scroll-driven animated timeline of the Indian Constitution from the Constituent Assembly (1946) to landmark amendments and modern governance.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="constitution-timeline-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/contributors/contributors.html
+++ b/frontend/contributors/contributors.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -36,6 +28,14 @@
         <meta property="og:type" content="website" />
     </head>
     <body class="clb-page" data-page="contributors">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- ========== NAVBAR ========== -->
         <header class="clb-navbar" id="clb-navbar">
             <div class="clb-nav-inner">

--- a/frontend/crowd-density/index.html
+++ b/frontend/crowd-density/index.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
@@ -284,6 +276,14 @@
 </head>
 
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
     <!-- SW Update Available Banner -->
     <div id="sw-update-banner" class="sw-update-banner" role="alert" aria-live="polite">

--- a/frontend/cuisine/cuisine.html
+++ b/frontend/cuisine/cuisine.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
@@ -49,6 +41,14 @@
 </head>
 
 <body class="cuisine-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
     <!-- Sticky Navigation Bar -->
     <header class="navbar scrolled" id="navbar">

--- a/frontend/culinary-game/culinary-game.html
+++ b/frontend/culinary-game/culinary-game.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Master Chef India Challenge. Cook iconic dishes from across India!">
@@ -45,6 +37,14 @@
 </head>
 
 <body class="challenge-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/cultural-dna/cultural-dna.html
+++ b/frontend/cultural-dna/cultural-dna.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore India's Cultural DNA with an interactive network graph showing how languages, architecture, music, cuisine, clothing, and philosophy connect and influence one another.">
@@ -45,6 +37,14 @@
 </head>
 
 <body class="dna-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/cultural-footprint/cultural-footprint.html
+++ b/frontend/cultural-footprint/cultural-footprint.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore how each state's culture influences other states through migration, cuisine, music, language, architecture, cinema, textiles, and festivals across India.">
@@ -24,6 +16,14 @@
 </head>
 
 <body class="footprint-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/culture/culture.html
+++ b/frontend/culture/culture.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Discover India's artistic soul: classical dance forms, classical music instruments, and colorful traditional attires.">
@@ -47,6 +39,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/culture.html">
 </head>
 <body class="culture-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
     <!-- Sticky Navigation Bar -->
     <header class="navbar scrolled" id="navbar">

--- a/frontend/dadasaheb-phalke-award-explorer/index.html
+++ b/frontend/dadasaheb-phalke-award-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Dadasaheb Phalke Award Explorer - Discover India's highest honour in cinema. Learn about its history, year instituted, eligibility, selection process, medal design, complete winners, timeline, and facts.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="dp-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/dance/dance.html
+++ b/frontend/dance/dance.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
@@ -45,6 +37,14 @@
 </head>
 
 <body class="dance-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/data-india/data-india.html
+++ b/frontend/data-india/data-india.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Data India - Interactive Statistics Dashboard and State Comparison.">
@@ -117,6 +109,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/data-india.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/deepor-beel-explorer/index.html
+++ b/frontend/deepor-beel-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="deepor-beel.css" />
     </head>
     <body class="deepor-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/destination-comparison/destination-comparison.html
+++ b/frontend/destination-comparison/destination-comparison.html
@@ -1,12 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<script>
-  (function () {
-    const theme = localStorage.getItem('theme') || 'dark';
-    if (theme === 'light') document.body.classList.add('light-theme');
-  })();
-</script>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Destination Comparison Tool | Incredible India Explorer</title>
@@ -125,6 +119,14 @@
 </style>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 <header class="navbar scrolled" id="navbar">
   <div class="nav-container">
     <a href="../../index.html#home" class="nav-logo">

--- a/frontend/drdo-innovations/drdo-innovations.html
+++ b/frontend/drdo-innovations/drdo-innovations.html
@@ -1,12 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') { document.body.classList.add('light-theme'); }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore DRDO Innovations Gallery — India's defence research breakthroughs in missiles, radar, UAVs, avionics, and more.">
@@ -21,6 +15,14 @@
     <meta name="twitter:title" content="DRDO Innovations Gallery | Incredible India Explorer">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Floating Particles Background -->
     <div class="drdo-particles" id="drdo-particles"></div>
 

--- a/frontend/dunagiri/dunagiri.html
+++ b/frontend/dunagiri/dunagiri.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Dunagiri, a majestic 7,066 m peak in the Garhwal Himalayas of Uttarakhand. Discover facts, trekking info, map locations, image gallery, and FAQs.">
@@ -32,6 +24,14 @@
 </head>
 
 <body class="dunagiri-body-wrapper">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/east-kolkata-wetlands-explorer/index.html
+++ b/frontend/east-kolkata-wetlands-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="east-kolkata.css" />
     </head>
     <body class="kolkata-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/excavations/excavations.html
+++ b/frontend/excavations/excavations.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore major archaeological excavation sites in India including Dholavira, Lothal, Rakhigarhi, Kalibangan, Keezhadi, Sinauli, and Bhimbetka with interactive timelines and artifacts.">
@@ -45,6 +37,14 @@
 </head>
 
 <body class="excavations-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/festival-games/festival-games.html
+++ b/frontend/festival-games/festival-games.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Festival Mini-Games Collection">
@@ -20,6 +12,14 @@
     <link rel="stylesheet" href="festival-games.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="index.html" class="nav-logo">

--- a/frontend/festivals/festivals.html
+++ b/frontend/festivals/festivals.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Discover the legends, myths, and celebrations behind India's major festivals. Read stories of Diwali, Holi, Eid, Pongal, Navratri, and Bihu.">
@@ -45,6 +37,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/festivals.html">
 </head>
 <body class="festivals-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
     <!-- Sticky Navigation Bar -->
     <header class="navbar scrolled" id="navbar">

--- a/frontend/folk-tales/folk-tales.html
+++ b/frontend/folk-tales/folk-tales.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Indian Folk Tales, regional oral traditions, legends, and trickster fables grouped by state with search and audio narration.">
@@ -45,6 +37,14 @@
 </head>
 
 <body class="folk-tales-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/fort-architecture/fort-architecture.html
+++ b/frontend/fort-architecture/fort-architecture.html
@@ -1,12 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') { document.body.classList.add('light-theme'); }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Compare Rajput, Mughal, Maratha, and European colonial fort architecture across India — side-by-side architectural highlights, defensive design, and landmark examples.">
@@ -36,6 +30,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/fort-architecture.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo">

--- a/frontend/forts/bidar-fort.html
+++ b/frontend/forts/bidar-fort.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Bidar Fort - An important Bahmani-era fort known for its Persian-inspired architecture and royal palaces.">
@@ -25,6 +17,14 @@
     <link rel="stylesheet" href="bidar-fort.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">

--- a/frontend/forts/chitradurga-fort.html
+++ b/frontend/forts/chitradurga-fort.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Chitradurga Fort - One of India's greatest hill forts, famous for its massive stone fortifications and the legendary tale of Onake Obavva.">
@@ -25,6 +17,14 @@
     <link rel="stylesheet" href="chitradurga-fort.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">

--- a/frontend/forts/fort-william.html
+++ b/frontend/forts/fort-william.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Fort William - The historic British fort in Kolkata that remains an active military establishment.">
@@ -25,6 +17,14 @@
     <link rel="stylesheet" href="fort-william.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">

--- a/frontend/forts/index.html
+++ b/frontend/forts/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Indian Forts Explorer - Discover famous forts across India with their rich history and architecture.">
@@ -20,6 +12,14 @@
     <link rel="stylesheet" href="../traditional-games/style.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../traditional-games/index.html" class="nav-logo">

--- a/frontend/forts/rohtasgarh-fort.html
+++ b/frontend/forts/rohtasgarh-fort.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Rohtasgarh Fort - One of eastern India's largest hill forts, known for its massive gateways and rich medieval history.">
@@ -25,6 +17,14 @@
     <link rel="stylesheet" href="rohtasgarh-fort.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">

--- a/frontend/forts/st-angelo-fort.html
+++ b/frontend/forts/st-angelo-fort.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore St. Angelo Fort - A historic Portuguese fort overlooking the Arabian Sea, later occupied by the Dutch and British.">
@@ -25,6 +17,14 @@
     <link rel="stylesheet" href="st-angelo-fort.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">

--- a/frontend/forts/tiruchirappalli-rock-fort.html
+++ b/frontend/forts/tiruchirappalli-rock-fort.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Tiruchirappalli Rock Fort - An iconic fort built on one of the world's oldest rock formations, renowned for its temples and panoramic views.">
@@ -25,6 +17,14 @@
     <link rel="stylesheet" href="tiruchirappalli-rock-fort.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">

--- a/frontend/forts/vellore-fort.html
+++ b/frontend/forts/vellore-fort.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Vellore Fort - One of the finest surviving examples of military architecture in South India and the site of the Vellore Mutiny of 1806.">
@@ -25,6 +17,14 @@
     <link rel="stylesheet" href="vellore-fort.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">

--- a/frontend/forts/vijaydurg-fort.html
+++ b/frontend/forts/vijaydurg-fort.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Vijaydurg Fort - One of the oldest sea forts on the Konkan coast and a major naval base of the Maratha Empire.">
@@ -25,6 +17,14 @@
     <link rel="stylesheet" href="vijaydurg-fort.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">

--- a/frontend/freedom-fighters-hub/index.html
+++ b/frontend/freedom-fighters-hub/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -31,6 +23,14 @@
     </head>
 
     <body class="ff-hub-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/freedom-movement-explorer/index.html
+++ b/frontend/freedom-movement-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="The Complete Indian Freedom Movement Explorer (1770–1947) — Comprehensive educational portal covering Early Resistance, Swadeshi Movement, Non-Cooperation, Civil Disobedience, Quit India, INA, Revolutionary Organizations, Major Leaders, and Primary Historical Documents.">
@@ -24,6 +16,14 @@
 </head>
 
 <body class="freedom-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/freedom-story/freedom-story.html
+++ b/frontend/freedom-story/freedom-story.html
@@ -2,14 +2,6 @@
 
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="Interactive Freedom Story - Choose your path and experience the Indian Independence Movement." name="description"/>
@@ -67,6 +59,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/freedom-story.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 <main class="story-container" id="app-root">
 <a class="back-link" href="../personalities/personalities.html">← Back to Personalities</a>
 <!-- Screen 1: The Crossroads -->

--- a/frontend/gamification/achievements.html
+++ b/frontend/gamification/achievements.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Track your XP, level, travel streak, badges, and daily/weekly/monthly challenges on the Incredible India Explorer.">
@@ -25,6 +17,14 @@
 </head>
 
 <body class="gamification-body" data-page="achievements" data-gam-daily-login="true">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/gamification/leaderboard.html
+++ b/frontend/gamification/leaderboard.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="See how your India exploration XP stacks up on the global and friends leaderboards.">
@@ -25,6 +17,14 @@
 </head>
 
 <body class="gamification-body" data-page="leaderboard">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/ganges-scrollytelling/index.html
+++ b/frontend/ganges-scrollytelling/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Embark on a guided scrollytelling journey following the Ganges River from its origin at Gangotri Glacier down to the Bay of Bengal, exploring geography, ecology, and cultural heritage.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="ganges-scrolly-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/general-elections-timeline/index.html
+++ b/frontend/general-elections-timeline/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -31,6 +23,14 @@
     </head>
 
     <body class="elections-timeline-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/geological-wonders/index.html
+++ b/frontend/geological-wonders/index.html
@@ -1,6 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Indian Geological Wonders Explorer</title>
+    <link rel="stylesheet" href="../traditional-games/style.css">
+</head>
+<body>
     <script>
         (function() {
             const theme = localStorage.getItem('theme') || 'dark';
@@ -9,12 +15,6 @@
             }
         })();
     </script>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Indian Geological Wonders Explorer</title>
-    <link rel="stylesheet" href="../traditional-games/style.css">
-</head>
-<body>
     <header>
         <h1>Indian Geological Wonders Explorer</h1>
         <p>Discover India's unique geological formations</p>

--- a/frontend/gi-tags-explorer/index.html
+++ b/frontend/gi-tags-explorer/index.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <script>(function(){const t=localStorage.getItem('theme')||'dark';if(t==='light')document.body.classList.add('light-theme')})();</script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Explore India's Geographical Indication (GI) tags — browse 50+ GI-protected products by state and category, learn how GI registration works, and test yourself with an interactive quiz." />
@@ -13,6 +12,14 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo" id="nav-logo"><span class="saffron">Incredible</span> <span class="gold">India</span> <span class="green">Explorer</span></a>

--- a/frontend/glaciers-explorer/index.html
+++ b/frontend/glaciers-explorer/index.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <script>(function(){const t=localStorage.getItem('theme')||'dark';if(t==='light')document.body.classList.add('light-theme')})();</script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Explore the Himalayan glaciers of India — Siachen, Gangotri, Zemu, Bara Shigri and more — with basin and range filters, retreat comparisons, glacier anatomy, GLOF case studies and monitoring institutions." />
@@ -13,6 +12,14 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo" id="nav-logo"><span class="saffron">Incredible</span> <span class="gold">India</span> <span class="green">Explorer</span></a>

--- a/frontend/great-nicobar/great-nicobar.html
+++ b/frontend/great-nicobar/great-nicobar.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Great Nicobar Island — India's largest island in the Nicobar group. History, geography, Indira Point, Campbell Bay National Park, flora & fauna, climate, an interactive map and image gallery.">
@@ -46,6 +38,14 @@
 </head>
 
 <body class="nicobar-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/green-revolution/green-revolution.html
+++ b/frontend/green-revolution/green-revolution.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Animated Explainer: The Green Revolution in India - Explore the 1960s-70s agricultural transformation, HYV seeds, irrigation expansion, animated yield-increase chart, and balanced ecological analysis.">
@@ -24,6 +16,14 @@
 </head>
 
 <body class="explainer-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/guess-up-district/guess-up-district.html
+++ b/frontend/guess-up-district/guess-up-district.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Guess the Uttar Pradesh District Game - Educational quiz where users identify UP districts based on clues across Easy, Medium, Hard, and Timed Challenge modes.">
@@ -24,6 +16,14 @@
 </head>
 
 <body class="district-game-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/haiderpur-wetland-explorer/index.html
+++ b/frontend/haiderpur-wetland-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="haiderpur.css" />
     </head>
     <body class="haiderpur-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/handloom/index.html
+++ b/frontend/handloom/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Explore India's famous handloom traditions by state, weaving techniques, and cultural significance.">
@@ -20,6 +12,14 @@
   <link rel="stylesheet" href="../traditional-games/style.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/help/help.html
+++ b/frontend/help/help.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Find answers about the Interactive Map, Bookmarks, States, Offline Mode, and more in the Incredible India Explorer Help Center.">
@@ -45,6 +37,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/help/help.html">
 </head>
 <body class="help-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
     <!-- Sticky Navigation Bar -->
     <header class="navbar scrolled" id="navbar">

--- a/frontend/heritage-threats/heritage-threats.html
+++ b/frontend/heritage-threats/heritage-threats.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Heritage Threat Monitor highlighting endangered heritage sites in India threatened by pollution, climate change, tourism pressure, and neglect.">
@@ -38,6 +30,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/heritage-threats.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo">

--- a/frontend/heritage-trees/heritage-trees.html
+++ b/frontend/heritage-trees/heritage-trees.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Explore historically and culturally significant heritage trees across India.">
@@ -38,6 +30,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/heritage-trees.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo">

--- a/frontend/heritage/heritage.html
+++ b/frontend/heritage/heritage.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Heritage Sites Explorer - Discover India's magnificent UNESCO and national heritage monuments.">
@@ -122,6 +114,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/heritage.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../traditional-games/index.html" class="nav-logo">

--- a/frontend/hidden-gems/hidden-gems.html
+++ b/frontend/hidden-gems/hidden-gems.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="description" content="Discover India's hidden gems — offbeat valleys, islands, deserts and hill stations beyond the well-trodden tourist trail.">
@@ -215,6 +207,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/hidden-gems.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
     <!-- Sticky Navigation Bar -->
     <header class="navbar scrolled" id="navbar">

--- a/frontend/hidden-wonders/hidden-wonders.html
+++ b/frontend/hidden-wonders/hidden-wonders.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Explore India's lesser-known natural wonders with search, state filters, image galleries and fun facts.">
@@ -38,6 +30,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/hidden-wonders.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo">

--- a/frontend/hill-stations/hill-stations.html
+++ b/frontend/hill-stations/hill-stations.html
@@ -2,14 +2,6 @@
 
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="Explore popular and lesser-known hill stations across India by region, altitude, season, and attractions." name="description"/>
@@ -395,6 +387,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/hill-stations.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 <header class="navbar scrolled" id="navbar">
 <div class="nav-container">
 <a class="nav-logo" href="../../index.html#home" id="nav-logo">

--- a/frontend/himalayan-game/himalayan-game.html
+++ b/frontend/himalayan-game/himalayan-game.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Himalayan Expedition Survival Game.">
@@ -20,6 +12,14 @@
     <link rel="stylesheet" href="himalayan-game.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="index.html" class="nav-logo">

--- a/frontend/hirakud-reservoir-wetland-explorer/index.html
+++ b/frontend/hirakud-reservoir-wetland-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -39,6 +31,14 @@
     </head>
 
     <body class="hirakud-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/hygam-wetland-explorer/index.html
+++ b/frontend/hygam-wetland-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="hygam.css" />
     </head>
     <body class="hygam-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/india-3d-map/india-3d-map.html
+++ b/frontend/india-3d-map/india-3d-map.html
@@ -2,14 +2,6 @@
 
 <html lang="en">
 <head>
-<script>
-    (function() {
-        const theme = localStorage.getItem('theme') || 'dark';
-        if (theme === 'light') {
-            document.body.classList.add('light-theme');
-        }
-    })();
-</script>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="Explore India in 3D — zoom from a national view down to individual states and cities, filter destinations by category, and discover nearby attractions on an interactive map." name="description"/>
@@ -49,6 +41,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/india-3d-map.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 <!-- Sticky Navigation Bar -->
 <header class="navbar scrolled" id="navbar">
 <div class="nav-container">

--- a/frontend/indian-census-visualizer/index.html
+++ b/frontend/indian-census-visualizer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Indian Census Data Visualizer - Interactive visualization of India's census data including population growth, literacy rates, gender ratio, and rural vs urban demographics across states from 1951 to 2011.">
@@ -20,6 +12,14 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/indian-empires-explorer/index.html
+++ b/frontend/indian-empires-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Every Major Empire of India Interactive Timeline — Explore 10 great empires and civilizations from Indus Valley, Mahajanapadas, Maurya, Gupta, Chalukya, Chola, Vijayanagara, Mughal, Maratha, and Sikh Empire with interactive territorial expansion and decline maps.">
@@ -24,6 +16,14 @@
 </head>
 
 <body class="empires-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/indias-firsts/indias-firsts.html
+++ b/frontend/indias-firsts/indias-firsts.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="India's 'Firsts' Encyclopedia - Interactive hub celebrating major Indian achievements: First Satellite (Aryabhata), First Woman PM (Indira Gandhi), First Metro (Kolkata), First IIT (Kharagpur), First High Court, First Nobel Laureate (Tagore), and First National Park (Corbett).">
@@ -24,6 +16,14 @@
 </head>
 
 <body class="firsts-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/innovation-timeline/index.html
+++ b/frontend/innovation-timeline/index.html
@@ -1,6 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Indian Innovation Timeline</title>
+    <link rel="stylesheet" href="../traditional-games/style.css">
+</head>
+<body>
     <script>
         (function() {
             const theme = localStorage.getItem('theme') || 'dark';
@@ -9,12 +15,6 @@
             }
         })();
     </script>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Indian Innovation Timeline</title>
-    <link rel="stylesheet" href="../traditional-games/style.css">
-</head>
-<body>
     <div class="container">
         <header>
             <h1>Indian Innovation Timeline</h1>

--- a/frontend/islands-explorer/index.html
+++ b/frontend/islands-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="style.css" />
     </head>
     <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/islands/islands.html
+++ b/frontend/islands/islands.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore the Islands of India — Andaman & Nicobar, Lakshadweep, Majuli, the Sundarbans and more — with an interactive map, searchable island cards, and key statistics.">
@@ -46,6 +38,14 @@
 </head>
 
 <body class="islands-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/journey/journey.html
+++ b/frontend/journey/journey.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="My India Journey - all the monuments, dishes, sites and stories you've bookmarked across every explorer, in one place.">
@@ -38,6 +30,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/journey.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo">

--- a/frontend/kanchenjunga/kanchenjunga.html
+++ b/frontend/kanchenjunga/kanchenjunga.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Kanchenjunga, India's highest mountain at 8,586 m in Sikkim. Discover facts, map locations, image gallery, trekking info, and more.">
@@ -32,6 +24,14 @@
 </head>
 
 <body class="kanchenjunga-body-wrapper">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/kanwar-lake-explorer/index.html
+++ b/frontend/kanwar-lake-explorer/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>(function () { const t = localStorage.getItem('theme') || 'dark'; if (t === 'light') document.body.classList.add('light-theme') })();</script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description"
@@ -18,6 +17,14 @@
 </head>
 
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo"><span class="saffron">Incredible</span><span

--- a/frontend/kavaratti-island/kavaratti-island.html
+++ b/frontend/kavaratti-island/kavaratti-island.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Kavaratti Island — the administrative capital of Lakshadweep, known for its calm lagoon, marine aquarium, coral reefs, culture, tourism and historic mosques.">
@@ -46,6 +38,14 @@
 </head>
 
 <body class="kavaratti-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/kedarnath/kedarnath.html
+++ b/frontend/kedarnath/kedarnath.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Kedarnath Peak, a sacred 6,940 m mountain in the Garhwal Himalayas of Uttarakhand. Discover facts, map locations, image gallery, trekking info, and more.">
@@ -32,6 +24,14 @@
 </head>
 
 <body class="kedarnath-body-wrapper">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/keshopur-miani-wetland-explorer/index.html
+++ b/frontend/keshopur-miani-wetland-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="keshopur-miani.css" />
     </head>
     <body class="keshopur-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/kingdoms/index.html
+++ b/frontend/kingdoms/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Explore India's major ancient kingdoms and empires through an animated timeline and interactive cards.">
@@ -17,6 +9,14 @@
   <link rel="stylesheet" href="../traditional-games/style.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo">

--- a/frontend/kolleru-lake/index.html
+++ b/frontend/kolleru-lake/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -39,6 +31,14 @@
     </head>
 
     <body class="kolleru-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/lalit-kala-akademi-award-explorer/index.html
+++ b/frontend/lalit-kala-akademi-award-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Lalit Kala Akademi Award Explorer - Discover India's National Academy of Art and its honours recognizing excellence in the visual arts, covering history, eligibility, painting, sculpture, printmaking, ceramics, selection process, awardees, and gallery.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="lka-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/languages/languages.html
+++ b/frontend/languages/languages.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Languages of India - Explore the linguistic diversity, dialects, and scripts.">
@@ -238,6 +230,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/languages.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/learn/learn.html
+++ b/frontend/learn/learn.html
@@ -2,14 +2,6 @@
 
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="Learn India - Interactive Courses, Quizzes, and Kids Zone." name="description"/>
@@ -118,6 +110,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/learn.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 <header class="navbar scrolled" id="navbar">
 <div class="nav-container">
 <a class="nav-logo" href="../../index.html#home" id="nav-logo">

--- a/frontend/lighthouses/lighthouses.html
+++ b/frontend/lighthouses/lighthouses.html
@@ -2,14 +2,6 @@
 
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="Explore historic and modern lighthouses along India's coastline." name="description"/>
@@ -350,6 +342,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/lighthouses.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 <header class="navbar scrolled" id="navbar">
 <div class="nav-container">
 <a class="nav-logo" href="../../index.html#home" id="nav-logo">

--- a/frontend/literacy-chart-race/literacy-chart-race.html
+++ b/frontend/literacy-chart-race/literacy-chart-race.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Data Viz: Literacy Rate Growth by State (Animated Bar-Chart Race) - Interactive visualization tracking Indian literacy rate progression across Census years from 1951 to 2011.">
@@ -24,6 +16,14 @@
 </head>
 
 <body class="race-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/literature/literature.html
+++ b/frontend/literature/literature.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
@@ -46,6 +38,14 @@
 </head>
 
 <body class="literature-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/little-andaman/index.html
+++ b/frontend/little-andaman/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Little Andaman Island — Butler Bay surfing, White Surf Waterfall, pristine rainforests, dugong habitat, and the island's unique geography. Interactive map, image gallery, and detailed guides.">
@@ -46,6 +38,14 @@
 </head>
 
 <body class="little-andaman-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/loktak-lake/index.html
+++ b/frontend/loktak-lake/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -39,6 +31,14 @@
     </head>
 
     <body class="loktak-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/making-of-modern-india/index.html
+++ b/frontend/making-of-modern-india/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="The Making of Modern India (1757–1947) — Interactive historical journey from the Battle of Plassey to Indian Independence featuring Governors-General, British Acts, Revolts, Social Reforms, Freedom Movements, and Interactive SVG Historic Centers Map.">
@@ -24,6 +16,14 @@
 </head>
 
 <body class="modern-india-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/maritime-heritage-explorer/index.html
+++ b/frontend/maritime-heritage-explorer/index.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <script>(function(){const t=localStorage.getItem('theme')||'dark';if(t==='light')document.body.classList.add('light-theme')})();</script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Explore India's maritime heritage — from the Lothal dockyard and Muziris to the Chola navy and the 13 modern major ports — with a 5,000-year timeline, traditional shipbuilding and navigation." />
@@ -13,6 +12,14 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo" id="nav-logo"><span class="saffron">Incredible</span> <span class="gold">India</span> <span class="green">Explorer</span></a>

--- a/frontend/martial-arts-explorer/index.html
+++ b/frontend/martial-arts-explorer/index.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <script>(function(){const t=localStorage.getItem('theme')||'dark';if(t==='light')document.body.classList.add('light-theme')})();</script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Explore India's traditional martial arts — Kalaripayattu, Silambam, Thang-Ta, Gatka, Mardani Khel, Kushti and more, with training stages, weapons, history and an endangerment status for each." />
@@ -13,6 +12,14 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo" id="nav-logo"><span class="saffron">Incredible</span> <span class="gold">India</span> <span class="green">Explorer</span></a>

--- a/frontend/medicinal-plants/medicinal-plants.html
+++ b/frontend/medicinal-plants/medicinal-plants.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Explore Indian medicinal plants, botanical names, traditional Ayurvedic uses, habitats, and interesting facts.">
@@ -38,6 +30,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/medicinal-plants.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo">

--- a/frontend/meru-peak/meru-peak.html
+++ b/frontend/meru-peak/meru-peak.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Meru Peak Mountain, a 6,660 m high peak in the Garhwal Range of Uttarakhand. Discover facts, map locations, image gallery, and climb details.">
@@ -47,6 +39,14 @@
 </head>
 
 <body class="meru-peak-body-wrapper">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/middle-andaman/middle-andaman.html
+++ b/frontend/middle-andaman/middle-andaman.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Middle Andaman — Baratang's limestone caves, mangrove forests, beaches, villages, and flora & fauna, with an interactive map and image gallery.">
@@ -46,6 +38,14 @@
 </head>
 
 <body class="mandaman-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/minicoy-island/minicoy-island.html
+++ b/frontend/minicoy-island/minicoy-island.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Minicoy Island — home to a historic lighthouse, a thriving tuna fishing industry, the Mahl-speaking community, expansive lagoons, rich marine biodiversity and a distinct culture.">
@@ -46,6 +38,14 @@
 </head>
 
 <body class="minicoy-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/monsoon-explainer/index.html
+++ b/frontend/monsoon-explainer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore the scientific meteorology of the Indian monsoon system — differential heating, wind reversals, Southwest vs. Northeast monsoon wind paths based on India Meteorological Department (IMD) principles.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="monsoon-explainer-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/monsoon-game/monsoon-game.html
+++ b/frontend/monsoon-game/monsoon-game.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Monsoon Strategy Game: Balance water levels to prevent floods and droughts.">
@@ -45,6 +37,14 @@
 </head>
 
 <body class="challenge-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/monument-puzzle/monument-puzzle.html
+++ b/frontend/monument-puzzle/monument-puzzle.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Monument Builder Challenge - Reconstruct iconic Indian monuments in this puzzle game.">
@@ -20,6 +12,14 @@
     <link rel="stylesheet" href="monument-puzzle.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">

--- a/frontend/monuments/monuments.html
+++ b/frontend/monuments/monuments.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Monuments Explorer - Discover famous Indian monuments and architectural wonders.">
@@ -139,6 +131,14 @@ body{
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/monuments.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../traditional-games/index.html" class="nav-logo">

--- a/frontend/mountain-railways-explorer/index.html
+++ b/frontend/mountain-railways-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="railways.css" />
     </head>
     <body class="railways-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/mountain-ranges/index.html
+++ b/frontend/mountain-ranges/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="style.css" />
     </head>
     <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/mountains/index.html
+++ b/frontend/mountains/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore India's majestic mountains — from Himalayan giants to the Western Ghats. Discover peaks by range, height, difficulty, and region.">
@@ -27,6 +19,14 @@
 </head>
 
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a class="nav-logo" href="../../index.html#home" id="nav-logo">

--- a/frontend/museums/museums.html
+++ b/frontend/museums/museums.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Explore important museums across India by city, state, and category.">
@@ -40,6 +32,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/museums.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/music/music.html
+++ b/frontend/music/music.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
@@ -47,6 +39,14 @@
 </head>
 
 <body class="music-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
     <!-- Sticky Navigation Bar -->
     <header class="navbar scrolled" id="navbar">

--- a/frontend/musical-instruments/musical-instruments.html
+++ b/frontend/musical-instruments/musical-instruments.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Explore Indian traditional musical instruments by category, region, music tradition, construction, and cultural context.">
@@ -40,6 +32,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/musical-instruments.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo">

--- a/frontend/nanda-devi/nanda-devi.html
+++ b/frontend/nanda-devi/nanda-devi.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Nanda Devi, India's second highest mountain at 7,816 m in Uttarakhand. Discover facts, biodiversity, trekking info, map locations, image gallery, and FAQs.">
@@ -32,6 +24,14 @@
 </head>
 
 <body class="nanda-devi-body-wrapper">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/nanda-kot/nanda-kot.html
+++ b/frontend/nanda-kot/nanda-kot.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Nanda Kot Mountain, a 6,861 m high peak in the Kumaon Himalayas of Uttarakhand. Discover facts, map locations, image gallery, and climb details.">
@@ -47,6 +39,14 @@
 </head>
 
 <body class="nanda-kot-body-wrapper">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/nao-sena-medal-explorer/index.html
+++ b/frontend/nao-sena-medal-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Nao Sena Medal Explorer - Explore the Indian Navy's gallantry honour awarded for exceptional devotion to duty or courage of special significance to the Navy. History, eligibility, medal design, naval operations, selection process, awardees, timeline, and image gallery.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="nsm-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/narcondam-island/narcondam-island.html
+++ b/frontend/narcondam-island/narcondam-island.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Narcondam Island — a remote, extinct volcanic island in the Bay of Bengal and the only home of the endemic Narcondam Hornbill.">
@@ -46,6 +38,14 @@
 </head>
 
 <body class="narcondam-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/national-awards-timeline-quiz-hub/index.html
+++ b/frontend/national-awards-timeline-quiz-hub/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Indian National Awards Timeline & Interactive Quiz Hub - Explore, compare, and test your knowledge of India's Civilian, Gallantry, Sports, Literature, and Science honours.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="hub-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/national-awards/national-awards.html
+++ b/frontend/national-awards/national-awards.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore India's National Awards Explorer: Searchable encyclopedia of Civilian, Gallantry, Sports, and Literature honours detailing Eligibility, History, Medal Design, Winners, and Interesting Facts.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="awards-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/national-bal-shree-award-explorer/index.html
+++ b/frontend/national-bal-shree-award-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="National Bal Shree Award Explorer - Discover India's prestigious award recognizing exceptional creative talent among children. Learn about history, eligibility, categories, selection process, and past winners.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="bal-shree-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/national-communal-harmony-award-explorer/index.html
+++ b/frontend/national-communal-harmony-award-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="National Communal Harmony Award Explorer - Discover India's prestigious national honour recognizing individuals and organizations promoting peace, communal harmony, and national integration.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="harmony-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/national-energy-conservation-awards-explorer/index.html
+++ b/frontend/national-energy-conservation-awards-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="National Energy Conservation Awards Explorer - Discover India's prestigious awards recognizing excellence in energy efficiency. Learn about its history, eligibility, award categories, selection process, conservation initiatives, awardees, and timeline.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="nec-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/national-florence-nightingale-award-explorer/index.html
+++ b/frontend/national-florence-nightingale-award-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="National Florence Nightingale Award Explorer - Discover India's highest recognition for excellence in nursing services and healthcare contributions.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="florence-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/national-parks-explorer/index.html
+++ b/frontend/national-parks-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="/frontend/national-parks-explorer/styles.css" />
     </head>
     <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/national-parks-timeline/national-parks-timeline.html
+++ b/frontend/national-parks-timeline/national-parks-timeline.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore the history and timeline of India's national parks, biosphere reserves, and wildlife sanctuaries from 1936 to the present.">
@@ -45,6 +37,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/national-parks-timeline.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Sticky Navigation Bar -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/national-parks/balpakram-national-park-explorer/index.html
+++ b/frontend/national-parks/balpakram-national-park-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -31,6 +23,14 @@
     </head>
 
     <body class="balpakram-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/national-parks/bandhavgarh-national-park-explorer/index.html
+++ b/frontend/national-parks/bandhavgarh-national-park-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>
-    (function() {
-      const theme = localStorage.getItem('theme') || 'dark';
-      if (theme === 'light') {
-        document.body.classList.add('light-theme');
-      }
-    })();
-  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Explore Bandhavgarh National Park in Madhya Pradesh — home to the highest density of Bengal Tigers in India and the ancient Bandhavgarh Fort." />
@@ -23,6 +15,14 @@
   <meta property="og:type" content="website" />
 </head>
 <body class="bandhavgarh-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/national-parks/bannerghatta-national-park-explorer/index.html
+++ b/frontend/national-parks/bannerghatta-national-park-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>
-    (function() {
-      const theme = localStorage.getItem('theme') || 'dark';
-      if (theme === 'light') {
-        document.body.classList.add('light-theme');
-      }
-    })();
-  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Explore Bannerghatta National Park near Bengaluru — famous for its grand safari, India's first Butterfly Park, and wildlife rescue centre." />
@@ -23,6 +15,14 @@
   <meta property="og:type" content="website" />
 </head>
 <body class="bannerghatta-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/national-parks/clouded-leopard-national-park/clouded-leopard-national-park.html
+++ b/frontend/national-parks/clouded-leopard-national-park/clouded-leopard-national-park.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Clouded Leopard National Park Explorer - Explore India's only national park named after the elusive Clouded Leopard, located in Tripura." name="description"/>
@@ -42,6 +34,14 @@
     </script>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/national-parks/dachigam-national-park-explorer/index.html
+++ b/frontend/national-parks/dachigam-national-park-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>
-    (function() {
-      const theme = localStorage.getItem('theme') || 'dark';
-      if (theme === 'light') {
-        document.body.classList.add('light-theme');
-      }
-    })();
-  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Explore Dachigam National Park in Jammu & Kashmir — the last refuge of the endangered Hangul (Kashmir Stag) in the Himalayas." />
@@ -23,6 +15,14 @@
   <meta property="og:type" content="website" />
 </head>
 <body class="dachigam-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/national-parks/dibru-saikhowa-national-park/dibru-saikhowa-national-park.html
+++ b/frontend/national-parks/dibru-saikhowa-national-park/dibru-saikhowa-national-park.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Dibru-Saikhowa National Park Explorer - Discover the unique river island ecosystem, feral horses, and wetlands of Assam." name="description"/>
@@ -42,6 +34,14 @@
     </script>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/national-parks/dudhwa-national-park-explorer/index.html
+++ b/frontend/national-parks/dudhwa-national-park-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -39,6 +31,14 @@
     </head>
 
     <body class="dudhwa-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/national-parks/gorumara-national-park/gorumara-national-park.html
+++ b/frontend/national-parks/gorumara-national-park/gorumara-national-park.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Gorumara National Park Explorer - Discover the Indian One-Horned Rhinoceros, dense Sal forests, and watchtowers in the Dooars region of West Bengal." name="description"/>
@@ -42,6 +34,14 @@
     </script>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/national-parks/gulf-of-mannar-marine-national-park/gulf-of-mannar-marine-national-park.html
+++ b/frontend/national-parks/gulf-of-mannar-marine-national-park/gulf-of-mannar-marine-national-park.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Gulf of Mannar Marine National Park Explorer - Discover India's first marine biosphere reserve, home to coral reefs, dugongs, and dolphins." name="description"/>
@@ -42,6 +34,14 @@
     </script>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/national-parks/hemis-national-park-explorer/index.html
+++ b/frontend/national-parks/hemis-national-park-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -39,6 +31,14 @@
     </head>
 
     <body class="hemis-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/national-parks/indravati-national-park/indravati-national-park.html
+++ b/frontend/national-parks/indravati-national-park/indravati-national-park.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Indravati National Park Explorer - Discover the Tiger Reserve, Wild Buffalo, Indravati River, and dense forests of Chhattisgarh." name="description"/>
@@ -42,6 +34,14 @@
     </script>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/national-parks/jim-corbett-national-park-explorer/index.html
+++ b/frontend/national-parks/jim-corbett-national-park-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -36,6 +28,14 @@
     </head>
 
     <body class="corbett-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/national-parks/kanha-national-park-explorer/index.html
+++ b/frontend/national-parks/kanha-national-park-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -31,6 +23,14 @@
     </head>
 
     <body class="kanha-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/national-parks/kaziranga-national-park-explorer/index.html
+++ b/frontend/national-parks/kaziranga-national-park-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -39,6 +31,14 @@
     </head>
 
     <body class="kaziranga-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/national-parks/keoladeo-national-park-explorer/index.html
+++ b/frontend/national-parks/keoladeo-national-park-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -39,6 +31,14 @@
     </head>
 
     <body class="keoladeo-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/national-parks/kuno-national-park-explorer/index.html
+++ b/frontend/national-parks/kuno-national-park-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>
-    (function() {
-      const theme = localStorage.getItem('theme') || 'dark';
-      if (theme === 'light') {
-        document.body.classList.add('light-theme');
-      }
-    })();
-  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Explore Kuno National Park in Madhya Pradesh — globally recognized for the historic African Cheetah reintroduction project." />
@@ -23,6 +15,14 @@
   <meta property="og:type" content="website" />
 </head>
 <body class="kuno-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/national-parks/manas-national-park-explorer/index.html
+++ b/frontend/national-parks/manas-national-park-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -39,6 +31,14 @@
     </head>
 
     <body class="manas-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/national-parks/mouling-national-park-explorer/index.html
+++ b/frontend/national-parks/mouling-national-park-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -39,6 +31,14 @@
     </head>
 
     <body class="mouling-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/national-parks/namdapha-national-park-explorer/index.html
+++ b/frontend/national-parks/namdapha-national-park-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -39,6 +31,14 @@
     </head>
 
     <body class="namdapha-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/national-parks/orang-national-park/orang-national-park.html
+++ b/frontend/national-parks/orang-national-park/orang-national-park.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Orang National Park Explorer - Discover the 'Mini Kaziranga', home to the One-Horned Rhinoceros and the Bengal Tiger in Assam." name="description"/>
@@ -42,6 +34,14 @@
     </script>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/national-parks/panna-national-park/panna-national-park.html
+++ b/frontend/national-parks/panna-national-park/panna-national-park.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Panna National Park Explorer - Discover the UNESCO Biosphere Reserve, Tiger Conservation, Ken River, and rich wildlife." name="description"/>
@@ -42,6 +34,14 @@
     </script>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/national-parks/pench-national-park-explorer/index.html
+++ b/frontend/national-parks/pench-national-park-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>
-    (function() {
-      const theme = localStorage.getItem('theme') || 'dark';
-      if (theme === 'light') {
-        document.body.classList.add('light-theme');
-      }
-    })();
-  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Explore Pench National Park in Madhya Pradesh — the forest that inspired Rudyard Kipling's The Jungle Book." />
@@ -23,6 +15,14 @@
   <meta property="og:type" content="website" />
 </head>
 <body class="pench-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/national-parks/periyar-national-park-explorer/index.html
+++ b/frontend/national-parks/periyar-national-park-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -31,6 +23,14 @@
     </head>
 
     <body class="periyar-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/national-parks/rajaji-national-park-explorer/index.html
+++ b/frontend/national-parks/rajaji-national-park-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>
-    (function() {
-      const theme = localStorage.getItem('theme') || 'dark';
-      if (theme === 'light') {
-        document.body.classList.add('light-theme');
-      }
-    })();
-  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Explore Rajaji National Park in Uttarakhand — a vital elephant corridor and tiger reserve nestled in the Shivalik Hills." />
@@ -23,6 +15,14 @@
   <meta property="og:type" content="website" />
 </head>
 <body class="rajaji-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/national-parks/simlipal-national-park-explorer/index.html
+++ b/frontend/national-parks/simlipal-national-park-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -39,6 +31,14 @@
     </head>
 
     <body class="simlipal-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/national-parks/sri-venkateswara-national-park/sri-venkateswara-national-park.html
+++ b/frontend/national-parks/sri-venkateswara-national-park/sri-venkateswara-national-park.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Sri Venkateswara National Park Explorer - Discover the rugged Eastern Ghats, majestic waterfalls like Talakona, and sacred forests of Andhra Pradesh." name="description"/>
@@ -42,6 +34,14 @@
     </script>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/national-parks/valmiki-national-park-explorer/index.html
+++ b/frontend/national-parks/valmiki-national-park-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <script>
-    (function() {
-      const theme = localStorage.getItem('theme') || 'dark';
-      if (theme === 'light') {
-        document.body.classList.add('light-theme');
-      }
-    })();
-  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Explore Valmiki National Park in Bihar — the state's only National Park and a vital Tiger Reserve in the Terai region." />
@@ -23,6 +15,14 @@
   <meta property="og:type" content="website" />
 </head>
 <body class="valmiki-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/national-teachers-award-explorer/index.html
+++ b/frontend/national-teachers-award-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="National Teachers' Award Explorer - Discover India's national honour recognizing exceptional contributions made by teachers towards education and nation-building. Learn about its history, eligibility, selection process, categories, ceremony, and distinguished teachers.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="nta-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/national-tourism-awards-explorer/index.html
+++ b/frontend/national-tourism-awards-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="National Tourism Awards Explorer - Discover India's prestigious awards presented for excellence in promoting tourism, hospitality, and heritage conservation. Learn about its history, purpose, eligibility, award categories, selection process, awardees, timeline, and interesting facts.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="nta-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/neelkanth/neelkanth.html
+++ b/frontend/neelkanth/neelkanth.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Neelkanth, a 6,596 m peak in the Garhwal Himalayas of Uttarakhand. Discover facts, trekking information, map locations, image gallery, and FAQs.">
@@ -43,6 +35,14 @@
 </head>
 
 <body class="neelkanth-body-wrapper">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/newsletter/newsletter.html
+++ b/frontend/newsletter/newsletter.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
@@ -31,6 +23,14 @@
 </head>
 
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
     <!-- Sticky Navigation Bar -->
     <header class="navbar" id="navbar">

--- a/frontend/north-andaman-island/north-andaman-island.html
+++ b/frontend/north-andaman-island/north-andaman-island.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore North Andaman — home to Saddle Peak, the highest point in the Andaman & Nicobar Islands, along with Saddle Peak National Park, mangrove creeks, wildlife, trekking trails and tropical climate.">
@@ -46,6 +38,14 @@
 </head>
 
 <body class="north-andaman-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/north-sentinel-island/north-sentinel-island.html
+++ b/frontend/north-sentinel-island/north-sentinel-island.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="An educational, respectful look at North Sentinel Island — home to the uncontacted Sentinelese people. Geography, conservation status, history and wildlife. Entry is prohibited by law; this page does not promote tourism.">
@@ -44,6 +36,14 @@
 </head>
 
 <body class="sentinel-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/offline-regions/index.html
+++ b/frontend/offline-regions/index.html
@@ -1,12 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<script>
-(function() {
-  const theme = localStorage.getItem('theme') || 'dark';
-  if (theme === 'light') document.body.classList.add('light-theme');
-})();
-</script>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="Download complete destination packages for any Indian state and explore them fully offline — no connection required." name="description"/>
@@ -61,6 +55,14 @@
 </style>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
 <header class="navbar" id="navbar">
   <div class="nav-container">

--- a/frontend/padma-bhushan-explorer/index.html
+++ b/frontend/padma-bhushan-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Padma Bhushan Explorer - Comprehensive page about India's third-highest civilian award presented for distinguished service of a high order. Includes history, eligibility, medal design, selection process, fields, notable awardees, timeline, facts, and gallery.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="pb-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/padma-shri-explorer/index.html
+++ b/frontend/padma-shri-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Padma Shri Explorer - Informative page about India's fourth-highest civilian award recognizing distinguished contributions across arts, literature, science, sports, and grassroots heroes. History, eligibility, medal design, selection process, famous recipients, timeline, facts, and gallery.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="ps-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/padma-vibhushan-explorer/index.html
+++ b/frontend/padma-vibhushan-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Padma Vibhushan Explorer - Educational page about India's second-highest civilian award recognizing exceptional and distinguished service. History, eligibility, medal design, selection process, categories, recipients, timeline, FAQs, and gallery.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="pv-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/pala-wetland-explorer/index.html
+++ b/frontend/pala-wetland-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="pala.css" />
     </head>
     <body class="pala-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/panchachuli-i/panchachuli-i.html
+++ b/frontend/panchachuli-i/panchachuli-i.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Panchachuli I, a 6,355 m peak in the Kumaon Himalayas of Uttarakhand. Discover facts, trekking information, map locations, image gallery, and FAQs.">
@@ -43,6 +35,14 @@
 </head>
 
 <body class="panchachuli-body-wrapper">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/panchachuli-ii/panchachuli-ii.html
+++ b/frontend/panchachuli-ii/panchachuli-ii.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Panchachuli II Mountain, a 6,904 m high peak in the Kumaon Range of Uttarakhand. Discover facts, map locations, image gallery, and climb details.">
@@ -47,6 +39,14 @@
 </head>
 
 <body class="panchachuli-ii-body-wrapper">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/param-vir-chakra-explorer/index.html
+++ b/frontend/param-vir-chakra-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="pvc.css" />
     </head>
     <body class="pvc-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/partition-1947/partition-1947.html
+++ b/frontend/partition-1947/partition-1947.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Partition of India, 1947 — Interactive Educational Explorer covering pre-1947 political history (1905-1950), Mountbatten Plan, Radcliffe Line, migration maps, refugee camps, leaders, oral history, and knowledge quiz.">
@@ -24,6 +16,14 @@
 </head>
 
 <body class="partition-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/passport-quest/passport-quest.html
+++ b/frontend/passport-quest/passport-quest.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Passport Quest: A State-by-State Mission & Stamp Collection System.">
@@ -45,6 +37,14 @@
 </head>
 
 <body class="challenge-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/personalities/personalities.html
+++ b/frontend/personalities/personalities.html
@@ -2,14 +2,6 @@
 
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="Famous Personalities - The legends, freedom fighters, and modern icons of India." name="description"/>
@@ -270,6 +262,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/personalities.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 <header class="navbar scrolled" id="navbar">
 <div class="nav-container">
 <a class="nav-logo" href="../../index.html#home" id="nav-logo">

--- a/frontend/photography-locations/photography-locations.html
+++ b/frontend/photography-locations/photography-locations.html
@@ -1,12 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') { document.body.classList.add('light-theme'); }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Discover India's best photography locations — sunrise viewpoints, sunset spots, seasonal landscapes, and golden hour destinations across India's diverse terrain.">
@@ -36,6 +30,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/photography-locations.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo">

--- a/frontend/pichavaram-mangrove-wetlands-explorer/index.html
+++ b/frontend/pichavaram-mangrove-wetlands-explorer/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>(function () { const t = localStorage.getItem('theme') || 'dark'; if (t === 'light') document.body.classList.add('light-theme') })();</script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description"
@@ -18,6 +17,14 @@
 </head>
 
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo"><span class="saffron">Incredible</span><span

--- a/frontend/pm-award-excellence-public-administration-explorer/index.html
+++ b/frontend/pm-award-excellence-public-administration-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Prime Minister's Award for Excellence in Public Administration Explorer - Discover India's highest honour for civil servants, honoring innovative and impactful governance initiatives. Learn about its history, purpose, eligibility, categories, selection process, and success stories.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="pa-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/point-calimere-wetland-explorer/index.html
+++ b/frontend/point-calimere-wetland-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="point-calimere.css" />
     </head>
     <body class="point-calimere-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <div class="scroll-progress" id="scroll-progress" aria-hidden="true"></div>
 
         <header class="navbar scrolled" id="navbar">

--- a/frontend/postal-stamps/index.html
+++ b/frontend/postal-stamps/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Explore commemorative Indian postage stamps celebrating historical events, personalities, monuments, festivals, wildlife, and achievements.">
@@ -20,6 +12,14 @@
   <link rel="stylesheet" href="../traditional-games/style.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/premium/premium.html
+++ b/frontend/premium/premium.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Premium Experiences - India Through Time, 3D Globe, Metaverse, and Documentary Hub.">
@@ -46,6 +38,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/premium.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/privacy/privacy.html
+++ b/frontend/privacy/privacy.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
@@ -27,6 +19,14 @@
 </head>
 
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Sticky Navigation Bar -->
     <header class="navbar" id="navbar">
         <div class="nav-container">

--- a/frontend/ragas-time-explainer/ragas-time-explainer.html
+++ b/frontend/ragas-time-explainer/ragas-time-explainer.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Animated Explainer: How Indian Classical Ragas Work (Time-of-Day Theory) - Interactive 24-hour clock-face UI exploring Samaya Chakra, swara structures, Vadi & Samvadi notes, and traditional time associations.">
@@ -24,6 +16,14 @@
 </head>
 
 <body class="raga-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/railway-game/railway-game.html
+++ b/frontend/railway-game/railway-game.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Indian Railway Traffic & Route Management Game.">
@@ -20,6 +12,14 @@
     <link rel="stylesheet" href="railway-game.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="index.html" class="nav-logo">

--- a/frontend/railways-timeline/railways-timeline.html
+++ b/frontend/railways-timeline/railways-timeline.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Animated Timeline: History of Indian Railways - Interactive historical narrative from the first passenger train in 1853 through colonial expansion, nationalization, electric traction, and modern Vande Bharat & High-Speed corridors.">
@@ -24,6 +16,14 @@
 </head>
 
 <body class="timeline-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/railways/railways.html
+++ b/frontend/railways/railways.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Indian Railways Explorer | railways.html</title>
@@ -196,6 +188,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/railways.html">
 </head>
 <body data-page="railways">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
   <!-- Sticky Navigation Bar (matches site-wide navbar) -->
   <header class="navbar scrolled" id="navbar">

--- a/frontend/rashtriya-vigyan-puraskar-explorer/index.html
+++ b/frontend/rashtriya-vigyan-puraskar-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Rashtriya Vigyan Puraskar Explorer - Discover India's prestigious national science awards recognizing excellence in scientific achievements and innovation. Learn about history, categories, eligibility, and awardees.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="vigyan-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/rbi-explorer/index.html
+++ b/frontend/rbi-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore the Reserve Bank of India (RBI) Explorer: Interactive educational portal covering RBI history, core functions, Monetary Policy Committee (MPC), Repo Rate, CRR, SLR, currency printing, and inflation control mechanisms.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="rbi-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/renewable-energy/renewable-energy.html
+++ b/frontend/renewable-energy/renewable-energy.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Explore India's shift toward solar and wind energy with animated capacity-growth charts." name="description"/>
@@ -23,6 +15,14 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a class="nav-logo" href="index.html#home" id="nav-logo">

--- a/frontend/rimo-i/rimo-i.html
+++ b/frontend/rimo-i/rimo-i.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Rimo I, a 7,385 m high peak in the Karakoram Range of Ladakh. Discover facts, map locations, image gallery, and climb details.">
@@ -47,6 +39,14 @@
 </head>
 
 <body class="rimo-body-wrapper">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/river-game/river-game.html
+++ b/frontend/river-game/river-game.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="River Navigation & Cultural Explorer Game. Steer your boat down India's mighty rivers!">
@@ -45,6 +37,14 @@
 </head>
 
 <body class="challenge-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/river/river.html
+++ b/frontend/river/river.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore the great rivers of India — their origins, sacred significance, ecology and the states, cities and civilizations they nourish.">
@@ -46,6 +38,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/river.html">
 </head>
 <body class="rivers-page-body" data-page="rivers">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/route-planner/route-planner.html
+++ b/frontend/route-planner/route-planner.html
@@ -1,12 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<script>
-(function() {
-  const theme = localStorage.getItem('theme') || 'dark';
-  if (theme === 'light') document.body.classList.add('light-theme');
-})();
-</script>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="Plan multi-city routes across India with distance and travel time estimates for road, rail, and air." name="description"/>
@@ -149,6 +143,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/route-planner.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 <header class="navbar scrolled" id="navbar">
   <div class="nav-container">
     <a class="nav-logo" href="../../index.html#home" id="nav-logo">

--- a/frontend/sacred-groves-explorer/index.html
+++ b/frontend/sacred-groves-explorer/index.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <script>(function(){const t=localStorage.getItem('theme')||'dark';if(t==='light')document.body.classList.add('light-theme')})();</script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Explore India's sacred groves — kavu, devrai, sarna, oran and law kyntang — community-protected forests with their deities, taboos, ecology, threats and legal status." />
@@ -13,6 +12,14 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo" id="nav-logo"><span class="saffron">Incredible</span> <span class="gold">India</span> <span class="green">Explorer</span></a>

--- a/frontend/sakhya-sagar-explorer/index.html
+++ b/frontend/sakhya-sagar-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -39,6 +31,14 @@
     </head>
 
     <body class="sakhya-sagar-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/sambhar-lake-explorer/index.html
+++ b/frontend/sambhar-lake-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="sambhar-lake.css" />
     </head>
     <body class="sambhar-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/satellite-mission/index.html
+++ b/frontend/satellite-mission/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="ISRO Satellite Mission Simulator - Interactively launch Chandrayaan, Mangalyaan, Aditya-L1, and Gaganyaan missions by selecting correct launch vehicles, objectives, and trajectories.">
@@ -25,6 +17,14 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body class="isro-sim-body" data-page="satellite-mission">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
     <!-- Sticky Navigation Bar -->
     <header class="navbar scrolled" id="navbar">

--- a/frontend/satkosia-gorge-wetlands-explorer/index.html
+++ b/frontend/satkosia-gorge-wetlands-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="satkosia.css" />
     </head>
     <body class="satkosia-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/satopanth/satopanth.html
+++ b/frontend/satopanth/satopanth.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Satopanth Mountain, a 7,075 m high peak in the Garhwal Range of Uttarakhand. Discover facts, map locations, image gallery, and climb details.">
@@ -47,6 +39,14 @@
 </head>
 
 <body class="satopanth-body-wrapper">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/science/science.html
+++ b/frontend/science/science.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
@@ -45,6 +37,14 @@
 </head>
 
 <body class="science-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/scientific-institutions/scientific-institutions.html
+++ b/frontend/scientific-institutions/scientific-institutions.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore India's premier scientific, academic, space research, and defense institutions including IISc, IITs, ISRO, DRDO, and CSIR.">
@@ -24,6 +16,14 @@
     <link rel="stylesheet" href="scientific-institutions.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navigation Bar -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/scripts/scripts.html
+++ b/frontend/scripts/scripts.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Explore Indian scripts and writing systems, their periods, regions, associated languages, and historical significance.">
@@ -40,6 +32,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/scripts.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo">

--- a/frontend/shaheed-dweep/shaheed-dweep.html
+++ b/frontend/shaheed-dweep/shaheed-dweep.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Shaheed Dweep (Neil Island) — the Natural Bridge, Bharatpur & Laxmanpur beaches, coral reefs, vegetable farms and laid-back tourism, with an interactive map and image gallery.">
@@ -46,6 +38,14 @@
 </head>
 
 <body class="andaman-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/shallabug-wetland-explorer/index.html
+++ b/frontend/shallabug-wetland-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="shallabug.css" />
     </head>
     <body class="shallabug-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/shivling/shivling.html
+++ b/frontend/shivling/shivling.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Shivling Mountain, a 6,543 m high peak in the Garhwal Range of Uttarakhand. Discover facts, map locations, image gallery, and climb details.">
@@ -47,6 +39,14 @@
 </head>
 
 <body class="shivling-body-wrapper">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/sirpur-wetland-explorer/index.html
+++ b/frontend/sirpur-wetland-explorer/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>(function () { const t = localStorage.getItem('theme') || 'dark'; if (t === 'light') document.body.classList.add('light-theme') })();</script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description"
@@ -18,6 +17,14 @@
 </head>
 
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo"><span class="saffron">Incredible</span><span

--- a/frontend/smart-cities/smart-cities.html
+++ b/frontend/smart-cities/smart-cities.html
@@ -2,14 +2,6 @@
 
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="Smart City Explorer - Dashboards and statistics of major Indian cities." name="description"/>
@@ -122,6 +114,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/smart-cities.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 <header class="navbar scrolled" id="navbar">
 <div class="nav-container">
 <a class="nav-logo" href="../../index.html#home" id="nav-logo">

--- a/frontend/south-andaman/south-andaman.html
+++ b/frontend/south-andaman/south-andaman.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore South Andaman — Port Blair, the Cellular Jail, Chidiya Tapu, Ross Island, museums and tourism, with an interactive map and image gallery.">
@@ -46,6 +38,14 @@
 </head>
 
 <body class="andaman-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/space/space.html
+++ b/frontend/space/space.html
@@ -7,14 +7,6 @@
     <title>Indian Space Heritage Explorer | Incredible India</title>
     
     <!-- Prevent FOUC (Flash of Unstyled Content) for Theme Switch -->
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
 
     <link rel="icon" href="data:,">
     <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -26,6 +18,14 @@
 </head>
 
 <body class="space-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/spiritual/spiritual.html
+++ b/frontend/spiritual/spiritual.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Spiritual India - Explore Pilgrimages, Temples, Mosques, and Architectural wonders.">
@@ -216,6 +208,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/spiritual.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/sports/sports.html
+++ b/frontend/sports/sports.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
@@ -47,6 +39,14 @@
 </head>
 
 <body class="sports-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
     <!-- Sticky Navigation Bar -->
     <header class="navbar scrolled" id="navbar">

--- a/frontend/startup/startup.html
+++ b/frontend/startup/startup.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
@@ -46,6 +38,14 @@
 </head>
 
 <body class="startup-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/state-achievements/state-achievements.html
+++ b/frontend/state-achievements/state-achievements.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore landmark state achievements of India across sports, science, education, economy, literature, technology, and environmental conservation in an interactive timeline.">
@@ -24,6 +16,14 @@
 </head>
 
 <body class="achievements-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/state-border-changes/state-border-changes.html
+++ b/frontend/state-border-changes/state-border-changes.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Discover how language, script, food, dress, climate, architecture, and traditions change across state borders in India with an interactive border transition explorer.">
@@ -25,6 +17,14 @@
     <link rel="stylesheet" href="state-border-changes.css">
 </head>
 <body class="border-changes-page-body" data-page="state-border-changes">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
     <!-- Sticky Navbar -->
     <header class="navbar scrolled" id="navbar">

--- a/frontend/state-challenge/state-challenge.html
+++ b/frontend/state-challenge/state-challenge.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Embark on the State Borders Journey Challenge. Travel across India by crossing adjacent states, answering regional trivia quizzes, and earning achievement badges.">
@@ -45,6 +37,14 @@
 </head>
 
 <body class="challenge-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/state-chief-ministers-explorer/index.html
+++ b/frontend/state-chief-ministers-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -31,6 +23,14 @@
     </head>
 
     <body class="cm-explorer-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/state-evolution/state-evolution.html
+++ b/frontend/state-evolution/state-evolution.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore the historical state evolution timeline of India from 1947 to present day—track boundary changes, name updates, capitals, and administrative reorganization.">
@@ -25,6 +17,14 @@
     <link rel="stylesheet" href="state-evolution.css">
 </head>
 <body class="evolution-page-body" data-page="state-evolution">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
     <!-- Sticky Navigation Bar -->
     <header class="navbar scrolled" id="navbar">

--- a/frontend/state-jigsaw/state-jigsaw.html
+++ b/frontend/state-jigsaw/state-jigsaw.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="An interactive jigsaw puzzle game where players assemble pieces to reconstruct the maps of individual Indian states across multiple difficulty levels.">
@@ -24,6 +16,14 @@
 </head>
 
 <body class="jigsaw-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/state-names-explorer/state-names-explorer.html
+++ b/frontend/state-names-explorer/state-names-explorer.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore the origin and meaning behind the names of every Indian state and union territory — etymology, pronunciation, former names, historical references, and the full timeline of official renamings, on an interactive map.">
@@ -45,6 +37,14 @@
 </head>
 
 <body class="snx-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/state/state.html
+++ b/frontend/state/state.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="" id="meta-description">
@@ -50,6 +42,14 @@
     <link rel="stylesheet" href="../../styles.css">
 </head>
 <body class="state-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/stepwells/stepwells.html
+++ b/frontend/stepwells/stepwells.html
@@ -2,14 +2,6 @@
 
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="Explore historic stepwells across India by region, dynasty, architecture, and significance." name="description"/>
@@ -41,6 +33,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/stepwells.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 <header class="navbar scrolled" id="navbar">
 <div class="nav-container">
 <a class="nav-logo" href="../../index.html#home">

--- a/frontend/sultanpur-national-park-explorer/index.html
+++ b/frontend/sultanpur-national-park-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="sultanpur.css" />
     </head>
     <body class="sultanpur-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/support/support.html
+++ b/frontend/support/support.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
@@ -27,6 +19,14 @@
 </head>
 
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Sticky Navigation Bar -->
     <header class="navbar" id="navbar">
         <div class="nav-container">

--- a/frontend/surinsar-mansar-lakes-explorer/index.html
+++ b/frontend/surinsar-mansar-lakes-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -39,6 +31,14 @@
         <link rel="stylesheet" href="surinsar-mansar.css" />
     </head>
     <body class="sm-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/swaraj-dweep/swaraj-dweep.html
+++ b/frontend/swaraj-dweep/swaraj-dweep.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Swaraj Dweep (Havelock Island) — Radhanagar and Elephant Beach, coral reefs, marine life, scuba diving and water sports, and the island's history, with an interactive map and image gallery.">
@@ -46,6 +38,14 @@
 </head>
 
 <body class="swaraj-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/swargarohini/swargarohini.html
+++ b/frontend/swargarohini/swargarohini.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Swargarohini Mountain, a 6,252 m high massif in the Garhwal Himalayas of Uttarakhand. Discover mythological links, maps, photos, and trek info.">
@@ -47,6 +39,14 @@
 </head>
 
 <body class="swargarohini-body-wrapper">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/tagore-award-cultural-harmony-explorer/index.html
+++ b/frontend/tagore-award-cultural-harmony-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Tagore Award for Cultural Harmony Explorer - Discover India's international award recognizing outstanding contributions to cultural harmony and universal values, instituted in commemoration of Gurudev Rabindranath Tagore's 150th birth anniversary.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="ta-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/tampara-lake-explorer/index.html
+++ b/frontend/tampara-lake-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="tampara.css" />
     </head>
     <body class="tampara-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/terms/terms.html
+++ b/frontend/terms/terms.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
@@ -27,6 +19,14 @@
 </head>
 
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Sticky Navigation Bar -->
     <header class="navbar" id="navbar">
         <div class="nav-container">

--- a/frontend/textiles/textiles.html
+++ b/frontend/textiles/textiles.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Explore Indian textile traditions, weaving styles, materials, regions, and cultural significance.">
@@ -40,6 +32,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/textiles.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo">

--- a/frontend/thane-creek-wetlands-explorer/index.html
+++ b/frontend/thane-creek-wetlands-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -39,6 +31,14 @@
     </head>
 
     <body class="thane-creek-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/then-vs-now/then-vs-now.html
+++ b/frontend/then-vs-now/then-vs-now.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Compare historical and present-day images of India's iconic heritage sites with an interactive before/after slider. Explore restoration, preservation, and architectural evolution.">
@@ -38,6 +30,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/then-vs-now.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo">

--- a/frontend/timezone-myth-buster/timezone-myth-buster.html
+++ b/frontend/timezone-myth-buster/timezone-myth-buster.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Time Zone Myth-Buster — Test your knowledge of why India uses a single time zone despite its east-west width.">
@@ -20,6 +12,14 @@
     <link rel="stylesheet" href="timezone-myth-buster.css">
 </head>
 <body class="tz-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
     <!-- Sticky Navigation Bar -->
     <header class="navbar scrolled" id="navbar">

--- a/frontend/trade-routes/trade-routes.html
+++ b/frontend/trade-routes/trade-routes.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore the ancient Indian trade network. Visualize historic land and maritime trade routes like the Silk Road and Spice Route connecting India with Rome, Arabia, and China.">
@@ -45,6 +37,14 @@
 </head>
 
 <body class="trade-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/traditional-games/index.html
+++ b/frontend/traditional-games/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore traditional games played across different regions of India. Discover ancient board games, outdoor sports, and folk games with their rules and origins.">
@@ -23,6 +15,14 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
     <!-- Sticky Navigation Bar -->
     <header class="navbar scrolled" id="navbar">

--- a/frontend/travel-timeline/travel-timeline.html
+++ b/frontend/travel-timeline/travel-timeline.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Travel Timeline - relive your completed trips across India in chronological order, with photos, notes, ratings, and a trip replay mode.">
@@ -18,6 +10,14 @@
     <link rel="stylesheet" href="travel-timeline.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="index.html#home" class="nav-logo">

--- a/frontend/travel/travel.html
+++ b/frontend/travel/travel.html
@@ -2,14 +2,6 @@
 
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="Travel Explorer - Discover the diverse destinations and breathtaking road trips of Incredible India." name="description"/>
@@ -290,6 +282,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/travel.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 <!-- Sticky Navigation Bar -->
 <header class="navbar scrolled" id="navbar">
 <div class="nav-container">

--- a/frontend/treasure-hunt/treasure-hunt.html
+++ b/frontend/treasure-hunt/treasure-hunt.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Interactive Map Clue & Treasure Hunt Game">
@@ -20,6 +12,14 @@
     <link rel="stylesheet" href="treasure-hunt.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="index.html" class="nav-logo">

--- a/frontend/tribes/tribes.html
+++ b/frontend/tribes/tribes.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore India's tribal communities and indigenous cultures - their traditions, festivals, attire, art and beliefs across every region of India.">
@@ -45,6 +37,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/tribes.html">
 </head>
 <body class="tribes-page-body" data-page="tribes">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
     <!-- Sticky Navigation Bar -->
     <header class="navbar scrolled" id="navbar">

--- a/frontend/trip-planner/trip-planner.html
+++ b/frontend/trip-planner/trip-planner.html
@@ -2,14 +2,6 @@
 
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="Trip Planner - Generate a budget-optimized, multi-city India itinerary based on your budget, trip length, and travel preferences." name="description"/>
@@ -42,6 +34,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/trip-planner.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 <!-- Sticky Navigation Bar -->
 <header class="navbar scrolled" id="navbar">
 <div class="nav-container">

--- a/frontend/trisul-i/trisul-i.html
+++ b/frontend/trisul-i/trisul-i.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore Trisul I Mountain, a 7,120 m high peak in the Garhwal Himalayas of Uttarakhand. Discover facts, map locations, image gallery, and climb details.">
@@ -47,6 +39,14 @@
 </head>
 
 <body class="trisul-i-body-wrapper">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/udhwa-wetlands-explorer/index.html
+++ b/frontend/udhwa-wetlands-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="udhwa.css" />
     </head>
     <body class="udhwa-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/unesco/unesco.html
+++ b/frontend/unesco/unesco.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore India's UNESCO World Heritage Sites by category, region, state, and inscription year.">
@@ -38,6 +30,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/unesco.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo">

--- a/frontend/union-territory-sorter/index.html
+++ b/frontend/union-territory-sorter/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Test your Indian geography skills in the Union Territory Sorter game! Drag or tap to categorize all 28 states and 8 union territories into correct bins with instant feedback.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="ut-sorter-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/universities/universities.html
+++ b/frontend/universities/universities.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Explore ancient Indian universities, their subjects, scholars, locations, and historical legacy.">
@@ -38,6 +30,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/universities.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo">

--- a/frontend/up-dashboard/up-dashboard.html
+++ b/frontend/up-dashboard/up-dashboard.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Uttar Pradesh Tourism Dashboard - Modern central portal for exploring heritage, religious sites, cuisine, festivals, travel circuits, wildlife, handicrafts, history, games, and district explorer.">
@@ -24,6 +16,14 @@
 </head>
 
 <body class="dashboard-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/up-district-explorer/up-district-explorer.html
+++ b/frontend/up-district-explorer/up-district-explorer.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Uttar Pradesh District Explorer - Interactive map and comprehensive guide to all 75 districts of Uttar Pradesh covering headquarters, attractions, industries, cuisine, and festivals.">
@@ -24,6 +16,14 @@
 </head>
 
 <body class="district-explorer-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/up-festival-calendar/up-festival-calendar.html
+++ b/frontend/up-festival-calendar/up-festival-calendar.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Uttar Pradesh Festival Calendar - Interactive yearly calendar showcasing celebrations across UP including Dev Deepawali, Lathmar Holi, Ram Navami, Janmashtami, Ganga Mahotsav, Kumbh Mela, and Magh Mela.">
@@ -24,6 +16,14 @@
 </head>
 
 <body class="calendar-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/up-filming/up-filming.html
+++ b/frontend/up-filming/up-filming.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore iconic Uttar Pradesh filming locations from Varanasi Ghats, Taj Mahal, Lucknow, Agra, Jhansi, and Prayagraj featured in classic Indian movies with behind-the-scenes trivia.">
@@ -24,6 +16,14 @@
 </head>
 
 <body class="filming-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/up-monuments/up-monuments.html
+++ b/frontend/up-monuments/up-monuments.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Famous Monuments Explorer - Interactive 3D visual explorer showcasing Taj Mahal, Agra Fort, Fatehpur Sikri, Bara Imambara, Chota Imambara, Rumi Darwaza, and Jhansi Fort with historical timeline, architecture specs, and gallery.">
@@ -24,6 +16,14 @@
 </head>
 
 <body class="monuments-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/up-pilgrimage/up-pilgrimage.html
+++ b/frontend/up-pilgrimage/up-pilgrimage.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Plan sacred religious journeys across Uttar Pradesh visiting Ayodhya, Varanasi, Mathura, Vrindavan, Prayagraj, Chitrakoot, Kushinagar, and Sarnath.">
@@ -24,6 +16,14 @@
 </head>
 
 <body class="pilgrimage-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/valley-of-flowers-explorer/index.html
+++ b/frontend/valley-of-flowers-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="valley.css" />
     </head>
     <body class="valley-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/vellode-wetland-explorer/index.html
+++ b/frontend/vellode-wetland-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="vellode.css" />
     </head>
     <body class="vellode-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/vembanad-lake-explorer/index.html
+++ b/frontend/vembanad-lake-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="vembanad-lake.css" />
     </head>
     <body class="vembanad-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/vigyan-ratna-award-explorer/index.html
+++ b/frontend/vigyan-ratna-award-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Vigyan Ratna Award Explorer - Discover India's highest honour in science, technology, and innovation. Learn about its history, purpose, eligibility, selection process, categories, recipients, timeline, and facts.">
@@ -30,6 +22,14 @@
 </head>
 
 <body class="vr-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/frontend/volcanoes-geology/volcanoes-geology.html
+++ b/frontend/volcanoes-geology/volcanoes-geology.html
@@ -1,12 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') { document.body.classList.add('light-theme'); }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore India's volcanic regions, lava plateaus, meteor craters, karst cave systems, and extraordinary geological formations from Barren Island to the Deccan Traps.">
@@ -36,6 +30,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/volcanoes-geology.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo">

--- a/frontend/wadhvana-wetland-explorer/index.html
+++ b/frontend/wadhvana-wetland-explorer/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="wadhvana.css" />
     </head>
     <body class="wadhvana-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/water-systems/water-systems.html
+++ b/frontend/water-systems/water-systems.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Explore Indian traditional water conservation systems, climate adaptations, water-harvesting methods, and ecological importance.">
@@ -40,6 +32,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/water-systems.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo">

--- a/frontend/waterfalls-of-india/index.html
+++ b/frontend/waterfalls-of-india/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -28,6 +20,14 @@
         <link rel="stylesheet" href="style.css" />
     </head>
     <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">
                 <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/wetlands-conservation-hub/index.html
+++ b/frontend/wetlands-conservation-hub/index.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html lang="en">
 <head>
-  <script>(function(){const t=localStorage.getItem('theme')||'dark';if(t==='light')document.body.classList.add('light-theme')})();</script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="description" content="Explore the Indian Wetlands Conservation Hub — an interactive guide to wetlands, Ramsar sites, ecosystem services, conservation initiatives, and biodiversity." />
@@ -13,6 +12,14 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <header class="navbar scrolled" id="navbar">
     <div class="nav-container">
       <a href="../../index.html#home" class="nav-logo" id="nav-logo"><span class="saffron">Incredible</span> <span class="gold">India</span> <span class="green">Explorer</span></a>

--- a/frontend/wetlands/index.html
+++ b/frontend/wetlands/index.html
@@ -1,14 +1,6 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <script>
-            (function () {
-                const theme = localStorage.getItem('theme') || 'dark';
-                if (theme === 'light') {
-                    document.body.classList.add('light-theme');
-                }
-            })();
-        </script>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <meta
@@ -39,6 +31,14 @@
     </head>
 
     <body class="wetlands-main">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
         <!-- Site Navbar -->
         <header class="navbar scrolled" id="navbar">
             <div class="nav-container">

--- a/frontend/wildlife-rescue/wildlife-rescue.html
+++ b/frontend/wildlife-rescue/wildlife-rescue.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Wildlife Rescue Strategy Game: Protect endangered animals across India's National Parks.">
@@ -45,6 +37,14 @@
 </head>
 
 <body class="challenge-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../../index.html#home" class="nav-logo" id="nav-logo">

--- a/frontend/wildlife/wildlife.html
+++ b/frontend/wildlife/wildlife.html
@@ -2,14 +2,6 @@
 
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
 <meta charset="utf-8"/>
 <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
 <meta content="Nature &amp; Wildlife - Explore National Parks, Biodiversity, and majestic animals of India." name="description"/>
@@ -223,6 +215,14 @@
   <link rel="stylesheet" href="../card-deeplink/card-deeplink.css">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 <header class="navbar scrolled" id="navbar">
 <div class="nav-container">
 <a class="nav-logo" href="../../index.html#home" id="nav-logo">

--- a/governance/cabinet-ministries/index.html
+++ b/governance/cabinet-ministries/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Explore the Cabinet Ministries of India — their roles, ministers, departments, and organizational structure." name="description"/>
@@ -20,6 +12,14 @@
     <link href="styles.css" rel="stylesheet"/>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a class="nav-logo" href="../../index.html#home" id="nav-logo">

--- a/governance/election-commission/index.html
+++ b/governance/election-commission/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Explore the interactive timeline of the Chief Election Commissioners of India." name="description"/>
@@ -20,6 +12,14 @@
     <link href="styles.css" rel="stylesheet"/>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a class="nav-logo" href="../../index.html#home" id="nav-logo">

--- a/governance/prime-ministers/index.html
+++ b/governance/prime-ministers/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Explore the interactive timeline of the Prime Ministers of India." name="description"/>
@@ -20,6 +12,14 @@
     <link href="styles.css" rel="stylesheet"/>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a class="nav-logo" href="../../index.html#home" id="nav-logo">

--- a/governance/vice-presidents/index.html
+++ b/governance/vice-presidents/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Explore the interactive timeline of the Vice Presidents of India." name="description"/>
@@ -20,6 +12,14 @@
     <link href="styles.css" rel="stylesheet"/>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a class="nav-logo" href="../../index.html#home" id="nav-logo">

--- a/history/battles/index.html
+++ b/history/battles/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Explore India's most important historical battles — from Kalinga to Kargil — with interactive timelines, maps, and detailed battle summaries." name="description"/>
@@ -20,6 +12,14 @@
     <link href="styles.css" rel="stylesheet"/>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a class="nav-logo" href="../../index.html#home" id="nav-logo">

--- a/history/dynasties/index.html
+++ b/history/dynasties/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Explore India's major dynasties — Maurya, Gupta, Chola, Mughal, Vijayanagara, Maratha, and Delhi Sultanate — with interactive timelines, maps, and detailed dynasty profiles." name="description"/>
@@ -20,6 +12,14 @@
     <link href="styles.css" rel="stylesheet"/>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a class="nav-logo" href="../../index.html#home" id="nav-logo">

--- a/history/education/index.html
+++ b/history/education/index.html
@@ -4,17 +4,19 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>History of Indian Education | Incredible India</title>
-  <script>
-    (function () {
-      const theme = localStorage.getItem('theme');
-      if (theme === 'light') document.body.classList.add('light-theme');
-    })();
-  </script>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet"/>
   <link href="../../styles.css" rel="stylesheet"/>
   <link href="styles.css" rel="stylesheet"/>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <nav class="navbar">
     <div class="nav-container">
       <a href="../../index.html" class="nav-logo">

--- a/history/laws/index.html
+++ b/history/laws/index.html
@@ -4,17 +4,19 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>History of Indian Laws | Incredible India</title>
-  <script>
-    (function () {
-      const theme = localStorage.getItem('theme');
-      if (theme === 'light') document.body.classList.add('light-theme');
-    })();
-  </script>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet"/>
   <link href="../../styles.css" rel="stylesheet"/>
   <link href="styles.css" rel="stylesheet"/>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <nav class="navbar">
     <div class="nav-container">
       <a href="../../index.html" class="nav-logo">

--- a/history/memorials/index.html
+++ b/history/memorials/index.html
@@ -4,17 +4,19 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>National Memorials Explorer | Incredible India</title>
-  <script>
-    (function () {
-      const theme = localStorage.getItem('theme');
-      if (theme === 'light') document.body.classList.add('light-theme');
-    })();
-  </script>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet"/>
   <link href="../../styles.css" rel="stylesheet"/>
   <link href="styles.css" rel="stylesheet"/>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
   <nav class="navbar">
     <div class="nav-container">
       <a href="../../index.html" class="nav-logo">

--- a/hokersar-wetland-explorer/hokersar-wetland-explorer.html
+++ b/hokersar-wetland-explorer/hokersar-wetland-explorer.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Hokersar Wetland Explorer - Explore Jammu & Kashmir's only Ramsar wetland, a vital Himalayan sanctuary for thousands of migratory birds on the Central Asian Flyway." name="description"/>
@@ -43,6 +35,14 @@
     </script>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../index.html#home" class="nav-logo" id="nav-logo">

--- a/index.html
+++ b/index.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
@@ -284,6 +276,14 @@
 </head>
 
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
     <!-- SW Update Available Banner -->
     <div id="sw-update-banner" class="sw-update-banner" role="alert" aria-live="polite">

--- a/login.html
+++ b/login.html
@@ -2,14 +2,6 @@
 <html lang="en">
 
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Login or Sign up to Incredible India Explorer">
@@ -396,6 +388,14 @@
 </head>
 
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
 
     <main class="auth-page" id="app-root">
         <a href="frontend/traditional-games/index.html" class="auth-topbar">

--- a/national-bravery-awards.html
+++ b/national-bravery-awards.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore the National Bravery Awards, honoring extraordinary acts of courage, selflessness, and valor displayed by children across India.">
@@ -36,6 +28,14 @@
     <link rel="stylesheet" href="national-bravery-awards.css">
 </head>
 <body class="nba-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/offline.html
+++ b/offline.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Offline | Incredible India Explorer</title>
@@ -348,6 +340,14 @@
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/offline.html">
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <div class="container">
         <div class="offline-badge" role="status" aria-live="polite">
             <span class="status-dot" aria-hidden="true"></span>

--- a/police-medal-for-gallantry.html
+++ b/police-medal-for-gallantry.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore the Police Medal for Gallantry (PMG), awarded to police personnel for exceptional courage and bravery in the line of duty.">
@@ -35,6 +27,14 @@
     <link rel="stylesheet" href="police-medal-for-gallantry.css">
 </head>
 <body class="pmg-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="index.html#home" class="nav-logo" id="nav-logo">

--- a/pong-dam-lake-explorer/pong-dam-lake-explorer.html
+++ b/pong-dam-lake-explorer/pong-dam-lake-explorer.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Pong Dam Lake Explorer - Explore the internationally important Ramsar Wetland supporting thousands of migratory birds in Himachal Pradesh, India." name="description"/>
@@ -42,6 +34,14 @@
     </script>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../index.html#home" class="nav-logo" id="nav-logo">

--- a/pradhan-mantri-rashtriya-bal-puraskar.html
+++ b/pradhan-mantri-rashtriya-bal-puraskar.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore the Pradhan Mantri Rashtriya Bal Puraskar (PMRBP), India's highest civilian honour for children recognizing excellence in Innovation, Sports, Arts, Social Service, and Bravery.">
@@ -36,6 +28,14 @@
     <link rel="stylesheet" href="pradhan-mantri-rashtriya-bal-puraskar.css">
 </head>
 <body class="pmrbp-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/presidents-police-medal.html
+++ b/presidents-police-medal.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore the President's Police Medal (PPM), awarded for distinguished service and gallantry to police personnel across India.">
@@ -36,6 +28,14 @@
     <link rel="stylesheet" href="presidents-police-medal.css">
 </head>
 <body class="ppm-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Main Header Navbar -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/ropar-wetland-explorer/ropar-wetland-explorer.html
+++ b/ropar-wetland-explorer/ropar-wetland-explorer.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Ropar Wetland Explorer - Discover the Ramsar Wetland formed by the Sutlej River in Punjab, India. A rich ecosystem supporting migratory birds and aquatic biodiversity." name="description"/>
@@ -43,6 +35,14 @@
     </script>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../index.html#home" class="nav-logo" id="nav-logo">

--- a/sandi-bird-sanctuary-explorer/sandi-bird-sanctuary-explorer.html
+++ b/sandi-bird-sanctuary-explorer/sandi-bird-sanctuary-explorer.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Sandi Bird Sanctuary Explorer - Discover the Ramsar Wetland and freshwater sanctuary in Hardoi, Uttar Pradesh, India. A critical habitat for resident and migratory birds." name="description"/>
@@ -43,6 +35,14 @@
     </script>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../index.html#home" class="nav-logo" id="nav-logo">

--- a/sanjay-chopra-award.html
+++ b/sanjay-chopra-award.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore the Sanjay Chopra Award, presented to boys for exceptional acts of bravery under the National Bravery Awards.">
@@ -35,6 +27,14 @@
     <link rel="stylesheet" href="sanjay-chopra-award.css">
 </head>
 <body class="sca-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="index.html#home" class="nav-logo" id="nav-logo">

--- a/science/isro-explorer/index.html
+++ b/science/isro-explorer/index.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Explore ISRO's missions — Chandrayaan, Mangalyaan, Aditya-L1, Gaganyaan — launch vehicles, timeline, and achievements." name="description"/>
@@ -20,6 +12,14 @@
     <link href="styles.css" rel="stylesheet"/>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a class="nav-logo" href="../../index.html#home" id="nav-logo">

--- a/scripts/layout.html
+++ b/scripts/layout.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="{{description}}">
@@ -50,6 +42,14 @@
     {{extra_head}}
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="{{relative_path}}index.html" class="nav-logo">

--- a/shanti-swarup-bhatnagar-prize.html
+++ b/shanti-swarup-bhatnagar-prize.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore the Shanti Swarup Bhatnagar Prize, India's most prestigious science award recognizing outstanding research in Science and Technology.">
@@ -35,6 +27,14 @@
     <link rel="stylesheet" href="shanti-swarup-bhatnagar-prize.css">
 </head>
 <body class="ssb-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="index.html#home" class="nav-logo" id="nav-logo">

--- a/sultanpur-wetland-explorer/sultanpur-wetland-explorer.html
+++ b/sultanpur-wetland-explorer/sultanpur-wetland-explorer.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Sultanpur Wetland Explorer - Explore the birding paradise of Sultanpur National Park, near Delhi, known for hundreds of migratory and resident bird species." name="description"/>
@@ -43,6 +35,14 @@
     </script>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../index.html#home" class="nav-logo" id="nav-logo">

--- a/tests/unit/theme-bootstrap-placement.test.js
+++ b/tests/unit/theme-bootstrap-placement.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const IGNORED = new Set(['.git', 'node_modules', 'dist', 'coverage']);
+
+function htmlFiles(dir, found = []) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (IGNORED.has(e.name)) continue;
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) htmlFiles(p, found);
+    else if (e.name.endsWith('.html')) found.push(p);
+  }
+  return found;
+}
+
+const THEME_WRITE = /document\.body\.classList\.add\('light-theme'\)/;
+
+describe('theme bootstrap placement', () => {
+  const pages = htmlFiles('.').map((file) => {
+    const content = fs.readFileSync(file, 'utf8');
+    return { file, content };
+  });
+
+  it('scans the repository', () => {
+    expect(pages.length).toBeGreaterThan(0);
+  });
+
+  it('never touches document.body before <body> is parsed', () => {
+    const offenders = pages
+      .filter(({ content }) => THEME_WRITE.test(content))
+      .filter(({ content }) => {
+        const write = content.search(THEME_WRITE);
+        const bodyTag = content.search(/<body[\s>]/i);
+        if (bodyTag < 0) return false;
+        if (write > bodyTag) return false;
+        // A guarded write (`if (document.body)`) is safe wherever it sits.
+        return !/if\s*\(\s*document\.body\s*\)/.test(content);
+      })
+      .map(({ file }) => file);
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tso-moriri-wetland-explorer/tso-moriri-wetland-explorer.html
+++ b/tso-moriri-wetland-explorer/tso-moriri-wetland-explorer.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Tso Moriri Wetland Explorer - Explore the breathtaking high-altitude Himalayan lake and Ramsar Site in Ladakh, India." name="description"/>
@@ -42,6 +34,14 @@
     </script>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../index.html#home" class="nav-logo" id="nav-logo">

--- a/vishisht-seva-medal.html
+++ b/vishisht-seva-medal.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore the Vishisht Seva Medal (VSM), recognizing distinguished service of a high order in the Indian Armed Forces.">
@@ -36,6 +28,14 @@
     <link rel="stylesheet" href="vishisht-seva-medal.css">
 </head>
 <body class="vsm-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <!-- Navbar Header -->
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">

--- a/yashwant-sagar-wetland-explorer/yashwant-sagar-wetland-explorer.html
+++ b/yashwant-sagar-wetland-explorer/yashwant-sagar-wetland-explorer.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="utf-8"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <meta content="Yashwant Sagar Wetland Explorer - Explore the internationally recognized Ramsar Wetland and Important Bird Habitat near Indore, Madhya Pradesh." name="description"/>
@@ -43,6 +35,14 @@
     </script>
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="../index.html#home" class="nav-logo" id="nav-logo">

--- a/yudh-seva-medal.html
+++ b/yudh-seva-medal.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Explore the Yudh Seva Medal (YSM), awarded for distinguished service of a high order during war, conflict, or hostilities.">
@@ -35,6 +27,14 @@
     <link rel="stylesheet" href="yudh-seva-medal.css">
 </head>
 <body class="ysm-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar scrolled" id="navbar">
         <div class="nav-container">
             <a href="index.html#home" class="nav-logo" id="nav-logo">


### PR DESCRIPTION
Closes #1287

## Problem

The theme-bootstrap IIFE that most pages carry in `<head>` could never work:

```html
<head>
    <script>
        (function() {
            const theme = localStorage.getItem('theme') || 'dark';
            if (theme === 'light') {
                document.body.classList.add('light-theme');   // document.body is null here
            }
        })();
    </script>
```

A script in `<head>` runs before `<body>` is parsed, so `document.body` is `null`, the property access throws a `TypeError`, and the IIFE aborts. The theme was then applied late by `app.js` on DOM ready — which is exactly the late application the inline script was written to prevent. Users with light mode saw a dark flash on every single navigation, plus a console error on every page.

Reproduced before the fix:

```
$ node verify.mjs        # JSDOM, localStorage.theme = 'light'
TypeError: Cannot read properties of null (reading 'classList')
    at https://example.org/:5:31
```

**330 of 460 pages** were affected.

## Why move the script rather than switch to `documentElement`

The issue suggested `document.documentElement`, which is valid in `<head>`. I went the other way, and it's worth explaining why.

All the theme CSS is written against `body`:

```
$ grep -ro "body\.light-theme" --include="*.css" . | wc -l
1463
$ grep -ro "html\.light-theme"  --include="*.css" . | wc -l
0
```

Switching the JS to `documentElement` without rewriting those **1463 selectors across 151 CSS files** would stop the `TypeError` while silently breaking light mode everywhere — strictly worse than the current bug, and much harder to spot in review. Rewriting them is possible but there's no single stylesheet every page loads (the top one, `styles.css`, covers 393 of 460 pages), so it would be a sprawling, high-risk diff touching selector specificity across the whole site.

Moving the script to just after `<body>` is the smaller, safer change. It still runs inline and render-blocking **before first paint**, so it solves the FOUC just as well, and the CSS is untouched.

Incidentally, 2 pages already used `documentElement` — meaning light mode was silently broken on those. This fix corrects them too.

## What changed

The snippet moves from `<head>` to immediately after the `<body>` open tag on 330 pages:

```diff
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
 ...
 </head>
 <body class="tribes-page-body" data-page="tribes">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
```

The snippet existed in **6 different spellings** across the repo (varying indentation, `function()` vs `function ()`, a minified one-liner, one missing the `|| 'dark'` default, and the two `documentElement` ones). All are normalised to the same form, so the next person to grep for it finds one shape.

One page is deliberately left alone: `frontend/national-symbols-gallery/national-symbols-gallery.html` already guards with `if (document.body)` and falls back to `DOMContentLoaded`, so it was never broken.

## Verification

**Before/after in JSDOM** with `localStorage.theme = 'light'`:

| Page | Before | After |
|---|---|---|
| `frontend/tribes/tribes.html` | `TypeError` | `light-theme` applied, 0 errors |
| `index.html` | `TypeError` | `light-theme` applied, 0 errors |
| `forts/mirjan-fort.html` | `TypeError` | `light-theme` applied, 0 errors |

**The diff is a pure move.** Since this touches 330 files, I verified mechanically that nothing else changed — for every file, I stripped the snippet from both the committed and working versions, normalised whitespace, and compared:

```
checked 330 files | unexpected content changes: 0
```

**Regression test.** `tests/unit/theme-bootstrap-placement.test.js` fails if any page writes to `document.body` before `<body>` is parsed. Confirmed it actually catches the bug by restoring one pre-fix file:

```
× never touches document.body before <body> is parsed
  → expected [ 'frontend\tribes\tribes.html' ] to deeply equal []
```

It allows a guarded `if (document.body)` write, so the national-symbols-gallery pattern stays legal.

**No regressions.** Full suite on `main` vs this branch:

| | Test files | Tests |
|---|---|---|
| `main` (baseline) | 16 failed, 153 passed | 3 failed, 1402 passed |
| this branch | 16 failed, **154** passed | 3 failed, **1404** passed |

Identical failures both runs — pre-existing and unrelated (`national-awards.js` and several park explorers fail Vite's import analysis). My 2 tests are the delta.

## Notes for reviewers

It's a big file count but a mechanically uniform change, and the pure-move check above is the thing worth trusting over reading 330 diffs.

This bug is a good argument for #1291 (shared page templating): the correct snippet has been sitting in `scripts/layout.html` the whole time, but with every page hand-copied there was no way for the fix to propagate. Until that lands, the new test is what stops it coming back.

I'd suggest merging this before or after #1350 rather than alongside — both touch `tests/unit/`, though they add different files so they shouldn't actually conflict.
