### PR TITLE
fix(generator): repair the page layout and enforce generated output in CI

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -29,5 +29,8 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Verify generated pages are up to date
+        run: npm run generate:check
+
       - name: Run PR Health Checker
         run: node scripts/pr-health-checker.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,6 +187,19 @@ Loose HTML, CSS, or JavaScript files inside the `frontend` directory are **not a
 - Include `aria-label`, `role`, and `alt` attributes for accessibility.
 - Use lowercase for tag and attribute names.
 
+### Generated pages
+
+State pages under `dist/states/` are **generated** from `scripts/layout.html` and
+`data.js` — do not hand-edit them. Edit the layout or the data, then run:
+
+```bash
+npm run generate        # rewrite dist/states/
+npm run generate:check  # verify the committed output is current (CI runs this)
+```
+
+`npm run generate:check` fails if `dist/` has drifted from the layout, so commit
+the regenerated files alongside any layout change.
+
 ### CSS
 
 - Use CSS custom properties from `:root` in `styles.css` for consistency.

--- a/dist/states/andaman-and-nicobar-islands.html
+++ b/dist/states/andaman-and-nicobar-islands.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="An archipelago of tropical islands in the Bay of Bengal, famous for white sand beaches, marine life, and Cellular Jail national memorial.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,7 +89,7 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Andaman and Nicobar Islands</h1>
         <p><strong>Capital:</strong> Port Blair</p>
-        <p><strong>Famous Food:</strong> Coconut Prawn Curry & Lobster</p>
+        <p><strong>Famous Food:</strong> Coconut Prawn Curry &amp; Lobster</p>
         <p><strong>Major Festival:</strong> Island Tourism Festival</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
@@ -97,7 +97,7 @@
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>An archipelago of tropical islands in the Bay of Bengal, famous for white sand beaches, marine life, and Cellular Jail national memorial.<br><br>The vibrant region of Andaman and Nicobar Islands is governed from its beautiful capital, Port Blair. The land is deeply connected to its roots, celebrating grand occasions like Island Tourism Festival with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Coconut Prawn Curry & Lobster, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Andaman and Nicobar Islands is a journey through time, culture, and nature.</p>
+            <p>An archipelago of tropical islands in the Bay of Bengal, famous for white sand beaches, marine life, and Cellular Jail national memorial.<br><br>The vibrant region of Andaman and Nicobar Islands is governed from its beautiful capital, Port Blair. The land is deeply connected to its roots, celebrating grand occasions like Island Tourism Festival with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Coconut Prawn Curry &amp; Lobster, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Andaman and Nicobar Islands is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/andhra-pradesh.html
+++ b/dist/states/andhra-pradesh.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Andhra Pradesh boasts a long coastline and rich history, famous for the classical dance Kuchipudi, ancient temples, and spicy culinary traditions.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,7 +89,7 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Andhra Pradesh</h1>
         <p><strong>Capital:</strong> Amaravati</p>
-        <p><strong>Famous Food:</strong> Pootharekulu & Gongura Pachadi</p>
+        <p><strong>Famous Food:</strong> Pootharekulu &amp; Gongura Pachadi</p>
         <p><strong>Major Festival:</strong> Ugadi</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
@@ -97,7 +97,7 @@
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>Andhra Pradesh boasts a long coastline and rich history, famous for the classical dance Kuchipudi, ancient temples, and spicy culinary traditions.<br><br>The vibrant region of Andhra Pradesh is governed from its beautiful capital, Amaravati. The land is deeply connected to its roots, celebrating grand occasions like Ugadi with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Pootharekulu & Gongura Pachadi, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Andhra Pradesh is a journey through time, culture, and nature.</p>
+            <p>Andhra Pradesh boasts a long coastline and rich history, famous for the classical dance Kuchipudi, ancient temples, and spicy culinary traditions.<br><br>The vibrant region of Andhra Pradesh is governed from its beautiful capital, Amaravati. The land is deeply connected to its roots, celebrating grand occasions like Ugadi with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Pootharekulu &amp; Gongura Pachadi, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Andhra Pradesh is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/arunachal-pradesh.html
+++ b/dist/states/arunachal-pradesh.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Known as the Land of the Dawn-Lit Mountains, Arunachal Pradesh is home to pristine valleys, diverse tribal cultures, and historic Tibetan Buddhist monasteries.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,15 +89,15 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Arunachal Pradesh</h1>
         <p><strong>Capital:</strong> Itanagar</p>
-        <p><strong>Famous Food:</strong> Thukpa & Pehak</p>
-        <p><strong>Major Festival:</strong> Solung & Losar</p>
+        <p><strong>Famous Food:</strong> Thukpa &amp; Pehak</p>
+        <p><strong>Major Festival:</strong> Solung &amp; Losar</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
             <p>Known as the Land of the Dawn-Lit Mountains, Arunachal Pradesh is home to pristine valleys, diverse tribal cultures, and historic Tibetan Buddhist monasteries.</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>Known as the Land of the Dawn-Lit Mountains, Arunachal Pradesh is home to pristine valleys, diverse tribal cultures, and historic Tibetan Buddhist monasteries.<br><br>The vibrant region of Arunachal Pradesh is governed from its beautiful capital, Itanagar. The land is deeply connected to its roots, celebrating grand occasions like Solung & Losar with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Thukpa & Pehak, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Arunachal Pradesh is a journey through time, culture, and nature.</p>
+            <p>Known as the Land of the Dawn-Lit Mountains, Arunachal Pradesh is home to pristine valleys, diverse tribal cultures, and historic Tibetan Buddhist monasteries.<br><br>The vibrant region of Arunachal Pradesh is governed from its beautiful capital, Itanagar. The land is deeply connected to its roots, celebrating grand occasions like Solung &amp; Losar with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Thukpa &amp; Pehak, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Arunachal Pradesh is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/assam.html
+++ b/dist/states/assam.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Famous worldwide for its fragrant black tea, exquisite Muga silk, and the rich biodiversity of Kaziranga National Park, home of the one-horned rhino.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">

--- a/dist/states/bihar.html
+++ b/dist/states/bihar.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Bihar is the historic cradle of Buddhism and Jainism. It is home to Bodh Gaya, Nalanda University, and the ancient capital of Pataliputra.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">

--- a/dist/states/chandigarh.html
+++ b/dist/states/chandigarh.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="A clean, modern union territory and planned city designed by Le Corbusier, acting as the joint capital of Punjab and Haryana.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,15 +89,15 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Chandigarh</h1>
         <p><strong>Capital:</strong> Chandigarh</p>
-        <p><strong>Famous Food:</strong> Butter Chicken & Amritsari Kulcha</p>
-        <p><strong>Major Festival:</strong> Rose Festival & Mango Festival</p>
+        <p><strong>Famous Food:</strong> Butter Chicken &amp; Amritsari Kulcha</p>
+        <p><strong>Major Festival:</strong> Rose Festival &amp; Mango Festival</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
             <p>A clean, modern union territory and planned city designed by Le Corbusier, acting as the joint capital of Punjab and Haryana.</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>A clean, modern union territory and planned city designed by Le Corbusier, acting as the joint capital of Punjab and Haryana.<br><br>The vibrant region of Chandigarh is governed from its beautiful capital, Chandigarh. The land is deeply connected to its roots, celebrating grand occasions like Rose Festival & Mango Festival with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Butter Chicken & Amritsari Kulcha, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Chandigarh is a journey through time, culture, and nature.</p>
+            <p>A clean, modern union territory and planned city designed by Le Corbusier, acting as the joint capital of Punjab and Haryana.<br><br>The vibrant region of Chandigarh is governed from its beautiful capital, Chandigarh. The land is deeply connected to its roots, celebrating grand occasions like Rose Festival &amp; Mango Festival with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Butter Chicken &amp; Amritsari Kulcha, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Chandigarh is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/chhattisgarh.html
+++ b/dist/states/chhattisgarh.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Chhattisgarh is renowned for its thick forests, majestic waterfalls like Chitrakote, Dhokra metal craft, and ancient tribal customs.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">

--- a/dist/states/dadra-and-nagar-haveli.html
+++ b/dist/states/dadra-and-nagar-haveli.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Dadra and Nagar Haveli is a green enclave known for its Portuguese heritage, tribal arts, and serene gardens along the Daman Ganga river.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,7 +89,7 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Dadra and Nagar Haveli</h1>
         <p><strong>Capital:</strong> Silvassa</p>
-        <p><strong>Famous Food:</strong> Ubadiyu & Tribal Dishes</p>
+        <p><strong>Famous Food:</strong> Ubadiyu &amp; Tribal Dishes</p>
         <p><strong>Major Festival:</strong> Tarpa Festival</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
@@ -97,7 +97,7 @@
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>Dadra and Nagar Haveli is a green enclave known for its Portuguese heritage, tribal arts, and serene gardens along the Daman Ganga river.<br><br>The vibrant region of Dadra and Nagar Haveli is governed from its beautiful capital, Silvassa. The land is deeply connected to its roots, celebrating grand occasions like Tarpa Festival with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Ubadiyu & Tribal Dishes, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Dadra and Nagar Haveli is a journey through time, culture, and nature.</p>
+            <p>Dadra and Nagar Haveli is a green enclave known for its Portuguese heritage, tribal arts, and serene gardens along the Daman Ganga river.<br><br>The vibrant region of Dadra and Nagar Haveli is governed from its beautiful capital, Silvassa. The land is deeply connected to its roots, celebrating grand occasions like Tarpa Festival with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Ubadiyu &amp; Tribal Dishes, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Dadra and Nagar Haveli is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/daman-and-diu.html
+++ b/dist/states/daman-and-diu.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Daman and Diu are historic coastal enclaves blending Portuguese colonial forts, beaches, and Gujarati traditions.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,15 +89,15 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Daman and Diu</h1>
         <p><strong>Capital:</strong> Daman</p>
