### PR TITLE
feat: Create Daulatabad Fort Explorer (Issue #1181)

### DIFF
--- a/frontend/daulatabad-fort-explorer/daulatabad-data.js
+++ b/frontend/daulatabad-fort-explorer/daulatabad-data.js
@@ -1,0 +1,52 @@
+/**
+ * Daulatabad Fort Explorer — Data
+ * Historical facts, defence mechanisms, architecture, and gallery content
+ * for Daulatabad (Devagiri) Fort, Maharashtra.
+ */
+
+const DAULATABAD_FORT = {
+    name: 'Daulatabad Fort',
+    alternateNames: 'Devagiri Fort, Deogiri Fort',
+    location: 'Daulatabad, near Aurangabad (Chhatrapati Sambhajinagar), Maharashtra',
+    coordinates: { lat: 19.9425, lng: 75.2144 },
+    built: 'c. 1187 (as Devagiri); fortifications expanded 14th–16th century',
+    builtBy: 'Bhillama V of the Yadava (Seuna) Dynasty',
+    era: 'Yadava → Delhi Sultanate → Bahmani → Ahmadnagar → Mughal',
+    height: '200 metres (fort hill above surrounding plain)',
+    area: 'Approx. 94.6 hectares fortified complex',
+
+    overview:
+        'Daulatabad Fort, originally known as Devagiri, is one of the most formidable hill forts in India, rising roughly 200 metres above the Deccan plateau near present-day Chhatrapati Sambhajinagar (Aurangabad). Renowned for its near-impregnable, multi-layered defences — a deep moat cut directly into solid rock, a dark disorienting tunnel, and cannon-mounted bastions — the fort briefly served as the capital of the entire Delhi Sultanate in the 14th century, a bold and famously disastrous experiment by Sultan Muhammad bin Tughlaq.',
+
+    history:
+        'Devagiri was founded around 1187 by Bhillama V, who established it as the capital of the Yadava (Seuna) dynasty, ruling much of the Deccan. The Yadavas fortified the natural conical hill, exploiting its steep scarp for defence. In 1296 and again in 1308, the fort fell to the forces of the Delhi Sultanate under Alauddin Khalji, ending Yadava independence. The fort\'s most dramatic chapter came in 1327, when Sultan Muhammad bin Tughlaq renamed it Daulatabad ("Abode of Fortune") and controversially shifted the entire capital of the Delhi Sultanate here from Delhi, reportedly forcing the population to make the 1,100 km journey south. The arid climate and logistical strain made the new capital unsustainable, and within years the court returned to Delhi, earning Tughlaq the epithet "the Mad King" in popular history. The fort later passed through Bahmani, Nizam Shahi (Ahmadnagar), Mughal, and Maratha hands, with successive rulers strengthening its already formidable defences.',
+
+    builder:
+        'The fort was originally raised by Bhillama V of the Yadava dynasty around 1187, who chose the site for its natural defensive advantage — a steep, cone-shaped hill that could be scarped into an almost vertical rock face. Later rulers, particularly the Bahmani Sultans and the Nizam Shahi rulers of Ahmadnagar, added extensive fortification layers, the towering Chand Minar, and additional bastions, transforming it from a Yadava hill-fort into one of the most sophisticated defensive complexes in medieval India.',
+
+    yadavaDynasty:
+        'The Yadava (or Seuna) dynasty ruled a large part of the Deccan from the 9th to the 14th century, with Devagiri as their capital from the late 12th century onward. Under rulers like Bhillama V and later Singhana II, the Yadavas were significant patrons of Marathi language and literature and controlled a prosperous trade region. Devagiri\'s natural hill and the dynasty\'s fortification works made it one of the most secure capitals in the Deccan, until the dynasty was ultimately overthrown by repeated invasions from the Delhi Sultanate in the early 14th century.',
+
+    defenceMechanisms:
+        'Daulatabad is considered one of the most scientifically engineered forts in India. Its defences include: a deep moat carved directly into the surrounding rock, once filled with water and crocodiles, crossed only by a retractable drawbridge; a dark, pitch-black zig-zag tunnel (known as the "Andheri" or dark passage) cut through the rock that attackers had to pass through single-file, where defenders could trap and disorient them using smoke, fire, or heated metal plates; a heavily scarped, smooth vertical rock face around the citadel that made climbing virtually impossible; and multiple concentric walls and bastions mounted with cannons, including large siege guns positioned at key points.',
+
+    architecture:
+        'The fort blends Yadava-era stone fortification with later Indo-Islamic and Persian additions. Its centerpiece, the Chand Minar (Tower of the Moon), was built in 1445 by the Bahmani Sultan Ala-ud-Din Ahmad Shah to commemorate a military victory, modeled after Delhi\'s Qutb Minar and finished in Persian blue-tile work — it stands 63 metres tall across four storeys. The Chini Mahal, a structure believed to date to the Nizam Shahi period, was later used as a prison, reputedly holding the Golconda ruler Abul Hasan Qutb Shah under Mughal captivity. The overall complex is arranged in three concentric fortification rings, moving from the outer town wall, to the middle Mahakot wall, to the innermost Kalakot citadel at the summit.',
+
+    interestingFacts: [
+        'Daulatabad briefly served as the capital of the entire Delhi Sultanate (1327–c.1334) — one of history\'s most infamous failed capital relocations.',
+        'The fort\'s dark defensive tunnel was intentionally built pitch black and disorienting, so defenders stationed at its exit could ambush intruding attackers who had lost their bearings.',
+        'The Chand Minar was directly inspired by the Qutb Minar in Delhi and remains one of the finest examples of Indo-Islamic tower architecture in the Deccan.',
+        'The fort\'s scarped hill and moat defences were so effective that in over 500 years of recorded conflict, it was rarely taken by direct assault — most conquests came through siege, betrayal, or negotiated surrender rather than storming the walls.',
+        'Its original name, Devagiri, means "Hill of the Gods."'
+    ],
+
+    gallery: [
+        { emoji: '🏰', caption: 'Daulatabad Fort rising above the Deccan plateau' },
+        { emoji: '🗼', caption: 'Chand Minar — the 63m Tower of the Moon' },
+        { emoji: '🕳️', caption: 'The dark defensive tunnel (Andheri)' },
+        { emoji: '💧', caption: 'The rock-cut moat surrounding the citadel' },
+        { emoji: '⚔️', caption: 'Cannon bastions along the fortification walls' },
+        { emoji: '🏯', caption: 'Chini Mahal — the former Nizam Shahi structure' }
+    ]
+};

--- a/frontend/daulatabad-fort-explorer/daulatabad.css
+++ b/frontend/daulatabad-fort-explorer/daulatabad.css
@@ -1,0 +1,381 @@
+/* ==========================================================================
+   Daulatabad Fort Explorer — Styles
+   ========================================================================== */
+
+:root {
+    --fort-stone: #8b7355;
+    --fort-gold: #ffb01f;
+    --fort-dark: #1a1410;
+    --card-bg-glass: rgba(15, 23, 42, 0.45);
+    --card-border: rgba(255, 255, 255, 0.08);
+    --text-main: #f8fafc;
+    --text-sub: #94a3b8;
+    --gold-accent: #ffb01f;
+}
+
+.light-theme {
+    --card-bg-glass: rgba(255, 255, 255, 0.75);
+    --card-border: rgba(0, 0, 0, 0.08);
+    --text-main: #0f172a;
+    --text-sub: #475569;
+}
+
+.fort-page {
+    background: linear-gradient(135deg, #1a1410, #0d0906);
+    color: var(--text-main);
+    font-family: 'Outfit', sans-serif;
+    min-height: 100vh;
+    padding-top: 80px;
+    overflow-x: hidden;
+}
+
+.light-theme .fort-page {
+    background: linear-gradient(135deg, #f5f0e8, #e8dfd0);
+}
+
+.section-container {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0 20px;
+}
+
+.section-container.two-col {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 40px;
+}
+
+@media (max-width: 800px) {
+    .section-container.two-col {
+        grid-template-columns: 1fr;
+    }
+}
+
+.section-header {
+    text-align: center;
+    margin-bottom: 24px;
+}
+
+.section-header.left-align {
+    text-align: left;
+}
+
+.section-badge {
+    display: inline-block;
+    background: linear-gradient(135deg, var(--fort-stone), var(--fort-gold));
+    color: #1a1410;
+    padding: 5px 16px;
+    border-radius: 20px;
+    font-size: 0.78rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 12px;
+}
+
+.section-header h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2rem;
+    font-weight: 700;
+    margin-bottom: 8px;
+}
+
+.section-subtitle {
+    color: var(--text-sub);
+    font-size: 1rem;
+    max-width: 700px;
+    margin: 0 auto;
+}
+
+.section-body {
+    color: var(--text-sub);
+    font-size: 1.05rem;
+    line-height: 1.75;
+    max-width: 850px;
+    margin: 0 auto;
+}
+
+.section-header.left-align + .section-body {
+    margin: 0;
+}
+
+/* Hero */
+.fort-hero {
+    position: relative;
+    padding: 90px 20px 60px;
+    text-align: center;
+    overflow: hidden;
+}
+
+.fort-hero .hero-fort-bg {
+    position: absolute;
+    inset: 0;
+    background:
+        linear-gradient(135deg, rgba(26, 20, 16, 0.9), rgba(13, 9, 6, 0.96)),
+        linear-gradient(to bottom right, #8b735533, #ffb01f22, #8b735533);
+    z-index: 0;
+}
+
+.fort-hero .hero-overlay {
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(ellipse at center, transparent 30%, rgba(0, 0, 0, 0.6) 100%);
+    z-index: 1;
+}
+
+.fort-hero .hero-container {
+    position: relative;
+    z-index: 2;
+    max-width: 780px;
+    margin: 0 auto;
+}
+
+.hero-badges {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    flex-wrap: wrap;
+    margin-bottom: 20px;
+}
+
+.hero-mini-badge {
+    background: rgba(255, 255, 255, 0.08);
+    border: 1px solid var(--card-border);
+    padding: 6px 14px;
+    border-radius: 20px;
+    font-size: 0.8rem;
+    color: var(--text-sub);
+}
+
+.fort-hero h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: 3rem;
+    font-weight: 800;
+    line-height: 1.15;
+    margin-bottom: 16px;
+}
+
+.fort-hero h1 span {
+    background: linear-gradient(135deg, var(--fort-gold), #d97706);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+.fort-hero p {
+    color: var(--text-sub);
+    font-size: 1.1rem;
+    line-height: 1.6;
+    max-width: 700px;
+    margin: 0 auto 28px;
+}
+
+.hero-quick-stats {
+    display: flex;
+    justify-content: center;
+    gap: 40px;
+    flex-wrap: wrap;
+}
+
+.hero-quick-stats .quick-stat {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.hero-quick-stats .quick-stat strong {
+    font-size: 1.4rem;
+    font-weight: 800;
+    color: var(--fort-gold);
+    line-height: 1.2;
+    margin-bottom: 4px;
+    max-width: 180px;
+}
+
+.hero-quick-stats .quick-stat span {
+    color: var(--text-sub);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+/* Sections */
+.fort-section {
+    padding: 50px 0;
+}
+
+.fort-section.alt-bg {
+    background: linear-gradient(to bottom, transparent, rgba(139, 115, 85, 0.06), transparent);
+}
+
+.back-cta {
+    padding-bottom: 70px;
+}
+
+.btn-back-forts {
+    display: inline-block;
+    padding: 12px 28px;
+    background: linear-gradient(135deg, var(--fort-stone), var(--fort-gold));
+    color: #1a1410;
+    font-weight: 700;
+    border-radius: 999px;
+    text-decoration: none;
+    transition: transform 0.2s;
+}
+
+.btn-back-forts:hover {
+    transform: translateY(-2px);
+}
+
+/* Facts Grid */
+.facts-grid {
+    list-style: none;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 16px;
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 0;
+}
+
+.facts-grid li {
+    background: var(--card-bg-glass);
+    border: 1px solid var(--card-border);
+    border-radius: 14px;
+    padding: 18px 20px;
+    color: var(--text-sub);
+    font-size: 0.92rem;
+    line-height: 1.5;
+    display: flex;
+    gap: 10px;
+}
+
+.facts-grid li::before {
+    content: '⚜️';
+    flex-shrink: 0;
+}
+
+/* Gallery */
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 16px;
+}
+
+.gallery-card {
+    background: var(--card-bg-glass);
+    border: 1px solid var(--card-border);
+    border-radius: 16px;
+    overflow: hidden;
+    cursor: pointer;
+    transition:
+        transform 0.3s,
+        border-color 0.3s;
+    text-align: center;
+}
+
+.gallery-card:hover {
+    transform: translateY(-4px);
+    border-color: var(--fort-gold);
+}
+
+.gallery-card-emoji {
+    font-size: 3.5rem;
+    padding: 40px 0 20px;
+    background: linear-gradient(135deg, #2a2018, #1a1410);
+}
+
+.gallery-card-caption {
+    padding: 14px 16px 18px;
+    font-size: 0.88rem;
+    color: var(--text-sub);
+}
+
+/* Lightbox */
+.lightbox {
+    position: fixed;
+    inset: 0;
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.lightbox.hidden {
+    display: none;
+}
+
+.lightbox-backdrop {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.92);
+}
+
+.lightbox-content {
+    position: relative;
+    max-width: 90vw;
+    text-align: center;
+}
+
+.lightbox-emoji {
+    font-size: 8rem;
+    margin-bottom: 20px;
+}
+
+.lightbox-close {
+    position: absolute;
+    top: -50px;
+    right: 0;
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 2rem;
+    cursor: pointer;
+}
+
+.lightbox-prev,
+.lightbox-next {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    background: rgba(255, 255, 255, 0.15);
+    border: none;
+    color: #fff;
+    font-size: 2.2rem;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    cursor: pointer;
+}
+
+.lightbox-prev {
+    left: -60px;
+}
+.lightbox-next {
+    right: -60px;
+}
+
+@media (max-width: 700px) {
+    .lightbox-prev {
+        left: 5px;
+    }
+    .lightbox-next {
+        right: 5px;
+    }
+}
+
+.lightbox-caption {
+    color: var(--text-sub);
+    font-size: 1rem;
+    max-width: 500px;
+    margin: 0 auto;
+}
+
+@media (max-width: 768px) {
+    .fort-hero h1 {
+        font-size: 2.1rem;
+    }
+    .section-header h2 {
+        font-size: 1.5rem;
+    }
+}

--- a/frontend/daulatabad-fort-explorer/daulatabad.css
+++ b/frontend/daulatabad-fort-explorer/daulatabad.css
@@ -23,7 +23,7 @@
 .fort-page {
     background: linear-gradient(135deg, #1a1410, #0d0906);
     color: var(--text-main);
-    font-family: 'Outfit', sans-serif;
+    font-family: Outfit, sans-serif;
     min-height: 100vh;
     padding-top: 80px;
     overflow-x: hidden;

--- a/frontend/daulatabad-fort-explorer/daulatabad.js
+++ b/frontend/daulatabad-fort-explorer/daulatabad.js
@@ -8,12 +8,32 @@
     const lightboxState = { index: 0 };
 
     document.addEventListener('DOMContentLoaded', function () {
+        initTheme();
         renderHeroStats();
         renderText();
         renderFacts();
         renderGallery();
         bindLightboxEvents();
     });
+
+    function initTheme() {
+        const themeBtn = document.getElementById('theme-toggle');
+        if (!themeBtn) return;
+
+        const applyIcon = function () {
+            const isLight = document.documentElement.classList.contains('light-theme');
+            themeBtn.textContent = isLight ? '🌙' : '☀️';
+            themeBtn.title = isLight ? 'Toggle Dark Mode' : 'Toggle Light Mode';
+        };
+
+        applyIcon();
+
+        themeBtn.addEventListener('click', function () {
+            const isLight = document.documentElement.classList.toggle('light-theme');
+            localStorage.setItem('theme', isLight ? 'light' : 'dark');
+            applyIcon();
+        });
+    }
 
     function renderHeroStats() {
         const el = document.getElementById('hero-quick-stats');
@@ -88,6 +108,13 @@
         });
     }
 
+    function getLightboxFocusable() {
+        const lb = document.getElementById('lightbox');
+        if (!lb) return [];
+        const selector = '#lightbox-close, #lightbox-prev, #lightbox-next';
+        return Array.prototype.slice.call(lb.querySelectorAll(selector));
+    }
+
     function bindLightboxEvents() {
         const closeBtn = document.getElementById('lightbox-close');
         const prevBtn = document.getElementById('lightbox-prev');
@@ -111,6 +138,19 @@
             if (e.key === 'Escape') closeLightbox();
             if (e.key === 'ArrowLeft') navigateLightbox(-1);
             if (e.key === 'ArrowRight') navigateLightbox(1);
+            if (e.key === 'Tab') {
+                const focusable = getLightboxFocusable();
+                if (!focusable.length) return;
+                const first = focusable[0];
+                const last = focusable[focusable.length - 1];
+                if (e.shiftKey && document.activeElement === first) {
+                    e.preventDefault();
+                    last.focus();
+                } else if (!e.shiftKey && document.activeElement === last) {
+                    e.preventDefault();
+                    first.focus();
+                }
+            }
         });
     }
 

--- a/frontend/daulatabad-fort-explorer/daulatabad.js
+++ b/frontend/daulatabad-fort-explorer/daulatabad.js
@@ -1,0 +1,163 @@
+/**
+ * Daulatabad Fort Explorer — Script
+ * Renders fort data into the page and powers the emoji-gallery lightbox.
+ */
+(function () {
+    'use strict';
+
+    const lightboxState = { index: 0 };
+
+    document.addEventListener('DOMContentLoaded', function () {
+        renderHeroStats();
+        renderText();
+        renderFacts();
+        renderGallery();
+        bindLightboxEvents();
+    });
+
+    function renderHeroStats() {
+        const el = document.getElementById('hero-quick-stats');
+        if (!el) return;
+        el.innerHTML =
+            statHtml(DAULATABAD_FORT.height, 'Hill Height') +
+            statHtml(DAULATABAD_FORT.built, 'Founded') +
+            statHtml(DAULATABAD_FORT.builtBy, 'Founded By');
+    }
+
+    function statHtml(value, label) {
+        return (
+            '<div class="quick-stat"><strong>' + esc(value) + '</strong><span>' + esc(label) + '</span></div>'
+        );
+    }
+
+    function renderText() {
+        setText('overview-text', DAULATABAD_FORT.overview);
+        setText('history-text', DAULATABAD_FORT.history);
+        setText('builder-text', DAULATABAD_FORT.builder);
+        setText('yadava-text', DAULATABAD_FORT.yadavaDynasty);
+        setText('defence-text', DAULATABAD_FORT.defenceMechanisms);
+        setText('architecture-text', DAULATABAD_FORT.architecture);
+    }
+
+    function setText(id, value) {
+        const el = document.getElementById(id);
+        if (el) el.textContent = value;
+    }
+
+    function renderFacts() {
+        const el = document.getElementById('facts-grid');
+        if (!el) return;
+        el.innerHTML = DAULATABAD_FORT.interestingFacts
+            .map(function (f) {
+                return '<li>' + esc(f) + '</li>';
+            })
+            .join('');
+    }
+
+    function renderGallery() {
+        const el = document.getElementById('gallery-grid');
+        if (!el) return;
+        el.innerHTML = DAULATABAD_FORT.gallery
+            .map(function (item, i) {
+                return (
+                    '<div class="gallery-card" data-index="' +
+                    i +
+                    '" role="listitem" tabindex="0" aria-label="' +
+                    escA(item.caption) +
+                    '">' +
+                    '<div class="gallery-card-emoji" aria-hidden="true">' +
+                    item.emoji +
+                    '</div>' +
+                    '<div class="gallery-card-caption">' +
+                    esc(item.caption) +
+                    '</div></div>'
+                );
+            })
+            .join('');
+
+        el.querySelectorAll('.gallery-card').forEach(function (card) {
+            card.addEventListener('click', function () {
+                openLightbox(parseInt(card.dataset.index, 10));
+            });
+            card.addEventListener('keydown', function (e) {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    openLightbox(parseInt(card.dataset.index, 10));
+                }
+            });
+        });
+    }
+
+    function bindLightboxEvents() {
+        const closeBtn = document.getElementById('lightbox-close');
+        const prevBtn = document.getElementById('lightbox-prev');
+        const nextBtn = document.getElementById('lightbox-next');
+        const backdrop = document.getElementById('lightbox-backdrop');
+
+        if (closeBtn) closeBtn.addEventListener('click', closeLightbox);
+        if (backdrop) backdrop.addEventListener('click', closeLightbox);
+        if (prevBtn)
+            prevBtn.addEventListener('click', function () {
+                navigateLightbox(-1);
+            });
+        if (nextBtn)
+            nextBtn.addEventListener('click', function () {
+                navigateLightbox(1);
+            });
+
+        document.addEventListener('keydown', function (e) {
+            const lb = document.getElementById('lightbox');
+            if (!lb || lb.classList.contains('hidden')) return;
+            if (e.key === 'Escape') closeLightbox();
+            if (e.key === 'ArrowLeft') navigateLightbox(-1);
+            if (e.key === 'ArrowRight') navigateLightbox(1);
+        });
+    }
+
+    function openLightbox(index) {
+        lightboxState.index = index;
+        const lb = document.getElementById('lightbox');
+        lb.classList.remove('hidden');
+        lb.setAttribute('aria-hidden', 'false');
+        document.body.style.overflow = 'hidden';
+        updateLightbox();
+        const closeBtn = document.getElementById('lightbox-close');
+        if (closeBtn) closeBtn.focus();
+    }
+
+    function closeLightbox() {
+        const lb = document.getElementById('lightbox');
+        lb.classList.add('hidden');
+        lb.setAttribute('aria-hidden', 'true');
+        document.body.style.overflow = '';
+    }
+
+    function navigateLightbox(dir) {
+        const len = DAULATABAD_FORT.gallery.length;
+        lightboxState.index = (lightboxState.index + dir + len) % len;
+        updateLightbox();
+    }
+
+    function updateLightbox() {
+        const item = DAULATABAD_FORT.gallery[lightboxState.index];
+        if (!item) return;
+        document.getElementById('lightbox-emoji').textContent = item.emoji;
+        document.getElementById('lightbox-caption').textContent =
+            lightboxState.index + 1 + ' / ' + DAULATABAD_FORT.gallery.length + ' — ' + item.caption;
+    }
+
+    function esc(str) {
+        const d = document.createElement('div');
+        d.textContent = str;
+        return d.innerHTML;
+    }
+
+    function escA(str) {
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+    }
+})();

--- a/frontend/daulatabad-fort-explorer/index.html
+++ b/frontend/daulatabad-fort-explorer/index.html
@@ -5,7 +5,7 @@
             (function () {
                 const theme = localStorage.getItem('theme') || 'dark';
                 if (theme === 'light') {
-                    document.body.classList.add('light-theme');
+                    document.documentElement.classList.add('light-theme');
                 }
             })();
         </script>

--- a/frontend/daulatabad-fort-explorer/index.html
+++ b/frontend/daulatabad-fort-explorer/index.html
@@ -1,0 +1,228 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    document.body.classList.add('light-theme');
+                }
+            })();
+        </script>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Explore Daulatabad (Devagiri) Fort — one of India's most formidable hill forts, famous for its rock-cut moat, dark defensive tunnel, and the towering Chand Minar."
+        />
+        <title>Daulatabad Fort Explorer | Incredible India</title>
+
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+            rel="stylesheet"
+        />
+
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="daulatabad.css" />
+    </head>
+    <body>
+        <header class="navbar scrolled" id="navbar">
+            <div class="nav-container">
+                <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </button>
+                <nav class="nav-menu" id="nav-menu">
+                    <a href="../../index.html#home" class="nav-link" id="link-home">Home</a>
+                    <a href="../forts/index.html" class="nav-link" id="link-forts">Forts</a>
+                    <a href="index.html" class="nav-link active" id="link-daulatabad" style="color: var(--gold-accent)"
+                        >Daulatabad Explorer</a
+                    >
+                    <button
+                        id="theme-toggle"
+                        class="btn-theme-toggle"
+                        aria-label="Toggle Dark/Light Mode"
+                        title="Toggle Light Mode"
+                    >
+                        ☀️
+                    </button>
+                </nav>
+            </div>
+        </header>
+
+        <main class="fort-page">
+            <!-- Hero Section -->
+            <section class="fort-hero">
+                <div class="hero-fort-bg"></div>
+                <div class="hero-overlay"></div>
+                <div class="hero-container">
+                    <div class="hero-badges">
+                        <span class="hero-mini-badge">📍 Near Aurangabad, Maharashtra</span>
+                        <span class="hero-mini-badge">🏰 Yadava → Delhi Sultanate → Bahmani</span>
+                        <span class="hero-mini-badge">📐 200m Fortified Hill</span>
+                    </div>
+                    <h1>Daulatabad <span>Fort</span> Explorer</h1>
+                    <p>
+                        Step inside one of India's most scientifically engineered fortresses — a rock-cut moat, a
+                        pitch-black defensive tunnel, and a towering minaret that once briefly held the capital of
+                        the entire Delhi Sultanate.
+                    </p>
+                    <div class="hero-quick-stats" id="hero-quick-stats">
+                        <!-- Populated by JS -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Overview -->
+            <section class="fort-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Overview</span>
+                        <h2>Abode of Fortune</h2>
+                    </div>
+                    <p class="section-body" id="overview-text"></p>
+                </div>
+            </section>
+
+            <!-- History -->
+            <section class="fort-section alt-bg">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">History</span>
+                        <h2>From Devagiri to Daulatabad</h2>
+                    </div>
+                    <p class="section-body" id="history-text"></p>
+                </div>
+            </section>
+
+            <!-- Builder & Yadava Dynasty -->
+            <section class="fort-section">
+                <div class="section-container two-col">
+                    <div>
+                        <div class="section-header left-align">
+                            <span class="section-badge">Builder</span>
+                            <h2>Bhillama V</h2>
+                        </div>
+                        <p class="section-body" id="builder-text"></p>
+                    </div>
+                    <div>
+                        <div class="section-header left-align">
+                            <span class="section-badge">The Yadava Dynasty</span>
+                            <h2>Rulers of the Deccan</h2>
+                        </div>
+                        <p class="section-body" id="yadava-text"></p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Defence Mechanisms -->
+            <section class="fort-section alt-bg">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Defence Mechanisms</span>
+                        <h2>An Almost Unconquerable Fortress</h2>
+                    </div>
+                    <p class="section-body" id="defence-text"></p>
+                </div>
+            </section>
+
+            <!-- Architecture -->
+            <section class="fort-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Architecture</span>
+                        <h2>Chand Minar & Beyond</h2>
+                    </div>
+                    <p class="section-body" id="architecture-text"></p>
+                </div>
+            </section>
+
+            <!-- Interesting Facts -->
+            <section class="fort-section alt-bg">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Trivia</span>
+                        <h2>Interesting Facts</h2>
+                    </div>
+                    <ul class="facts-grid" id="facts-grid">
+                        <!-- Populated by JS -->
+                    </ul>
+                </div>
+            </section>
+
+            <!-- Gallery -->
+            <section class="fort-section">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-badge">Visual Journey</span>
+                        <h2>Fort Gallery</h2>
+                        <p class="section-subtitle">Click any card to view it full-screen with caption details.</p>
+                    </div>
+                    <div id="gallery-grid" class="gallery-grid" role="list" aria-label="Daulatabad Fort gallery">
+                        <!-- Populated by JS -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Back to Forts Explorer -->
+            <section class="fort-section back-cta">
+                <div class="section-container" style="text-align: center">
+                    <a href="../forts/index.html" class="btn-back-forts">← Back to Indian Forts Explorer</a>
+                </div>
+            </section>
+
+            <!-- Lightbox -->
+            <div
+                id="lightbox"
+                class="lightbox hidden"
+                role="dialog"
+                aria-modal="true"
+                aria-label="Image Lightbox"
+                aria-hidden="true"
+            >
+                <div class="lightbox-backdrop" id="lightbox-backdrop"></div>
+                <div class="lightbox-content">
+                    <button class="lightbox-close" id="lightbox-close" aria-label="Close lightbox">&times;</button>
+                    <button class="lightbox-prev" id="lightbox-prev" aria-label="Previous image">&#8249;</button>
+                    <button class="lightbox-next" id="lightbox-next" aria-label="Next image">&#8250;</button>
+                    <div class="lightbox-emoji" id="lightbox-emoji"></div>
+                    <div class="lightbox-caption" id="lightbox-caption" aria-live="polite"></div>
+                </div>
+            </div>
+        </main>
+
+        <footer class="footer">
+            <div class="footer-container">
+                <div class="footer-brand">
+                    <h3>Incredible India Explorer</h3>
+                    <p>
+                        An interactive digital guide to the geography, food, festivals, and cultural heritage of India.
+                    </p>
+                </div>
+                <div class="footer-links">
+                    <h3>Quick Navigation</h3>
+                    <ul>
+                        <li><a href="../../index.html#home">Home</a></li>
+                        <li><a href="../forts/index.html">Indian Forts Explorer</a></li>
+                    </ul>
+                </div>
+            </div>
+            <div class="footer-credits footer-credits-center">
+                <p>&copy; 2026 Incredible India Explorer. Created with Vanilla HTML, CSS & JavaScript.</p>
+            </div>
+        </footer>
+
+        <script src="../../app.js" defer></script>
+        <script src="daulatabad-data.js" defer></script>
+        <script src="daulatabad.js" defer></script>
+        <script type="module" src="../../auth.js"></script>
+    </body>
+</html>

