### PR TITLE
feat: Create Gagron Fort Explorer page and add it to Indian Forts Explorer landing page

### DIFF
--- a/frontend/forts/agra-fort.css
+++ b/frontend/forts/agra-fort.css
@@ -1,0 +1,304 @@
+/* ==========================================================================
+   AGRA FORT EXPLORER - STYLES
+   ========================================================================== */
+
+.hero-section {
+    position: relative;
+    height: 60vh;
+    min-height: 400px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    color: var(--text-light);
+    overflow: hidden;
+}
+
+.hero-bg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+}
+
+.hero-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.hero-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(to bottom, rgba(0, 0, 0, 0.35) 0%, rgba(0, 0, 0, 0.8) 100%);
+}
+
+.hero-content {
+    z-index: 1;
+    max-width: 800px;
+    padding: 2rem;
+}
+
+.hero-content .badge {
+    background-color: var(--saffron);
+    color: #fff;
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 1rem;
+    display: inline-block;
+}
+
+.hero-content .title {
+    font-size: clamp(2.5rem, 5vw, 4.5rem);
+    font-family: var(--font-heading);
+    margin: 0.5rem 0;
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+}
+
+.hero-content .subtitle {
+    font-size: 1.2rem;
+    margin-bottom: 2rem;
+    opacity: 0.95;
+}
+
+.hero-meta {
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+    flex-wrap: wrap;
+}
+
+.meta-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 500;
+}
+
+.main-content-wrapper {
+    display: grid;
+    grid-template-columns: 250px 1fr;
+    gap: 3rem;
+    padding: 4rem 2rem;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.sticky-nav {
+    position: sticky;
+    top: 100px;
+}
+
+.sticky-nav ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.sticky-nav li {
+    margin-bottom: 1rem;
+}
+
+.sticky-nav a {
+    color: var(--text-muted);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.3s ease;
+    display: block;
+    padding: 0.5rem;
+    border-left: 2px solid transparent;
+}
+
+.sticky-nav a:hover,
+.sticky-nav a.active {
+    color: var(--saffron);
+    border-left-color: var(--saffron);
+}
+
+.content-sections {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.content-section {
+    padding: 2rem;
+    border-radius: 12px;
+}
+
+.glass-panel {
+    background: var(--bg-dark-card);
+    backdrop-filter: blur(10px);
+    border: 1px solid var(--glass-border);
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.content-section h2 {
+    font-family: var(--font-heading);
+    color: var(--saffron);
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+    font-size: 2rem;
+    border-bottom: 1px solid var(--glass-border);
+    padding-bottom: 0.5rem;
+}
+
+.content-section p {
+    line-height: 1.8;
+    margin-bottom: 1rem;
+    color: var(--text-light);
+}
+
+.content-section ul {
+    padding-left: 1.5rem;
+    margin-bottom: 1rem;
+    color: var(--text-light);
+    line-height: 1.7;
+}
+
+.content-section li {
+    margin-bottom: 0.5rem;
+}
+
+.content-section strong {
+    color: var(--gold);
+}
+
+.highlight-panel {
+    background: linear-gradient(135deg, rgba(255, 153, 51, 0.1), rgba(19, 136, 8, 0.1));
+    border-left: 4px solid var(--saffron);
+}
+
+.facts-list {
+    list-style: disc;
+}
+
+/* Quick Facts (Builder / Year Built / Dynasty) */
+.quick-facts-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+}
+
+.quick-fact-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    padding: 1rem;
+    background: var(--bg-dark-card);
+    border: 1px solid var(--glass-border);
+    border-radius: 8px;
+}
+
+.quick-fact-label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+}
+
+.quick-fact-value {
+    font-weight: 600;
+    color: var(--gold);
+}
+
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.gallery-item {
+    border-radius: 8px;
+    overflow: hidden;
+    height: 200px;
+    border: 1px solid var(--glass-border);
+}
+
+.gallery-item img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.3s ease;
+}
+
+.gallery-item img:hover {
+    transform: scale(1.05);
+}
+
+.map-placeholder {
+    margin-top: 1rem;
+}
+
+.map-mockup {
+    height: 300px;
+    background: var(--bg-dark-card);
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px dashed var(--glass-border);
+    color: var(--text-muted);
+    text-align: center;
+    padding: 1rem;
+}
+
+/* FAQs */
+.faq-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.faq-item {
+    background: var(--bg-dark-card);
+    border: 1px solid var(--glass-border);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+}
+
+.faq-item summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--text-light);
+    list-style: none;
+}
+
+.faq-item summary::-webkit-details-marker {
+    display: none;
+}
+
+.faq-item summary::before {
+    content: "+ ";
+    color: var(--saffron);
+    font-weight: 700;
+}
+
+.faq-item[open] summary::before {
+    content: "- ";
+}
+
+.faq-item p {
+    margin-top: 0.75rem;
+    margin-bottom: 0;
+}
+
+@media (max-width: 768px) {
+    .main-content-wrapper {
+        grid-template-columns: 1fr;
+        padding: 2rem 1rem;
+    }
+
+    .sidebar-nav {
+        display: none;
+    }
+}