-        <p><strong>Famous Food:</strong> Seafood & Coastal Gujarati Thali</p>
-        <p><strong>Major Festival:</strong> Nariyal Poornima & Garba</p>
+        <p><strong>Famous Food:</strong> Seafood &amp; Coastal Gujarati Thali</p>
+        <p><strong>Major Festival:</strong> Nariyal Poornima &amp; Garba</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
             <p>Daman and Diu are historic coastal enclaves blending Portuguese colonial forts, beaches, and Gujarati traditions.</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>Daman and Diu are historic coastal enclaves blending Portuguese colonial forts, beaches, and Gujarati traditions.<br><br>The vibrant region of Daman and Diu is governed from its beautiful capital, Daman. The land is deeply connected to its roots, celebrating grand occasions like Nariyal Poornima & Garba with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Seafood & Coastal Gujarati Thali, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Daman and Diu is a journey through time, culture, and nature.</p>
+            <p>Daman and Diu are historic coastal enclaves blending Portuguese colonial forts, beaches, and Gujarati traditions.<br><br>The vibrant region of Daman and Diu is governed from its beautiful capital, Daman. The land is deeply connected to its roots, celebrating grand occasions like Nariyal Poornima &amp; Garba with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Seafood &amp; Coastal Gujarati Thali, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Daman and Diu is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/delhi.html
+++ b/dist/states/delhi.html
@@ -1,17 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="India's capital city Delhi represents centuries of history. It features monuments like Red Fort, Qutub Minar, and bustling street markets.">
+    <meta name="description" content="India&#39;s capital city Delhi represents centuries of history. It features monuments like Red Fort, Qutub Minar, and bustling street markets.">
     <title>Delhi | Incredible India Explorer</title>
 
     <meta http-equiv="Content-Security-Policy" content="
@@ -28,7 +20,7 @@
 
     <!-- Open Graph / Social Meta Tags -->
     <meta property="og:title" content="Delhi | Incredible India Explorer">
-    <meta property="og:description" content="India's capital city Delhi represents centuries of history. It features monuments like Red Fort, Qutub Minar, and bustling street markets.">
+    <meta property="og:description" content="India&#39;s capital city Delhi represents centuries of history. It features monuments like Red Fort, Qutub Minar, and bustling street markets.">
     <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/assets/Brihadeeswara_Temple.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -39,7 +31,7 @@
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Delhi | Incredible India Explorer">
-    <meta name="twitter:description" content="India's capital city Delhi represents centuries of history. It features monuments like Red Fort, Qutub Minar, and bustling street markets.">
+    <meta name="twitter:description" content="India&#39;s capital city Delhi represents centuries of history. It features monuments like Red Fort, Qutub Minar, and bustling street markets.">
     <meta name="twitter:image" content="https://incredibleindiaexplorer.gov.in/assets/Brihadeeswara_Temple.png">
     <!-- Canonical URL -->
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/states/delhi.html">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,15 +89,15 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Delhi</h1>
         <p><strong>Capital:</strong> New Delhi</p>
-        <p><strong>Famous Food:</strong> Chole Bhature & Old Delhi Street Food</p>
-        <p><strong>Major Festival:</strong> Qutub Festival & India Gate events</p>
+        <p><strong>Famous Food:</strong> Chole Bhature &amp; Old Delhi Street Food</p>
+        <p><strong>Major Festival:</strong> Qutub Festival &amp; India Gate events</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
-            <p>India's capital city Delhi represents centuries of history. It features monuments like Red Fort, Qutub Minar, and bustling street markets.</p>
+            <p>India&#39;s capital city Delhi represents centuries of history. It features monuments like Red Fort, Qutub Minar, and bustling street markets.</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>India's capital city Delhi represents centuries of history. It features monuments like Red Fort, Qutub Minar, and bustling street markets.<br><br>The vibrant region of Delhi is governed from its beautiful capital, New Delhi. The land is deeply connected to its roots, celebrating grand occasions like Qutub Festival & India Gate events with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Chole Bhature & Old Delhi Street Food, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Delhi is a journey through time, culture, and nature.</p>
+            <p>India&#39;s capital city Delhi represents centuries of history. It features monuments like Red Fort, Qutub Minar, and bustling street markets.<br><br>The vibrant region of Delhi is governed from its beautiful capital, New Delhi. The land is deeply connected to its roots, celebrating grand occasions like Qutub Festival &amp; India Gate events with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Chole Bhature &amp; Old Delhi Street Food, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Delhi is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/goa.html
+++ b/dist/states/goa.html
@@ -1,17 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Goa is India's coastal paradise, celebrated for its golden beaches, Portuguese-colonial architecture, spice plantations, and laidback vibe.">
+    <meta name="description" content="Goa is India&#39;s coastal paradise, celebrated for its golden beaches, Portuguese-colonial architecture, spice plantations, and laidback vibe.">
     <title>Goa | Incredible India Explorer</title>
 
     <meta http-equiv="Content-Security-Policy" content="
@@ -28,7 +20,7 @@
 
     <!-- Open Graph / Social Meta Tags -->
     <meta property="og:title" content="Goa | Incredible India Explorer">
-    <meta property="og:description" content="Goa is India's coastal paradise, celebrated for its golden beaches, Portuguese-colonial architecture, spice plantations, and laidback vibe.">
+    <meta property="og:description" content="Goa is India&#39;s coastal paradise, celebrated for its golden beaches, Portuguese-colonial architecture, spice plantations, and laidback vibe.">
     <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/assets/Brihadeeswara_Temple.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -39,7 +31,7 @@
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Goa | Incredible India Explorer">
-    <meta name="twitter:description" content="Goa is India's coastal paradise, celebrated for its golden beaches, Portuguese-colonial architecture, spice plantations, and laidback vibe.">
+    <meta name="twitter:description" content="Goa is India&#39;s coastal paradise, celebrated for its golden beaches, Portuguese-colonial architecture, spice plantations, and laidback vibe.">
     <meta name="twitter:image" content="https://incredibleindiaexplorer.gov.in/assets/Brihadeeswara_Temple.png">
     <!-- Canonical URL -->
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/states/goa.html">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,15 +89,15 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Goa</h1>
         <p><strong>Capital:</strong> Panaji</p>
-        <p><strong>Famous Food:</strong> Fish Curry Rice & Bebinca</p>
-        <p><strong>Major Festival:</strong> Shigmo & Carnival</p>
+        <p><strong>Famous Food:</strong> Fish Curry Rice &amp; Bebinca</p>
+        <p><strong>Major Festival:</strong> Shigmo &amp; Carnival</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
-            <p>Goa is India's coastal paradise, celebrated for its golden beaches, Portuguese-colonial architecture, spice plantations, and laidback vibe.</p>
+            <p>Goa is India&#39;s coastal paradise, celebrated for its golden beaches, Portuguese-colonial architecture, spice plantations, and laidback vibe.</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>Goa is India's coastal paradise, celebrated for its golden beaches, Portuguese-colonial architecture, spice plantations, and laidback vibe.<br><br>The vibrant region of Goa is governed from its beautiful capital, Panaji. The land is deeply connected to its roots, celebrating grand occasions like Shigmo & Carnival with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Fish Curry Rice & Bebinca, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Goa is a journey through time, culture, and nature.</p>
+            <p>Goa is India&#39;s coastal paradise, celebrated for its golden beaches, Portuguese-colonial architecture, spice plantations, and laidback vibe.<br><br>The vibrant region of Goa is governed from its beautiful capital, Panaji. The land is deeply connected to its roots, celebrating grand occasions like Shigmo &amp; Carnival with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Fish Curry Rice &amp; Bebinca, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Goa is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/gujarat.html
+++ b/dist/states/gujarat.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="A land of business and legends, Gujarat is famous for the salt deserts of Rann of Kutch, Asiatic lions in Gir, and vibrant Garba dances.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,7 +89,7 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Gujarat</h1>
         <p><strong>Capital:</strong> Gandhinagar</p>
-        <p><strong>Famous Food:</strong> Dhokla, Khandvi & Thepla</p>
+        <p><strong>Famous Food:</strong> Dhokla, Khandvi &amp; Thepla</p>
         <p><strong>Major Festival:</strong> Navratri (Garba)</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
@@ -97,7 +97,7 @@
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>A land of business and legends, Gujarat is famous for the salt deserts of Rann of Kutch, Asiatic lions in Gir, and vibrant Garba dances.<br><br>The vibrant region of Gujarat is governed from its beautiful capital, Gandhinagar. The land is deeply connected to its roots, celebrating grand occasions like Navratri (Garba) with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Dhokla, Khandvi & Thepla, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Gujarat is a journey through time, culture, and nature.</p>
+            <p>A land of business and legends, Gujarat is famous for the salt deserts of Rann of Kutch, Asiatic lions in Gir, and vibrant Garba dances.<br><br>The vibrant region of Gujarat is governed from its beautiful capital, Gandhinagar. The land is deeply connected to its roots, celebrating grand occasions like Navratri (Garba) with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Dhokla, Khandvi &amp; Thepla, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Gujarat is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/haryana.html
+++ b/dist/states/haryana.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="The cradle of Vedic civilization, Haryana is a prosperous agrarian state famous for milk products, historical Kurukshetra, and world-class athletes.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,15 +89,15 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Haryana</h1>
         <p><strong>Capital:</strong> Chandigarh</p>
-        <p><strong>Famous Food:</strong> Bajra Khichdi & Kheer</p>
-        <p><strong>Major Festival:</strong> Teej & Baisakhi</p>
+        <p><strong>Famous Food:</strong> Bajra Khichdi &amp; Kheer</p>
+        <p><strong>Major Festival:</strong> Teej &amp; Baisakhi</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
             <p>The cradle of Vedic civilization, Haryana is a prosperous agrarian state famous for milk products, historical Kurukshetra, and world-class athletes.</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>The cradle of Vedic civilization, Haryana is a prosperous agrarian state famous for milk products, historical Kurukshetra, and world-class athletes.<br><br>The vibrant region of Haryana is governed from its beautiful capital, Chandigarh. The land is deeply connected to its roots, celebrating grand occasions like Teej & Baisakhi with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Bajra Khichdi & Kheer, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Haryana is a journey through time, culture, and nature.</p>