--- a/frontend/forts/script.js
+++ b/frontend/forts/script.js
@@ -400,7 +400,11 @@ function openModal(fort) {
         const linkDiv = document.createElement('div');
         linkDiv.id = 'modal-explorer-link';
         linkDiv.style.cssText = 'margin-top: 1.5rem; text-align: center;';
-        linkDiv.innerHTML = `<a href="${fort.explorerUrl}" style="display:inline-block; padding:0.75rem 1.5rem; background:linear-gradient(135deg, #ffb01f, #d97706); color:#000; font-weight:700; border-radius:999px; text-decoration:none;">Launch Dedicated Explorer ➔</a>`;
+        const explorerLink = document.createElement('a');
+        explorerLink.href = fort.explorerUrl;
+        explorerLink.textContent = 'Launch Dedicated Explorer ➔';
+        explorerLink.style.cssText = 'display:inline-block; padding:0.75rem 1.5rem; background:linear-gradient(135deg, #ffb01f, #d97706); color:#000; font-weight:700; border-radius:999px; text-decoration:none;';
+        linkDiv.appendChild(explorerLink);
         document.querySelector('.modal-highlights').appendChild(linkDiv);
     }
     fortModal.classList.add('active');

--- a/frontend/forts/script.js
+++ b/frontend/forts/script.js
@@ -231,6 +231,26 @@ const fortsData = [
             "Sriranganathaswamy Temple",
             "Located on an island in River Kaveri"
         ]
