### PR TITLE
perf(images): lazy-load 103 below-the-fold images

### DIFF
--- a/frontend/arts-crafts/arts-crafts.html
+++ b/frontend/arts-crafts/arts-crafts.html
@@ -480,7 +480,7 @@
                     <div class="atlas-row reverse">
                         <div class="atlas-media">
                             <span class="atlas-tag">📍 Karnataka</span>
-                            <img src="../../assets/sandalwood.png" alt="Wood Carving" class="atlas-photo" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
+                            <img src="../../assets/sandalwood.png" alt="Wood Carving" class="atlas-photo" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';" loading="lazy">
                             <div class="animated-placeholder" style="display:none;">Wood Carving</div>
                         </div>
                         <div class="atlas-content">
@@ -495,7 +495,7 @@
                     <div class="atlas-row">
                         <div class="atlas-media">
                             <span class="atlas-tag">📍 Rajasthan</span>
-                            <img src="../../assets/Blue_Pottery.png" alt="Blue Pottery" class="atlas-photo" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
+                            <img src="../../assets/Blue_Pottery.png" alt="Blue Pottery" class="atlas-photo" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';" loading="lazy">
                             <div class="animated-placeholder" style="display:none;">Blue Pottery</div>
                         </div>
                         <div class="atlas-content">
@@ -510,7 +510,7 @@
                     <div class="atlas-row reverse">
                         <div class="atlas-media">
                             <span class="atlas-tag">📍 Tamil Nadu</span>
-                            <img src="../../assets/Kanchipuram_silk.png" alt="Kanchipuram Weaves" class="atlas-photo" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
+                            <img src="../../assets/Kanchipuram_silk.png" alt="Kanchipuram Weaves" class="atlas-photo" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';" loading="lazy">
                             <div class="animated-placeholder" style="display:none;">Kanchipuram Weaves</div>
                         </div>
                         <div class="atlas-content">
@@ -535,7 +535,7 @@
                     <div class="gi-item">
                         <div class="gi-media">
                             <span class="gi-badge">GI</span>
-                            <img src="../../assets/Darjeeling.png" alt="Darjeeling Tea" class="gi-photo" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
+                            <img src="../../assets/Darjeeling.png" alt="Darjeeling Tea" class="gi-photo" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';" loading="lazy">
                             <div class="animated-placeholder small-ph" style="display:none;">Darjeeling Tea</div>
                         </div>
                         <div class="gi-body">
@@ -549,7 +549,7 @@
                     <div class="gi-item">
                         <div class="gi-media">
                             <span class="gi-badge">GI</span>
-                            <img src="../../assets/Hyderabadi_Basmati_Rice.png" alt="Hyderabadi Basmati Rice" class="gi-photo" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
+                            <img src="../../assets/Hyderabadi_Basmati_Rice.png" alt="Hyderabadi Basmati Rice" class="gi-photo" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';" loading="lazy">
                             <div class="animated-placeholder small-ph" style="display:none;">Hyderabadi Basmati Rice</div>
                         </div>
                         <div class="gi-body">
@@ -563,7 +563,7 @@
                     <div class="gi-item">
                         <div class="gi-media">
                             <span class="gi-badge">GI</span>
-                            <img src="../../assets/Alphonso.png" alt="Alphonso Mango" class="gi-photo" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
+                            <img src="../../assets/Alphonso.png" alt="Alphonso Mango" class="gi-photo" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';" loading="lazy">
                             <div class="animated-placeholder small-ph" style="display:none;">Alphonso Mango</div>
                         </div>
                         <div class="gi-body">
@@ -577,7 +577,7 @@
                     <div class="gi-item">
                         <div class="gi-media">
                             <span class="gi-badge">GI</span>
-                            <img src="../../assets/KanchipuramSilk.png" alt="Kanchipuram Silk" class="gi-photo" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
+                            <img src="../../assets/KanchipuramSilk.png" alt="Kanchipuram Silk" class="gi-photo" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';" loading="lazy">
                             <div class="animated-placeholder small-ph" style="display:none;">Kanchipuram Silk</div>
                         </div>
                         <div class="gi-body">
@@ -591,7 +591,7 @@
                     <div class="gi-item">
                         <div class="gi-media">
                             <span class="gi-badge">GI</span>
-                            <img src="../../assets/Makrana_Marble.png" alt="Makrana Marble" class="gi-photo" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
+                            <img src="../../assets/Makrana_Marble.png" alt="Makrana Marble" class="gi-photo" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';" loading="lazy">
                             <div class="animated-placeholder small-ph" style="display:none;">Makrana Marble</div>
                         </div>
                         <div class="gi-body">
@@ -605,7 +605,7 @@
                     <div class="gi-item">
                         <div class="gi-media">
                             <span class="gi-badge">GI</span>
-                            <img src="../../assets/Dhokra_Art.png" alt="Dhokra Craft" class="gi-photo" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
+                            <img src="../../assets/Dhokra_Art.png" alt="Dhokra Craft" class="gi-photo" onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';" loading="lazy">
                             <div class="animated-placeholder small-ph" style="display:none;">Dhokra Craft</div>
                         </div>
                         <div class="gi-body">