+            <p>The cradle of Vedic civilization, Haryana is a prosperous agrarian state famous for milk products, historical Kurukshetra, and world-class athletes.<br><br>The vibrant region of Haryana is governed from its beautiful capital, Chandigarh. The land is deeply connected to its roots, celebrating grand occasions like Teej &amp; Baisakhi with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Bajra Khichdi &amp; Kheer, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Haryana is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/himachal-pradesh.html
+++ b/dist/states/himachal-pradesh.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Nestled in the Himalayas, Himachal Pradesh is a tourist haven popular for adventure sports, orchards, scenic hill stations, and peaceful valleys.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,7 +89,7 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Himachal Pradesh</h1>
         <p><strong>Capital:</strong> Shimla</p>
-        <p><strong>Famous Food:</strong> Dham & Siddu</p>
+        <p><strong>Famous Food:</strong> Dham &amp; Siddu</p>
         <p><strong>Major Festival:</strong> Kullu Dussehra</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
@@ -97,7 +97,7 @@
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>Nestled in the Himalayas, Himachal Pradesh is a tourist haven popular for adventure sports, orchards, scenic hill stations, and peaceful valleys.<br><br>The vibrant region of Himachal Pradesh is governed from its beautiful capital, Shimla. The land is deeply connected to its roots, celebrating grand occasions like Kullu Dussehra with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Dham & Siddu, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Himachal Pradesh is a journey through time, culture, and nature.</p>
+            <p>Nestled in the Himalayas, Himachal Pradesh is a tourist haven popular for adventure sports, orchards, scenic hill stations, and peaceful valleys.<br><br>The vibrant region of Himachal Pradesh is governed from its beautiful capital, Shimla. The land is deeply connected to its roots, celebrating grand occasions like Kullu Dussehra with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Dham &amp; Siddu, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Himachal Pradesh is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/jammu-and-kashmir.html
+++ b/dist/states/jammu-and-kashmir.html
@@ -1,17 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Renowned as 'Paradise on Earth', Jammu & Kashmir is globally famous for snow-capped peaks, houseboats on Dal Lake, saffron, and pashmina shawls.">
+    <meta name="description" content="Renowned as &#39;Paradise on Earth&#39;, Jammu &amp; Kashmir is globally famous for snow-capped peaks, houseboats on Dal Lake, saffron, and pashmina shawls.">
     <title>Jammu and Kashmir | Incredible India Explorer</title>
 
     <meta http-equiv="Content-Security-Policy" content="
@@ -28,7 +20,7 @@
 
     <!-- Open Graph / Social Meta Tags -->
     <meta property="og:title" content="Jammu and Kashmir | Incredible India Explorer">
-    <meta property="og:description" content="Renowned as 'Paradise on Earth', Jammu & Kashmir is globally famous for snow-capped peaks, houseboats on Dal Lake, saffron, and pashmina shawls.">
+    <meta property="og:description" content="Renowned as &#39;Paradise on Earth&#39;, Jammu &amp; Kashmir is globally famous for snow-capped peaks, houseboats on Dal Lake, saffron, and pashmina shawls.">
     <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/assets/Brihadeeswara_Temple.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -39,7 +31,7 @@
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Jammu and Kashmir | Incredible India Explorer">
-    <meta name="twitter:description" content="Renowned as 'Paradise on Earth', Jammu & Kashmir is globally famous for snow-capped peaks, houseboats on Dal Lake, saffron, and pashmina shawls.">
+    <meta name="twitter:description" content="Renowned as &#39;Paradise on Earth&#39;, Jammu &amp; Kashmir is globally famous for snow-capped peaks, houseboats on Dal Lake, saffron, and pashmina shawls.">
     <meta name="twitter:image" content="https://incredibleindiaexplorer.gov.in/assets/Brihadeeswara_Temple.png">
     <!-- Canonical URL -->
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/states/jammu-and-kashmir.html">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,15 +89,15 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Jammu and Kashmir</h1>
         <p><strong>Capital:</strong> Srinagar (Summer) / Jammu (Winter)</p>
-        <p><strong>Famous Food:</strong> Rogan Josh & Kashmiri Kahwa</p>
-        <p><strong>Major Festival:</strong> Shikara & Tulip Festival</p>
+        <p><strong>Famous Food:</strong> Rogan Josh &amp; Kashmiri Kahwa</p>
+        <p><strong>Major Festival:</strong> Shikara &amp; Tulip Festival</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
-            <p>Renowned as 'Paradise on Earth', Jammu & Kashmir is globally famous for snow-capped peaks, houseboats on Dal Lake, saffron, and pashmina shawls.</p>
+            <p>Renowned as &#39;Paradise on Earth&#39;, Jammu &amp; Kashmir is globally famous for snow-capped peaks, houseboats on Dal Lake, saffron, and pashmina shawls.</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>Renowned as 'Paradise on Earth', Jammu & Kashmir is globally famous for snow-capped peaks, houseboats on Dal Lake, saffron, and pashmina shawls.<br><br>The vibrant region of Jammu and Kashmir is governed from its beautiful capital, Srinagar (Summer) / Jammu (Winter). The land is deeply connected to its roots, celebrating grand occasions like Shikara & Tulip Festival with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Rogan Josh & Kashmiri Kahwa, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Jammu and Kashmir is a journey through time, culture, and nature.</p>
+            <p>Renowned as &#39;Paradise on Earth&#39;, Jammu &amp; Kashmir is globally famous for snow-capped peaks, houseboats on Dal Lake, saffron, and pashmina shawls.<br><br>The vibrant region of Jammu and Kashmir is governed from its beautiful capital, Srinagar (Summer) / Jammu (Winter). The land is deeply connected to its roots, celebrating grand occasions like Shikara &amp; Tulip Festival with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Rogan Josh &amp; Kashmiri Kahwa, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Jammu and Kashmir is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/jharkhand.html
+++ b/dist/states/jharkhand.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Known as the Land of Forests, Jharkhand features gorgeous waterfalls, hills, holy temples like Deoghar, and rich tribal art forms like Sohrai paintings.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,15 +89,15 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Jharkhand</h1>
         <p><strong>Capital:</strong> Ranchi</p>
-        <p><strong>Famous Food:</strong> Dhuska & Litti Chokha</p>
-        <p><strong>Major Festival:</strong> Sarhul & Karam</p>
+        <p><strong>Famous Food:</strong> Dhuska &amp; Litti Chokha</p>
+        <p><strong>Major Festival:</strong> Sarhul &amp; Karam</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
             <p>Known as the Land of Forests, Jharkhand features gorgeous waterfalls, hills, holy temples like Deoghar, and rich tribal art forms like Sohrai paintings.</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>Known as the Land of Forests, Jharkhand features gorgeous waterfalls, hills, holy temples like Deoghar, and rich tribal art forms like Sohrai paintings.<br><br>The vibrant region of Jharkhand is governed from its beautiful capital, Ranchi. The land is deeply connected to its roots, celebrating grand occasions like Sarhul & Karam with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Dhuska & Litti Chokha, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Jharkhand is a journey through time, culture, and nature.</p>
+            <p>Known as the Land of Forests, Jharkhand features gorgeous waterfalls, hills, holy temples like Deoghar, and rich tribal art forms like Sohrai paintings.<br><br>The vibrant region of Jharkhand is governed from its beautiful capital, Ranchi. The land is deeply connected to its roots, celebrating grand occasions like Sarhul &amp; Karam with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Dhuska &amp; Litti Chokha, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Jharkhand is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/karnataka.html
+++ b/dist/states/karnataka.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Karnataka blends modern technology hubs with historical marvels like Hampi. It boasts stunning coastlines, western ghats, and rich Carnatic music.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,7 +89,7 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Karnataka</h1>
         <p><strong>Capital:</strong> Bengaluru</p>
-        <p><strong>Famous Food:</strong> Bisi Bele Bath & Mysore Pak</p>
+        <p><strong>Famous Food:</strong> Bisi Bele Bath &amp; Mysore Pak</p>
         <p><strong>Major Festival:</strong> Mysore Dasara</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
@@ -97,7 +97,7 @@
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>Karnataka blends modern technology hubs with historical marvels like Hampi. It boasts stunning coastlines, western ghats, and rich Carnatic music.<br><br>The vibrant region of Karnataka is governed from its beautiful capital, Bengaluru. The land is deeply connected to its roots, celebrating grand occasions like Mysore Dasara with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Bisi Bele Bath & Mysore Pak, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Karnataka is a journey through time, culture, and nature.</p>
+            <p>Karnataka blends modern technology hubs with historical marvels like Hampi. It boasts stunning coastlines, western ghats, and rich Carnatic music.<br><br>The vibrant region of Karnataka is governed from its beautiful capital, Bengaluru. The land is deeply connected to its roots, celebrating grand occasions like Mysore Dasara with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Bisi Bele Bath &amp; Mysore Pak, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Karnataka is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/kerala.html
+++ b/dist/states/kerala.html
@@ -1,17 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Often called 'God's Own Country', Kerala is famous for backwaters, coconut groves, Kathakali dance, Ayurvedic healing, and high literacy.">
+    <meta name="description" content="Often called &#39;God&#39;s Own Country&#39;, Kerala is famous for backwaters, coconut groves, Kathakali dance, Ayurvedic healing, and high literacy.">
     <title>Kerala | Incredible India Explorer</title>
 
     <meta http-equiv="Content-Security-Policy" content="
@@ -28,7 +20,7 @@
 
     <!-- Open Graph / Social Meta Tags -->
     <meta property="og:title" content="Kerala | Incredible India Explorer">
-    <meta property="og:description" content="Often called 'God's Own Country', Kerala is famous for backwaters, coconut groves, Kathakali dance, Ayurvedic healing, and high literacy.">
+    <meta property="og:description" content="Often called &#39;God&#39;s Own Country&#39;, Kerala is famous for backwaters, coconut groves, Kathakali dance, Ayurvedic healing, and high literacy.">
     <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/assets/Brihadeeswara_Temple.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -39,7 +31,7 @@
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Kerala | Incredible India Explorer">
-    <meta name="twitter:description" content="Often called 'God's Own Country', Kerala is famous for backwaters, coconut groves, Kathakali dance, Ayurvedic healing, and high literacy.">
+    <meta name="twitter:description" content="Often called &#39;God&#39;s Own Country&#39;, Kerala is famous for backwaters, coconut groves, Kathakali dance, Ayurvedic healing, and high literacy.">
     <meta name="twitter:image" content="https://incredibleindiaexplorer.gov.in/assets/Brihadeeswara_Temple.png">
     <!-- Canonical URL -->
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/states/kerala.html">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,15 +89,15 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Kerala</h1>
         <p><strong>Capital:</strong> Thiruvananthapuram</p>