+    },
+    {
+        id: 13,
+        name: "Daulatabad Fort",
+        location: "Daulatabad, near Aurangabad",
+        state: "Maharashtra",
+        built: "c. 1187 (fortifications expanded 14th–16th century)",
+        builtBy: "Bhillama V (Yadava Dynasty)",
+        era: "Yadava Era",
+        architecture: "Deccan Hill Fort / Indo-Islamic",
+        image: "https://commons.wikimedia.org/wiki/Special:FilePath/Daulatabad%20Fort%20a%20view.JPG",
+        history: "Originally known as Devagiri, this near-impregnable hill fort briefly served as the capital of the entire Delhi Sultanate under Muhammad bin Tughlaq in 1327. Famous for its rock-cut moat, dark defensive tunnel, and the towering Chand Minar.",
+        highlights: [
+            "Rock-cut moat once filled with crocodiles",
+            "Pitch-black defensive tunnel (Andheri)",
+            "63-metre Chand Minar tower",
+            "Briefly capital of the Delhi Sultanate (1327)",
+            "Considered one of India's most impregnable forts"
+        ],
+        explorerUrl: "../daulatabad-fort-explorer/index.html"
     }
 ];
 
@@ -373,7 +393,16 @@ function openModal(fort) {
         li.textContent = highlight;
         highlightsList.appendChild(li);
     });