--- a/frontend/forts/agra-fort.html
+++ b/frontend/forts/agra-fort.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Explore Agra Fort - a UNESCO World Heritage Site and one of India's most significant Mughal forts, home to royal palaces and centuries of imperial history.">
+    <title>Agra Fort Explorer | Incredible India</title>
+    <meta property="og:title" content="Agra Fort Explorer | Incredible India">
+    <meta property="og:description" content="Discover Agra Fort - a red sandstone Mughal citadel on the banks of the Yamuna, and a UNESCO World Heritage Site since 1983.">
+    <meta property="og:type" content="website">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="agra-fort.css">
+</head>
+<body>
+    <header class="navbar" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html" class="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">☰</button>
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html" class="nav-link">Home</a>
+                <a href="index.html" class="nav-link">Forts</a>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Light/Dark Mode">☀️</button>
+            </nav>
+        </div>
+    </header>
+
+    <main>
+        <!-- Overview / Hero -->
+        <section class="hero-section" id="overview">
+            <div class="hero-bg">
+                <img src="https://images.unsplash.com/photo-1587474260584-136574528ed5?w=1600&q=80" alt="Agra Fort red sandstone ramparts" class="hero-image">
+                <div class="hero-overlay"></div>
+            </div>
+            <div class="hero-content">
+                <span class="badge">Agra, Uttar Pradesh</span>
+                <h1 class="title">Agra Fort</h1>
+                <p class="subtitle">A UNESCO World Heritage Site and the principal residence of the Mughal Emperors.</p>
+                <div class="hero-meta">
+                    <div class="meta-item">
+                        <span class="icon">📍</span>
+                        <span>Banks of the Yamuna, Agra</span>
+                    </div>
+                    <div class="meta-item">
+                        <span class="icon">🏛️</span>
+                        <span>Mughal Heritage</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <div class="container main-content-wrapper">
+            <!-- Sidebar Navigation -->
+            <aside class="sidebar-nav">
+                <nav class="sticky-nav">
+                    <ul>
+                        <li><a href="#overview">Overview</a></li>
+                        <li><a href="#history">History</a></li>
+                        <li><a href="#quick-facts">Quick Facts</a></li>
+                        <li><a href="#architecture">Architecture</a></li>
+                        <li><a href="#location">Location</a></li>
+                        <li><a href="#unesco-status">UNESCO Status</a></li>
+                        <li><a href="#attractions">Major Attractions</a></li>
+                        <li><a href="#significance">Historical Significance</a></li>
+                        <li><a href="#facts">Interesting Facts</a></li>
+                        <li><a href="#gallery">Image Gallery</a></li>
+                        <li><a href="#faqs">FAQs</a></li>
+                    </ul>
+                </nav>
+            </aside>
+
+            <!-- Main Content Area -->
+            <div class="content-sections">
+                <!-- Overview -->
+                <section id="overview-text" class="content-section glass-panel">
+                    <h2>Overview</h2>
+                    <p>Agra Fort is a massive red sandstone fortress on the western bank of the Yamuna river in Agra, Uttar Pradesh. For nearly a century, it served as the main residence of the emperors of the <strong>Mughal Dynasty</strong>, until the capital was shifted to Delhi in 1638.</p>
+                    <p>Also known as the "Red Fort of Agra" or "Lal Qila," it is often overshadowed by the nearby Taj Mahal, yet it stands as one of the finest examples of Mughal military and palace architecture, blending defensive strength with imperial luxury.</p>
+                </section>
+
+                <!-- History -->
+                <section id="history" class="content-section glass-panel">
+                    <h2>History</h2>
+                    <p>The site of Agra Fort was originally an earlier brick fort held by Hindu Rajput rulers before it came under Mughal control. Emperor <strong>Akbar</strong> rebuilt it almost entirely in red sandstone starting in 1565, making it his primary residence and seat of power.</p>
+                    <p>Successive emperors - <strong>Jahangir</strong> and especially <strong>Shah Jahan</strong> - added white marble palaces, mosques, and gardens within its walls. In a dramatic turn of history, Shah Jahan himself was imprisoned in the fort's Musamman Burj tower by his son Aurangzeb, where he reportedly spent his final years gazing at the Taj Mahal he had built for his wife.</p>
+                </section>
+
+                <!-- Quick Facts: Builder, Year Built, Dynasty -->
+                <section id="quick-facts" class="content-section glass-panel highlight-panel">
+                    <h2>Quick Facts</h2>
+                    <div class="quick-facts-grid">
+                        <div class="quick-fact-item">
+                            <span class="quick-fact-label">Builder</span>
+                            <span class="quick-fact-value">Emperor Akbar (later additions by Jahangir and Shah Jahan)</span>
+                        </div>
+                        <div class="quick-fact-item">
+                            <span class="quick-fact-label">Year Built</span>
+                            <span class="quick-fact-value">1565-1573 CE</span>
+                        </div>
+                        <div class="quick-fact-item">
+                            <span class="quick-fact-label">Dynasty</span>
+                            <span class="quick-fact-value">Mughal Dynasty</span>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- Architecture -->
+                <section id="architecture" class="content-section glass-panel">
+                    <h2>Architecture</h2>
+                    <p>Agra Fort showcases the evolution of <strong>Mughal architecture</strong> - from Akbar's robust red sandstone military structures to Shah Jahan's refined white marble pavilions inlaid with precious stones.</p>
+                    <ul>
+                        <li><strong>Red Sandstone Walls:</strong> Massive double-walled ramparts rising about 70 feet, built by Akbar for defence.</li>
+                        <li><strong>Marble Pavilions:</strong> Shah Jahan's additions, such as the Khas Mahal and Sheesh Mahal, feature delicate marble screens and mirror-work.</li>
+                        <li><strong>Persian & Timurid Influence:</strong> Symmetrical layouts, arched gateways, and formal gardens reflect Central Asian design traditions adapted to Indian craftsmanship.</li>
+                        <li><strong>Semi-Circular Plan:</strong> The fort is built in the shape of a semicircle, with its straight side facing the Yamuna river.</li>
+                    </ul>
+                </section>
+
+                <!-- Location -->
+                <section id="location" class="content-section glass-panel">
+                    <h2>Location</h2>
+                    <p>Agra Fort stands on the west bank of the River Yamuna in Agra, Uttar Pradesh, roughly 2.5 km northwest of the Taj Mahal. Its riverside position allowed Mughal emperors, including Shah Jahan during his imprisonment, a direct view of the Taj Mahal in the distance.</p>
+                    <div class="map-placeholder">
+                        <div class="map-mockup">
+                            <span>🗺️ Map View of Agra Fort, Agra, Uttar Pradesh</span>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- UNESCO Status -->
+                <section id="unesco-status" class="content-section glass-panel highlight-panel">
+                    <h2>UNESCO Status</h2>
+                    <p>Agra Fort was inscribed as a <strong>UNESCO World Heritage Site in 1983</strong>, recognised for its outstanding representation of Mughal military and civil architecture. It was among the first sites in India to receive this designation, alongside the Taj Mahal and Ajanta Caves.</p>
+                </section>
+
+                <!-- Major Attractions -->
+                <section id="attractions" class="content-section glass-panel">
+                    <h2>Major Attractions</h2>
+                    <ul>
+                        <li><strong>Jahangir Mahal:</strong> A grand red sandstone palace built by Akbar, blending Hindu and Central Asian styles.</li>
+                        <li><strong>Diwan-i-Am & Diwan-i-Khas:</strong> The halls of public and private audience, used by the emperor to meet subjects and nobles.</li>
+                        <li><strong>Sheesh Mahal:</strong> The "Mirror Palace," once used as a royal dressing room, with walls embedded with tiny mirrored glass pieces.</li>
+                        <li><strong>Musamman Burj:</strong> An octagonal marble tower where Shah Jahan was held captive, offering a distant view of the Taj Mahal.</li>
+                        <li><strong>Moti Masjid:</strong> The "Pearl Mosque," a serene white marble mosque built by Shah Jahan for the royal household.</li>
+                        <li><strong>Anguri Bagh:</strong> A charbagh-style ("grape garden") formal garden framed by marble pavilions.</li>
+                    </ul>
+                </section>
+
+                <!-- Historical Significance -->
+                <section id="significance" class="content-section glass-panel">
+                    <h2>Historical Significance</h2>
+                    <p>Agra Fort was the political and ceremonial heart of the Mughal Empire during its golden age, hosting the coronations, courts, and daily governance of emperors from Akbar to Aurangzeb.</p>
+                    <p>It witnessed pivotal moments in Indian history, including Shah Jahan's imprisonment and the fort's later use as a British military garrison and administrative centre after 1803. Today, it remains a powerful symbol of Mughal authority, artistry, and the dramatic family history behind the Taj Mahal.</p>
+                </section>
+
+                <!-- Interesting Facts -->
+                <section id="facts" class="content-section glass-panel">
+                    <h2>Interesting Facts</h2>
+                    <ul class="facts-list">
+                        <li>Agra Fort is sometimes called the "Red Fort of Agra," distinct from the Red Fort in Delhi built later by Shah Jahan.</li>
+                        <li>The fort is estimated to have around <strong>500 buildings</strong> in Bengali and Gujarati styles at its peak, though most were later demolished by Shah Jahan and the British.</li>
+                        <li>Shah Jahan spent his final years imprisoned in the fort, reportedly viewing the Taj Mahal from the Musamman Burj.</li>
+                        <li>The fort's massive walls and moat made it one of the most formidable Mughal military strongholds.</li>
+                        <li>It served as the capital of the Mughal Empire until 1638, when Shah Jahan shifted the capital to Delhi.</li>
+                    </ul>
+                </section>
+
+                <!-- Image Gallery -->
+                <section id="gallery" class="content-section glass-panel">
+                    <h2>Image Gallery</h2>
+                    <div class="gallery-grid">
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1587474260584-136574528ed5?w=500&q=80" alt="Agra Fort outer walls" loading="lazy">
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1596176530529-78163a4f7af2?w=500&q=80" alt="Fort gateway" loading="lazy">
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1609766856923-7e0a0c0622d4?w=500&q=80" alt="Marble palace interior" loading="lazy">
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1599661046289-e31897846e41?w=500&q=80" alt="Riverside view of the fort" loading="lazy">
+                        </div>
+                    </div>
+                </section>
+
+                <!-- FAQs -->
+                <section id="faqs" class="content-section glass-panel">
+                    <h2>FAQs</h2>
+                    <div class="faq-list">
+                        <details class="faq-item">
+                            <summary>Who built Agra Fort?</summary>
+                            <p>Emperor Akbar began rebuilding the fort in red sandstone in 1565. His successors, Jahangir and Shah Jahan, later added marble palaces and mosques within it.</p>
+                        </details>
+                        <details class="faq-item">
+                            <summary>Is Agra Fort the same as the Red Fort in Delhi?</summary>
+                            <p>No. They are two different forts. Agra Fort predates the Red Fort in Delhi, which Shah Jahan built later after shifting the Mughal capital from Agra to Delhi.</p>
+                        </details>
+                        <details class="faq-item">
+                            <summary>Why is Agra Fort a UNESCO World Heritage Site?</summary>
+                            <p>It was inscribed in 1983 for its exceptional representation of Mughal architecture, combining military fortification with palatial residences.</p>
+                        </details>
+                        <details class="faq-item">
+                            <summary>Why was Shah Jahan imprisoned in Agra Fort?</summary>
+                            <p>His son Aurangzeb seized the throne and held Shah Jahan under house arrest in the Musamman Burj for the final years of his life.</p>
+                        </details>
+                        <details class="faq-item">
+                            <summary>How far is Agra Fort from the Taj Mahal?</summary>
+                            <p>Agra Fort is about 2.5 km northwest of the Taj Mahal, and both monuments are visible from each other along the Yamuna river.</p>
+                        </details>
+                    </div>
+                </section>
+            </div>
+        </div>
+    </main>
+
+    <footer class="footer">
+        <div class="footer-container">
+            <div class="footer-brand">
+                <h3>Incredible India Explorer</h3>
+                <p>An interactive digital guide to the geography, food, festivals, wildlife, and cultural heritage of India.</p>
+            </div>
+            <div class="footer-links">
+                <h3>Quick Navigation</h3>
+                <ul>
+                    <li><a href="../../index.html">Home</a></li>
+                    <li><a href="index.html">Indian Forts Explorer</a></li>
+                    <li><a href="agra-fort.html">Agra Fort</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="footer-credits footer-credits-center">
+            <p>&copy; 2026 Incredible India Explorer. Agra Fort Explorer.</p>
+        </div>
+    </footer>
+
+    <!-- Scroll To Top Button -->
+    <button class="btn-scroll-top" id="btn-scroll-top" aria-label="Scroll to Top">&#8593;</button>
+
+    <script src="../../app.js" defer></script>
+    <script src="../../router.js" defer></script>
+    <script type="module" src="../../auth.js"></script>
+</body>
+</html>