-        <p><strong>Famous Food:</strong> Karimeen Pollichathu & Sadya</p>
-        <p><strong>Major Festival:</strong> Onam & Vishu</p>
+        <p><strong>Famous Food:</strong> Karimeen Pollichathu &amp; Sadya</p>
+        <p><strong>Major Festival:</strong> Onam &amp; Vishu</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
-            <p>Often called 'God's Own Country', Kerala is famous for backwaters, coconut groves, Kathakali dance, Ayurvedic healing, and high literacy.</p>
+            <p>Often called &#39;God&#39;s Own Country&#39;, Kerala is famous for backwaters, coconut groves, Kathakali dance, Ayurvedic healing, and high literacy.</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>Often called 'God's Own Country', Kerala is famous for backwaters, coconut groves, Kathakali dance, Ayurvedic healing, and high literacy.<br><br>The vibrant region of Kerala is governed from its beautiful capital, Thiruvananthapuram. The land is deeply connected to its roots, celebrating grand occasions like Onam & Vishu with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Karimeen Pollichathu & Sadya, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Kerala is a journey through time, culture, and nature.</p>
+            <p>Often called &#39;God&#39;s Own Country&#39;, Kerala is famous for backwaters, coconut groves, Kathakali dance, Ayurvedic healing, and high literacy.<br><br>The vibrant region of Kerala is governed from its beautiful capital, Thiruvananthapuram. The land is deeply connected to its roots, celebrating grand occasions like Onam &amp; Vishu with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Karimeen Pollichathu &amp; Sadya, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Kerala is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/lakshadweep.html
+++ b/dist/states/lakshadweep.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="A stunning coral archipelago in the Laccadive Sea, famous for crystal-clear lagoons, coconut palms, scuba diving, and pristine nature.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,15 +89,15 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Lakshadweep</h1>
         <p><strong>Capital:</strong> Kavaratti</p>
-        <p><strong>Famous Food:</strong> Mus Kavaab (Tuna curry) & Fish fry</p>
-        <p><strong>Major Festival:</strong> Eid-ul-Fitr & Milad-un-Nabi</p>
+        <p><strong>Famous Food:</strong> Mus Kavaab (Tuna curry) &amp; Fish fry</p>
+        <p><strong>Major Festival:</strong> Eid-ul-Fitr &amp; Milad-un-Nabi</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
             <p>A stunning coral archipelago in the Laccadive Sea, famous for crystal-clear lagoons, coconut palms, scuba diving, and pristine nature.</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>A stunning coral archipelago in the Laccadive Sea, famous for crystal-clear lagoons, coconut palms, scuba diving, and pristine nature.<br><br>The vibrant region of Lakshadweep is governed from its beautiful capital, Kavaratti. The land is deeply connected to its roots, celebrating grand occasions like Eid-ul-Fitr & Milad-un-Nabi with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Mus Kavaab (Tuna curry) & Fish fry, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Lakshadweep is a journey through time, culture, and nature.</p>
+            <p>A stunning coral archipelago in the Laccadive Sea, famous for crystal-clear lagoons, coconut palms, scuba diving, and pristine nature.<br><br>The vibrant region of Lakshadweep is governed from its beautiful capital, Kavaratti. The land is deeply connected to its roots, celebrating grand occasions like Eid-ul-Fitr &amp; Milad-un-Nabi with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Mus Kavaab (Tuna curry) &amp; Fish fry, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Lakshadweep is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/madhya-pradesh.html
+++ b/dist/states/madhya-pradesh.html
@@ -1,17 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="The 'Heart of India', Madhya Pradesh contains tiger reserves, stupas of Sanchi, forts of Gwalior, and the medieval temples of Khajuraho.">
+    <meta name="description" content="The &#39;Heart of India&#39;, Madhya Pradesh contains tiger reserves, stupas of Sanchi, forts of Gwalior, and the medieval temples of Khajuraho.">
     <title>Madhya Pradesh | Incredible India Explorer</title>
 
     <meta http-equiv="Content-Security-Policy" content="
@@ -28,7 +20,7 @@
 
     <!-- Open Graph / Social Meta Tags -->
     <meta property="og:title" content="Madhya Pradesh | Incredible India Explorer">
-    <meta property="og:description" content="The 'Heart of India', Madhya Pradesh contains tiger reserves, stupas of Sanchi, forts of Gwalior, and the medieval temples of Khajuraho.">
+    <meta property="og:description" content="The &#39;Heart of India&#39;, Madhya Pradesh contains tiger reserves, stupas of Sanchi, forts of Gwalior, and the medieval temples of Khajuraho.">
     <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/assets/Brihadeeswara_Temple.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -39,7 +31,7 @@
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Madhya Pradesh | Incredible India Explorer">
-    <meta name="twitter:description" content="The 'Heart of India', Madhya Pradesh contains tiger reserves, stupas of Sanchi, forts of Gwalior, and the medieval temples of Khajuraho.">
+    <meta name="twitter:description" content="The &#39;Heart of India&#39;, Madhya Pradesh contains tiger reserves, stupas of Sanchi, forts of Gwalior, and the medieval temples of Khajuraho.">
     <meta name="twitter:image" content="https://incredibleindiaexplorer.gov.in/assets/Brihadeeswara_Temple.png">
     <!-- Canonical URL -->
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/states/madhya-pradesh.html">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,15 +89,15 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Madhya Pradesh</h1>
         <p><strong>Capital:</strong> Bhopal</p>
-        <p><strong>Famous Food:</strong> Poha Jalebi & Bhutte ka Kees</p>
+        <p><strong>Famous Food:</strong> Poha Jalebi &amp; Bhutte ka Kees</p>
         <p><strong>Major Festival:</strong> Khajuraho Dance Festival</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
-            <p>The 'Heart of India', Madhya Pradesh contains tiger reserves, stupas of Sanchi, forts of Gwalior, and the medieval temples of Khajuraho.</p>
+            <p>The &#39;Heart of India&#39;, Madhya Pradesh contains tiger reserves, stupas of Sanchi, forts of Gwalior, and the medieval temples of Khajuraho.</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>The 'Heart of India', Madhya Pradesh contains tiger reserves, stupas of Sanchi, forts of Gwalior, and the medieval temples of Khajuraho.<br><br>The vibrant region of Madhya Pradesh is governed from its beautiful capital, Bhopal. The land is deeply connected to its roots, celebrating grand occasions like Khajuraho Dance Festival with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Poha Jalebi & Bhutte ka Kees, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Madhya Pradesh is a journey through time, culture, and nature.</p>
+            <p>The &#39;Heart of India&#39;, Madhya Pradesh contains tiger reserves, stupas of Sanchi, forts of Gwalior, and the medieval temples of Khajuraho.<br><br>The vibrant region of Madhya Pradesh is governed from its beautiful capital, Bhopal. The land is deeply connected to its roots, celebrating grand occasions like Khajuraho Dance Festival with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Poha Jalebi &amp; Bhutte ka Kees, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Madhya Pradesh is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/maharashtra.html
+++ b/dist/states/maharashtra.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Maharashtra is a powerhouse of commerce and culture, featuring Ajanta-Ellora caves, the Western Ghats, and the bustling capital Mumbai, home to Bollywood.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,7 +89,7 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Maharashtra</h1>
         <p><strong>Capital:</strong> Mumbai</p>
-        <p><strong>Famous Food:</strong> Vada Pav, Pav Bhaji & Puran Poli</p>
+        <p><strong>Famous Food:</strong> Vada Pav, Pav Bhaji &amp; Puran Poli</p>
         <p><strong>Major Festival:</strong> Ganesh Chaturthi</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
@@ -97,7 +97,7 @@
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>Maharashtra is a powerhouse of commerce and culture, featuring Ajanta-Ellora caves, the Western Ghats, and the bustling capital Mumbai, home to Bollywood.<br><br>The vibrant region of Maharashtra is governed from its beautiful capital, Mumbai. The land is deeply connected to its roots, celebrating grand occasions like Ganesh Chaturthi with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Vada Pav, Pav Bhaji & Puran Poli, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Maharashtra is a journey through time, culture, and nature.</p>
+            <p>Maharashtra is a powerhouse of commerce and culture, featuring Ajanta-Ellora caves, the Western Ghats, and the bustling capital Mumbai, home to Bollywood.<br><br>The vibrant region of Maharashtra is governed from its beautiful capital, Mumbai. The land is deeply connected to its roots, celebrating grand occasions like Ganesh Chaturthi with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Vada Pav, Pav Bhaji &amp; Puran Poli, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Maharashtra is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/manipur.html
+++ b/dist/states/manipur.html
@@ -1,17 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Manipur, the 'Jewel of India', is famous for its graceful Manipuri classical dance, floating Loktak Lake, and traditional handloom industry.">
+    <meta name="description" content="Manipur, the &#39;Jewel of India&#39;, is famous for its graceful Manipuri classical dance, floating Loktak Lake, and traditional handloom industry.">
     <title>Manipur | Incredible India Explorer</title>
 
     <meta http-equiv="Content-Security-Policy" content="
@@ -28,7 +20,7 @@
 
     <!-- Open Graph / Social Meta Tags -->
     <meta property="og:title" content="Manipur | Incredible India Explorer">