-
+    // Show dedicated explorer link if available
+    let explorerLinkContainer = document.getElementById('modal-explorer-link');
+    if (explorerLinkContainer) explorerLinkContainer.remove();
+    if (fort.explorerUrl) {
+        const linkDiv = document.createElement('div');
+        linkDiv.id = 'modal-explorer-link';
+        linkDiv.style.cssText = 'margin-top: 1.5rem; text-align: center;';
+        linkDiv.innerHTML = `<a href="${fort.explorerUrl}" style="display:inline-block; padding:0.75rem 1.5rem; background:linear-gradient(135deg, #ffb01f, #d97706); color:#000; font-weight:700; border-radius:999px; text-decoration:none;">Launch Dedicated Explorer ➔</a>`;
+        document.querySelector('.modal-highlights').appendChild(linkDiv);
+    }
     fortModal.classList.add('active');
     document.body.style.overflow = 'hidden';
 }


### PR DESCRIPTION
## Summary
Adds a new dedicated explorer page for Daulatabad (Devagiri) Fort and integrates it into the Indian Forts Explorer landing page.

## Changes
- Created `frontend/daulatabad-fort-explorer/` with:
  - `index.html` — hero section, overview, history, builder, Yadava dynasty, defence mechanisms, architecture, interesting facts, and gallery
  - `daulatabad.css` — page-specific styling
  - `daulatabad.js` — content rendering and gallery lightbox interactivity
  - `daulatabad-data.js` — structured fort facts, history, and gallery content