--- a/frontend/forts/gagron-fort.css
+++ b/frontend/forts/gagron-fort.css
@@ -1,0 +1,239 @@
+/* ==========================================================================
+   GAGRON FORT EXPLORER - STYLES
+   ========================================================================== */
+
+.hero-section {
+    position: relative;
+    height: 60vh;
+    min-height: 400px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    color: var(--text-light);
+    overflow: hidden;
+}
+
+.hero-bg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+}
+
+.hero-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.hero-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(to bottom, rgba(0, 0, 0, 0.35) 0%, rgba(0, 0, 0, 0.8) 100%);
+}
+
+.hero-content {
+    z-index: 1;
+    max-width: 800px;
+    padding: 2rem;
+}
+
+.hero-content .badge {
+    background-color: var(--saffron);
+    color: #fff;
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 1rem;
+    display: inline-block;
+}
+
+.hero-content .title {
+    font-size: clamp(2.5rem, 5vw, 4.5rem);
+    font-family: var(--font-heading);
+    margin: 0.5rem 0;
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+}
+
+.hero-content .subtitle {
+    font-size: 1.2rem;
+    margin-bottom: 2rem;
+    opacity: 0.95;
+}
+
+.hero-meta {
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+    flex-wrap: wrap;
+}
+
+.meta-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 500;
+}
+
+.main-content-wrapper {
+    display: grid;
+    grid-template-columns: 250px 1fr;
+    gap: 3rem;
+    padding: 4rem 2rem;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.sticky-nav {
+    position: sticky;
+    top: 100px;
+}
+
+.sticky-nav ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.sticky-nav li {
+    margin-bottom: 1rem;
+}
+
+.sticky-nav a {
+    color: var(--text-muted);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.3s ease;
+    display: block;
+    padding: 0.5rem;
+    border-left: 2px solid transparent;
+}
+
+.sticky-nav a:hover,
+.sticky-nav a.active {
+    color: var(--saffron);
+    border-left-color: var(--saffron);
+}
+
+.content-sections {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.content-section {
+    padding: 2rem;
+    border-radius: 12px;
+}
+
+.glass-panel {
+    background: var(--bg-dark-card);
+    backdrop-filter: blur(10px);
+    border: 1px solid var(--glass-border);
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.content-section h2 {
+    font-family: var(--font-heading);
+    color: var(--saffron);
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+    font-size: 2rem;
+    border-bottom: 1px solid var(--glass-border);
+    padding-bottom: 0.5rem;
+}
+
+.content-section p {
+    line-height: 1.8;
+    margin-bottom: 1rem;
+    color: var(--text-light);
+}
+
+.content-section ul {
+    padding-left: 1.5rem;
+    margin-bottom: 1rem;
+    color: var(--text-light);
+    line-height: 1.7;
+}
+
+.content-section li {
+    margin-bottom: 0.5rem;
+}
+
+.content-section strong {
+    color: var(--gold);
+}
+
+.highlight-panel {
+    background: linear-gradient(135deg, rgba(255, 153, 51, 0.1), rgba(19, 136, 8, 0.1));
+    border-left: 4px solid var(--saffron);
+}
+
+.facts-list {
+    list-style: disc;
+}
+
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.gallery-item {
+    border-radius: 8px;
+    overflow: hidden;
+    height: 200px;
+    border: 1px solid var(--glass-border);
+}
+
+.gallery-item img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.3s ease;
+}
+
+.gallery-item img:hover {
+    transform: scale(1.05);
+}
+
+.map-placeholder {
+    margin-top: 1rem;
+}
+
+.map-mockup {
+    height: 300px;
+    background: var(--bg-dark-card);
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px dashed var(--glass-border);
+    color: var(--text-muted);
+    text-align: center;
+    padding: 1rem;
+}
+
+.reference-list {
+    list-style: disc;
+}
+
+@media (max-width: 768px) {
+    .main-content-wrapper {
+        grid-template-columns: 1fr;
+        padding: 2rem 1rem;
+    }
+
+    .sidebar-nav {
+        display: none;
+    }
+}

--- a/frontend/forts/gagron-fort.html
+++ b/frontend/forts/gagron-fort.html
@@ -1,0 +1,242 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Explore Gagron Fort - a unique hill-and-water fort in Jhalawar, Rajasthan, and a UNESCO World Heritage Site.">
+    <title>Gagron Fort Explorer | Incredible India</title>
+    <meta property="og:title" content="Gagron Fort Explorer | Incredible India">
+    <meta property="og:description" content="Discover Gagron Fort - the only hill fort in India surrounded by water on three sides, with no moat of its own.">
+    <meta property="og:type" content="website">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="gagron-fort.css">
+</head>
+<body>
+    <header class="navbar" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html" class="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">☰</button>
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html" class="nav-link">Home</a>
+                <a href="index.html" class="nav-link">Forts</a>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Light/Dark Mode">☀️</button>
+            </nav>
+        </div>
+    </header>
+
+    <main>
+        <!-- Overview / Hero -->
+        <section class="hero-section" id="overview">
+            <div class="hero-bg">
+                <img src="https://images.unsplash.com/photo-1599661046289-e31897846e41?w=1600&q=80" alt="Gagron Fort surrounded by rivers" class="hero-image">
+                <div class="hero-overlay"></div>
+            </div>
+            <div class="hero-content">
+                <span class="badge">Jhalawar, Rajasthan</span>
+                <h1 class="title">Gagron Fort</h1>
+                <p class="subtitle">A rare hill-and-water fort encircled by two rivers on three sides - so naturally defended that it needed no moat.</p>
+                <div class="hero-meta">
+                    <div class="meta-item">
+                        <span class="icon">📍</span>
+                        <span>Confluence of Kali Sindh &amp; Ahu Rivers</span>
+                    </div>
+                    <div class="meta-item">
+                        <span class="icon">🏆</span>
+                        <span>UNESCO World Heritage Site</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <div class="container main-content-wrapper">
+            <!-- Sidebar Navigation -->
+            <aside class="sidebar-nav">
+                <nav class="sticky-nav">
+                    <ul>
+                        <li><a href="#overview">Overview</a></li>
+                        <li><a href="#history">History</a></li>
+                        <li><a href="#builder">Builder</a></li>
+                        <li><a href="#unesco">UNESCO Status</a></li>
+                        <li><a href="#water-fort">Water Fort Features</a></li>
+                        <li><a href="#architecture">Architecture</a></li>
+                        <li><a href="#battles">Battles</a></li>
+                        <li><a href="#facts">Interesting Facts</a></li>
+                        <li><a href="#gallery">Gallery</a></li>
+                        <li><a href="#location">Location & Map</a></li>
+                        <li><a href="#references">References</a></li>
+                    </ul>
+                </nav>
+            </aside>
+
+            <!-- Main Content Area -->
+            <div class="content-sections">
+                <!-- Overview -->
+                <section id="overview-text" class="content-section glass-panel">
+                    <h2>Overview</h2>
+                    <p>Gagron Fort stands on a rocky hill at the confluence of the <strong>Kali Sindh and Ahu rivers</strong> in the Jhalawar district of Rajasthan. It is one of the rarest forts in India, classified as both a <strong>Giri Durg (hill fort)</strong> and a <strong>Jal Durg (water fort)</strong>.</p>
+                    <p>Unlike almost every other fort in the country, Gagron has no moat and needs none - the two rivers wrap around three sides of the hill, while a deep ravine guards the fourth, making the fort a natural island fortress.</p>
+                </section>
+
+                <!-- History -->
+                <section id="history" class="content-section glass-panel">
+                    <h2>History</h2>
+                    <p>The origins of Gagron Fort are traced to the <strong>7th-14th centuries</strong>, with the present structure largely attributed to the Khichi Chauhan Rajput rulers who governed the region. Owing to its commanding position on the routes linking Malwa and Mewar, the fort changed hands many times over the centuries.</p>
+                    <p>It witnessed repeated conflict with the Sultanate of Malwa and later came under Mughal and Jhalawar princely state control. Despite its formidable natural defences, the fort's location made it a constant target for regional powers seeking to control the strategic Malwa route.</p>
+                </section>
+
+                <!-- Builder -->
+                <section id="builder" class="content-section glass-panel">
+                    <h2>Builder</h2>
+                    <p>Gagron Fort is generally credited to the <strong>Dod Rajput</strong> rulers who first built a stronghold on the site, with major construction and strengthening carried out by the <strong>Khichi Chauhan</strong> dynasty that ruled Gagron for several centuries.</p>
+                    <p>Successive rulers added to the fort's palaces, gateways, and fortifications, taking advantage of the site's natural river defences to reduce reliance on man-made walls and ditches.</p>
+                </section>
+
+                <!-- UNESCO Status -->
+                <section id="unesco" class="content-section glass-panel highlight-panel">
+                    <h2>UNESCO Status</h2>
+                    <p>In <strong>2013</strong>, Gagron Fort was inscribed as a UNESCO World Heritage Site as part of the serial listing <strong>"Hill Forts of Rajasthan"</strong>, alongside the forts of Chittorgarh, Kumbhalgarh, Ranthambore, Amber, and Jaisalmer.</p>
+                    <ul>
+                        <li>Recognised for representing the distinct Rajput military hill architecture of the region.</li>
+                        <li>Listed as an outstanding example of a fort using natural terrain and water bodies as its primary defence.</li>
+                        <li>Valued for its largely intact fortifications, gateways, and palace structures.</li>
+                    </ul>
+                </section>
+
+                <!-- Water Fort Features -->
+                <section id="water-fort" class="content-section glass-panel highlight-panel">
+                    <h2>Water Fort Features</h2>
+                    <p>Gagron's defining feature is its water-based defence system, which sets it apart from every other major fort in Rajasthan.</p>
+                    <ul>
+                        <li>Surrounded by the <strong>Kali Sindh River</strong> on one side and the <strong>Ahu River</strong> on another, meeting at the base of the fort.</li>
+                        <li>A steep ravine protects the remaining side, completing a nearly all-round natural barrier.</li>
+                        <li>The fort is the <strong>only hill fort in Rajasthan without a moat</strong>, since the surrounding rivers make one unnecessary.</li>
+                        <li>Seasonal flooding of the rivers historically made the fort even more difficult to approach or besiege.</li>
+                    </ul>
+                </section>
+
+                <!-- Architecture -->
+                <section id="architecture" class="content-section glass-panel">
+                    <h2>Architecture</h2>
+                    <p>The fort follows a linear layout stretching along the hill ridge, with a series of gates, courtyards, and bastions built to make use of the rocky terrain.</p>
+                    <ul>
+                        <li><strong>Multiple Gateways:</strong> A succession of fortified gates leads through the fort, each designed to slow an advancing attacker.</li>
+                        <li><strong>Bastions & Ramparts:</strong> Sturdy stone walls follow the natural contour of the hill rather than a regular geometric plan.</li>
+                        <li><strong>Palace Structures:</strong> Remains of royal residential quarters reflect a blend of Rajput and later Mughal architectural influences.</li>
+                        <li><strong>Madho Singh Cenotaph:</strong> A memorial within the fort complex commemorating a local ruler.</li>
+                        <li><strong>Mitthe Shah Dargah:</strong> A Sufi shrine inside the fort, still an active site of pilgrimage.</li>
+                    </ul>
+                </section>
+
+                <!-- Battles -->
+                <section id="battles" class="content-section glass-panel">
+                    <h2>Battles</h2>
+                    <p>Gagron Fort's strategic location made it the site of repeated sieges between regional Rajput rulers and the Sultanate of Malwa.</p>
+                    <ul>
+                        <li>A major siege in the early 15th century by <strong>Sultan Hoshang Shah of Malwa</strong> led to the defenders performing <strong>jauhar</strong>, the ritual mass self-sacrifice, rather than face defeat.</li>
+                        <li>A second jauhar is recorded in <strong>1444</strong>, when the fort was besieged again by forces of Malwa under Mahmud Khalji.</li>
+                        <li>The fort's natural river defences meant that most successful attacks relied on prolonged siege and blockade rather than direct assault.</li>
+                    </ul>
+                </section>
+
+                <!-- Interesting Facts -->
+                <section id="facts" class="content-section glass-panel">
+                    <h2>Interesting Facts</h2>
+                    <ul class="facts-list">
+                        <li>Gagron is one of the very few forts in the world classified as both a <strong>hill fort and a water fort</strong>.</li>
+                        <li>It is the only fort in Rajasthan that has <strong>no moat</strong>, since two rivers naturally encircle it.</li>
+                        <li>The fort witnessed <strong>two jauhars</strong>, in the 15th century, during sieges by the Sultanate of Malwa.</li>
+                        <li>The shrine of Sufi saint <strong>Mitthe Shah Peer</strong> inside the fort draws devotees of multiple faiths.</li>
+                        <li>An annual fair, the <strong>Gagron Fair</strong>, is held near the fort in honour of the saint.</li>
+                        <li>The fort forms part of the UNESCO "Hill Forts of Rajasthan" listing, inscribed in 2013.</li>
+                    </ul>
+                </section>
+
+                <!-- Gallery -->
+                <section id="gallery" class="content-section glass-panel">
+                    <h2>Gallery</h2>
+                    <div class="gallery-grid">
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1599661046289-e31897846e41?w=500&q=80" alt="Gagron Fort walls" loading="lazy">
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1548013146-72479768bada?w=500&q=80" alt="Rivers surrounding Gagron Fort" loading="lazy">
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1596176530529-78163a4f7af2?w=500&q=80" alt="Gagron Fort gateway" loading="lazy">
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1561361513-2d000a50f0dc?w=500&q=80" alt="Hilltop view of Gagron Fort" loading="lazy">
+                        </div>
+                    </div>
+                </section>
+
+                <!-- Location / Map -->
+                <section id="location" class="content-section glass-panel">
+                    <h2>Location & Map</h2>
+                    <p>Gagron Fort is located about 15 km from Jhalawar town in south-eastern Rajasthan, at the confluence of the Kali Sindh and Ahu rivers, close to the Rajasthan-Madhya Pradesh border.</p>
+                    <div class="map-placeholder">
+                        <div class="map-mockup">
+                            <span>🗺️ Map View of Gagron Fort, Jhalawar, Rajasthan</span>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- References -->
+                <section id="references" class="content-section glass-panel">
+                    <h2>References</h2>
+                    <ul class="reference-list">
+                        <li>UNESCO World Heritage Centre - "Hill Forts of Rajasthan"</li>
+                        <li>Archaeological Survey of India (ASI) - Jhalawar Circle</li>
+                        <li>Rajasthan Tourism Development Corporation (RTDC)</li>
+                        <li>Department of Archaeology and Museums, Government of Rajasthan</li>
+                    </ul>
+                </section>
+            </div>
+        </div>
+    </main>
+
+    <footer class="footer">
+        <div class="footer-container">
+            <div class="footer-brand">
+                <h3>Incredible India Explorer</h3>
+                <p>An interactive digital guide to the geography, food, festivals, wildlife, and cultural heritage of India.</p>
+            </div>
+            <div class="footer-links">
+                <h3>Quick Navigation</h3>
+                <ul>
+                    <li><a href="../../index.html">Home</a></li>
+                    <li><a href="index.html">Indian Forts Explorer</a></li>
+                    <li><a href="gagron-fort.html">Gagron Fort</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="footer-credits footer-credits-center">
+            <p>&copy; 2026 Incredible India Explorer. Gagron Fort Explorer.</p>
+        </div>
+    </footer>
+
+    <!-- Scroll To Top Button -->
+    <button class="btn-scroll-top" id="btn-scroll-top" aria-label="Scroll to Top">&#8593;</button>
+
+    <script src="../../app.js" defer></script>
+    <script src="../../router.js" defer></script>
+    <script type="module" src="../../auth.js"></script>
+</body>
+</html>

--- a/frontend/forts/jaigarh-fort.css
+++ b/frontend/forts/jaigarh-fort.css
@@ -1,0 +1,258 @@
+/* ==========================================================================
+   JAIGARH FORT EXPLORER - STYLES
+   ========================================================================== */
+
+.hero-section {
+    position: relative;
+    height: 60vh;
+    min-height: 400px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    color: var(--text-light);
+    overflow: hidden;
+}
+
+.hero-bg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+}
+
+.hero-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.hero-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(to bottom, rgba(0, 0, 0, 0.35) 0%, rgba(0, 0, 0, 0.8) 100%);
+}
+
+.hero-content {
+    z-index: 1;
+    max-width: 800px;
+    padding: 2rem;
+}
+
+.hero-content .badge {
+    background-color: var(--saffron);
+    color: #fff;
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 1rem;
+    display: inline-block;
+}
+
+.hero-content .title {
+    font-size: clamp(2.5rem, 5vw, 4.5rem);
+    font-family: var(--font-heading);
+    margin: 0.5rem 0;
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+}
+
+.hero-content .subtitle {
+    font-size: 1.2rem;
+    margin-bottom: 2rem;
+    opacity: 0.95;
+}
+
+.hero-meta {
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+    flex-wrap: wrap;
+}
+
+.meta-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 500;
+}
+
+.main-content-wrapper {
+    display: grid;
+    grid-template-columns: 250px 1fr;
+    gap: 3rem;
+    padding: 4rem 2rem;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.sticky-nav {
+    position: sticky;
+    top: 100px;
+}
+
+.sticky-nav ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.sticky-nav li {
+    margin-bottom: 1rem;
+}
+
+.sticky-nav a {
+    color: var(--text-muted);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.3s ease;
+    display: block;
+    padding: 0.5rem;
+    border-left: 2px solid transparent;
+}
+
+.sticky-nav a:hover,
+.sticky-nav a.active {
+    color: var(--saffron);
+    border-left-color: var(--saffron);
+}
+
+.content-sections {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.content-section {
+    padding: 2rem;
+    border-radius: 12px;
+}
+
+.glass-panel {
+    background: var(--bg-dark-card);
+    backdrop-filter: blur(10px);
+    border: 1px solid var(--glass-border);
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.content-section h2 {
+    font-family: var(--font-heading);
+    color: var(--saffron);
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+    font-size: 2rem;
+    border-bottom: 1px solid var(--glass-border);
+    padding-bottom: 0.5rem;
+}
+
+.content-section p {
+    line-height: 1.8;
+    margin-bottom: 1rem;
+    color: var(--text-light);
+}
+
+.content-section ul {
+    padding-left: 1.5rem;
+    margin-bottom: 1rem;
+    color: var(--text-light);
+    line-height: 1.7;
+}
+
+.content-section li {
+    margin-bottom: 0.5rem;
+}
+
+.content-section strong {
+    color: var(--gold);
+}
+
+.highlight-panel {
+    background: linear-gradient(135deg, rgba(255, 153, 51, 0.1), rgba(19, 136, 8, 0.1));
+    border-left: 4px solid var(--saffron);
+}
+
+.facts-list {
+    list-style: disc;
+}
+
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.gallery-item {
+    border-radius: 8px;
+    overflow: hidden;
+    height: 200px;
+    border: 1px solid var(--glass-border);
+}
+
+.gallery-item img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.3s ease;
+}
+
+.gallery-item img:hover {
+    transform: scale(1.05);
+}
+
+/* FAQs */
+.faq-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.faq-item {
+    background: var(--bg-dark-card);
+    border: 1px solid var(--glass-border);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+}
+
+.faq-item summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--text-light);
+    list-style: none;
+}
+
+.faq-item summary::-webkit-details-marker {
+    display: none;
+}
+
+.faq-item summary::before {
+    content: "+ ";
+    color: var(--saffron);
+    font-weight: 700;
+}
+
+.faq-item[open] summary::before {
+    content: "- ";
+}
+
+.faq-item p {
+    margin-top: 0.75rem;
+    margin-bottom: 0;
+}
+
+@media (max-width: 768px) {
+    .main-content-wrapper {
+        grid-template-columns: 1fr;
+        padding: 2rem 1rem;
+    }
+
+    .sidebar-nav {
+        display: none;
+    }
+}