-    <meta property="og:description" content="Manipur, the 'Jewel of India', is famous for its graceful Manipuri classical dance, floating Loktak Lake, and traditional handloom industry.">
+    <meta property="og:description" content="Manipur, the &#39;Jewel of India&#39;, is famous for its graceful Manipuri classical dance, floating Loktak Lake, and traditional handloom industry.">
     <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/assets/Brihadeeswara_Temple.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -39,7 +31,7 @@
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Manipur | Incredible India Explorer">
-    <meta name="twitter:description" content="Manipur, the 'Jewel of India', is famous for its graceful Manipuri classical dance, floating Loktak Lake, and traditional handloom industry.">
+    <meta name="twitter:description" content="Manipur, the &#39;Jewel of India&#39;, is famous for its graceful Manipuri classical dance, floating Loktak Lake, and traditional handloom industry.">
     <meta name="twitter:image" content="https://incredibleindiaexplorer.gov.in/assets/Brihadeeswara_Temple.png">
     <!-- Canonical URL -->
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/states/manipur.html">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,15 +89,15 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Manipur</h1>
         <p><strong>Capital:</strong> Imphal</p>
-        <p><strong>Famous Food:</strong> Eromba & Kangshoi</p>
+        <p><strong>Famous Food:</strong> Eromba &amp; Kangshoi</p>
         <p><strong>Major Festival:</strong> Yaoshang</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
-            <p>Manipur, the 'Jewel of India', is famous for its graceful Manipuri classical dance, floating Loktak Lake, and traditional handloom industry.</p>
+            <p>Manipur, the &#39;Jewel of India&#39;, is famous for its graceful Manipuri classical dance, floating Loktak Lake, and traditional handloom industry.</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>Manipur, the 'Jewel of India', is famous for its graceful Manipuri classical dance, floating Loktak Lake, and traditional handloom industry.<br><br>The vibrant region of Manipur is governed from its beautiful capital, Imphal. The land is deeply connected to its roots, celebrating grand occasions like Yaoshang with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Eromba & Kangshoi, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Manipur is a journey through time, culture, and nature.</p>
+            <p>Manipur, the &#39;Jewel of India&#39;, is famous for its graceful Manipuri classical dance, floating Loktak Lake, and traditional handloom industry.<br><br>The vibrant region of Manipur is governed from its beautiful capital, Imphal. The land is deeply connected to its roots, celebrating grand occasions like Yaoshang with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Eromba &amp; Kangshoi, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Manipur is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/meghalaya.html
+++ b/dist/states/meghalaya.html
@@ -1,17 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Meghalaya, the 'Abode of Clouds', holds the wettest places on Earth, breathtaking living root bridges, cascading falls, and rock music heritage.">
+    <meta name="description" content="Meghalaya, the &#39;Abode of Clouds&#39;, holds the wettest places on Earth, breathtaking living root bridges, cascading falls, and rock music heritage.">
     <title>Meghalaya | Incredible India Explorer</title>
 
     <meta http-equiv="Content-Security-Policy" content="
@@ -28,7 +20,7 @@
 
     <!-- Open Graph / Social Meta Tags -->
     <meta property="og:title" content="Meghalaya | Incredible India Explorer">
-    <meta property="og:description" content="Meghalaya, the 'Abode of Clouds', holds the wettest places on Earth, breathtaking living root bridges, cascading falls, and rock music heritage.">
+    <meta property="og:description" content="Meghalaya, the &#39;Abode of Clouds&#39;, holds the wettest places on Earth, breathtaking living root bridges, cascading falls, and rock music heritage.">
     <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/assets/Brihadeeswara_Temple.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -39,7 +31,7 @@
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Meghalaya | Incredible India Explorer">
-    <meta name="twitter:description" content="Meghalaya, the 'Abode of Clouds', holds the wettest places on Earth, breathtaking living root bridges, cascading falls, and rock music heritage.">
+    <meta name="twitter:description" content="Meghalaya, the &#39;Abode of Clouds&#39;, holds the wettest places on Earth, breathtaking living root bridges, cascading falls, and rock music heritage.">
     <meta name="twitter:image" content="https://incredibleindiaexplorer.gov.in/assets/Brihadeeswara_Temple.png">
     <!-- Canonical URL -->
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/states/meghalaya.html">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,15 +89,15 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Meghalaya</h1>
         <p><strong>Capital:</strong> Shillong</p>
-        <p><strong>Famous Food:</strong> Jadoh & Tungrymbai</p>
-        <p><strong>Major Festival:</strong> Nongkrem & Wangala</p>
+        <p><strong>Famous Food:</strong> Jadoh &amp; Tungrymbai</p>
+        <p><strong>Major Festival:</strong> Nongkrem &amp; Wangala</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
-            <p>Meghalaya, the 'Abode of Clouds', holds the wettest places on Earth, breathtaking living root bridges, cascading falls, and rock music heritage.</p>
+            <p>Meghalaya, the &#39;Abode of Clouds&#39;, holds the wettest places on Earth, breathtaking living root bridges, cascading falls, and rock music heritage.</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>Meghalaya, the 'Abode of Clouds', holds the wettest places on Earth, breathtaking living root bridges, cascading falls, and rock music heritage.<br><br>The vibrant region of Meghalaya is governed from its beautiful capital, Shillong. The land is deeply connected to its roots, celebrating grand occasions like Nongkrem & Wangala with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Jadoh & Tungrymbai, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Meghalaya is a journey through time, culture, and nature.</p>
+            <p>Meghalaya, the &#39;Abode of Clouds&#39;, holds the wettest places on Earth, breathtaking living root bridges, cascading falls, and rock music heritage.<br><br>The vibrant region of Meghalaya is governed from its beautiful capital, Shillong. The land is deeply connected to its roots, celebrating grand occasions like Nongkrem &amp; Wangala with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Jadoh &amp; Tungrymbai, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Meghalaya is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/mizoram.html
+++ b/dist/states/mizoram.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Mizoram is a state of rolling green hills, bamboo forests, and musical people. It is famous for the Cheraw (bamboo) dance.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,7 +89,7 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Mizoram</h1>
         <p><strong>Capital:</strong> Aizawl</p>
-        <p><strong>Famous Food:</strong> Bai & Sawhchiar</p>
+        <p><strong>Famous Food:</strong> Bai &amp; Sawhchiar</p>
         <p><strong>Major Festival:</strong> Chapchar Kut</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
@@ -97,7 +97,7 @@
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>Mizoram is a state of rolling green hills, bamboo forests, and musical people. It is famous for the Cheraw (bamboo) dance.<br><br>The vibrant region of Mizoram is governed from its beautiful capital, Aizawl. The land is deeply connected to its roots, celebrating grand occasions like Chapchar Kut with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Bai & Sawhchiar, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Mizoram is a journey through time, culture, and nature.</p>
+            <p>Mizoram is a state of rolling green hills, bamboo forests, and musical people. It is famous for the Cheraw (bamboo) dance.<br><br>The vibrant region of Mizoram is governed from its beautiful capital, Aizawl. The land is deeply connected to its roots, celebrating grand occasions like Chapchar Kut with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Bai &amp; Sawhchiar, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Mizoram is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/nagaland.html
+++ b/dist/states/nagaland.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Nagaland is a vibrant mountainous state famous for its rich tribal warrior heritage, beautiful woven shawls, and the Hornbill Festival.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">

--- a/dist/states/odisha.html
+++ b/dist/states/odisha.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Odisha is famous for its majestic temples like Konark Sun Temple, ancient maritime history, handloom sarees, and classical Odissi dance.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,7 +89,7 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Odisha</h1>
         <p><strong>Capital:</strong> Bhubaneswar</p>
-        <p><strong>Famous Food:</strong> Dalma & Chenapoda</p>
+        <p><strong>Famous Food:</strong> Dalma &amp; Chenapoda</p>
         <p><strong>Major Festival:</strong> Ratha Yatra (Puri)</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
@@ -97,7 +97,7 @@
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>Odisha is famous for its majestic temples like Konark Sun Temple, ancient maritime history, handloom sarees, and classical Odissi dance.<br><br>The vibrant region of Odisha is governed from its beautiful capital, Bhubaneswar. The land is deeply connected to its roots, celebrating grand occasions like Ratha Yatra (Puri) with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Dalma & Chenapoda, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Odisha is a journey through time, culture, and nature.</p>
+            <p>Odisha is famous for its majestic temples like Konark Sun Temple, ancient maritime history, handloom sarees, and classical Odissi dance.<br><br>The vibrant region of Odisha is governed from its beautiful capital, Bhubaneswar. The land is deeply connected to its roots, celebrating grand occasions like Ratha Yatra (Puri) with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Dalma &amp; Chenapoda, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Odisha is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/puducherry.html
+++ b/dist/states/puducherry.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="A charming coastal French-style town featuring yellow colonial villas, seaside promenades, Auroville ashram, and peaceful beaches.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,15 +89,15 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Puducherry</h1>
         <p><strong>Capital:</strong> Puducherry</p>
-        <p><strong>Famous Food:</strong> Creole Fish Curry & Croissants</p>
-        <p><strong>Major Festival:</strong> Fete de Pondicherry & Yoga Festival</p>
+        <p><strong>Famous Food:</strong> Creole Fish Curry &amp; Croissants</p>
+        <p><strong>Major Festival:</strong> Fete de Pondicherry &amp; Yoga Festival</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
             <p>A charming coastal French-style town featuring yellow colonial villas, seaside promenades, Auroville ashram, and peaceful beaches.</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>A charming coastal French-style town featuring yellow colonial villas, seaside promenades, Auroville ashram, and peaceful beaches.<br><br>The vibrant region of Puducherry is governed from its beautiful capital, Puducherry. The land is deeply connected to its roots, celebrating grand occasions like Fete de Pondicherry & Yoga Festival with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Creole Fish Curry & Croissants, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Puducherry is a journey through time, culture, and nature.</p>
+            <p>A charming coastal French-style town featuring yellow colonial villas, seaside promenades, Auroville ashram, and peaceful beaches.<br><br>The vibrant region of Puducherry is governed from its beautiful capital, Puducherry. The land is deeply connected to its roots, celebrating grand occasions like Fete de Pondicherry &amp; Yoga Festival with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Creole Fish Curry &amp; Croissants, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Puducherry is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/punjab.html
+++ b/dist/states/punjab.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="The land of five rivers, Punjab is characterized by agricultural prosperity, rich folklore, high-energy Bhangra music, and the sacred Golden Temple.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,15 +89,15 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Punjab</h1>
         <p><strong>Capital:</strong> Chandigarh</p>