- Added a Daulatabad Fort card to `frontend/forts/script.js` (`fortsData` array), including an `explorerUrl` field
- Added a "Launch Dedicated Explorer" link inside the fort detail modal (`openModal()`) that appears when a fort has an `explorerUrl`, linking through to the dedicated page

## Content Covered (per issue requirements)
- Overview
- History
- Builder (Bhillama V)
- Yadava Dynasty
- Defence Mechanisms (rock-cut moat, dark tunnel, scarped walls, cannon bastions)
- Architecture (Chand Minar, Chini Mahal, concentric fortification rings)
- Interesting Facts
- Gallery (emoji-based visual cards with lightbox, avoiding broken image links)
- Landing Page Integration

## Testing
- Verified the dedicated Daulatabad Fort Explorer page renders all sections correctly with no new console errors
- Verified gallery lightbox navigation (prev/next/close/keyboard) works correctly
- Verified the "Back to Indian Forts Explorer" link works

## Note
While testing landing page integration, I found that the Forts landing page (`frontend/forts/index.html`) has a **pre-existing bug**: fort detail modals render empty (no State/Built/Architecture data) for all forts, including existing ones like Red Fort — this is unrelated to this PR's changes and appears to stem from the page loading `traditional-games/script.js` instead of `forts/script.js`. Console shows an unrelated `renderGames` TypeError from that shared script. Flagging this separately in case a maintainer wants to track it.

<img width="1440" height="852" alt="Screenshot 2026-08-02 122242" src="https://github.com/user-attachments/assets/95e58ba1-5e24-4057-b307-5c5f69dfca45" />
<img width="1440" height="852" alt="Screenshot 2026-08-02 122321" src="https://github.com/user-attachments/assets/66f20fd7-7b8a-4a33-b3de-c68b5b2d3d1e" />

Closes #1181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Daulatabad Fort Explorer page with historical, architectural, and defensive information.
  * Added key facts, highlights, trivia, and an interactive gallery with lightbox viewing and keyboard navigation.
  * Added responsive layouts, theme support, and accessible navigation controls.
  * Added Daulatabad Fort to the forts directory with a link to its detailed explorer page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->