--- a/frontend/bharat-ratna-gallery/index.html
+++ b/frontend/bharat-ratna-gallery/index.html
@@ -200,7 +200,7 @@
             container.innerHTML = list.map(r => `
                 <div class="br-card" data-id="${r.id}">
                     <div class="br-avatar-wrap">
-                        <img class="br-avatar-img" src="../../${r.portrait}" alt="${r.name}">
+                        <img class="br-avatar-img" src="../../${r.portrait}" alt="${r.name}" loading="lazy">
                     </div>
                     <h3 class="br-card-name">${r.name} ${r.posthumous ? '<span style="font-size:0.75rem; color:#94A3B8;">(Posthumous)</span>' : ''}</h3>
                     <div class="br-card-meta">
@@ -228,7 +228,7 @@
                     <div class="br-timeline-card br-card" data-id="${r.id}">
                         <div style="display: flex; gap: 16px; align-items: center; text-align: left;">
                             <div class="br-avatar-wrap" style="width: 64px; height: 64px; flex-shrink: 0; margin-bottom: 0;">
-                                <img class="br-avatar-img" src="../../${r.portrait}" alt="${r.name}">
+                                <img class="br-avatar-img" src="../../${r.portrait}" alt="${r.name}" loading="lazy">
                             </div>
                             <div>
                                 <span class="br-year-badge">${r.year}</span>

--- a/frontend/constitution-makers/index.html
+++ b/frontend/constitution-makers/index.html
@@ -252,7 +252,7 @@
                 <div class="cm-member-card">
                     <div class="cm-avatar-header">
                         <div class="cm-avatar-wrap" style="border-color: #F472B6;">
-                            <img class="cm-avatar-img" src="../../${w.portrait}" alt="${w.name}">
+                            <img class="cm-avatar-img" src="../../${w.portrait}" alt="${w.name}" loading="lazy">
                         </div>
                         <div>
                             <h3 class="cm-member-name">${w.name}</h3>

--- a/frontend/mountains/index.html
+++ b/frontend/mountains/index.html
@@ -158,7 +158,7 @@
         </article>
 
         <article class="mountain-card mana-peak-card">
-          <img src="assets/travel_mountains.png" alt="Mana Peak mountain in the Garhwal Himalayas">
+          <img src="assets/travel_mountains.png" alt="Mana Peak mountain in the Garhwal Himalayas" loading="lazy">
           <div class="mountain-card-content">
             <span class="mountain-badge">Uttarakhand · 7,272 m</span>
             <h3>Mana Peak</h3>
@@ -168,7 +168,7 @@
         </article>
 
         <article class="mountain-card kalanka-card">
-          <img src="assets/travel_mountains.png" alt="Kalanka mountain in the Garhwal Himalayas">
+          <img src="assets/travel_mountains.png" alt="Kalanka mountain in the Garhwal Himalayas" loading="lazy">
           <div class="mountain-card-content">
             <span class="mountain-badge">Uttarakhand · 6,931 m</span>
             <h3>Kalanka</h3>
@@ -178,7 +178,7 @@
         </article>
 
         <article class="mountain-card deo-tibba-card">
-          <img src="assets/travel_mountains.png" alt="Deo Tibba mountain in Himachal Pradesh">
+          <img src="assets/travel_mountains.png" alt="Deo Tibba mountain in Himachal Pradesh" loading="lazy">
           <div class="mountain-card-content">
             <span class="mountain-badge">Himachal Pradesh · 6,001 m</span>
             <h3>Deo Tibba</h3>
@@ -188,7 +188,7 @@
         </article>
 
         <article class="mountain-card friendship-peak-card">
-          <img src="assets/travel_mountains.png" alt="Friendship Peak mountain in Himachal Pradesh">
+          <img src="assets/travel_mountains.png" alt="Friendship Peak mountain in Himachal Pradesh" loading="lazy">
           <div class="mountain-card-content">
             <span class="mountain-badge">Himachal Pradesh · 5,289 m</span>
             <h3>Friendship Peak</h3>

--- a/frontend/national-parks/clouded-leopard-national-park/clouded-leopard-national-park.html
+++ b/frontend/national-parks/clouded-leopard-national-park/clouded-leopard-national-park.html
@@ -138,7 +138,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/Capped_langur.jpg/800px-Capped_langur.jpg" alt="Capped Langur" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/65/Capped_langur.jpg/800px-Capped_langur.jpg" alt="Capped Langur" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Capped Langur</h3>
                             <span class="wildlife-status status-vulnerable">Vulnerable</span>
@@ -146,7 +146,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/e5/Muntiacus_muntjak_%28Barking_deer%29.jpg/800px-Muntiacus_muntjak_%28Barking_deer%29.jpg" alt="Barking Deer" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/e5/Muntiacus_muntjak_%28Barking_deer%29.jpg/800px-Muntiacus_muntjak_%28Barking_deer%29.jpg" alt="Barking Deer" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Barking Deer (Muntjac)</h3>
                             <span class="wildlife-status status-least-concern">Least Concern</span>
@@ -154,7 +154,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/a/ab/Slow_Loris.jpg/800px-Slow_Loris.jpg" alt="Slow Loris" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/a/ab/Slow_Loris.jpg/800px-Slow_Loris.jpg" alt="Slow Loris" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Slow Loris</h3>
                             <span class="wildlife-status status-endangered">Endangered</span>

--- a/frontend/national-parks/dibru-saikhowa-national-park/dibru-saikhowa-national-park.html
+++ b/frontend/national-parks/dibru-saikhowa-national-park/dibru-saikhowa-national-park.html
@@ -138,7 +138,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b9/Panthera_tigris_tigris.jpg/800px-Panthera_tigris_tigris.jpg" alt="Bengal Tiger" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b9/Panthera_tigris_tigris.jpg/800px-Panthera_tigris_tigris.jpg" alt="Bengal Tiger" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Bengal Tiger</h3>
                             <span class="wildlife-status status-endangered">Endangered</span>
@@ -146,7 +146,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/36/Asian_Elephant_in_Kaziranga.jpg/800px-Asian_Elephant_in_Kaziranga.jpg" alt="Asian Elephant" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/36/Asian_Elephant_in_Kaziranga.jpg/800px-Asian_Elephant_in_Kaziranga.jpg" alt="Asian Elephant" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Asian Elephant</h3>
                             <span class="wildlife-status status-endangered">Endangered</span>
@@ -154,7 +154,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Platanista_gangetica_no_font.png/800px-Platanista_gangetica_no_font.png" alt="Gangetic Dolphin" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Platanista_gangetica_no_font.png/800px-Platanista_gangetica_no_font.png" alt="Gangetic Dolphin" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Gangetic Dolphin</h3>
                             <span class="wildlife-status status-endangered">Endangered</span>
@@ -162,7 +162,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Clouded_Leopard.jpg/800px-Clouded_Leopard.jpg" alt="Clouded Leopard" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4c/Clouded_Leopard.jpg/800px-Clouded_Leopard.jpg" alt="Clouded Leopard" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Clouded Leopard</h3>
                             <span class="wildlife-status status-vulnerable">Vulnerable</span>
@@ -170,7 +170,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Bengal_Slow_Loris.jpg/800px-Bengal_Slow_Loris.jpg" alt="Slow Loris" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/be/Bengal_Slow_Loris.jpg/800px-Bengal_Slow_Loris.jpg" alt="Slow Loris" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Slow Loris</h3>
                             <span class="wildlife-status status-endangered">Endangered</span>
@@ -191,7 +191,7 @@
                 </div>
                 <div class="wildlife-grid">
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/e0/White-winged_Duck.jpg/800px-White-winged_Duck.jpg" alt="White-winged Wood Duck" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/e0/White-winged_Duck.jpg/800px-White-winged_Duck.jpg" alt="White-winged Wood Duck" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">White-winged Wood Duck</h3>
                             <span class="wildlife-status status-endangered">Endangered</span>
@@ -199,7 +199,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Greater_Adjutant_%28Leptoptilos_dubius%29.jpg/800px-Greater_Adjutant_%28Leptoptilos_dubius%29.jpg" alt="Greater Adjutant" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Greater_Adjutant_%28Leptoptilos_dubius%29.jpg/800px-Greater_Adjutant_%28Leptoptilos_dubius%29.jpg" alt="Greater Adjutant" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Greater Adjutant Stork</h3>
                             <span class="wildlife-status status-endangered">Endangered</span>
@@ -249,16 +249,16 @@
                 </div>
                 <div class="gallery-grid" id="gallery-grid" role="group" aria-label="Image Gallery">
                     <div class="gallery-item" tabindex="0" role="button" aria-label="View Feral Horses Image">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cc/Wild_Horses_at_Dibru_Saikhowa.jpg/800px-Wild_Horses_at_Dibru_Saikhowa.jpg" alt="Feral horses grazing on the river islands">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cc/Wild_Horses_at_Dibru_Saikhowa.jpg/800px-Wild_Horses_at_Dibru_Saikhowa.jpg" alt="Feral horses grazing on the river islands" loading="lazy">
                     </div>
                     <div class="gallery-item" tabindex="0" role="button" aria-label="View Wetlands Image">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Dibru-Saikhowa_National_Park_Assam.jpg/800px-Dibru-Saikhowa_National_Park_Assam.jpg" alt="Wetland landscapes">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Dibru-Saikhowa_National_Park_Assam.jpg/800px-Dibru-Saikhowa_National_Park_Assam.jpg" alt="Wetland landscapes" loading="lazy">
                     </div>
                     <div class="gallery-item" tabindex="0" role="button" aria-label="View Boat Safari Image">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/f3/Brahmaputra_River_Sunset.jpg/800px-Brahmaputra_River_Sunset.jpg" alt="Sunset over the Brahmaputra River">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/f3/Brahmaputra_River_Sunset.jpg/800px-Brahmaputra_River_Sunset.jpg" alt="Sunset over the Brahmaputra River" loading="lazy">
                     </div>
                     <div class="gallery-item" tabindex="0" role="button" aria-label="View Forest Image">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/e0/White-winged_Duck.jpg/800px-White-winged_Duck.jpg" alt="White-winged Wood Duck">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/e0/White-winged_Duck.jpg/800px-White-winged_Duck.jpg" alt="White-winged Wood Duck" loading="lazy">
                     </div>
                 </div>
             </div>

--- a/frontend/national-parks/gorumara-national-park/gorumara-national-park.html
+++ b/frontend/national-parks/gorumara-national-park/gorumara-national-park.html
@@ -138,7 +138,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/36/Asian_Elephant_in_Kaziranga.jpg/800px-Asian_Elephant_in_Kaziranga.jpg" alt="Asian Elephant" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/36/Asian_Elephant_in_Kaziranga.jpg/800px-Asian_Elephant_in_Kaziranga.jpg" alt="Asian Elephant" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Asian Elephant</h3>
                             <span class="wildlife-status status-endangered">Endangered</span>
@@ -146,7 +146,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1e/Gaur_in_Bandipur.jpg/800px-Gaur_in_Bandipur.jpg" alt="Indian Bison (Gaur)" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1e/Gaur_in_Bandipur.jpg/800px-Gaur_in_Bandipur.jpg" alt="Indian Bison (Gaur)" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Indian Bison (Gaur)</h3>
                             <span class="wildlife-status status-vulnerable">Vulnerable</span>
@@ -154,7 +154,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4e/Leopard_africa.jpg/800px-Leopard_africa.jpg" alt="Indian Leopard" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4e/Leopard_africa.jpg/800px-Leopard_africa.jpg" alt="Indian Leopard" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Indian Leopard</h3>
                             <span class="wildlife-status status-vulnerable">Vulnerable</span>
@@ -175,7 +175,7 @@
                 </div>
                 <div class="wildlife-grid">
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Great_Hornbill_at_Khao_Yai_National_Park.jpg/800px-Great_Hornbill_at_Khao_Yai_National_Park.jpg" alt="Great Hornbill" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Great_Hornbill_at_Khao_Yai_National_Park.jpg/800px-Great_Hornbill_at_Khao_Yai_National_Park.jpg" alt="Great Hornbill" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Great Hornbill</h3>
                             <span class="wildlife-status status-vulnerable">Vulnerable</span>
@@ -183,7 +183,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/f6/Scarlet_Minivet_Male.jpg/800px-Scarlet_Minivet_Male.jpg" alt="Scarlet Minivet" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/f6/Scarlet_Minivet_Male.jpg/800px-Scarlet_Minivet_Male.jpg" alt="Scarlet Minivet" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Scarlet Minivet</h3>
                             <span class="wildlife-status status-least-concern">Least Concern</span>
@@ -191,7 +191,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/52/White-throated_Kingfisher_%28Halcyon_smyrnensis%29.jpg/800px-White-throated_Kingfisher_%28Halcyon_smyrnensis%29.jpg" alt="Kingfishers" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/52/White-throated_Kingfisher_%28Halcyon_smyrnensis%29.jpg/800px-White-throated_Kingfisher_%28Halcyon_smyrnensis%29.jpg" alt="Kingfishers" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Kingfishers</h3>
                             <span class="wildlife-status status-least-concern">Various</span>

--- a/frontend/national-parks/gulf-of-mannar-marine-national-park/gulf-of-mannar-marine-national-park.html
+++ b/frontend/national-parks/gulf-of-mannar-marine-national-park/gulf-of-mannar-marine-national-park.html
@@ -150,7 +150,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/a/ad/Stenella_longirostris_no_font.png/800px-Stenella_longirostris_no_font.png" alt="Spinner Dolphin" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/a/ad/Stenella_longirostris_no_font.png/800px-Stenella_longirostris_no_font.png" alt="Spinner Dolphin" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Spinner Dolphin</h3>
                             <span class="wildlife-status status-least-concern">Least Concern</span>
@@ -158,7 +158,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/Green_Sea_Turtle_grazing_seagrass.jpg/800px-Green_Sea_Turtle_grazing_seagrass.jpg" alt="Green Sea Turtle" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/Green_Sea_Turtle_grazing_seagrass.jpg/800px-Green_Sea_Turtle_grazing_seagrass.jpg" alt="Green Sea Turtle" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Green Sea Turtle</h3>
                             <span class="wildlife-status status-endangered">Endangered</span>
@@ -166,7 +166,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/63/Clownfish_%28Amphiprion_ocellaris%29.jpg/800px-Clownfish_%28Amphiprion_ocellaris%29.jpg" alt="Reef Fish" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/63/Clownfish_%28Amphiprion_ocellaris%29.jpg/800px-Clownfish_%28Amphiprion_ocellaris%29.jpg" alt="Reef Fish" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Reef Fish</h3>
                             <span class="wildlife-status status-least-concern">Various</span>
@@ -174,7 +174,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/e0/Acropora_cervicornis.jpg/800px-Acropora_cervicornis.jpg" alt="Hard Corals" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/e0/Acropora_cervicornis.jpg/800px-Acropora_cervicornis.jpg" alt="Hard Corals" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Hard Corals</h3>
                             <span class="wildlife-status status-critical">Threatened</span>

--- a/frontend/national-parks/indravati-national-park/indravati-national-park.html
+++ b/frontend/national-parks/indravati-national-park/indravati-national-park.html
@@ -158,7 +158,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cd/Wild_water_buffalo_%28Bubalus_arnee%29.jpg/800px-Wild_water_buffalo_%28Bubalus_arnee%29.jpg" alt="Wild Water Buffalo" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cd/Wild_water_buffalo_%28Bubalus_arnee%29.jpg/800px-Wild_water_buffalo_%28Bubalus_arnee%29.jpg" alt="Wild Water Buffalo" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Wild Water Buffalo</h3>
                             <span class="wildlife-status status-endangered">Endangered</span>
@@ -166,7 +166,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/07/Leopard_in_tree.jpg/800px-Leopard_in_tree.jpg" alt="Indian Leopard" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/07/Leopard_in_tree.jpg/800px-Leopard_in_tree.jpg" alt="Indian Leopard" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Indian Leopard</h3>
                             <span class="wildlife-status status-vulnerable">Vulnerable</span>
@@ -174,7 +174,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7b/Sloth_Bear_%28Melursus_ursinus%29.jpg/800px-Sloth_Bear_%28Melursus_ursinus%29.jpg" alt="Sloth Bear" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7b/Sloth_Bear_%28Melursus_ursinus%29.jpg/800px-Sloth_Bear_%28Melursus_ursinus%29.jpg" alt="Sloth Bear" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Sloth Bear</h3>
                             <span class="wildlife-status status-vulnerable">Vulnerable</span>
@@ -182,7 +182,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b3/Dhole_%28Cuon_alpinus%29_in_Nagarhole_National_Park.jpg/800px-Dhole_%28Cuon_alpinus%29_in_Nagarhole_National_Park.jpg" alt="Dhole (Wild Dog)" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b3/Dhole_%28Cuon_alpinus%29_in_Nagarhole_National_Park.jpg/800px-Dhole_%28Cuon_alpinus%29_in_Nagarhole_National_Park.jpg" alt="Dhole (Wild Dog)" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Dhole (Wild Dog)</h3>
                             <span class="wildlife-status status-endangered">Endangered</span>
@@ -190,7 +190,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/Gaur_in_Bandipur.jpg/800px-Gaur_in_Bandipur.jpg" alt="Gaur (Indian Bison)" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/Gaur_in_Bandipur.jpg/800px-Gaur_in_Bandipur.jpg" alt="Gaur (Indian Bison)" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Gaur (Indian Bison)</h3>
                             <span class="wildlife-status status-vulnerable">Vulnerable</span>
@@ -246,16 +246,16 @@
                 </div>
                 <div class="gallery-grid" id="gallery-grid" role="group" aria-label="Image Gallery">
                     <div class="gallery-item" tabindex="0" role="button" aria-label="View Tiger Image">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c8/Tiger_in_Panna_Tiger_Reserve.jpg/800px-Tiger_in_Panna_Tiger_Reserve.jpg" alt="Tiger in the wild">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c8/Tiger_in_Panna_Tiger_Reserve.jpg/800px-Tiger_in_Panna_Tiger_Reserve.jpg" alt="Tiger in the wild" loading="lazy">
                     </div>
                     <div class="gallery-item" tabindex="0" role="button" aria-label="View Wild Buffalo Image">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cd/Wild_water_buffalo_%28Bubalus_arnee%29.jpg/800px-Wild_water_buffalo_%28Bubalus_arnee%29.jpg" alt="Wild Water Buffalo grazing">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cd/Wild_water_buffalo_%28Bubalus_arnee%29.jpg/800px-Wild_water_buffalo_%28Bubalus_arnee%29.jpg" alt="Wild Water Buffalo grazing" loading="lazy">
                     </div>
                     <div class="gallery-item" tabindex="0" role="button" aria-label="View Forest Landscape Image">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Sal_forest_in_Kanha.jpg/800px-Sal_forest_in_Kanha.jpg" alt="Dense Sal forest">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/6/69/Sal_forest_in_Kanha.jpg/800px-Sal_forest_in_Kanha.jpg" alt="Dense Sal forest" loading="lazy">
                     </div>
                     <div class="gallery-item" tabindex="0" role="button" aria-label="View River Image">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7b/Indravati_river.jpg/800px-Indravati_river.jpg" alt="The Indravati River">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7b/Indravati_river.jpg/800px-Indravati_river.jpg" alt="The Indravati River" loading="lazy">
                     </div>
                 </div>
             </div>

--- a/frontend/national-parks/orang-national-park/orang-national-park.html
+++ b/frontend/national-parks/orang-national-park/orang-national-park.html
@@ -138,7 +138,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b9/Panthera_tigris_tigris.jpg/800px-Panthera_tigris_tigris.jpg" alt="Bengal Tiger" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b9/Panthera_tigris_tigris.jpg/800px-Panthera_tigris_tigris.jpg" alt="Bengal Tiger" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Bengal Tiger</h3>
                             <span class="wildlife-status status-endangered">Endangered</span>
@@ -146,7 +146,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/Pygmy_Hog.jpg/800px-Pygmy_Hog.jpg" alt="Pygmy Hog" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/Pygmy_Hog.jpg/800px-Pygmy_Hog.jpg" alt="Pygmy Hog" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Pygmy Hog</h3>
                             <span class="wildlife-status status-critically-endangered">Critically Endangered</span>
@@ -154,7 +154,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4e/Elephant_at_Kaziranga.jpg/800px-Elephant_at_Kaziranga.jpg" alt="Asian Elephant" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4e/Elephant_at_Kaziranga.jpg/800px-Elephant_at_Kaziranga.jpg" alt="Asian Elephant" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Asian Elephant</h3>
                             <span class="wildlife-status status-endangered">Endangered</span>
@@ -175,7 +175,7 @@
                 </div>
                 <div class="wildlife-grid">
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4e/Bengal_Florican_%28Houbaropsis_bengalensis%29.jpg/800px-Bengal_Florican_%28Houbaropsis_bengalensis%29.jpg" alt="Bengal Florican" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/4e/Bengal_Florican_%28Houbaropsis_bengalensis%29.jpg/800px-Bengal_Florican_%28Houbaropsis_bengalensis%29.jpg" alt="Bengal Florican" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Bengal Florican</h3>
                             <span class="wildlife-status status-critically-endangered">Critically Endangered</span>
@@ -183,7 +183,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Greater_Adjutant_%28Leptoptilos_dubius%29.jpg/800px-Greater_Adjutant_%28Leptoptilos_dubius%29.jpg" alt="Greater Adjutant" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Greater_Adjutant_%28Leptoptilos_dubius%29.jpg/800px-Greater_Adjutant_%28Leptoptilos_dubius%29.jpg" alt="Greater Adjutant" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Greater Adjutant Stork</h3>
                             <span class="wildlife-status status-endangered">Endangered</span>
@@ -191,7 +191,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/3f/Spot-billed_Pelican_%28Pelecanus_philippensis%29.jpg/800px-Spot-billed_Pelican_%28Pelecanus_philippensis%29.jpg" alt="Spot-billed Pelican" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/3f/Spot-billed_Pelican_%28Pelecanus_philippensis%29.jpg/800px-Spot-billed_Pelican_%28Pelecanus_philippensis%29.jpg" alt="Spot-billed Pelican" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Spot-billed Pelican</h3>
                             <span class="wildlife-status status-near-threatened">Near Threatened</span>
@@ -199,7 +199,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/52/White-throated_Kingfisher_%28Halcyon_smyrnensis%29.jpg/800px-White-throated_Kingfisher_%28Halcyon_smyrnensis%29.jpg" alt="Kingfishers" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/52/White-throated_Kingfisher_%28Halcyon_smyrnensis%29.jpg/800px-White-throated_Kingfisher_%28Halcyon_smyrnensis%29.jpg" alt="Kingfishers" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Kingfishers</h3>
                             <span class="wildlife-status status-least-concern">Least Concern</span>
@@ -250,16 +250,16 @@
                 </div>
                 <div class="gallery-grid" id="gallery-grid" role="group" aria-label="Image Gallery">
                     <div class="gallery-item" tabindex="0" role="button" aria-label="View Rhino Image">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1c/Indian_Rhinoceros.jpg/800px-Indian_Rhinoceros.jpg" alt="One-Horned Rhinoceros">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/1/1c/Indian_Rhinoceros.jpg/800px-Indian_Rhinoceros.jpg" alt="One-Horned Rhinoceros" loading="lazy">
                     </div>
                     <div class="gallery-item" tabindex="0" role="button" aria-label="View Tiger Image">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b9/Panthera_tigris_tigris.jpg/800px-Panthera_tigris_tigris.jpg" alt="Bengal Tiger">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/b9/Panthera_tigris_tigris.jpg/800px-Panthera_tigris_tigris.jpg" alt="Bengal Tiger" loading="lazy">
                     </div>
                     <div class="gallery-item" tabindex="0" role="button" aria-label="View Wetlands Image">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cb/Orang_National_Park.jpg/800px-Orang_National_Park.jpg" alt="Wetland landscapes of Orang">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cb/Orang_National_Park.jpg/800px-Orang_National_Park.jpg" alt="Wetland landscapes of Orang" loading="lazy">
                     </div>
                     <div class="gallery-item" tabindex="0" role="button" aria-label="View Birdlife Image">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Greater_Adjutant_%28Leptoptilos_dubius%29.jpg/800px-Greater_Adjutant_%28Leptoptilos_dubius%29.jpg" alt="Birdlife in the wetlands">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Greater_Adjutant_%28Leptoptilos_dubius%29.jpg/800px-Greater_Adjutant_%28Leptoptilos_dubius%29.jpg" alt="Birdlife in the wetlands" loading="lazy">
                     </div>
                 </div>
             </div>

--- a/frontend/national-parks/panna-national-park/panna-national-park.html
+++ b/frontend/national-parks/panna-national-park/panna-national-park.html
@@ -158,7 +158,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/07/Leopard_in_tree.jpg/800px-Leopard_in_tree.jpg" alt="Indian Leopard" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/07/Leopard_in_tree.jpg/800px-Leopard_in_tree.jpg" alt="Indian Leopard" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Indian Leopard</h3>
                             <span class="wildlife-status status-vulnerable">Vulnerable</span>
@@ -166,7 +166,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7b/Sloth_Bear_%28Melursus_ursinus%29.jpg/800px-Sloth_Bear_%28Melursus_ursinus%29.jpg" alt="Sloth Bear" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/7b/Sloth_Bear_%28Melursus_ursinus%29.jpg/800px-Sloth_Bear_%28Melursus_ursinus%29.jpg" alt="Sloth Bear" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Sloth Bear</h3>
                             <span class="wildlife-status status-vulnerable">Vulnerable</span>
@@ -174,7 +174,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/30/Indian_wolf_%28Canis_lupus_pallipes%29_by_Sandeep_Thakur.jpg/800px-Indian_wolf_%28Canis_lupus_pallipes%29_by_Sandeep_Thakur.jpg" alt="Indian Wolf" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/30/Indian_wolf_%28Canis_lupus_pallipes%29_by_Sandeep_Thakur.jpg/800px-Indian_wolf_%28Canis_lupus_pallipes%29_by_Sandeep_Thakur.jpg" alt="Indian Wolf" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Indian Wolf</h3>
                             <span class="wildlife-status status-endangered">Endangered</span>
@@ -182,7 +182,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/Gharial_%28Gavialis_gangeticus%29_at_Chambal_River.jpg/800px-Gharial_%28Gavialis_gangeticus%29_at_Chambal_River.jpg" alt="Gharial" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/Gharial_%28Gavialis_gangeticus%29_at_Chambal_River.jpg/800px-Gharial_%28Gavialis_gangeticus%29_at_Chambal_River.jpg" alt="Gharial" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Gharial</h3>
                             <span class="wildlife-status status-endangered">Critically Endangered</span>
@@ -242,16 +242,16 @@
                 </div>
                 <div class="gallery-grid" id="gallery-grid" role="group" aria-label="Image Gallery">
                     <div class="gallery-item" tabindex="0" role="button" aria-label="View Tiger Image">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c8/Tiger_in_Panna_Tiger_Reserve.jpg/800px-Tiger_in_Panna_Tiger_Reserve.jpg" alt="Tiger in Panna National Park">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c8/Tiger_in_Panna_Tiger_Reserve.jpg/800px-Tiger_in_Panna_Tiger_Reserve.jpg" alt="Tiger in Panna National Park" loading="lazy">
                     </div>
                     <div class="gallery-item" tabindex="0" role="button" aria-label="View Raneh Falls Image">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8c/Raneh_Falls_in_Monsoon.jpg/800px-Raneh_Falls_in_Monsoon.jpg" alt="Raneh Falls during monsoon">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8c/Raneh_Falls_in_Monsoon.jpg/800px-Raneh_Falls_in_Monsoon.jpg" alt="Raneh Falls during monsoon" loading="lazy">
                     </div>
                     <div class="gallery-item" tabindex="0" role="button" aria-label="View Ken River Image">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d3/Ken_River_at_Panna.jpg/800px-Ken_River_at_Panna.jpg" alt="Ken River flowing through Panna">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/d/d3/Ken_River_at_Panna.jpg/800px-Ken_River_at_Panna.jpg" alt="Ken River flowing through Panna" loading="lazy">
                     </div>
                     <div class="gallery-item" tabindex="0" role="button" aria-label="View Safari Image">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/e0/Panna_Safari.jpg/800px-Panna_Safari.jpg" alt="Tourists on a Jeep Safari">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/e0/Panna_Safari.jpg/800px-Panna_Safari.jpg" alt="Tourists on a Jeep Safari" loading="lazy">
                     </div>
                 </div>
             </div>

--- a/frontend/national-parks/sri-venkateswara-national-park/sri-venkateswara-national-park.html
+++ b/frontend/national-parks/sri-venkateswara-national-park/sri-venkateswara-national-park.html
@@ -138,7 +138,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8c/Sloth_Bear_%28Melursus_ursinus%29.jpg/800px-Sloth_Bear_%28Melursus_ursinus%29.jpg" alt="Sloth Bear" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/8/8c/Sloth_Bear_%28Melursus_ursinus%29.jpg/800px-Sloth_Bear_%28Melursus_ursinus%29.jpg" alt="Sloth Bear" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Sloth Bear</h3>
                             <span class="wildlife-status status-vulnerable">Vulnerable</span>
@@ -146,7 +146,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/e0/Ratufa_indica_centralis_-_Indian_giant_squirrel_at_BR_Hills.jpg/800px-Ratufa_indica_centralis_-_Indian_giant_squirrel_at_BR_Hills.jpg" alt="Indian Giant Squirrel" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/e/e0/Ratufa_indica_centralis_-_Indian_giant_squirrel_at_BR_Hills.jpg/800px-Ratufa_indica_centralis_-_Indian_giant_squirrel_at_BR_Hills.jpg" alt="Indian Giant Squirrel" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Indian Giant Squirrel</h3>
                             <span class="wildlife-status status-least-concern">Least Concern</span>
@@ -154,7 +154,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/77/Indian_Pangolin_%28Manis_crassicaudata%29.jpg/800px-Indian_Pangolin_%28Manis_crassicaudata%29.jpg" alt="Indian Pangolin" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/7/77/Indian_Pangolin_%28Manis_crassicaudata%29.jpg/800px-Indian_Pangolin_%28Manis_crassicaudata%29.jpg" alt="Indian Pangolin" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Indian Pangolin</h3>
                             <span class="wildlife-status status-endangered">Endangered</span>
@@ -170,7 +170,7 @@
                         </div>
                     </div>
                     <div class="wildlife-card">
-                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Jungle_Cat_%28Felis_chaus%29.jpg/800px-Jungle_Cat_%28Felis_chaus%29.jpg" alt="Jungle Cat" class="wildlife-img">
+                        <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/2/2f/Jungle_Cat_%28Felis_chaus%29.jpg/800px-Jungle_Cat_%28Felis_chaus%29.jpg" alt="Jungle Cat" class="wildlife-img" loading="lazy">
                         <div class="wildlife-info">
                             <h3 class="wildlife-name">Jungle Cat</h3>
                             <span class="wildlife-status status-least-concern">Least Concern</span>

--- a/frontend/personalities/personalities.html
+++ b/frontend/personalities/personalities.html
@@ -356,7 +356,7 @@
 </div>
 <div class="person-card" data-category="historical" data-id="personalities-chhatrapati-shivaji-maharaj">
 <div class="person-img-wrapper">
-<img alt="Chhatrapati Shivaji Maharaj" class="person-img" src="../../assets/Chhatrapati_Shivaji.png"/>
+<img alt="Chhatrapati Shivaji Maharaj" class="person-img" src="../../assets/Chhatrapati_Shivaji.png" loading="lazy"/>
 <button aria-label="Save Chhatrapati Shivaji Maharaj to My Journey" aria-pressed="false" class="person-card-bookmark-btn journey-bookmark-btn" data-bookmark-id="personalities-chhatrapati-shivaji-maharaj" type="button">♡</button></div>
 <div class="person-info">
 <h3 class="person-name">Chhatrapati Shivaji Maharaj</h3>
@@ -366,7 +366,7 @@
 </div>
 <div class="person-card" data-category="freedom-fighter" data-id="personalities-rani-lakshmibai">
 <div class="person-img-wrapper">
-<img alt="Rani Lakshmibai" class="person-img" src="../../assets/Rani_Lakshmibai.png"/>
+<img alt="Rani Lakshmibai" class="person-img" src="../../assets/Rani_Lakshmibai.png" loading="lazy"/>
 <button aria-label="Save Rani Lakshmibai to My Journey" aria-pressed="false" class="person-card-bookmark-btn journey-bookmark-btn" data-bookmark-id="personalities-rani-lakshmibai" type="button">♡</button></div>
 <div class="person-info">
 <h3 class="person-name">Rani Lakshmibai</h3>
@@ -376,7 +376,7 @@
 </div>
 <div class="person-card" data-category="freedom-fighter" data-id="personalities-mahatma-gandhi">
 <div class="person-img-wrapper">
-<img alt="Mahatma Gandhi" class="person-img" src="../../assets/Mahatma.png"/>
+<img alt="Mahatma Gandhi" class="person-img" src="../../assets/Mahatma.png" loading="lazy"/>
 <button aria-label="Save Mahatma Gandhi to My Journey" aria-pressed="false" class="person-card-bookmark-btn journey-bookmark-btn" data-bookmark-id="personalities-mahatma-gandhi" type="button">♡</button></div>
 <div class="person-info">
 <h3 class="person-name">Mahatma Gandhi</h3>
@@ -386,7 +386,7 @@
 </div>
 <div class="person-card" data-category="freedom-fighter" data-id="personalities-bhagat-singh">
 <div class="person-img-wrapper">
-<img alt="Bhagat Singh" class="person-img" src="../../assets/Bhagat.png"/>
+<img alt="Bhagat Singh" class="person-img" src="../../assets/Bhagat.png" loading="lazy"/>
 <button aria-label="Save Bhagat Singh to My Journey" aria-pressed="false" class="person-card-bookmark-btn journey-bookmark-btn" data-bookmark-id="personalities-bhagat-singh" type="button">♡</button></div>
 <div class="person-info">
 <h3 class="person-name">Bhagat Singh</h3>
@@ -396,7 +396,7 @@
 </div>
 <div class="person-card" data-category="freedom-fighter" data-id="personalities-subhas-chandra-bose">
 <div class="person-img-wrapper">
-<img alt="Subhas Chandra Bose" class="person-img" src="../../assets/Subhas_Chandra.png"/>
+<img alt="Subhas Chandra Bose" class="person-img" src="../../assets/Subhas_Chandra.png" loading="lazy"/>
 <button aria-label="Save Subhas Chandra Bose to My Journey" aria-pressed="false" class="person-card-bookmark-btn journey-bookmark-btn" data-bookmark-id="personalities-subhas-chandra-bose" type="button">♡</button></div>
 <div class="person-info">
 <h3 class="person-name">Subhas Chandra Bose</h3>
@@ -406,7 +406,7 @@
 </div>
 <div class="person-card" data-category="historical" data-id="personalities-maharana-pratap">
 <div class="person-img-wrapper">
-<img alt="Maharana Pratap" class="person-img" src="../../assets/Maharana.png"/>
+<img alt="Maharana Pratap" class="person-img" src="../../assets/Maharana.png" loading="lazy"/>
 <button aria-label="Save Maharana Pratap to My Journey" aria-pressed="false" class="person-card-bookmark-btn journey-bookmark-btn" data-bookmark-id="personalities-maharana-pratap" type="button">♡</button></div>
 <div class="person-info">
 <h3 class="person-name">Maharana Pratap</h3>
@@ -416,7 +416,7 @@
 </div>
 <div class="person-card" data-category="modern" data-id="personalities-dr-a-p-j-abdul-kalam">
 <div class="person-img-wrapper">
-<img alt="Dr. A. P. J. Abdul Kalam" class="person-img" src="../../assets/Abdul_kalam.png"/>
+<img alt="Dr. A. P. J. Abdul Kalam" class="person-img" src="../../assets/Abdul_kalam.png" loading="lazy"/>
 <button aria-label="Save Dr. A. P. J. Abdul Kalam to My Journey" aria-pressed="false" class="person-card-bookmark-btn journey-bookmark-btn" data-bookmark-id="personalities-dr-a-p-j-abdul-kalam" type="button">♡</button></div>
 <div class="person-info">
 <h3 class="person-name">Dr. A. P. J. Abdul Kalam</h3>
@@ -426,7 +426,7 @@
 </div>
 <div class="person-card" data-category="modern" data-id="personalities-ratan-tata">
 <div class="person-img-wrapper">
-<img alt="Ratan Tata" class="person-img" src="../../assets/Ratan_Tata.png"/>
+<img alt="Ratan Tata" class="person-img" src="../../assets/Ratan_Tata.png" loading="lazy"/>
 <button aria-label="Save Ratan Tata to My Journey" aria-pressed="false" class="person-card-bookmark-btn journey-bookmark-btn" data-bookmark-id="personalities-ratan-tata" type="button">♡</button></div>
 <div class="person-info">
 <h3 class="person-name">Ratan Tata</h3>
@@ -436,7 +436,7 @@
 </div>
 <div class="person-card" data-category="modern" data-id="personalities-sachin-tendulkar">
 <div class="person-img-wrapper">
-<img alt="Sachin Tendulkar" class="person-img" src="../../assets/Sachin.png"/>
+<img alt="Sachin Tendulkar" class="person-img" src="../../assets/Sachin.png" loading="lazy"/>
 <button aria-label="Save Sachin Tendulkar to My Journey" aria-pressed="false" class="person-card-bookmark-btn journey-bookmark-btn" data-bookmark-id="personalities-sachin-tendulkar" type="button">♡</button></div>
 <div class="person-info">
 <h3 class="person-name">Sachin Tendulkar</h3>
@@ -446,7 +446,7 @@
 </div>
 <div class="person-card" data-category="modern" data-id="personalities-n-r-narayana-murthy">
 <div class="person-img-wrapper">
-<img alt="N. R. Narayana Murthy" class="person-img" src="../../assets/Narayan.png"/>
+<img alt="N. R. Narayana Murthy" class="person-img" src="../../assets/Narayan.png" loading="lazy"/>
 <button aria-label="Save N. R. Narayana Murthy to My Journey" aria-pressed="false" class="person-card-bookmark-btn journey-bookmark-btn" data-bookmark-id="personalities-n-r-narayana-murthy" type="button">♡</button></div>
 <div class="person-info">
 <h3 class="person-name">N. R. Narayana Murthy</h3>
@@ -456,7 +456,7 @@
 </div>
 <div class="person-card" data-category="historical" data-id="personalities-akbar-the-great">
 <div class="person-img-wrapper">
-<img alt="Akbar the Great" class="person-img" src="../../assets/Akbar.png"/>
+<img alt="Akbar the Great" class="person-img" src="../../assets/Akbar.png" loading="lazy"/>
 <button aria-label="Save Akbar the Great to My Journey" aria-pressed="false" class="person-card-bookmark-btn journey-bookmark-btn" data-bookmark-id="personalities-akbar-the-great" type="button">♡</button></div>
 <div class="person-info">
 <h3 class="person-name">Akbar the Great</h3>

--- a/frontend/premium/premium.html
+++ b/frontend/premium/premium.html
@@ -265,7 +265,7 @@
                         <h3 style="margin-bottom: 15px; font-family: var(--font-body); font-weight: 700; color: var(--primary-gold);">Wildlife Films</h3>
                         <div class="netflix-row">
                             <div class="netflix-card">
-                                <img class="netflix-img" src="../../assets/travel_forests.png" alt="Tigers of Bandhavgarh">
+                                <img class="netflix-img" src="../../assets/travel_forests.png" alt="Tigers of Bandhavgarh" loading="lazy">
                                 <div class="netflix-info">
                                     <h4>Tigers of Bandhavgarh</h4>
                                     <p>
@@ -275,7 +275,7 @@
                                 </div>
                             </div>
                             <div class="netflix-card">
-                                <img class="netflix-img" src="../../assets/travel_beaches.png" alt="Elephant Whisperers">
+                                <img class="netflix-img" src="../../assets/travel_beaches.png" alt="Elephant Whisperers" loading="lazy">
                                 <div class="netflix-info">
                                     <h4>Elephant Whisperers</h4>
                                     <p>
@@ -285,7 +285,7 @@
                                 </div>
                             </div>
                             <div class="netflix-card">
-                                <img class="netflix-img" src="../../assets/travel_mountains.png" alt="Ghost of the Himalayas">
+                                <img class="netflix-img" src="../../assets/travel_mountains.png" alt="Ghost of the Himalayas" loading="lazy">
                                 <div class="netflix-info">
                                     <h4>Ghost of the Himalayas</h4>
                                     <p>
@@ -295,7 +295,7 @@
                                 </div>
                             </div>
                             <div class="netflix-card">
-                                <img class="netflix-img" src="../../assets/travel_islands.png" alt="Kaziranga Diaries">
+                                <img class="netflix-img" src="../../assets/travel_islands.png" alt="Kaziranga Diaries" loading="lazy">
                                 <div class="netflix-info">
                                     <h4>Kaziranga Diaries</h4>
                                     <p>
@@ -309,7 +309,7 @@
                         <h3 style="margin: 45px 0 15px; font-family: var(--font-body); font-weight: 700; color: var(--primary-gold);">State Documentaries</h3>
                         <div class="netflix-row">
                             <div class="netflix-card">
-                                <img class="netflix-img" src="../../assets/travel_deserts.png" alt="Rajasthan: The Royal Sand">
+                                <img class="netflix-img" src="../../assets/travel_deserts.png" alt="Rajasthan: The Royal Sand" loading="lazy">
                                 <div class="netflix-info">
                                     <h4>Rajasthan: The Royal Sand</h4>
                                     <p>
@@ -319,7 +319,7 @@
                                 </div>
                             </div>
                             <div class="netflix-card">
-                                <img class="netflix-img" src="../../assets/travel_beaches.png" alt="Kerala: God's Own Country">
+                                <img class="netflix-img" src="../../assets/travel_beaches.png" alt="Kerala: God's Own Country" loading="lazy">
                                 <div class="netflix-info">
                                     <h4>Kerala: God's Own Country</h4>
                                     <p>
@@ -329,7 +329,7 @@
                                 </div>
                             </div>
                             <div class="netflix-card">
-                                <img class="netflix-img" src="../../assets/travel_hidden.png" alt="Meghalaya: Living Bridges">
+                                <img class="netflix-img" src="../../assets/travel_hidden.png" alt="Meghalaya: Living Bridges" loading="lazy">
                                 <div class="netflix-info">
                                     <h4>Meghalaya: Living Bridges</h4>
                                     <p>
@@ -431,7 +431,7 @@
                             </div>
                         </div>
                         <div class="era-image-container">
-                            <img class="era-image" src="${eraData[val].image}" alt="${eraData[val].title}">
+                            <img class="era-image" src="${eraData[val].image}" alt="${eraData[val].title}" loading="lazy">
                         </div>
                     </div>
                 `;

--- a/frontend/press/press.html
+++ b/frontend/press/press.html
@@ -96,7 +96,7 @@
                 
                 <div class="card">
                     <div class="card-image-container">
-                        <img src="assets/screenshot-home.webp" alt="Incredible India Explorer Home Page Screenshot" class="asset-img" onerror="this.src='data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22400%22%20height%3D%22250%22%20viewBox%3D%220%200%20400%20250%22%3E%3Crect%20width%3D%22400%22%20height%3D%22250%22%20fill%3D%22%23e2e8f0%22%2F%3E%3Ctext%20x%3D%22200%22%20y%3D%22125%22%20font-family%3D%22sans-serif%22%20font-size%3D%2216%22%20fill%3D%22%2364748b%22%20text-anchor%3D%22middle%22%3EHome%20Page%20Screenshot%3C%2Ftext%3E%3C%2Fsvg%3E'">
+                        <img src="assets/screenshot-home.webp" alt="Incredible India Explorer Home Page Screenshot" class="asset-img" onerror="this.src='data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22400%22%20height%3D%22250%22%20viewBox%3D%220%200%20400%20250%22%3E%3Crect%20width%3D%22400%22%20height%3D%22250%22%20fill%3D%22%23e2e8f0%22%2F%3E%3Ctext%20x%3D%22200%22%20y%3D%22125%22%20font-family%3D%22sans-serif%22%20font-size%3D%2216%22%20fill%3D%22%2364748b%22%20text-anchor%3D%22middle%22%3EHome%20Page%20Screenshot%3C%2Ftext%3E%3C%2Fsvg%3E'" loading="lazy">
                     </div>
                     <div class="card-footer">
                         <h3>Home Page</h3>
@@ -106,7 +106,7 @@
 
                 <div class="card">
                     <div class="card-image-container">
-                        <img src="assets/screenshot-map.webp" alt="Incredible India Explorer Interactive Map Screenshot" class="asset-img" onerror="this.src='data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22400%22%20height%3D%22250%22%20viewBox%3D%220%200%20400%20250%22%3E%3Crect%20width%3D%22400%22%20height%3D%22250%22%20fill%3D%22%23e2e8f0%22%2F%3E%3Ctext%20x%3D%22200%22%20y%3D%22125%22%20font-family%3D%22sans-serif%22%20font-size%3D%2216%22%20fill%3D%22%2364748b%22%20text-anchor%3D%22middle%22%3EMap%20Screenshot%3C%2Ftext%3E%3C%2Fsvg%3E'">
+                        <img src="assets/screenshot-map.webp" alt="Incredible India Explorer Interactive Map Screenshot" class="asset-img" onerror="this.src='data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22400%22%20height%3D%22250%22%20viewBox%3D%220%200%20400%20250%22%3E%3Crect%20width%3D%22400%22%20height%3D%22250%22%20fill%3D%22%23e2e8f0%22%2F%3E%3Ctext%20x%3D%22200%22%20y%3D%22125%22%20font-family%3D%22sans-serif%22%20font-size%3D%2216%22%20fill%3D%22%2364748b%22%20text-anchor%3D%22middle%22%3EMap%20Screenshot%3C%2Ftext%3E%3C%2Fsvg%3E'" loading="lazy">
                     </div>
                     <div class="card-footer">
                         <h3>Interactive Map</h3>
@@ -116,7 +116,7 @@
 
                 <div class="card">
                     <div class="card-image-container">
-                        <img src="assets/screenshot-game.webp" alt="Incredible India Explorer Game Page Screenshot" class="asset-img" onerror="this.src='data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22400%22%20height%3D%22250%22%20viewBox%3D%220%200%20400%20250%22%3E%3Crect%20width%3D%22400%22%20height%3D%22250%22%20fill%3D%22%23e2e8f0%22%2F%3E%3Ctext%20x%3D%22200%22%20y%3D%22125%22%20font-family%3D%22sans-serif%22%20font-size%3D%2216%22%20fill%3D%22%2364748b%22%20text-anchor%3D%22middle%22%3EGame%20Screenshot%3C%2Ftext%3E%3C%2Fsvg%3E'">
+                        <img src="assets/screenshot-game.webp" alt="Incredible India Explorer Game Page Screenshot" class="asset-img" onerror="this.src='data:image/svg+xml;charset=UTF-8,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22400%22%20height%3D%22250%22%20viewBox%3D%220%200%20400%20250%22%3E%3Crect%20width%3D%22400%22%20height%3D%22250%22%20fill%3D%22%23e2e8f0%22%2F%3E%3Ctext%20x%3D%22200%22%20y%3D%22125%22%20font-family%3D%22sans-serif%22%20font-size%3D%2216%22%20fill%3D%22%2364748b%22%20text-anchor%3D%22middle%22%3EGame%20Screenshot%3C%2Ftext%3E%3C%2Fsvg%3E'" loading="lazy">
                     </div>
                     <div class="card-footer">
                         <h3>Game View</h3>

--- a/frontend/stepwells/stepwells.html
+++ b/frontend/stepwells/stepwells.html
@@ -282,15 +282,15 @@
 </div>
 <div class="gallery-grid">
 <figure class="gallery-item" data-caption="Temple-like heritage and sculptural traditions" tabindex="0">
-<img alt="Indian stone heritage" src="../../assets/Taj_Mahal.png"/>
+<img alt="Indian stone heritage" src="../../assets/Taj_Mahal.png" loading="lazy"/>
 <figcaption>Stone &amp; Sculpture</figcaption>
 </figure>
 <figure class="gallery-item" data-caption="Arid-region architecture and geometric water design" tabindex="0">
-<img alt="Rajasthan desert architecture" src="../../assets/travel_deserts.png"/>
+<img alt="Rajasthan desert architecture" src="../../assets/travel_deserts.png" loading="lazy"/>
 <figcaption>Geometry &amp; Climate</figcaption>
 </figure>
 <figure class="gallery-item" data-caption="Layered architectural traditions of western India" tabindex="0">
-<img alt="Historic Indian architecture" src="../../assets/Jama_Masjid.png"/>
+<img alt="Historic Indian architecture" src="../../assets/Jama_Masjid.png" loading="lazy"/>
 <figcaption>Architectural Synthesis</figcaption>
 </figure>
 </div>

--- a/frontend/travel/travel.html
+++ b/frontend/travel/travel.html
@@ -409,7 +409,7 @@
 </div>
 <button aria-label="Save Mountains to My Journey" aria-pressed="false" class="destination-card-bookmark-btn journey-bookmark-btn" data-bookmark-id="travel-mountains" type="button">♡</button></div>
 <div class="destination-card" data-id="travel-beaches">
-<img alt="Beaches" class="destination-img" src="../../assets/travel_beaches.png"/>
+<img alt="Beaches" class="destination-img" src="../../assets/travel_beaches.png" loading="lazy"/>
 <div class="destination-content">
 <span class="destination-tag">Coastal Lines</span>
 <h3 class="destination-title">Beaches</h3>
@@ -417,7 +417,7 @@
 </div>
 <button aria-label="Save Beaches to My Journey" aria-pressed="false" class="destination-card-bookmark-btn journey-bookmark-btn" data-bookmark-id="travel-beaches" type="button">♡</button></div>
 <div class="destination-card" data-id="travel-deserts">
-<img alt="Deserts" class="destination-img" src="../../assets/travel_deserts.png"/>
+<img alt="Deserts" class="destination-img" src="../../assets/travel_deserts.png" loading="lazy"/>
 <div class="destination-content">
 <span class="destination-tag">Thar Desert</span>
 <h3 class="destination-title">Deserts</h3>
@@ -425,7 +425,7 @@
 </div>
 <button aria-label="Save Deserts to My Journey" aria-pressed="false" class="destination-card-bookmark-btn journey-bookmark-btn" data-bookmark-id="travel-deserts" type="button">♡</button></div>
 <div class="destination-card" data-id="travel-forests">
-<img alt="Forests" class="destination-img" src="../../assets/travel_forests.png"/>
+<img alt="Forests" class="destination-img" src="../../assets/travel_forests.png" loading="lazy"/>
 <div class="destination-content">
 <span class="destination-tag">Western Ghats</span>
 <h3 class="destination-title">Forests</h3>
@@ -441,7 +441,7 @@
 </div>
 <button aria-label="Save Islands to My Journey" aria-pressed="false" class="destination-card-bookmark-btn journey-bookmark-btn" data-bookmark-id="travel-islands" type="button">♡</button></div>
 <div class="destination-card" data-id="travel-hidden-gems">
-<img alt="Hidden Gems" class="destination-img" src="../../assets/travel_hidden.png"/>
+<img alt="Hidden Gems" class="destination-img" src="../../assets/travel_hidden.png" loading="lazy"/>
 <div class="destination-content">
 <span class="destination-tag">Offbeat</span>
 <h3 class="destination-title">Hidden Gems</h3>
@@ -532,7 +532,7 @@
 <button class="btn btn-primary ripple roadtrip-flip-btn" style="width: 100%;">View Route Map</button>
 </div>
 <div class="roadtrip-card-back">
-<img alt="Leh-Ladakh Highway route map" src="../../assets/Manalileh.png"/>
+<img alt="Leh-Ladakh Highway route map" src="../../assets/Manalileh.png" loading="lazy"/>
 </div>
 </div>
 </div>
@@ -562,7 +562,7 @@
 <button class="btn btn-primary ripple roadtrip-flip-btn" style="width: 100%;">View Route Map</button>
 </div>
 <div class="roadtrip-card-back">
-<img alt="Leh-Ladakh Highway route map" src="../../assets/Kochitri.png"/>
+<img alt="Leh-Ladakh Highway route map" src="../../assets/Kochitri.png" loading="lazy"/>
 </div>
 </div>
 </div>

--- a/tests/unit/image-lazy-loading.test.js
+++ b/tests/unit/image-lazy-loading.test.js
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const IGNORED = new Set(['.git', 'node_modules', 'dist', 'coverage']);
+
+function htmlFiles(dir, found = []) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (IGNORED.has(e.name)) continue;
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) htmlFiles(p, found);
+    else if (e.name.endsWith('.html')) found.push(p);
+  }
+  return found;
+}
+
+const ABOVE_FOLD = /hero|banner|masthead|jumbotron|splash|cover|logo|brand/i;
+
+/** Images that should carry loading="lazy": below the fold, with a real src. */
+function lazyCandidates(content) {
+  const found = [];
+  let position = 0;
+  for (const m of content.matchAll(/<img\b[^>]*>/gi)) {
+    const tag = m[0];
+    const i = position++;
+    if (/\sdata-src\s*=/i.test(tag)) continue;
+    const src = tag.match(/\ssrc\s*=\s*["']([^"']*)["']/i);
+    if (!src || !src[1].trim()) continue;
+    if (i === 0) continue;
+    const context = content.slice(Math.max(0, m.index - 400), m.index + tag.length);
+    if (ABOVE_FOLD.test(tag) || ABOVE_FOLD.test(context)) continue;
+    found.push(tag);
+  }
+  return found;
+}
+
+describe('image lazy-loading', () => {
+  const pages = htmlFiles('.').map((file) => ({ file, content: fs.readFileSync(file, 'utf8') }));
+
+  it('scans the repository', () => {
+    expect(pages.length).toBeGreaterThan(0);
+  });
+
+  it('marks every below-the-fold image as lazy', () => {
+    const offenders = [];
+    for (const { file, content } of pages) {
+      for (const tag of lazyCandidates(content)) {
+        if (!/loading\s*=/i.test(tag)) offenders.push(`${file}: ${tag.slice(0, 70)}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('leaves above-the-fold images eager so they do not delay LCP', () => {
+    // lazyCandidates() is the rule that decides what gets the attribute; anything
+    // it rejects as above-the-fold must not have been marked lazy by this change.
+    for (const { content } of pages) {
+      for (const tag of lazyCandidates(content)) {
+        expect(tag).not.toMatch(/\bclass\s*=\s*["'][^"']*\bhero-image\b/i);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Closes #1288

> **Note on scope:** this PR delivers the lazy-loading portion of #1288. The remaining work (PNG→WebP conversion, `srcset`, de-duplicating assets, CI size guard) is described at the end of this description — worth splitting into a follow-up issue before merging if you'd rather keep #1288 open to track it.


## Scope

#1288 covers the whole image pipeline: 365 MB of PNGs, no WebP, no `srcset`, no lazy-loading, plus duplicate assets. That's far too much for one reviewable PR, and the format conversion needs its own discussion about tooling and browser support.

**This PR does the lazy-loading half only** — it's self-contained, needs no new dependencies, touches no binary assets, and delivers a real win immediately. Conversion and `srcset` should follow separately.

## Problem

```
$ # across all 460 HTML pages
total <img>      : 574
already lazy     : 223
no loading attr  : 351
```

351 images were fetched eagerly on load whether or not they were anywhere near the viewport. That matters more here than on a typical site: the underlying assets are large uncompressed PNGs (up to 3.2 MB), so an eagerly-loaded gallery well below the fold is megabytes of blocking transfer and metered mobile data spent on images the user may never scroll to.

## What changed

`loading="lazy"` added to **103 images across 17 files**.

103, not 351, because lazy-loading the wrong image makes things *worse*. Four categories are deliberately excluded:

| Skipped | Count | Why |
|---|---|---|
| Hero / banner / masthead / logo context | 75 | These are the LCP element. `loading="lazy"` defers the fetch past the initial layout pass, so it **delays** LCP rather than improving it. |
| Empty `src` | 114 | Lightbox and modal images populated by JS at runtime. Nothing to defer. |
| `data-src` present | 48 | A JS lazy-loader already manages these. Native lazy would fight it. |
| First image on the page | 11 | Almost always the hero, even when the class name doesn't say so. |

The hero exclusion is the one that matters most for review. Pages like `forts/*.html` open with:

```html
<section class="hero-section"><div class="hero-bg">
  <img src="...?w=1600&q=80" alt="Bahu Fort" class="hero-image">
```

That image is the LCP candidate. Marking it lazy would regress the exact metric this PR aims to improve, so the codemod checks both the tag and 400 characters of preceding context for hero-ish markers.

## Verification

**The diff is purely additive.** Since this is a mechanical change across 17 files, I verified that stripping ` loading="lazy"` from every changed file reproduces the committed version exactly:

```
files: 17 | attrs added: 103 | changed beyond the attribute: 0
malformed tags: 0
```

(One file, `stepwells.html`, initially flagged in that check — it turned out to be my verifier mishandling self-closing `<img ... />` tags, not a real difference. Its diff is 8 lines, all `<img>` pairs.)

**Regression guard.** `tests/unit/image-lazy-loading.test.js` encodes the same rule the codemod used, so a new below-the-fold image without `loading="lazy"` fails CI. Confirmed it actually catches a regression by removing one attribute:

```
× marks every below-the-fold image as lazy
  → + "frontend\stepwells\stepwells.html: <img alt=\"Indian stone heritage\" src=\"../../assets/Taj_Mahal.png\"/>"
```

A second test asserts the rule never selects a `hero-image`, so the LCP carve-out can't silently erode.

**No regressions.** Full suite on `main` vs this branch:

| | Test files | Tests |
|---|---|---|
| `main` (baseline) | 16 failed, 153 passed | 3 failed, 1402 passed |
| this branch | 16 failed, **154** passed | 3 failed, **1405** passed |

Same failures both runs — pre-existing and unrelated (`national-awards.js` and several park explorers fail Vite's import analysis). My 3 tests are the delta.

## Notes for reviewers

Worth knowing: 24 pages already had `loading="lazy"` on their *first* image before this PR — likely genuine mistakes that may be costing LCP on those pages. I left them alone since they're outside this change's scope, but they'd be worth a follow-up. Similarly, `frontend/bridges`, `space`, `trade-routes` and others have lazy modal images inside a `modal-hero-img-wrap` container — the "hero" there is a naming coincidence and lazy is correct for them.

Remaining #1288 work, in suggested order: de-duplicate the ~13 near-identical asset pairs, convert PNG→WebP, generate responsive variants with `srcset`, add a CI size guard. Happy to take those in follow-up PRs if maintainers agree with the sequencing.