-        <p><strong>Famous Food:</strong> Makki di Roti & Sarson ka Saag</p>
-        <p><strong>Major Festival:</strong> Baisakhi & Lohri</p>
+        <p><strong>Famous Food:</strong> Makki di Roti &amp; Sarson ka Saag</p>
+        <p><strong>Major Festival:</strong> Baisakhi &amp; Lohri</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
             <p>The land of five rivers, Punjab is characterized by agricultural prosperity, rich folklore, high-energy Bhangra music, and the sacred Golden Temple.</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>The land of five rivers, Punjab is characterized by agricultural prosperity, rich folklore, high-energy Bhangra music, and the sacred Golden Temple.<br><br>The vibrant region of Punjab is governed from its beautiful capital, Chandigarh. The land is deeply connected to its roots, celebrating grand occasions like Baisakhi & Lohri with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Makki di Roti & Sarson ka Saag, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Punjab is a journey through time, culture, and nature.</p>
+            <p>The land of five rivers, Punjab is characterized by agricultural prosperity, rich folklore, high-energy Bhangra music, and the sacred Golden Temple.<br><br>The vibrant region of Punjab is governed from its beautiful capital, Chandigarh. The land is deeply connected to its roots, celebrating grand occasions like Baisakhi &amp; Lohri with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Makki di Roti &amp; Sarson ka Saag, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Punjab is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/rajasthan.html
+++ b/dist/states/rajasthan.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="The Royal State of India, Rajasthan is globally famous for its desert sand dunes, magnificent palaces, camel festivals, and rich folk music.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,15 +89,15 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Rajasthan</h1>
         <p><strong>Capital:</strong> Jaipur</p>
-        <p><strong>Famous Food:</strong> Dal Baati Churma & Laal Maas</p>
-        <p><strong>Major Festival:</strong> Pushkar Fair & Teej</p>
+        <p><strong>Famous Food:</strong> Dal Baati Churma &amp; Laal Maas</p>
+        <p><strong>Major Festival:</strong> Pushkar Fair &amp; Teej</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
             <p>The Royal State of India, Rajasthan is globally famous for its desert sand dunes, magnificent palaces, camel festivals, and rich folk music.</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>The Royal State of India, Rajasthan is globally famous for its desert sand dunes, magnificent palaces, camel festivals, and rich folk music.<br><br>The vibrant region of Rajasthan is governed from its beautiful capital, Jaipur. The land is deeply connected to its roots, celebrating grand occasions like Pushkar Fair & Teej with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Dal Baati Churma & Laal Maas, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Rajasthan is a journey through time, culture, and nature.</p>
+            <p>The Royal State of India, Rajasthan is globally famous for its desert sand dunes, magnificent palaces, camel festivals, and rich folk music.<br><br>The vibrant region of Rajasthan is governed from its beautiful capital, Jaipur. The land is deeply connected to its roots, celebrating grand occasions like Pushkar Fair &amp; Teej with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Dal Baati Churma &amp; Laal Maas, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Rajasthan is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/sikkim.html
+++ b/dist/states/sikkim.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Sikkim is a clean, organic Himalayan state surrounding Mt. Kanchenjunga. It is famous for alpine meadows, glaciers, and Buddhist monasteries.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,15 +89,15 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Sikkim</h1>
         <p><strong>Capital:</strong> Gangtok</p>
-        <p><strong>Famous Food:</strong> Momo, Thukpa & Gundruk</p>
-        <p><strong>Major Festival:</strong> Saga Dawa & Losar</p>
+        <p><strong>Famous Food:</strong> Momo, Thukpa &amp; Gundruk</p>
+        <p><strong>Major Festival:</strong> Saga Dawa &amp; Losar</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
             <p>Sikkim is a clean, organic Himalayan state surrounding Mt. Kanchenjunga. It is famous for alpine meadows, glaciers, and Buddhist monasteries.</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>Sikkim is a clean, organic Himalayan state surrounding Mt. Kanchenjunga. It is famous for alpine meadows, glaciers, and Buddhist monasteries.<br><br>The vibrant region of Sikkim is governed from its beautiful capital, Gangtok. The land is deeply connected to its roots, celebrating grand occasions like Saga Dawa & Losar with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Momo, Thukpa & Gundruk, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Sikkim is a journey through time, culture, and nature.</p>
+            <p>Sikkim is a clean, organic Himalayan state surrounding Mt. Kanchenjunga. It is famous for alpine meadows, glaciers, and Buddhist monasteries.<br><br>The vibrant region of Sikkim is governed from its beautiful capital, Gangtok. The land is deeply connected to its roots, celebrating grand occasions like Saga Dawa &amp; Losar with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Momo, Thukpa &amp; Gundruk, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Sikkim is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/tamil-nadu.html
+++ b/dist/states/tamil-nadu.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Tamil Nadu is home to massive stone Dravidian temples, classical Bharatanatyam dance, Carnatic music, and a history stretching back to the ancient Sangam age.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,15 +89,15 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Tamil Nadu</h1>
         <p><strong>Capital:</strong> Chennai</p>
-        <p><strong>Famous Food:</strong> Dosa, Idli-Sambar & Pongal</p>
-        <p><strong>Major Festival:</strong> Pongal & Puthandu</p>
+        <p><strong>Famous Food:</strong> Dosa, Idli-Sambar &amp; Pongal</p>
+        <p><strong>Major Festival:</strong> Pongal &amp; Puthandu</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
             <p>Tamil Nadu is home to massive stone Dravidian temples, classical Bharatanatyam dance, Carnatic music, and a history stretching back to the ancient Sangam age.</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>Tamil Nadu is home to massive stone Dravidian temples, classical Bharatanatyam dance, Carnatic music, and a history stretching back to the ancient Sangam age.<br><br>The vibrant region of Tamil Nadu is governed from its beautiful capital, Chennai. The land is deeply connected to its roots, celebrating grand occasions like Pongal & Puthandu with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Dosa, Idli-Sambar & Pongal, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Tamil Nadu is a journey through time, culture, and nature.</p>
+            <p>Tamil Nadu is home to massive stone Dravidian temples, classical Bharatanatyam dance, Carnatic music, and a history stretching back to the ancient Sangam age.<br><br>The vibrant region of Tamil Nadu is governed from its beautiful capital, Chennai. The land is deeply connected to its roots, celebrating grand occasions like Pongal &amp; Puthandu with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Dosa, Idli-Sambar &amp; Pongal, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Tamil Nadu is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/telangana.html
+++ b/dist/states/telangana.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Telangana is a blend of Kakatiya history and Nizam culture, marked by the Charminar monument, IT hubs in Hyderabad, and Pochampally weaves.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,15 +89,15 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Telangana</h1>
         <p><strong>Capital:</strong> Hyderabad</p>
-        <p><strong>Famous Food:</strong> Hyderabadi Biryani & Haleem</p>
-        <p><strong>Major Festival:</strong> Bathukamma & Bonalu</p>
+        <p><strong>Famous Food:</strong> Hyderabadi Biryani &amp; Haleem</p>
+        <p><strong>Major Festival:</strong> Bathukamma &amp; Bonalu</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
             <p>Telangana is a blend of Kakatiya history and Nizam culture, marked by the Charminar monument, IT hubs in Hyderabad, and Pochampally weaves.</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>Telangana is a blend of Kakatiya history and Nizam culture, marked by the Charminar monument, IT hubs in Hyderabad, and Pochampally weaves.<br><br>The vibrant region of Telangana is governed from its beautiful capital, Hyderabad. The land is deeply connected to its roots, celebrating grand occasions like Bathukamma & Bonalu with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Hyderabadi Biryani & Haleem, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Telangana is a journey through time, culture, and nature.</p>
+            <p>Telangana is a blend of Kakatiya history and Nizam culture, marked by the Charminar monument, IT hubs in Hyderabad, and Pochampally weaves.<br><br>The vibrant region of Telangana is governed from its beautiful capital, Hyderabad. The land is deeply connected to its roots, celebrating grand occasions like Bathukamma &amp; Bonalu with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Hyderabadi Biryani &amp; Haleem, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Telangana is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/tripura.html
+++ b/dist/states/tripura.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Tripura features royal palaces like Ujjayanta, deep bamboo reserves, rubber plantations, and the ancient rock-cut carvings of Unakoti.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,7 +89,7 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Tripura</h1>
         <p><strong>Capital:</strong> Agartala</p>
-        <p><strong>Famous Food:</strong> Mui Borok (Fish & Bamboo Shoot)</p>
+        <p><strong>Famous Food:</strong> Mui Borok (Fish &amp; Bamboo Shoot)</p>
         <p><strong>Major Festival:</strong> Kharchi Puja</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
@@ -97,7 +97,7 @@
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>Tripura features royal palaces like Ujjayanta, deep bamboo reserves, rubber plantations, and the ancient rock-cut carvings of Unakoti.<br><br>The vibrant region of Tripura is governed from its beautiful capital, Agartala. The land is deeply connected to its roots, celebrating grand occasions like Kharchi Puja with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Mui Borok (Fish & Bamboo Shoot), which represents centuries of refined regional cooking techniques and traditional spices. A journey to Tripura is a journey through time, culture, and nature.</p>
+            <p>Tripura features royal palaces like Ujjayanta, deep bamboo reserves, rubber plantations, and the ancient rock-cut carvings of Unakoti.<br><br>The vibrant region of Tripura is governed from its beautiful capital, Agartala. The land is deeply connected to its roots, celebrating grand occasions like Kharchi Puja with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Mui Borok (Fish &amp; Bamboo Shoot), which represents centuries of refined regional cooking techniques and traditional spices. A journey to Tripura is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/uttar-pradesh.html
+++ b/dist/states/uttar-pradesh.html
@@ -1,17 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="India's cultural heartland, Uttar Pradesh is home to the world-renowned Taj Mahal, sacred Ganges at Varanasi, and historical cities of Ayodhya and Mathura.">
+    <meta name="description" content="India&#39;s cultural heartland, Uttar Pradesh is home to the world-renowned Taj Mahal, sacred Ganges at Varanasi, and historical cities of Ayodhya and Mathura.">
     <title>Uttar Pradesh | Incredible India Explorer</title>
 
     <meta http-equiv="Content-Security-Policy" content="