--- a/frontend/forts/jaigarh-fort.html
+++ b/frontend/forts/jaigarh-fort.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Explore Jaigarh Fort - the Rajasthan fortress that guards Amer Fort and houses Jaivana, the world's largest cannon on wheels.">
+    <title>Jaigarh Fort Explorer | Incredible India</title>
+    <meta property="og:title" content="Jaigarh Fort Explorer | Incredible India">
+    <meta property="og:description" content="Discover Jaigarh Fort near Jaipur - home to the mighty Jaivana cannon and a key defender of Amer Fort.">
+    <meta property="og:type" content="website">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="jaigarh-fort.css">
+</head>
+<body>
+    <header class="navbar" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html" class="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">☰</button>
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html" class="nav-link">Home</a>
+                <a href="index.html" class="nav-link">Forts</a>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Light/Dark Mode">☀️</button>
+            </nav>
+        </div>
+    </header>
+
+    <main>
+        <!-- Hero -->
+        <section class="hero-section" id="overview">
+            <div class="hero-bg">
+                <img src="https://images.unsplash.com/photo-1590716179555-8c8a9dc5c6d9?w=1600&q=80" alt="Jaigarh Fort walls overlooking Amer" class="hero-image">
+                <div class="hero-overlay"></div>
+            </div>
+            <div class="hero-content">
+                <span class="badge">Jaipur, Rajasthan</span>
+                <h1 class="title">Jaigarh Fort</h1>
+                <p class="subtitle">Guardian of Amer Fort, and home to the world's largest cannon on wheels.</p>
+                <div class="hero-meta">
+                    <div class="meta-item">
+                        <span class="icon">📍</span>
+                        <span>Cheel ka Teela, Aravalli Hills</span>
+                    </div>
+                    <div class="meta-item">
+                        <span class="icon">🏛️</span>
+                        <span>Kachwaha Rajput Heritage</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <div class="container main-content-wrapper">
+            <!-- Sidebar Navigation -->
+            <aside class="sidebar-nav">
+                <nav class="sticky-nav">
+                    <ul>
+                        <li><a href="#history">History</a></li>
+                        <li><a href="#builder">Builder</a></li>
+                        <li><a href="#architecture">Architecture</a></li>
+                        <li><a href="#jaivana-cannon">Jaivana Cannon</a></li>
+                        <li><a href="#military-importance">Military Importance</a></li>
+                        <li><a href="#facts">Interesting Facts</a></li>
+                        <li><a href="#gallery">Gallery</a></li>
+                        <li><a href="#faqs">FAQs</a></li>
+                    </ul>
+                </nav>
+            </aside>
+
+            <!-- Main Content Area -->
+            <div class="content-sections">
+                <!-- History -->
+                <section id="history" class="content-section glass-panel">
+                    <h2>History</h2>
+                    <p>Jaigarh Fort stands on a ridge known as Cheel ka Teela ("Hill of Eagles") in the Aravalli range, directly above Amer Fort near Jaipur, Rajasthan. It was built in <strong>1726</strong> by <strong>Sawai Jai Singh II</strong>, the founder of Jaipur city, on the foundations of earlier fortifications raised by his ancestors.</p>
+                    <p>For centuries, Jaigarh served as the principal stronghold and cannon foundry of the Kachwaha Rajputs, and was never conquered in battle. It remained largely inaccessible to the public for much of the 20th century, which helped preserve its structures, armoury, and cannon foundry in excellent condition.</p>
+                </section>
+
+                <!-- Builder -->
+                <section id="builder" class="content-section glass-panel highlight-panel">
+                    <h2>Builder</h2>
+                    <p>Jaigarh Fort was commissioned by <strong>Sawai Jai Singh II</strong> of the Kachwaha dynasty in 1726, primarily to strengthen the defences of Amer Fort and to house the state's artillery and cannon-casting foundry.</p>
+                    <p>Jai Singh II, also a noted astronomer, is remembered for founding the city of Jaipur and for planning many of the fortifications and observatories associated with the Kachwaha rulers.</p>
+                </section>
+
+                <!-- Architecture -->
+                <section id="architecture" class="content-section glass-panel">
+                    <h2>Architecture</h2>
+                    <p>Built almost entirely of local reddish sandstone, Jaigarh Fort follows a rugged, functional military layout designed for defence rather than display.</p>
+                    <ul>
+                        <li><strong>Massive Ramparts:</strong> Thick fortified walls run along the natural contours of the hill, connecting Jaigarh to Amer Fort.</li>
+                        <li><strong>Watchtowers:</strong> Multiple towers provide commanding views over the surrounding hills and the approach roads to Jaipur.</li>
+                        <li><strong>Cannon Foundry:</strong> One of the few surviving cannon foundries in Asia, where the fort's artillery, including the Jaivana cannon, was cast.</li>
+                        <li><strong>Diya Burj:</strong> A tall tower offering panoramic views, along with palace buildings, a granary, and a small museum of armoury.</li>
+                    </ul>
+                </section>
+
+                <!-- Jaivana Cannon -->
+                <section id="jaivana-cannon" class="content-section glass-panel highlight-panel">
+                    <h2>Jaivana Cannon</h2>
+                    <p>Jaigarh Fort's most famous feature is the <strong>Jaivana Cannon</strong>, cast in the fort's own foundry in 1720. It is widely recognised as the <strong>largest cannon on wheels in the world</strong>, with a barrel roughly 20 feet long and a total weight of around 50 tonnes.</p>
+                    <p>Despite its immense size, the Jaivana was fired only once, as a test shot, and was never used in actual warfare. Its massive scale was intended as much to demonstrate Kachwaha military strength as for practical use in battle.</p>
+                </section>
+
+                <!-- Military Importance -->
+                <section id="military-importance" class="content-section glass-panel">
+                    <h2>Military Importance</h2>
+                    <p>Jaigarh Fort was purpose-built to protect Amer Fort and, later, the city of Jaipur, forming an outer line of defence in the Aravalli hills. Its cannon foundry made it self-sufficient in producing artillery, reducing dependence on outside sources of weaponry.</p>
+                    <p>Thanks to its formidable defences and strategic hilltop position, Jaigarh Fort was never captured by an invading force, and it played a key role in safeguarding the Kachwaha rulers' seat of power for generations.</p>
+                </section>
+
+                <!-- Interesting Facts -->
+                <section id="facts" class="content-section glass-panel">
+                    <h2>Interesting Facts</h2>
+                    <ul class="facts-list">
+                        <li>The Jaivana Cannon is recognised as the largest cannon on wheels ever built, yet it was fired only once.</li>
+                        <li>Jaigarh Fort is connected to Amer Fort by a series of subterranean passages.</li>
+                        <li>The fort was closed to the public for several decades in the 20th century, in part due to persistent legends of hidden treasure.</li>
+                        <li>Jaigarh housed one of the very few cannon foundries in Asia during its time.</li>
+                        <li>Despite its formidable arsenal, Jaigarh Fort was never conquered in battle.</li>
+                    </ul>
+                </section>
+
+                <!-- Gallery -->
+                <section id="gallery" class="content-section glass-panel">
+                    <h2>Gallery</h2>
+                    <div class="gallery-grid">
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1590716179555-8c8a9dc5c6d9?w=500&q=80" alt="Jaigarh Fort ramparts" loading="lazy">
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1596176530529-78163a4f7af2?w=500&q=80" alt="Watchtower view" loading="lazy">
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1609766856923-7e0a0c0622d4?w=500&q=80" alt="Fort courtyard" loading="lazy">
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1599661046289-e31897846e41?w=500&q=80" alt="View over the Aravalli hills" loading="lazy">
+                        </div>
+                    </div>
+                </section>
+
+                <!-- FAQs -->
+                <section id="faqs" class="content-section glass-panel">
+                    <h2>FAQs</h2>
+                    <div class="faq-list">
+                        <details class="faq-item">
+                            <summary>Who built Jaigarh Fort?</summary>
+                            <p>Sawai Jai Singh II of the Kachwaha dynasty built Jaigarh Fort in 1726, mainly to protect Amer Fort and house the royal cannon foundry.</p>
+                        </details>
+                        <details class="faq-item">
+                            <summary>What is special about the Jaivana Cannon?</summary>
+                            <p>The Jaivana is regarded as the largest cannon on wheels ever made, weighing around 50 tonnes, though it was fired only once as a test.</p>
+                        </details>
+                        <details class="faq-item">
+                            <summary>How is Jaigarh Fort connected to Amer Fort?</summary>
+                            <p>The two forts are linked by underground passages, allowing safe movement of people and supplies between them, especially during sieges.</p>
+                        </details>
+                        <details class="faq-item">
+                            <summary>Was Jaigarh Fort ever captured?</summary>
+                            <p>No. Jaigarh Fort was never conquered in battle, thanks to its strong hilltop defences and self-sufficient cannon foundry.</p>
+                        </details>
+                        <details class="faq-item">
+                            <summary>Why was Jaigarh Fort closed to visitors for years?</summary>
+                            <p>It remained largely off-limits for much of the 20th century, partly linked to long-standing legends about hidden treasure within the fort.</p>
+                        </details>
+                    </div>
+                </section>
+            </div>
+        </div>
+    </main>
+
+    <footer class="footer">
+        <div class="footer-container">
+            <div class="footer-brand">
+                <h3>Incredible India Explorer</h3>
+                <p>An interactive digital guide to the geography, food, festivals, wildlife, and cultural heritage of India.</p>
+            </div>
+            <div class="footer-links">
+                <h3>Quick Navigation</h3>
+                <ul>
+                    <li><a href="../../index.html">Home</a></li>
+                    <li><a href="index.html">Indian Forts Explorer</a></li>
+                    <li><a href="jaigarh-fort.html">Jaigarh Fort</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="footer-credits footer-credits-center">
+            <p>&copy; 2026 Incredible India Explorer. Jaigarh Fort Explorer.</p>
+        </div>
+    </footer>
+
+    <!-- Scroll To Top Button -->
+    <button class="btn-scroll-top" id="btn-scroll-top" aria-label="Scroll to Top">&#8593;</button>
+
+    <script src="../../app.js" defer></script>
+    <script src="../../router.js" defer></script>
+    <script type="module" src="../../auth.js"></script>
+</body>
+</html>