@@ -28,7 +20,7 @@
 
     <!-- Open Graph / Social Meta Tags -->
     <meta property="og:title" content="Uttar Pradesh | Incredible India Explorer">
-    <meta property="og:description" content="India's cultural heartland, Uttar Pradesh is home to the world-renowned Taj Mahal, sacred Ganges at Varanasi, and historical cities of Ayodhya and Mathura.">
+    <meta property="og:description" content="India&#39;s cultural heartland, Uttar Pradesh is home to the world-renowned Taj Mahal, sacred Ganges at Varanasi, and historical cities of Ayodhya and Mathura.">
     <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/assets/Brihadeeswara_Temple.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -39,7 +31,7 @@
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Uttar Pradesh | Incredible India Explorer">
-    <meta name="twitter:description" content="India's cultural heartland, Uttar Pradesh is home to the world-renowned Taj Mahal, sacred Ganges at Varanasi, and historical cities of Ayodhya and Mathura.">
+    <meta name="twitter:description" content="India&#39;s cultural heartland, Uttar Pradesh is home to the world-renowned Taj Mahal, sacred Ganges at Varanasi, and historical cities of Ayodhya and Mathura.">
     <meta name="twitter:image" content="https://incredibleindiaexplorer.gov.in/assets/Brihadeeswara_Temple.png">
     <!-- Canonical URL -->
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/states/uttar-pradesh.html">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,15 +89,15 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Uttar Pradesh</h1>
         <p><strong>Capital:</strong> Lucknow</p>
-        <p><strong>Famous Food:</strong> Tunday Kababi, Petha & Chaat</p>
-        <p><strong>Major Festival:</strong> Durga Puja & Taj Mahotsav</p>
+        <p><strong>Famous Food:</strong> Tunday Kababi, Petha &amp; Chaat</p>
+        <p><strong>Major Festival:</strong> Durga Puja &amp; Taj Mahotsav</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
-            <p>India's cultural heartland, Uttar Pradesh is home to the world-renowned Taj Mahal, sacred Ganges at Varanasi, and historical cities of Ayodhya and Mathura.</p>
+            <p>India&#39;s cultural heartland, Uttar Pradesh is home to the world-renowned Taj Mahal, sacred Ganges at Varanasi, and historical cities of Ayodhya and Mathura.</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>India's cultural heartland, Uttar Pradesh is home to the world-renowned Taj Mahal, sacred Ganges at Varanasi, and historical cities of Ayodhya and Mathura.<br><br>The vibrant region of Uttar Pradesh is governed from its beautiful capital, Lucknow. The land is deeply connected to its roots, celebrating grand occasions like Durga Puja & Taj Mahotsav with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Tunday Kababi, Petha & Chaat, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Uttar Pradesh is a journey through time, culture, and nature.</p>
+            <p>India&#39;s cultural heartland, Uttar Pradesh is home to the world-renowned Taj Mahal, sacred Ganges at Varanasi, and historical cities of Ayodhya and Mathura.<br><br>The vibrant region of Uttar Pradesh is governed from its beautiful capital, Lucknow. The land is deeply connected to its roots, celebrating grand occasions like Durga Puja &amp; Taj Mahotsav with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Tunday Kababi, Petha &amp; Chaat, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Uttar Pradesh is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/uttarakhand.html
+++ b/dist/states/uttarakhand.html
@@ -1,17 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="The 'Land of Gods', Uttarakhand is a hub of pilgrimage (Char Dham), yoga (Rishikesh), wildlife (Jim Corbett Park), and snow-capped Himalayan peaks.">
+    <meta name="description" content="The &#39;Land of Gods&#39;, Uttarakhand is a hub of pilgrimage (Char Dham), yoga (Rishikesh), wildlife (Jim Corbett Park), and snow-capped Himalayan peaks.">
     <title>Uttarakhand | Incredible India Explorer</title>
 
     <meta http-equiv="Content-Security-Policy" content="
@@ -28,7 +20,7 @@
 
     <!-- Open Graph / Social Meta Tags -->
     <meta property="og:title" content="Uttarakhand | Incredible India Explorer">
-    <meta property="og:description" content="The 'Land of Gods', Uttarakhand is a hub of pilgrimage (Char Dham), yoga (Rishikesh), wildlife (Jim Corbett Park), and snow-capped Himalayan peaks.">
+    <meta property="og:description" content="The &#39;Land of Gods&#39;, Uttarakhand is a hub of pilgrimage (Char Dham), yoga (Rishikesh), wildlife (Jim Corbett Park), and snow-capped Himalayan peaks.">
     <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/assets/Brihadeeswara_Temple.png">
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
@@ -39,7 +31,7 @@
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Uttarakhand | Incredible India Explorer">
-    <meta name="twitter:description" content="The 'Land of Gods', Uttarakhand is a hub of pilgrimage (Char Dham), yoga (Rishikesh), wildlife (Jim Corbett Park), and snow-capped Himalayan peaks.">
+    <meta name="twitter:description" content="The &#39;Land of Gods&#39;, Uttarakhand is a hub of pilgrimage (Char Dham), yoga (Rishikesh), wildlife (Jim Corbett Park), and snow-capped Himalayan peaks.">
     <meta name="twitter:image" content="https://incredibleindiaexplorer.gov.in/assets/Brihadeeswara_Temple.png">
     <!-- Canonical URL -->
     <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/states/uttarakhand.html">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,15 +89,15 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>Uttarakhand</h1>
         <p><strong>Capital:</strong> Dehradun</p>
-        <p><strong>Famous Food:</strong> Kafuli & Aloo ke Gutke</p>
-        <p><strong>Major Festival:</strong> Ganga Aarti & Nanda Devi Jat</p>
+        <p><strong>Famous Food:</strong> Kafuli &amp; Aloo ke Gutke</p>
+        <p><strong>Major Festival:</strong> Ganga Aarti &amp; Nanda Devi Jat</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
-            <p>The 'Land of Gods', Uttarakhand is a hub of pilgrimage (Char Dham), yoga (Rishikesh), wildlife (Jim Corbett Park), and snow-capped Himalayan peaks.</p>
+            <p>The &#39;Land of Gods&#39;, Uttarakhand is a hub of pilgrimage (Char Dham), yoga (Rishikesh), wildlife (Jim Corbett Park), and snow-capped Himalayan peaks.</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>The 'Land of Gods', Uttarakhand is a hub of pilgrimage (Char Dham), yoga (Rishikesh), wildlife (Jim Corbett Park), and snow-capped Himalayan peaks.<br><br>The vibrant region of Uttarakhand is governed from its beautiful capital, Dehradun. The land is deeply connected to its roots, celebrating grand occasions like Ganga Aarti & Nanda Devi Jat with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Kafuli & Aloo ke Gutke, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Uttarakhand is a journey through time, culture, and nature.</p>
+            <p>The &#39;Land of Gods&#39;, Uttarakhand is a hub of pilgrimage (Char Dham), yoga (Rishikesh), wildlife (Jim Corbett Park), and snow-capped Himalayan peaks.<br><br>The vibrant region of Uttarakhand is governed from its beautiful capital, Dehradun. The land is deeply connected to its roots, celebrating grand occasions like Ganga Aarti &amp; Nanda Devi Jat with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Kafuli &amp; Aloo ke Gutke, which represents centuries of refined regional cooking techniques and traditional spices. A journey to Uttarakhand is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/dist/states/west-bengal.html
+++ b/dist/states/west-bengal.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="West Bengal is the cultural capital, famous for literature (Rabindranath Tagore), colonial structures in Kolkata, Darjeeling tea, and Sundarbans tigers.">
@@ -50,6 +42,14 @@
     
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="../../index.html" class="nav-logo">
@@ -89,15 +89,15 @@
     <div style="max-width: 800px; margin: 40px auto; padding: 20px;" class="glass-card">
         <h1>West Bengal</h1>
         <p><strong>Capital:</strong> Kolkata</p>
-        <p><strong>Famous Food:</strong> Machher Jhol & Rasgulla</p>
-        <p><strong>Major Festival:</strong> Durga Puja & Poila Baisakh</p>
+        <p><strong>Famous Food:</strong> Machher Jhol &amp; Rasgulla</p>
+        <p><strong>Major Festival:</strong> Durga Puja &amp; Poila Baisakh</p>
         <div style="margin-top: 20px;">
             <h3>Overview</h3>
             <p>West Bengal is the cultural capital, famous for literature (Rabindranath Tagore), colonial structures in Kolkata, Darjeeling tea, and Sundarbans tigers.</p>
         </div>
         <div style="margin-top: 20px;">
             <h3>Story</h3>
-            <p>West Bengal is the cultural capital, famous for literature (Rabindranath Tagore), colonial structures in Kolkata, Darjeeling tea, and Sundarbans tigers.<br><br>The vibrant region of West Bengal is governed from its beautiful capital, Kolkata. The land is deeply connected to its roots, celebrating grand occasions like Durga Puja & Poila Baisakh with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Machher Jhol & Rasgulla, which represents centuries of refined regional cooking techniques and traditional spices. A journey to West Bengal is a journey through time, culture, and nature.</p>
+            <p>West Bengal is the cultural capital, famous for literature (Rabindranath Tagore), colonial structures in Kolkata, Darjeeling tea, and Sundarbans tigers.<br><br>The vibrant region of West Bengal is governed from its beautiful capital, Kolkata. The land is deeply connected to its roots, celebrating grand occasions like Durga Puja &amp; Poila Baisakh with unmatched energy and devotion.<br><br>Visitors from around the world are mesmerized by the local culinary delights, particularly the iconic Machher Jhol &amp; Rasgulla, which represents centuries of refined regional cooking techniques and traditional spices. A journey to West Bengal is a journey through time, culture, and nature.</p>
         </div>
         <a href="../../index.html" class="btn btn-primary" style="margin-top: 20px; display: inline-block;">Back to Home</a>
     </div>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "test": "vitest run",
     "test:unit": "vitest run tests/unit/",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "generate": "node scripts/generate.cjs",