--- a/frontend/forts/kumbhalgarh-fort.css
+++ b/frontend/forts/kumbhalgarh-fort.css
@@ -1,0 +1,248 @@
+/* ==========================================================================
+   KUMBHALGARH FORT EXPLORER - STYLES
+   ========================================================================== */
+
+.hero-section {
+    position: relative;
+    height: 60vh;
+    min-height: 400px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    color: var(--text-light);
+    overflow: hidden;
+}
+
+.hero-bg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+}
+
+.hero-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.hero-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(to bottom, rgba(0, 0, 0, 0.35) 0%, rgba(0, 0, 0, 0.8) 100%);
+}
+
+.hero-content {
+    z-index: 1;
+    max-width: 800px;
+    padding: 2rem;
+}
+
+.hero-content .badge {
+    background-color: var(--saffron);
+    color: #fff;
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 1rem;
+    display: inline-block;
+}
+
+.hero-content .title {
+    font-size: clamp(2.5rem, 5vw, 4.5rem);
+    font-family: var(--font-heading);
+    margin: 0.5rem 0;
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+}
+
+.hero-content .subtitle {
+    font-size: 1.2rem;
+    margin-bottom: 2rem;
+    opacity: 0.95;
+}
+
+.hero-meta {
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+    flex-wrap: wrap;
+}
+
+.meta-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 500;
+}
+
+.main-content-wrapper {
+    display: grid;
+    grid-template-columns: 250px 1fr;
+    gap: 3rem;
+    padding: 4rem 2rem;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.sticky-nav {
+    position: sticky;
+    top: 100px;
+}
+
+.sticky-nav ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.sticky-nav li {
+    margin-bottom: 1rem;
+}
+
+.sticky-nav a {
+    color: var(--text-muted);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.3s ease;
+    display: block;
+    padding: 0.5rem;
+    border-left: 2px solid transparent;
+}
+
+.sticky-nav a:hover,
+.sticky-nav a.active {
+    color: var(--saffron);
+    border-left-color: var(--saffron);
+}
+
+.content-sections {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.content-section {
+    padding: 2rem;
+    border-radius: 12px;
+}
+
+.glass-panel {
+    background: var(--bg-dark-card);
+    backdrop-filter: blur(10px);
+    border: 1px solid var(--glass-border);
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.content-section h2 {
+    font-family: var(--font-heading);
+    color: var(--saffron);
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+    font-size: 2rem;
+    border-bottom: 1px solid var(--glass-border);
+    padding-bottom: 0.5rem;
+}
+
+.content-section p {
+    line-height: 1.8;
+    margin-bottom: 1rem;
+    color: var(--text-light);
+}
+
+.content-section ul {
+    padding-left: 1.5rem;
+    margin-bottom: 1rem;
+    color: var(--text-light);
+    line-height: 1.7;
+}
+
+.content-section li {
+    margin-bottom: 0.5rem;
+}
+
+.content-section strong {
+    color: var(--gold);
+}
+
+.highlight-panel {
+    background: linear-gradient(135deg, rgba(255, 153, 51, 0.1), rgba(19, 136, 8, 0.1));
+    border-left: 4px solid var(--saffron);
+}
+
+.facts-list {
+    list-style: disc;
+}
+
+/* Builder & Construction quick facts */
+.quick-facts-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.quick-fact-item {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    padding: 1rem;
+    background: var(--bg-dark-card);
+    border: 1px solid var(--glass-border);
+    border-radius: 8px;
+}
+
+.quick-fact-label {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+}
+
+.quick-fact-value {
+    font-weight: 600;
+    color: var(--gold);
+}
+
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.gallery-item {
+    border-radius: 8px;
+    overflow: hidden;
+    height: 200px;
+    border: 1px solid var(--glass-border);
+}
+
+.gallery-item img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.3s ease;
+}
+
+.gallery-item img:hover {
+    transform: scale(1.05);
+}
+
+@media (max-width: 768px) {
+    .main-content-wrapper {
+        grid-template-columns: 1fr;
+        padding: 2rem 1rem;
+    }
+
+    .sidebar-nav {
+        display: none;
+    }
+}

--- a/frontend/forts/kumbhalgarh-fort.html
+++ b/frontend/forts/kumbhalgarh-fort.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Explore Kumbhalgarh Fort - a UNESCO World Heritage Site in Rajasthan, famed for its massive wall, often called the Great Wall of India.">
+    <title>Kumbhalgarh Fort Explorer | Incredible India</title>
+    <meta property="og:title" content="Kumbhalgarh Fort Explorer | Incredible India">
+    <meta property="og:description" content="Discover Kumbhalgarh Fort - the birthplace of Maharana Pratap, protected by one of the longest continuous walls in the world.">
+    <meta property="og:type" content="website">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="kumbhalgarh-fort.css">
+</head>
+<body>
+    <header class="navbar" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html" class="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">☰</button>
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html" class="nav-link">Home</a>
+                <a href="index.html" class="nav-link">Forts</a>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Light/Dark Mode">☀️</button>
+            </nav>
+        </div>
+    </header>
+
+    <main>
+        <!-- Overview / Hero -->
+        <section class="hero-section" id="overview">
+            <div class="hero-bg">
+                <img src="https://images.unsplash.com/photo-1599661046289-e31897846e41?w=1600&q=80" alt="Kumbhalgarh Fort wall winding through the hills" class="hero-image">
+                <div class="hero-overlay"></div>
+            </div>
+            <div class="hero-content">
+                <span class="badge">Rajsamand, Rajasthan</span>
+                <h1 class="title">Kumbhalgarh Fort</h1>
+                <p class="subtitle">Guardian of Mewar, protected by one of the longest fortification walls in the world.</p>
+                <div class="hero-meta">
+                    <div class="meta-item">
+                        <span class="icon">📍</span>
+                        <span>Aravalli Hills, Rajasthan</span>
+                    </div>
+                    <div class="meta-item">
+                        <span class="icon">🏛️</span>
+                        <span>Mewar Heritage</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <div class="container main-content-wrapper">
+            <!-- Sidebar Navigation -->
+            <aside class="sidebar-nav">
+                <nav class="sticky-nav">
+                    <ul>
+                        <li><a href="#overview">Overview</a></li>
+                        <li><a href="#history">History</a></li>
+                        <li><a href="#builder-construction">Builder & Construction</a></li>
+                        <li><a href="#architecture">Architecture</a></li>
+                        <li><a href="#unesco-status">UNESCO Status</a></li>
+                        <li><a href="#great-wall">Great Wall of India</a></li>
+                        <li><a href="#structures">Major Structures</a></li>
+                        <li><a href="#facts">Interesting Facts</a></li>
+                        <li><a href="#gallery">Image Gallery</a></li>
+                    </ul>
+                </nav>
+            </aside>
+
+            <!-- Main Content Area -->
+            <div class="content-sections">
+                <!-- Overview -->
+                <section id="overview-text" class="content-section glass-panel">
+                    <h2>Overview</h2>
+                    <p>Kumbhalgarh Fort is a 15th-century hill fortress perched in the Aravalli Range of Rajasthan, roughly 82 km from Udaipur. It is the second most important fort in the Mewar region after Chittorgarh, and is best known for its colossal defensive wall that snakes across the surrounding hills.</p>
+                    <p>The fort remained impregnable for most of its history and served as a refuge for the rulers of Mewar during times of crisis, playing a defining role in the region's resistance against invading forces.</p>
+                </section>
+
+                <!-- History -->
+                <section id="history" class="content-section glass-panel">
+                    <h2>History</h2>
+                    <p>Kumbhalgarh's origins trace back to earlier structures on the site, but the fort as it stands today was built in the 15th century by <strong>Rana Kumbha</strong> of the Sisodia Rajput dynasty of Mewar. It served as an important stronghold and refuge for the rulers of Mewar for centuries.</p>
+                    <p>The fort is famously the <strong>birthplace of Maharana Pratap</strong>, one of Mewar's most celebrated warrior-kings. Kumbhalgarh was breached only once in its history, in 1576, when combined Mughal and Amber forces cut off its water supply - a testament to how formidable its defences otherwise were.</p>
+                </section>
+
+                <!-- Builder & Construction -->
+                <section id="builder-construction" class="content-section glass-panel highlight-panel">
+                    <h2>Builder & Construction</h2>
+                    <div class="quick-facts-grid">
+                        <div class="quick-fact-item">
+                            <span class="quick-fact-label">Builder</span>
+                            <span class="quick-fact-value">Rana Kumbha, with chief architect Mandan</span>
+                        </div>
+                        <div class="quick-fact-item">
+                            <span class="quick-fact-label">Construction Period</span>
+                            <span class="quick-fact-value">15th Century (circa 1443-1458 CE)</span>
+                        </div>
+                        <div class="quick-fact-item">
+                            <span class="quick-fact-label">Dynasty</span>
+                            <span class="quick-fact-value">Sisodia Rajputs of Mewar</span>
+                        </div>
+                    </div>
+                    <p>Construction is believed to have taken close to <strong>15 years</strong>, using rugged local stone hauled up the hillside. The fort was built to strengthen Mewar's defences and to take advantage of the natural protection offered by the Aravalli hills, with the wall following the contours of the ridge line.</p>
+                </section>
+
+                <!-- Architecture -->
+                <section id="architecture" class="content-section glass-panel">
+                    <h2>Architecture</h2>
+                    <p>Kumbhalgarh is a striking example of <strong>Rajput military architecture</strong>, designed to make the most of its hilltop setting.</p>
+                    <ul>
+                        <li><strong>Massive Ramparts:</strong> The perimeter wall is up to 15 feet thick and rises to around 36 feet in places, wide enough for several horsemen to ride abreast.</li>
+                        <li><strong>Seven Fortified Gates:</strong> Gateways such as Ram Pol and Hanuman Pol guard the approach to the upper fort.</li>
+                        <li><strong>Hilltop Palace:</strong> The Badal Mahal (Cloud Palace) sits at the fort's highest point, offering sweeping views of the Aravallis and, on clear days, the Thar Desert.</li>
+                        <li><strong>Temple Cluster:</strong> Within the walls lie numerous temples reflecting Rajput and Jain temple-building traditions.</li>
+                    </ul>
+                </section>
+
+                <!-- UNESCO Status -->
+                <section id="unesco-status" class="content-section glass-panel highlight-panel">
+                    <h2>UNESCO Status</h2>
+                    <p>Kumbhalgarh Fort was inscribed as a <strong>UNESCO World Heritage Site in 2013</strong>, as part of the serial nomination "Hill Forts of Rajasthan," which also includes Chittorgarh, Amber, Jaisalmer, Ranthambore, and Gagron forts, recognised for their outstanding Rajput military architecture.</p>
+                </section>
+
+                <!-- Great Wall of India -->
+                <section id="great-wall" class="content-section glass-panel">
+                    <h2>Great Wall of India</h2>
+                    <p>Kumbhalgarh's perimeter wall stretches for roughly <strong>36 kilometres</strong>, making it one of the longest continuous walls in the world - a scale that has earned it the nickname the <strong>"Great Wall of India."</strong></p>
+                    <p>The wall encircles the entire hilltop, enclosing not just the palace complex but also an extensive area that once included villages and farmland, allowing the fort to remain self-sufficient during long sieges.</p>
+                </section>
+
+                <!-- Major Structures -->
+                <section id="structures" class="content-section glass-panel">
+                    <h2>Major Structures</h2>
+                    <ul>
+                        <li><strong>Badal Mahal (Cloud Palace):</strong> The topmost palace, divided into zenana and mardana sections with brightly painted interiors.</li>
+                        <li><strong>Ram Pol & Hanuman Pol:</strong> Two of the fort's most prominent fortified gateways.</li>
+                        <li><strong>Vedi Temple:</strong> A three-storeyed Jain temple within the fort complex.</li>
+                        <li><strong>Neelkanth Mahadev Temple:</strong> A Shiva temple with a large stone lingam, located near the fort's centre.</li>
+                        <li><strong>Numerous Shrines:</strong> The fort complex is said to house well over 300 temples, both Hindu and Jain, built over successive reigns.</li>
+                    </ul>
+                </section>
+
+                <!-- Interesting Facts -->
+                <section id="facts" class="content-section glass-panel">
+                    <h2>Interesting Facts</h2>
+                    <ul class="facts-list">
+                        <li>Kumbhalgarh's wall is often cited as the second-longest continuous wall in the world after the Great Wall of China.</li>
+                        <li>The fort was breached only once in its history, in 1576, and even then through a water blockade rather than direct assault.</li>
+                        <li>It is the birthplace of Maharana Pratap, the legendary Mewar ruler known for resisting Mughal expansion.</li>
+                        <li>The fort complex reportedly contains more than 300 temples within its walls.</li>
+                        <li>Rana Kumbha is credited with building numerous forts across Mewar, of which Kumbhalgarh was among the most ambitious.</li>
+                    </ul>
+                </section>
+
+                <!-- Image Gallery -->
+                <section id="gallery" class="content-section glass-panel">
+                    <h2>Image Gallery</h2>
+                    <div class="gallery-grid">
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1599661046289-e31897846e41?w=500&q=80" alt="Kumbhalgarh fort wall" loading="lazy">
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1596176530529-78163a4f7af2?w=500&q=80" alt="Fort gateway" loading="lazy">
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1590716179555-8c8a9dc5c6d9?w=500&q=80" alt="Hilltop palace" loading="lazy">
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1548013146-72479768bada?w=500&q=80" alt="Aravalli hills surrounding the fort" loading="lazy">
+                        </div>
+                    </div>
+                </section>
+            </div>
+        </div>
+    </main>
+
+    <footer class="footer">
+        <div class="footer-container">
+            <div class="footer-brand">
+                <h3>Incredible India Explorer</h3>
+                <p>An interactive digital guide to the geography, food, festivals, wildlife, and cultural heritage of India.</p>
+            </div>
+            <div class="footer-links">
+                <h3>Quick Navigation</h3>
+                <ul>
+                    <li><a href="../../index.html">Home</a></li>
+                    <li><a href="index.html">Indian Forts Explorer</a></li>
+                    <li><a href="kumbhalgarh-fort.html">Kumbhalgarh Fort</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="footer-credits footer-credits-center">
+            <p>&copy; 2026 Incredible India Explorer. Kumbhalgarh Fort Explorer.</p>
+        </div>
+    </footer>
+
+    <!-- Scroll To Top Button -->
+    <button class="btn-scroll-top" id="btn-scroll-top" aria-label="Scroll to Top">&#8593;</button>
+
+    <script src="../../app.js" defer></script>
+    <script src="../../router.js" defer></script>
+    <script type="module" src="../../auth.js"></script>
+</body>
+</html>

--- a/frontend/forts/nahargarh-fort.css
+++ b/frontend/forts/nahargarh-fort.css
@@ -1,0 +1,218 @@
+/* ==========================================================================
+   NAHARGARH FORT EXPLORER - STYLES
+   ========================================================================== */
+
+.hero-section {
+    position: relative;
+    height: 60vh;
+    min-height: 400px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    color: var(--text-light);
+    overflow: hidden;
+}
+
+.hero-bg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+}
+
+.hero-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.hero-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(to bottom, rgba(0, 0, 0, 0.35) 0%, rgba(0, 0, 0, 0.8) 100%);
+}
+
+.hero-content {
+    z-index: 1;
+    max-width: 800px;
+    padding: 2rem;
+}
+
+.hero-content .badge {
+    background-color: var(--saffron);
+    color: #fff;
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 1rem;
+    display: inline-block;
+}
+
+.hero-content .title {
+    font-size: clamp(2.5rem, 5vw, 4.5rem);
+    font-family: var(--font-heading);
+    margin: 0.5rem 0;
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+}
+
+.hero-content .subtitle {
+    font-size: 1.2rem;
+    margin-bottom: 2rem;
+    opacity: 0.95;
+}
+
+.hero-meta {
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+    flex-wrap: wrap;
+}
+
+.meta-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 500;
+}
+
+.main-content-wrapper {
+    display: grid;
+    grid-template-columns: 250px 1fr;
+    gap: 3rem;
+    padding: 4rem 2rem;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.sticky-nav {
+    position: sticky;
+    top: 100px;
+}
+
+.sticky-nav ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.sticky-nav li {
+    margin-bottom: 1rem;
+}
+
+.sticky-nav a {
+    color: var(--text-muted);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.3s ease;
+    display: block;
+    padding: 0.5rem;
+    border-left: 2px solid transparent;
+}
+
+.sticky-nav a:hover,
+.sticky-nav a.active {
+    color: var(--saffron);
+    border-left-color: var(--saffron);
+}
+
+.content-sections {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.content-section {
+    padding: 2rem;
+    border-radius: 12px;
+}
+
+.glass-panel {
+    background: var(--bg-dark-card);
+    backdrop-filter: blur(10px);
+    border: 1px solid var(--glass-border);
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.content-section h2 {
+    font-family: var(--font-heading);
+    color: var(--saffron);
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+    font-size: 2rem;
+    border-bottom: 1px solid var(--glass-border);
+    padding-bottom: 0.5rem;
+}
+
+.content-section p {
+    line-height: 1.8;
+    margin-bottom: 1rem;
+    color: var(--text-light);
+}
+
+.content-section ul {
+    padding-left: 1.5rem;
+    margin-bottom: 1rem;
+    color: var(--text-light);
+    line-height: 1.7;
+}
+
+.content-section li {
+    margin-bottom: 0.5rem;
+}
+
+.content-section strong {
+    color: var(--gold);
+}
+
+.highlight-panel {
+    background: linear-gradient(135deg, rgba(255, 153, 51, 0.1), rgba(19, 136, 8, 0.1));
+    border-left: 4px solid var(--saffron);
+}
+
+.facts-list {
+    list-style: disc;
+}
+
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.gallery-item {
+    border-radius: 8px;
+    overflow: hidden;
+    height: 200px;
+    border: 1px solid var(--glass-border);
+}
+
+.gallery-item img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.3s ease;
+}
+
+.gallery-item img:hover {
+    transform: scale(1.05);
+}
+
+@media (max-width: 768px) {
+    .main-content-wrapper {
+        grid-template-columns: 1fr;
+        padding: 2rem 1rem;
+    }
+
+    .sidebar-nav {
+        display: none;
+    }
+}

--- a/frontend/forts/nahargarh-fort.html
+++ b/frontend/forts/nahargarh-fort.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Explore Nahargarh Fort - the hilltop fortress overlooking Jaipur, part of the city's historic defense ring alongside Amer and Jaigarh forts.">
+    <title>Nahargarh Fort Explorer | Incredible India</title>
+    <meta property="og:title" content="Nahargarh Fort Explorer | Incredible India">
+    <meta property="og:description" content="Discover Nahargarh Fort - guardian of Jaipur, home to the Madhavendra Bhawan and sweeping views of the Pink City.">
+    <meta property="og:type" content="website">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="nahargarh-fort.css">
+</head>
+<body>
+    <header class="navbar" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html" class="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">☰</button>
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html" class="nav-link">Home</a>
+                <a href="index.html" class="nav-link">Forts</a>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Light/Dark Mode">☀️</button>
+            </nav>
+        </div>
+    </header>
+
+    <main>
+        <!-- Overview / Hero -->
+        <section class="hero-section" id="overview">
+            <div class="hero-bg">
+                <img src="https://images.unsplash.com/photo-1596176530529-78163a4f7af2?w=1600&q=80" alt="Nahargarh Fort overlooking Jaipur" class="hero-image">
+                <div class="hero-overlay"></div>
+            </div>
+            <div class="hero-content">
+                <span class="badge">Jaipur, Rajasthan</span>
+                <h1 class="title">Nahargarh Fort</h1>
+                <p class="subtitle">The hilltop sentinel that watches over the Pink City of Jaipur.</p>
+                <div class="hero-meta">
+                    <div class="meta-item">
+                        <span class="icon">📍</span>
+                        <span>Aravalli Hills, Jaipur</span>
+                    </div>
+                    <div class="meta-item">
+                        <span class="icon">🏛️</span>
+                        <span>Kachwaha Rajput Heritage</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <div class="container main-content-wrapper">
+            <!-- Sidebar Navigation -->
+            <aside class="sidebar-nav">
+                <nav class="sticky-nav">
+                    <ul>
+                        <li><a href="#overview">Overview</a></li>
+                        <li><a href="#history">History</a></li>
+                        <li><a href="#architecture">Architecture</a></li>
+                        <li><a href="#builder">Builder</a></li>
+                        <li><a href="#legends">Legends</a></li>
+                        <li><a href="#attractions">Major Attractions</a></li>
+                        <li><a href="#facts">Interesting Facts</a></li>
+                        <li><a href="#gallery">Gallery</a></li>
+                    </ul>
+                </nav>
+            </aside>
+
+            <!-- Main Content Area -->
+            <div class="content-sections">
+                <!-- Overview -->
+                <section id="overview-text" class="content-section glass-panel">
+                    <h2>Overview</h2>
+                    <p>Nahargarh Fort stands atop a rocky ridge of the Aravalli hills on the northern edge of Jaipur, Rajasthan. Along with Amer Fort and Jaigarh Fort, it formed a strong triangular defense system that protected the city of Jaipur.</p>
+                    <p>Unlike Amer and Jaigarh, Nahargarh was built primarily as a retreat and defensive outpost rather than a royal residence, and today it is best known for its sweeping views over the "Pink City" below, especially at sunset.</p>
+                </section>
+
+                <!-- History -->
+                <section id="history" class="content-section glass-panel">
+                    <h2>History</h2>
+                    <p>Nahargarh Fort was originally built in <strong>1734</strong> under <strong>Sawai Jai Singh II</strong>, the founder of Jaipur, as part of the city's outer defenses. It was significantly expanded in <strong>1868</strong> by <strong>Sawai Ram Singh</strong>, who added several structures within the fort complex.</p>
+                    <p>The fort also served as a shelter for European residents of Jaipur during the unrest of 1857, and later hosted meetings between the rulers of several princely states, underlining its role beyond pure military defense.</p>
+                </section>
+
+                <!-- Architecture -->
+                <section id="architecture" class="content-section glass-panel">
+                    <h2>Architecture</h2>
+                    <p>Nahargarh blends traditional Rajput fort design with later touches of European influence, reflecting the different phases of its construction.</p>
+                    <ul>
+                        <li><strong>Fortified Walls:</strong> Thick stone ramparts follow the natural ridge line, linking Nahargarh visually and strategically to Jaigarh Fort nearby.</li>
+                        <li><strong>Madhavendra Bhawan:</strong> A two-storey palace with nine identical, symmetrical suites - one for the king and one each for his queens - connected by covered corridors.</li>
+                        <li><strong>Indo-European Detailing:</strong> Later additions from the 1868 expansion introduced European-style arches and decorative elements alongside traditional Rajput motifs.</li>
+                        <li><strong>Hilltop Layout:</strong> The fort's elevated position offers natural defensive advantages and panoramic views in every direction.</li>
+                    </ul>
+                </section>
+
+                <!-- Builder -->
+                <section id="builder" class="content-section glass-panel highlight-panel">
+                    <h2>Builder</h2>
+                    <p>Nahargarh Fort was originally constructed by <strong>Sawai Jai Singh II</strong> of the Kachwaha dynasty in 1734. It was later substantially expanded and remodelled by his successor <strong>Sawai Ram Singh</strong> in 1868, and further additions were made by <strong>Sawai Madho Singh</strong>, who commissioned the Madhavendra Bhawan for his queens.</p>
+                </section>
+
+                <!-- Legends -->
+                <section id="legends" class="content-section glass-panel">
+                    <h2>Legends</h2>
+                    <p>The fort's name is closely tied to local legend. It is said that the spirit of a local prince named <strong>Nahar Singh Bhomia</strong> repeatedly disrupted construction of the fort, causing structures to collapse overnight.</p>
+                    <p>According to the legend, work could only continue after a temple was built in his honour within the fort to appease his spirit, and the fort was subsequently renamed "Nahargarh" - meaning "abode of tigers" or, in some interpretations, linked to Nahar Singh's name itself.</p>
+                </section>
+
+                <!-- Major Attractions -->
+                <section id="attractions" class="content-section glass-panel">
+                    <h2>Major Attractions</h2>
+                    <ul>
+                        <li><strong>Madhavendra Bhawan:</strong> The fort's centrepiece palace, known for its symmetrical suites and delicate wall paintings.</li>
+                        <li><strong>Sunset Point:</strong> A popular viewpoint offering panoramic views of Jaipur city as it turns golden at dusk.</li>
+                        <li><strong>Nahargarh Biological Park:</strong> A wildlife park located near the fort, home to leopards and other native species.</li>
+                        <li><strong>Padao Restaurant:</strong> A restaurant within the fort complex that lets visitors dine while overlooking the city skyline.</li>
+                    </ul>
+                </section>
+
+                <!-- Interesting Facts -->
+                <section id="facts" class="content-section glass-panel">
+                    <h2>Interesting Facts</h2>
+                    <ul class="facts-list">
+                        <li>Nahargarh, Jaigarh, and Amer forts were connected by fortified walls, forming a combined defense network for Jaipur.</li>
+                        <li>The fort provided refuge to European residents of Jaipur during the events of 1857.</li>
+                        <li>Madhavendra Bhawan's nine suites are all identically designed, so no queen's quarters could be seen as superior to another's.</li>
+                        <li>Nahargarh Fort has featured as a filming location in several Bollywood productions, including "Rang De Basanti."</li>
+                        <li>The fort's name is popularly linked to the legend of Nahar Singh Bhomia's restless spirit.</li>
+                    </ul>
+                </section>
+
+                <!-- Gallery -->
+                <section id="gallery" class="content-section glass-panel">
+                    <h2>Gallery</h2>
+                    <div class="gallery-grid">
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1596176530529-78163a4f7af2?w=500&q=80" alt="Nahargarh Fort walls" loading="lazy">
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1590716179555-8c8a9dc5c6d9?w=500&q=80" alt="Palace courtyard" loading="lazy">
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1609766856923-7e0a0c0622d4?w=500&q=80" alt="View over Jaipur city" loading="lazy">
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1599661046289-e31897846e41?w=500&q=80" alt="Fort at sunset" loading="lazy">
+                        </div>
+                    </div>
+                </section>
+            </div>
+        </div>
+    </main>
+
+    <footer class="footer">
+        <div class="footer-container">
+            <div class="footer-brand">
+                <h3>Incredible India Explorer</h3>
+                <p>An interactive digital guide to the geography, food, festivals, wildlife, and cultural heritage of India.</p>
+            </div>
+            <div class="footer-links">
+                <h3>Quick Navigation</h3>
+                <ul>
+                    <li><a href="../../index.html">Home</a></li>
+                    <li><a href="index.html">Indian Forts Explorer</a></li>
+                    <li><a href="nahargarh-fort.html">Nahargarh Fort</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="footer-credits footer-credits-center">
+            <p>&copy; 2026 Incredible India Explorer. Nahargarh Fort Explorer.</p>
+        </div>
+    </footer>
+
+    <!-- Scroll To Top Button -->
+    <button class="btn-scroll-top" id="btn-scroll-top" aria-label="Scroll to Top">&#8593;</button>
+
+    <script src="../../app.js" defer></script>
+    <script src="../../router.js" defer></script>
+    <script type="module" src="../../auth.js"></script>
+</body>
+</html>

--- a/frontend/forts/script.js
+++ b/frontend/forts/script.js
@@ -371,6 +371,26 @@ const fortsData = [
         ]
     },
     {
+        id: "nahargarh-fort",
+        name: "Nahargarh Fort",
+        location: "Jaipur",
+        state: "Rajasthan",
+        built: "1734 (expanded 1868)",
+        builtBy: "Sawai Jai Singh II",
+        era: "Kachwaha Era",
+        architecture: "Rajput-Indo-European Architecture",
+        image: "https://images.unsplash.com/photo-1596176530529-78163a4f7af2?w=800&q=80",
+        history: "Nahargarh Fort was built in 1734 by Sawai Jai Singh II as part of Jaipur's defense ring alongside Amer and Jaigarh forts, and was later expanded in 1868 by Sawai Ram Singh. Perched on a ridge overlooking the city, it is famed for the Madhavendra Bhawan palace and panoramic sunset views of the Pink City.",
+        highlights: [
+            "Part of Jaipur's triangular defense system with Amer and Jaigarh forts",
+            "Madhavendra Bhawan with nine identical queens' suites",
+            "Popular sunset viewpoint over Jaipur",
+            "Linked to the legend of Nahar Singh Bhomia",
+            "Featured in films including Rang De Basanti"
+        ],
+        customUrl: "nahargarh-fort.html"
+    },
+        {
         id: "jaigarh-fort",
         name: "Jaigarh Fort",
         location: "Jaipur",

--- a/frontend/forts/script.js
+++ b/frontend/forts/script.js
@@ -367,10 +367,29 @@ const fortsData = [
             "Tipu's Summer Palace (Dariya Daulat Bagh)",
             "Gumbaz (Tipu's mausoleum)",
             "Sriranganathaswamy Temple",
-            "Located on an island in River Kaveri"
+"Located on an island in River Kaveri"
         ]
     },
     {
+        id: "agra-fort",
+        name: "Agra Fort",
+        location: "Agra",
+        state: "Uttar Pradesh",
+        built: "1565-1573 CE",
+        builtBy: "Emperor Akbar",
+        era: "Mughal Era",
+        architecture: "Mughal Architecture",
+        image: "https://images.unsplash.com/photo-1587474260584-136574528ed5?w=800&q=80",
+        history: "Agra Fort is a massive red sandstone fortress on the banks of the Yamuna river, rebuilt by Emperor Akbar from 1565 and later enriched with white marble palaces by Jahangir and Shah Jahan. It served as the main residence of the Mughal emperors until the capital moved to Delhi in 1638, and is where Shah Jahan was later imprisoned by his son Aurangzeb.",
+        highlights: [
+            "UNESCO World Heritage Site since 1983",
+            "Musamman Burj - where Shah Jahan was imprisoned",
+            "Sheesh Mahal (Mirror Palace)",
+            "Moti Masjid (Pearl Mosque)",
+            "Distant view of the Taj Mahal"
+        ],
+        customUrl: "agra-fort.html"
+    },    {
         id: 13,
         name: "Rajgad Fort",
         location: "Pune",

--- a/frontend/forts/script.js
+++ b/frontend/forts/script.js
@@ -371,6 +371,26 @@ const fortsData = [
         ]
     },
     {
+        id: "kumbhalgarh-fort",
+        name: "Kumbhalgarh Fort",
+        location: "Kumbhalgarh",
+        state: "Rajasthan",
+        built: "15th Century (c. 1443-1458 CE)",
+        builtBy: "Rana Kumbha",
+        era: "Mewar Era",
+        architecture: "Rajput Hill Fort Architecture",
+        image: "https://images.unsplash.com/photo-1599661046289-e31897846e41?w=800&q=80",
+        history: "Kumbhalgarh Fort was built in the 15th century by Rana Kumbha of Mewar and is best known for its massive fortification wall, often called the Great Wall of India, stretching roughly 36 kilometres across the Aravalli hills. It is the birthplace of Maharana Pratap and was breached only once in its history.",
+        highlights: [
+            "UNESCO World Heritage Site (Hill Forts of Rajasthan, 2013)",
+            "One of the longest continuous walls in the world",
+            "Birthplace of Maharana Pratap",
+            "Badal Mahal (Cloud Palace)",
+            "Over 300 temples within the fort walls"
+        ],
+        customUrl: "kumbhalgarh-fort.html"
+    },
+        {
         id: "agra-fort",
         name: "Agra Fort",
         location: "Agra",

--- a/frontend/forts/script.js
+++ b/frontend/forts/script.js
@@ -349,12 +349,30 @@ const fortsData = [
             "Hidden 1.4 km underwater wall",
             "Kanhoji Angre's headquarters"
         ],
-        customUrl: "vijaydurg-fort.html"
+customUrl: "vijaydurg-fort.html"
+    },
+    {
+        id: "gagron-fort",
+        name: "Gagron Fort",
+        location: "Jhalawar",
+        state: "Rajasthan",
+        built: "7th-14th Century",
+        builtBy: "Dod Rajputs / Khichi Chauhan Dynasty",
+        era: "Rajput Era",
+        architecture: "Rajput Hill-and-Water Fort Architecture",
+        image: "https://images.unsplash.com/photo-1599661046289-e31897846e41?w=800&q=80",
+        history: "A rare hill-and-water fort at the confluence of the Kali Sindh and Ahu rivers, encircled by water on three sides and needing no moat, later recognised as a UNESCO World Heritage Site.",
+        highlights: [
+            "UNESCO World Heritage Site",
+            "Only fort in Rajasthan without a moat",
+            "Surrounded by two rivers",
+            "Site of two historic jauhars"
+        ],
+        customUrl: "gagron-fort.html"
     },
     {
         id: 12,
-        name: "Srirangapatna Fort",
-        location: "Srirangapatna",
+        name: "Srirangapatna Fort",        location: "Srirangapatna",
         state: "Karnataka",
         built: "15th Century",
         builtBy: "Tipu Sultan",

--- a/frontend/forts/script.js
+++ b/frontend/forts/script.js
@@ -371,6 +371,26 @@ const fortsData = [
         ]
     },
     {
+        id: "jaigarh-fort",
+        name: "Jaigarh Fort",
+        location: "Jaipur",
+        state: "Rajasthan",
+        built: "1726",
+        builtBy: "Sawai Jai Singh II",
+        era: "Kachwaha Era",
+        architecture: "Rajput Military Architecture",
+        image: "https://images.unsplash.com/photo-1590716179555-8c8a9dc5c6d9?w=800&q=80",
+        history: "Jaigarh Fort was built in 1726 by Sawai Jai Singh II to strengthen the defences of Amer Fort and house the state's cannon foundry. Perched on Cheel ka Teela in the Aravalli hills, it was never conquered in battle and is famed for the Jaivana Cannon, the largest cannon on wheels in the world.",
+        highlights: [
+            "Houses the Jaivana Cannon, the world's largest cannon on wheels",
+            "Connected to Amer Fort by underground passages",
+            "One of Asia's few surviving cannon foundries",
+            "Never captured in battle",
+            "Panoramic views from the Diya Burj watchtower"
+        ],
+        customUrl: "jaigarh-fort.html"
+    },
+        {
         id: "kumbhalgarh-fort",
         name: "Kumbhalgarh Fort",
         location: "Kumbhalgarh",


### PR DESCRIPTION
## Description
This PR adds a new "Gagron Fort Explorer" page to the Indian Forts Explorer section, closing #1170.

Gagron Fort (Jhalawar, Rajasthan) is a unique hill-and-water fort surrounded by the Kali Sindh and Ahu rivers on three sides, making it the only major fort in Rajasthan without a moat. It is part of the UNESCO World Heritage "Hill Forts of Rajasthan" listing (2013).

## Changes
- Added `frontend/forts/gagron-fort.html`: new fort page covering History, Builder, UNESCO Status, Water Fort Features, Architecture, Battles, Gallery, Interesting Facts, Location & Map, and References.
- Added `frontend/forts/gagron-fort.css`: stylesheet reusing the shared fort-page layout used by other fort pages (e.g. Vijaydurg Fort).
- Updated `frontend/forts/script.js`: added a Gagron Fort entry to `fortsData` with `customUrl: "gagron-fort.html"` so it appears as a card on the Indian Forts Explorer landing page and links to the new page.

## Testing
- Verified the new card appears on the Indian Forts Explorer landing page grid.
- Verified clicking the Gagron Fort card navigates to `gagron-fort.html`.
- Verified all sidebar anchor links on the new page scroll to the correct sections.
- Verified the page matches the layout, theming, and responsive behavior of existing fort pages.

Closes #1170 

@Eshajha19 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.