+    "generate:check": "node scripts/generate.cjs --check"
   },
   "devDependencies": {
     "jsdom": "^29.1.1",

--- a/scripts/generate.cjs
+++ b/scripts/generate.cjs
@@ -1,6 +1,11 @@
 const fs = require('fs');
 const path = require('path');
 
+// --check verifies the committed output matches what the layout would produce
+// now, instead of writing files. Used by CI to catch stale dist/.
+const checkOnly = process.argv.includes('--check');
+const stale = [];
+
 // Load data.js - read file directly and evaluate to bypass any module caching issues
 const dataCode = fs.readFileSync(path.join(__dirname, '..', 'data.js'), 'utf8');
 const dataModule = { exports: {} };
@@ -99,8 +104,24 @@ locations.forEach(state => {
 
     // Write file
     const outputPath = path.join(statesDir, `${slug}.html`);
+
+    if (checkOnly) {
+        const existing = fs.existsSync(outputPath) ? fs.readFileSync(outputPath, 'utf8') : null;
+        if (existing !== pageHtml) stale.push(`dist/states/${slug}.html`);
+        return;
+    }
+
     fs.writeFileSync(outputPath, pageHtml);
     console.log(`Generated: dist/states/${slug}.html`);
 });
 
-console.log('Static Site Generation complete!');
+if (checkOnly) {
+    if (stale.length) {
+        console.error(`${stale.length} generated page(s) are out of date:\n  ${stale.join('\n  ')}`);
+        console.error('\nRun `npm run generate` and commit the result.');
+        process.exit(1);
+    }
+    console.log(`All ${generatedSlugs.size} generated pages are up to date.`);
+} else {
+    console.log('Static Site Generation complete!');
+}

--- a/scripts/layout.html
+++ b/scripts/layout.html
@@ -1,14 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <script>
-        (function() {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.documentElement.classList.add('light-theme');
-            }
-        })();
-    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="{{description}}">
@@ -50,6 +42,14 @@
     {{extra_head}}
 </head>
 <body>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
     <header class="navbar" id="navbar">
         <div class="nav-container">
             <a href="{{relative_path}}index.html" class="nav-logo">

--- a/tests/unit/page-generator.test.js
+++ b/tests/unit/page-generator.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const LAYOUT = fs.readFileSync('scripts/layout.html', 'utf8');
+const GENERATED_DIR = 'dist/states';
+const pages = fs.readdirSync(GENERATED_DIR).filter((f) => f.endsWith('.html'));
+
+describe('page layout template', () => {
+  it('applies the theme class to body, matching the CSS selectors', () => {
+    // Every light-mode rule in styles/ is written as `body.light-theme`, so the
+    // bootstrap must class the body. Targeting documentElement silently no-ops.
+    expect(LAYOUT).toMatch(/document\.body\.classList\.add\('light-theme'\)/);
+    expect(LAYOUT).not.toMatch(/document\.documentElement\.classList\.add\('light-theme'\)/);
+  });
+
+  it('runs the theme bootstrap after <body> so document.body exists', () => {
+    const script = LAYOUT.search(/document\.body\.classList\.add\('light-theme'\)/);
+    const body = LAYOUT.search(/<body[\s>]/i);
+    expect(script).toBeGreaterThan(body);
+  });
+
+  it('sets a Content-Security-Policy', () => {
+    expect(LAYOUT).toMatch(/http-equiv="Content-Security-Policy"/);
+  });
+});
+
+describe('generated state pages', () => {
+  it('generates a page per state', () => {
+    expect(pages.length).toBeGreaterThan(0);
+  });
+
+  it('escapes HTML metacharacters from the data source', () => {
+    // data.js contains values like "Machher Jhol & Rasgulla"; an unescaped &
+    // produces invalid markup and can break downstream parsing.
+    const withAmp = pages
+      .map((p) => fs.readFileSync(path.join(GENERATED_DIR, p), 'utf8'))
+      .filter((html) => /Machher Jhol/.test(html));
+    expect(withAmp.length).toBeGreaterThan(0);
+    for (const html of withAmp) {
+      expect(html).toMatch(/Machher Jhol &amp; Rasgulla/);
+    }
+  });
+
+  it('carries the shared chrome on every page', () => {
+    for (const page of pages) {
+      const html = fs.readFileSync(path.join(GENERATED_DIR, page), 'utf8');
+      expect(html, page).toMatch(/<header class="navbar"/);
+      expect(html, page).toMatch(/<footer class="footer">/);
+      expect(html, page).toMatch(/http-equiv="Content-Security-Policy"/);
+    }
+  });
+
+  it('leaves no unsubstituted template placeholders', () => {
+    for (const page of pages) {
+      const html = fs.readFileSync(path.join(GENERATED_DIR, page), 'utf8');
+      expect(html.match(/\{\{\w+\}\}/g), page).toBeNull();
+    }
+  });
+
+  it('is in sync with the current layout', () => {
+    // Fails if someone edits layout.html without regenerating — the exact drift
+    // that left dist/ stale and light mode broken on these pages.
+    expect(() => execFileSync('node', ['scripts/generate.cjs', '--check'])).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #1291

> **Note on scope:** this PR fixes and enforces the existing generator for #1291. The remaining work (migrating hand-authored pages onto the layout, CSP rollout, data-driven metadata) is described at the end of this description — worth splitting into a follow-up issue before merging if you'd rather keep #1291 open to track it.


## Scope

#1291 is about 460 pages hand-copying the same header, nav and footer. The full fix is a migration of every page onto a shared template — far too large and too conflict-prone to land in one PR while dozens of feature PRs are in flight.

**This PR fixes the templating infrastructure that already exists** and puts CI behind it. No existing page is migrated, so nothing here conflicts with in-flight work. It's the prerequisite step: make the generator correct and trustworthy first, migrate onto it second.

While doing that I found two real bugs in the generated output.

## Bug 1 — light mode was silently dead on all 36 generated pages

`scripts/layout.html` classed the **root element**:

```js
document.documentElement.classList.add('light-theme');
```

But every light-mode rule in the stylesheets targets `body`:

```
$ grep -rho "body\.light-theme" styles/*.css | wc -l
470
$ grep -rho "html\.light-theme" styles/*.css | wc -l
0
```

So the class landed on `<html>`, no selector matched it, and nothing changed colour. No console error — the page just stayed dark. Confirmed in JSDOM against the committed output:

```
js errors               : none
html has .light-theme   : true     <- class applied here
body has .light-theme   : false    <- but every CSS rule looks here
```

`CONTRIBUTING.md` already documents "*Support both dark (default) and light theme via `.light-theme` on `<body>`*" — the layout simply disagreed with the project's own stated convention.

Fixed by targeting `document.body` and moving the snippet to just after the `<body>` open tag, so it can't dereference `null` (the same failure mode as #1287) while still running inline before first paint. After:

```
js errors            : none
body has .light-theme: true
has CSP meta         : true
```

## Bug 2 — the committed `dist/` was stale

Running the generator with no source changes rewrote **32 of 36 files**. The committed output predated the generator's HTML-escaping fix:

```diff
-        <p><strong>Famous Food:</strong> Machher Jhol & Rasgulla</p>
+        <p><strong>Famous Food:</strong> Machher Jhol &amp; Rasgulla</p>
```

So the shipped pages contained unescaped `&` in markup — invalid HTML that the current generator already knows how to prevent. The fix existed; the output was just never regenerated.

This is the same failure pattern as #1287, and it's exactly why the guard below matters more than either individual fix.

## What this adds

- **`--check` mode** on the generator: compares committed output against what the layout would produce now, exits 1 on drift.
- **CI enforcement**: `npm run generate:check` runs in `ci-tests.yml`, so `dist/` can never silently drift from `layout.html` again.
- **`npm run generate` / `npm run generate:check`** scripts.
- **`CONTRIBUTING.md`** section explaining that `dist/states/` is generated, must not be hand-edited, and needs regenerating alongside layout changes.
- **`tests/unit/page-generator.test.js`** (8 tests) covering the theme-class target, bootstrap placement, CSP presence, HTML escaping, shared chrome on every page, no unsubstituted `{{placeholders}}`, and layout/output sync.

## Verification

**`--check` behaves correctly:**

```
$ node scripts/generate.cjs --check   # against the stale committed output
36 generated page(s) are out of date: ...
Run `npm run generate` and commit the result.
EXIT: 1

$ npm run generate && node scripts/generate.cjs --check
All 36 generated pages are up to date.
EXIT: 0
```

**The sync guard actually catches drift.** Edited one string in `layout.html` without regenerating:

```
× generated state pages > is in sync with the current layout
```

**No regressions.** Full suite on `main` vs this branch:

| | Test files | Tests |
|---|---|---|
| `main` (baseline) | 16 failed, 153 passed | 3 failed, 1402 passed |
| this branch | 16 failed, **154** passed | 3 failed, **1410** passed |

Identical pre-existing failures (`national-awards.js` and several park explorers fail Vite's import analysis, unrelated to this PR). My 8 tests are the delta.

## What's deliberately left for follow-ups

The bulk of #1291 remains, and I'd rather agree the approach on the issue before moving 460 pages:

- **Migrating hand-authored pages** onto the layout — one directory per PR so review stays tractable and conflicts stay local.
- **CSP for hand-authored pages.** The layout sets a Content-Security-Policy; none of the 460 hand-written pages have one. They'll inherit it as they migrate.
- **Deriving per-page metadata** (title, description, canonical, OG) from a data file, which is what permanently kills the drift class of bug — e.g. `frontend/tribes/tribes.html` currently declares `og:url` as `/tribes.html`, which isn't where it lives.
- **A CI check rejecting new hand-authored pages** once enough have migrated for that to be realistic.

## Notes for reviewers

The diff looks large but is mostly the 32 regenerated files, which are a mechanical consequence of the two fixes — `git show --stat` separates them cleanly from the 6 source changes.

Worth deciding explicitly: **should `dist/` stay committed at all?** It's generated output in version control, which is what allowed it to go stale unnoticed. Building it in CI instead would be cleaner, but `app.js` and `frontend/india-3d-map/india-3d-map.js` link into `dist/states/`, and the site is served statically — so removing it needs a deployment story. I kept it committed and guarded it instead, but I'm happy to go the other way if maintainers prefer.

