### PR TITLE
feat: Create UNESCO Intangible Cultural Heritage of India Explorer (#1440)

### DIFF
--- a/frontend/intangible-heritage-explorer/data.js
+++ b/frontend/intangible-heritage-explorer/data.js
@@ -1,0 +1,532 @@
+/* ==========================================================================
+   UNESCO INTANGIBLE CULTURAL HERITAGE OF INDIA — DATASET
+
+   These are living traditions held by specific communities. Each entry names
+   the community that holds the practice. Nothing here is described in the
+   past tense unless the practice genuinely has ceased, and inscription is
+   presented as recognition — it confers no ownership, no exclusivity and no
+   legal protection.
+   ========================================================================== */
+
+const ICH_DOMAINS = [
+  {
+    key: 'oral',
+    name: 'Oral Traditions & Expressions',
+    icon: '🗣️',
+    blurb: 'Including language as a vehicle of intangible heritage — recitation, epic, proverb, chant.',
+  },
+  {
+    key: 'performing',
+    name: 'Performing Arts',
+    icon: '🎭',
+    blurb: 'Music, dance, theatre and the forms that combine them.',
+  },
+  {
+    key: 'social',
+    name: 'Social Practices, Rituals & Festive Events',
+    icon: '🎉',
+    blurb: 'The practices that structure community life and mark the calendar.',
+  },
+  {
+    key: 'nature',
+    name: 'Knowledge & Practices Concerning Nature',
+    icon: '🌿',
+    blurb: 'Knowledge of the natural world and the universe, and the practices built on it.',
+  },
+  {
+    key: 'craft',
+    name: 'Traditional Craftsmanship',
+    icon: '🔨',
+    blurb: 'The skill itself, not the object — the Convention safeguards the knowing-how.',
+  },
+];
+
+const ICH_REGIONS = [
+  { key: 'south', name: 'South India', icon: '🌴' },
+  { key: 'north', name: 'North India', icon: '🏔️' },
+  { key: 'east', name: 'East India', icon: '🌾' },
+  { key: 'west', name: 'West India', icon: '🏜️' },
+  { key: 'northeast', name: 'Northeast India', icon: '🍃' },
+  { key: 'pan', name: 'Pan-Indian / Multiple States', icon: '🇮🇳' },
+];
+
+/* --------------------------------------------------- the 15 inscriptions */
+const ICH_ELEMENTS = [
+  {
+    name: 'Kutiyattam, Sanskrit Theatre',
+    icon: '🎭',
+    year: 2008,
+    proclaimed: 2001,
+    domain: 'performing',
+    region: 'south',
+    state: 'Kerala',
+    community: 'Chakyar and Nambiar families, and the Ammannur and Kalamandalam lineages',
+    tagline: 'One of the first elements UNESCO ever recognised',
+    desc: 'Kutiyattam is a Sanskrit theatre form of Kerala, generally held to be around two thousand years old and among the oldest continuously performed theatre traditions anywhere. A single act can take days to perform, because the actor elaborates each moment through netrabhinaya — expression carried almost entirely by the eyes — at a pace no other theatre attempts. It was proclaimed a Masterpiece of the Oral and Intangible Heritage of Humanity in 2001 and formally inscribed in 2008.',
+    status: 'Practised by a small number of families and institutions. Transmission depends heavily on a handful of teachers, and the number of trained performers is low.',
+    detail: 'Historically performed only in koothambalams, the theatre halls attached to Kerala temples, and only by hereditary performer communities. Ammannur Madhava Chakyar was central to bringing it to wider audiences in the twentieth century.',
+  },
+  {
+    name: 'Tradition of Vedic Chanting',
+    icon: '📿',
+    year: 2008,
+    proclaimed: 2003,
+    domain: 'oral',
+    region: 'pan',
+    state: 'Multiple states',
+    community: 'Brahmin reciter lineages across several regional schools (shakhas)',
+    tagline: 'A text transmitted orally with astonishing fidelity for three thousand years',
+    desc: 'The Vedas have been transmitted by voice for roughly three thousand years, and the remarkable part is the accuracy. Recitation methods such as jata-patha and ghana-patha reorder the words in fixed permuted patterns, so that any error in one recitation is detectable against the others. It is, in effect, an oral error-correcting code, developed long before anyone had the vocabulary for that idea.',
+    status: 'Continues in traditional schools, though the number of reciters trained in the more elaborate patha methods has fallen sharply.',
+    detail: 'Different shakhas preserve different regional recitation traditions. What is safeguarded is the manner of recitation — pitch, permutation, pronunciation — rather than the text itself, which exists in written form as well.',
+  },
+  {
+    name: 'Ramlila, the Traditional Performance of the Ramayana',
+    icon: '🏹',
+    year: 2008,
+    proclaimed: 2005,
+    domain: 'performing',
+    region: 'north',
+    state: 'Uttar Pradesh and across north India',
+    community: 'Local Ramlila committees and whole towns, particularly Ramnagar in Varanasi',
+    tagline: 'A month-long performance staged across an entire town',
+    desc: 'Ramlila stages the Ramayana over days or weeks, most famously at Ramnagar near Varanasi where the performance runs for about a month and the town itself becomes the set — different neighbourhoods stand in for Ayodhya, Lanka and the forest, and the audience walks between them. It is not theatre with an audience so much as a participatory ritual that happens to have actors.',
+    status: 'Widely and vigorously practised across north India, though some traditional forms compete with commercial and televised versions.',
+    detail: 'Performers are frequently amateurs from the local community rather than professionals, and roles are often held for years or passed within families.',
+  },
+  {
+    name: 'Ramman: Religious Festival and Ritual Theatre of Garhwal',
+    icon: '🎭',
+    year: 2009,
+    proclaimed: null,
+    domain: 'social',
+    region: 'north',
+    state: 'Uttarakhand',
+    community: 'The villages of Saloor-Dungra in Chamoli district',
+    tagline: 'Performed in two villages, and nowhere else',
+    desc: 'Ramman is an annual festival of the twin villages of Saloor-Dungra in the Painkhanda valley, combining masked dance, ritual, recitation and historical narrative in honour of the local deity Bhumiyal Devta. Its scope is unusually narrow — this is not a regional form but the practice of a specific pair of villages, with roles assigned by caste and family.',
+    status: 'Highly vulnerable. Out-migration from the villages directly threatens transmission, since specific families hold specific roles.',
+    detail: 'The masks are made by a designated family, drums are played by another, and the Bhumiyal Devta mask is hosted in a different household each year. Remove one family and part of the festival cannot be performed.',
+  },
+  {
+    name: 'Chhau Dance',
+    icon: '⚔️',
+    year: 2010,
+    proclaimed: null,
+    domain: 'performing',
+    region: 'east',
+    state: 'Odisha, West Bengal, Jharkhand',
+    community: 'Communities of Seraikela, Purulia and Mayurbhanj',
+    tagline: 'Three regional styles, and only two of them use masks',
+    desc: 'Chhau is a martial-derived dance-theatre with three distinct regional styles: Seraikela in Jharkhand and Purulia in West Bengal use masks, while Mayurbhanj in Odisha does not. It draws on the Mahabharata, the Ramayana and local folklore, and its vocabulary comes visibly out of martial training — the stance and footwork are those of a fighter.',
+    status: 'Actively performed, with state academies supporting training. Mask-making in Purulia and Seraikela is a related craft under its own pressure.',
+    detail: 'Traditionally performed during the spring Chaitra Parva festival, over several nights, in the open and by torchlight.',
+  },
+  {
+    name: 'Kalbelia Folk Songs and Dances of Rajasthan',
+    icon: '🐍',
+    year: 2010,
+    proclaimed: null,
+    domain: 'performing',
+    region: 'west',
+    state: 'Rajasthan',
+    community: 'The Kalbelia community',
+    tagline: 'A tradition that survived the loss of its livelihood',
+    desc: 'The Kalbelia were traditionally snake handlers, and their songs and dances carry that history in their movement vocabulary. When the Wildlife Protection Act, 1972 ended snake charming as a livelihood, the community faced the loss of its economic base — and the performing tradition became both a cultural continuity and a source of income. The songs are largely improvised and composed spontaneously in performance.',
+    status: 'Actively performed and internationally visible. Economic precarity within the community remains the underlying issue.',
+    detail: 'The women\'s black skirts with mirror-work and silver thread are a recognisable feature, and the movement is often described as serpentine — a direct reference to the community\'s earlier occupation.',
+  },
+  {
+    name: 'Mudiyettu, Ritual Theatre and Dance Drama of Kerala',
+    icon: '🔥',
+    year: 2010,
+    proclaimed: null,
+    domain: 'social',
+    region: 'south',
+    state: 'Kerala',
+    community: 'Village communities of the Chalakkudy, Periyar and Moovattupuzha river basins',
+    tagline: 'A ritual the whole village prepares, not a performance it watches',
+    desc: 'Mudiyettu enacts the battle between the goddess Kali and the demon Darika, performed in temples after the harvest. Its distinctive feature is the kalam — a large drawing of the goddess made on the temple floor in coloured powders, which is created, worshipped and then deliberately erased. The whole village participates in preparation; the performance is a collective act rather than a staged one.',
+    status: 'Performed in a limited number of temples. The number of families holding the specialised roles has declined.',
+    detail: 'Roles are hereditary and specific — particular families hold the right and duty to perform particular characters.',
+  },
+  {
+    name: 'Buddhist Chanting of Ladakh',
+    icon: '🏔️',
+    year: 2012,
+    proclaimed: null,
+    domain: 'oral',
+    region: 'north',
+    state: 'Ladakh',
+    community: 'Monastic communities of the Nyingma, Kagyu, Gelug and Sakya orders',
+    tagline: 'Recitation of the sacred texts of Mahayana and Vajrayana Buddhism',
+    desc: 'Monks in the monasteries of the Ladakh Himalaya chant Buddhist texts as part of daily practice and at major ceremonies, in styles that vary between the four orders. The chanting is accompanied by hand gestures, cymbals, drums and horns, and is understood as a practice in itself rather than as accompaniment to one.',
+    status: 'Continues in monasteries across Ladakh, but fewer young people are entering monastic life and some chanting styles have very few remaining transmitters.',
+    detail: 'Two forms are distinguished: the daily recitation and the elaborate ceremonial chanting performed on specific dates in the monastic calendar.',
+  },
+  {
+    name: 'Sankirtana: Ritual Singing, Drumming and Dancing of Manipur',
+    icon: '🥁',
+    year: 2013,
+    proclaimed: null,
+    domain: 'performing',
+    region: 'northeast',
+    state: 'Manipur',
+    community: 'Vaishnava communities of the Manipuri plains',
+    tagline: 'Performed in the middle of the hall, with the audience all around',
+    desc: 'Sankirtana is performed in the mandap of a Vaishnava temple, with the singers and drummers in the centre and the congregation seated around them on all sides. The pung drum and the cymbals drive it. It marks the whole cycle of life events — birth, initiation, marriage, death — so it is embedded in the community\'s calendar rather than staged as a separate occasion.',
+    status: 'Actively practised, and central to Manipuri Vaishnava community life.',
+    detail: 'The pung cholom, a drum dance performed within the sankirtana tradition, is one of its most recognisable elements.',
+  },
+  {
+    name: 'Traditional Brass and Copper Craft of Utensil Making, Thatheras of Jandiala Guru',
+    icon: '🔨',
+    year: 2014,
+    proclaimed: null,
+    domain: 'craft',
+    region: 'north',
+    state: 'Punjab',
+    community: 'The Thathera community of Jandiala Guru, Amritsar district',
+    tagline: 'A single town\'s craft, inscribed on its own',
+    desc: 'The Thatheras of Jandiala Guru make brass and copper utensils entirely by hand, heating cakes of metal and beating them into shape with repeated hammering and annealing. What UNESCO inscribed is the skill and its transmission, not the objects — the Convention protects the knowing-how, which is precisely what disappears when a craft stops being taught.',
+    status: 'Vulnerable. Competition from steel and aluminium has shrunk the market, and the number of working families has fallen substantially.',
+    detail: 'The Punjab government and community organisations have run revival programmes since the inscription, including training and market linkage for younger craftspeople.',
+  },
+  {
+    name: 'Nowruz',
+    icon: '🌱',
+    year: 2016,
+    proclaimed: null,
+    domain: 'social',
+    region: 'pan',
+    state: 'Multiple states (multinational inscription)',
+    community: 'Parsi and Irani Zoroastrian communities in India, among many others internationally',
+    tagline: 'A multinational inscription shared by twelve countries',
+    desc: 'Nowruz marks the spring equinox and the start of the new year in the Persian calendar, and is celebrated across a wide region from the Balkans to South Asia. India is one of twelve states party to the inscription, through its Parsi and Irani communities — a reminder that ICH elements are not necessarily bounded by national borders, and that the Convention accommodates that.',
+    status: 'Practised, though India\'s Parsi population is small and declining.',
+    detail: 'The multinational format is deliberate: it lets states jointly nominate a practice that no one of them can claim exclusively.',
+  },
+  {
+    name: 'Yoga',
+    icon: '🧘',
+    year: 2016,
+    proclaimed: null,
+    domain: 'nature',
+    region: 'pan',
+    state: 'Pan-Indian',
+    community: 'Practitioner lineages, ashrams, gurus and institutions across India',
+    tagline: 'Inscribed under knowledge concerning nature and the universe, not performing arts',
+    desc: 'Yoga was inscribed in 2016 under the domain of knowledge and practices concerning nature and the universe — a categorisation worth noticing, because it reflects yoga as a system of thought about the self and the body rather than as physical exercise. The nomination covered the philosophical framework, breath and posture practice, meditation, ethical observances and the guru-shishya transmission that carries all of it.',
+    status: 'Practised worldwide on an enormous scale. Commercialisation and the detachment of posture practice from its philosophical frame are the concerns most often raised.',
+    detail: 'Of India\'s inscriptions this is by far the most globally visible, and the one where the gap between the inscribed element and its popular form is widest.',
+  },
+  {
+    name: 'Kumbh Mela',
+    icon: '🕉️',
+    year: 2017,
+    proclaimed: null,
+    domain: 'social',
+    region: 'north',
+    state: 'Uttar Pradesh, Uttarakhand, Madhya Pradesh, Maharashtra',
+    community: 'Akharas, ascetic orders, and pilgrims from across India',
+    tagline: 'The largest peaceful gathering of people anywhere on earth',
+    desc: 'The Kumbh Mela rotates between Prayagraj, Haridwar, Ujjain and Nashik on an astronomical cycle, and draws tens of millions of pilgrims — routinely described as the largest peaceful congregation of human beings anywhere. The akharas, the ascetic orders, process in a fixed order of precedence that is itself part of the tradition. UNESCO noted its inclusiveness: participation is not restricted by caste, creed or gender.',
+    status: 'Practised at very large and growing scale. The management challenge — sanitation, crowd safety, river health — grows with it.',
+    detail: 'The timing is set by the positions of Jupiter, the Sun and the Moon, which is why the cycle and the location shift together.',
+  },
+  {
+    name: 'Durga Puja in Kolkata',
+    icon: '🪔',
+    year: 2021,
+    proclaimed: null,
+    domain: 'social',
+    region: 'east',
+    state: 'West Bengal',
+    community: 'Neighbourhood puja committees, Kumartuli idol-makers, artists and designers of Kolkata',
+    tagline: 'Inscribed for the city, not the festival in general',
+    desc: 'The inscription is specifically for Durga Puja as practised in Kolkata, where the festival functions as a citywide public art event as much as a religious one. Neighbourhood committees commission elaborate temporary pandals from named artists and designers, the idols are made in the Kumartuli potters\' quarter, and the whole thing is dismantled and immersed at the end. UNESCO cited its collapsing of class, religious and ethnic boundaries in public space.',
+    status: 'Enormously vigorous, with a substantial associated economy in art, design, lighting and craft.',
+    detail: 'Kumartuli, the idol-makers\' quarter, is a working neighbourhood whose craft is inseparable from the festival — the inscription covers the whole ecosystem, not the ritual alone.',
+  },
+  {
+    name: 'Garba of Gujarat',
+    icon: '💃',
+    year: 2023,
+    proclaimed: null,
+    domain: 'social',
+    region: 'west',
+    state: 'Gujarat',
+    community: 'Communities across Gujarat and the Gujarati diaspora',
+    tagline: 'India\'s most recent inscription',
+    desc: 'Garba is a devotional circle dance performed during Navratri around a centrally placed earthen lamp or an image of the goddess. UNESCO\'s citation emphasised its inclusiveness — it is danced across caste, class, gender and, in many places, religious lines, and participation requires no training. It was inscribed in December 2023, the fifteenth Indian element on the Representative List.',
+    status: 'Practised on a very large scale in Gujarat and throughout the Gujarati diaspora.',
+    detail: 'The word derives from garbha, meaning womb — a reference to the lamp at the centre of the circle, around which the dance turns.',
+  },
+];
+
+/* --------------------------------------------------------- two conventions */
+const ICH_COMPARISON = [
+  {
+    aspect: 'Convention',
+    tangible: 'World Heritage Convention, 1972',
+    intangible: 'Convention for the Safeguarding of the Intangible Cultural Heritage, 2003',
+  },
+  {
+    aspect: 'What it covers',
+    tangible: 'Places — monuments, sites, natural properties',
+    intangible: 'Practices — performance, ritual, knowledge, craftsmanship',
+  },
+  {
+    aspect: 'The list',
+    tangible: 'World Heritage List',
+    intangible: 'Representative List, plus the Urgent Safeguarding List',
+  },
+  {
+    aspect: 'India\'s entries',
+    tangible: '40+ World Heritage Sites',
+    intangible: '15 elements on the Representative List',
+  },
+  {
+    aspect: 'Criterion',
+    tangible: 'Outstanding Universal Value',
+    intangible: 'Representative of the community\'s heritage; no comparative ranking',
+  },
+  {
+    aspect: 'Who holds it',
+    tangible: 'The State Party, which owns and manages the property',
+    intangible: 'The community that practises it. The state nominates but does not own',
+  },
+  {
+    aspect: 'What is protected',
+    tangible: 'Physical fabric and setting, with conservation obligations',
+    intangible: 'Transmission — the passing on of the practice to the next generation',
+  },
+  {
+    aspect: 'Danger listing',
+    tangible: 'List of World Heritage in Danger',
+    intangible: 'List of Intangible Cultural Heritage in Need of Urgent Safeguarding',
+  },
+];
+
+/* ------------------------------------------------------------- nomination */
+const ICH_PROCESS = [
+  { step: '1', icon: '👥', title: 'Community consent', desc: 'A nomination requires the free, prior and informed consent of the community that practises the element. This is not a formality — a nomination made over a community\'s head does not meet the Convention\'s requirements.' },
+  { step: '2', icon: '📋', title: 'National inventory', desc: 'The element must already appear in the State Party\'s own inventory of intangible heritage. India\'s National ICH Inventory is maintained by the Sangeet Natak Akademi, the nodal agency.' },
+  { step: '3', icon: '📝', title: 'Nomination file', desc: 'The file documents what the element is, who practises it, how it is transmitted, its current viability, and the safeguarding measures proposed. Video and photographic documentation are required.' },
+  { step: '4', icon: '🔍', title: 'Evaluation', desc: 'The Evaluation Body reviews the file against the criteria and recommends inscription, referral or rejection. Files are routinely referred back for more information.' },
+  { step: '5', icon: '🗳️', title: 'Committee decision', desc: 'The Intergovernmental Committee, meeting annually, takes the final decision. States are limited in how many files they may submit per cycle, which is why the list grows slowly.' },
+  { step: '6', icon: '📅', title: 'Periodic reporting', desc: 'Inscription is not the end. States report periodically on the status of inscribed elements and on the safeguarding measures actually implemented.' },
+];
+
+/* ---------------------------------------------------------- myth-busting */
+const ICH_MYTHS = [
+  {
+    myth: 'Inscription protects the tradition',
+    reality: 'It does not. Inscription is recognition, not protection. It carries no legal force in Indian law, imposes no restriction on anyone, and does not by itself fund anything. What safeguards a tradition is transmission — someone teaching it to someone younger.',
+    icon: '🛡️',
+  },
+  {
+    myth: 'It gives India ownership of the practice',
+    reality: 'It gives no ownership to anyone. The heritage belongs to the communities that practise it, not to the state that nominated it. Nowruz is inscribed jointly by twelve countries precisely because no one of them can claim it.',
+    icon: '🔓',
+  },
+  {
+    myth: 'It means the tradition is the best of its kind',
+    reality: 'The Representative List makes no comparative judgment at all. There is no ranking, no "better than", and an element not on the list is not thereby less significant. This is a deliberate difference from the World Heritage criterion of Outstanding Universal Value.',
+    icon: '⚖️',
+  },
+  {
+    myth: 'Only inscribed elements are protected traditions',
+    reality: 'India\'s National ICH Inventory lists hundreds of elements. UNESCO inscription covers fifteen because states may submit only a limited number of files per cycle — the list reflects nomination capacity as much as cultural significance.',
+    icon: '📚',
+  },
+  {
+    myth: 'It restricts who may perform',
+    reality: 'It restricts nobody. Inscription does not create a licence, a monopoly or a certification. Anyone the community\'s own norms permit may continue to practise exactly as before.',
+    icon: '🚪',
+  },
+  {
+    myth: 'The tradition is now frozen in its inscribed form',
+    reality: 'The Convention explicitly recognises that living heritage changes. An element is expected to be recreated by its community in response to its environment. Freezing a practice at its documented state would defeat the purpose.',
+    icon: '🔄',
+  },
+];
+
+/* ------------------------------------------------------------- timeline */
+const ICH_TIMELINE = [
+  { year: '2001', title: 'Kutiyattam proclaimed', desc: 'Kutiyattam is proclaimed a Masterpiece of the Oral and Intangible Heritage of Humanity in the first-ever round, before the 2003 Convention exists.' },
+  { year: '2003', title: 'Vedic chanting proclaimed', desc: 'The tradition of Vedic chanting is proclaimed in the second round of Masterpieces.' },
+  { year: '2003', title: 'The Convention is adopted', desc: 'UNESCO adopts the Convention for the Safeguarding of the Intangible Cultural Heritage, creating a framework separate from the 1972 World Heritage Convention.' },
+  { year: '2005', title: 'Ramlila proclaimed', desc: 'Ramlila is proclaimed in the third and final round of Masterpieces.' },
+  { year: '2008', title: 'Three elements inscribed', desc: 'The three earlier Masterpieces — Kutiyattam, Vedic chanting and Ramlila — are incorporated into the new Representative List.' },
+  { year: '2009', title: 'Ramman', desc: 'The ritual theatre of two Garhwal villages is inscribed — the narrowest in geographic scope of India\'s elements.' },
+  { year: '2010', title: 'Three inscriptions', desc: 'Chhau Dance, Kalbelia folk songs and dances, and Mudiyettu are inscribed together.' },
+  { year: '2012', title: 'Buddhist Chanting of Ladakh', desc: 'The recitation traditions of the Ladakhi monasteries are inscribed.' },
+  { year: '2013', title: 'Sankirtana of Manipur', desc: 'The ritual singing, drumming and dancing of the Manipuri Vaishnava tradition is inscribed.' },
+  { year: '2014', title: 'Thatheras of Jandiala Guru', desc: 'India\'s only craft inscription, and the only one covering a single town\'s community.' },
+  { year: '2016', title: 'Nowruz and Yoga', desc: 'India joins the multinational Nowruz inscription, and Yoga is inscribed under knowledge concerning nature and the universe.' },
+  { year: '2017', title: 'Kumbh Mela', desc: 'The largest peaceful gathering on earth is inscribed, with UNESCO noting its inclusiveness across caste, creed and gender.' },
+  { year: '2021', title: 'Durga Puja in Kolkata', desc: 'Inscribed specifically as practised in Kolkata, for its function as citywide public art and its collapsing of social boundaries.' },
+  { year: '2023', title: 'Garba of Gujarat', desc: 'India\'s fifteenth inscription, in December 2023.' },
+];
+
+/* ----------------------------------------------------------- safeguarding */
+const ICH_SAFEGUARD = [
+  { icon: '👨‍👩‍👧', title: 'Transmission is the whole point', desc: 'The Convention defines safeguarding as ensuring viability — identification, documentation, research, preservation, promotion, and above all transmission through formal and non-formal education. A tradition nobody is learning is not safeguarded, however well documented it is.' },
+  { icon: '📉', title: 'Where the pressure is', desc: 'Out-migration is the most common threat on this list. Ramman needs specific families in specific villages; Kutiyattam needs a small number of teachers; the Thatheras need a market for hand-beaten utensils. In each case the practice depends on people staying and continuing.' },
+  { icon: '🏛️', title: 'Sangeet Natak Akademi', desc: 'India\'s nodal agency for intangible cultural heritage. It maintains the National ICH Inventory, prepares nomination files, and runs the guru-shishya parampara scheme that funds masters to teach students directly.' },
+  { icon: '💰', title: 'Scheme support', desc: 'The Ministry of Culture runs schemes for safeguarding intangible heritage, supporting documentation, training and performance. Inscription itself brings no automatic funding — the money comes from national schemes, not from UNESCO.' },
+  { icon: '⚠️', title: 'The commercialisation problem', desc: 'Visibility cuts both ways. It can create livelihoods, as with Kalbelia performance after snake charming ended, and it can hollow a practice out into a version shaped for audiences rather than for the community. Both happen, sometimes to the same tradition.' },
+  { icon: '📼', title: 'Documentation is not preservation', desc: 'Recording a practice preserves a record of it. It does not preserve the practice. This distinction is central to the 2003 Convention and is the main way it differs in spirit from the 1972 one.' },
+];
+
+/* -------------------------------------------------------------- gallery */
+const ICH_GALLERY = [
+  { icon: '👁️', title: 'Netrabhinaya', caption: 'In Kutiyattam, a whole scene can be carried by the eyes alone.' },
+  { icon: '📿', title: 'Ghana-patha', caption: 'Permuted recitation that makes an oral text self-checking.' },
+  { icon: '🏘️', title: 'Ramnagar Ramlila', caption: 'A month long, with the town itself as the set.' },
+  { icon: '🎭', title: 'Chhau Masks', caption: 'Seraikela and Purulia use them; Mayurbhanj does not.' },
+  { icon: '🎨', title: 'The Kalam', caption: 'In Mudiyettu the goddess is drawn on the floor, worshipped, and erased.' },
+  { icon: '🥁', title: 'Pung Cholom', caption: 'The drum dance at the centre of Manipuri sankirtana.' },
+  { icon: '🔨', title: 'Hand-beaten Brass', caption: 'The Thatheras of Jandiala Guru — one town, one craft, one inscription.' },
+  { icon: '🪔', title: 'Kumartuli', caption: 'The idol-makers\' quarter that Durga Puja in Kolkata runs on.' },
+  { icon: '🕉️', title: 'Kumbh', caption: 'Tens of millions of people, timed by the positions of the planets.' },
+  { icon: '💃', title: 'Garba', caption: 'A circle around a lamp — garbha, the womb.' },
+];
+
+/* ---------------------------------------------------------------- facts */
+const ICH_FACTS = [
+  'UNESCO runs two entirely separate conventions. The 1972 one covers World Heritage Sites — places. The 2003 one covers intangible cultural heritage — practices. India has 40+ of the first and 15 of the second, and they are routinely confused.',
+  'Kutiyattam was among the very first elements UNESCO recognised anywhere, proclaimed a Masterpiece in 2001 — two years before the Convention that now governs the list existed.',
+  'Vedic chanting methods such as jata-patha and ghana-patha recite the text in fixed permuted orders, so an error in one recitation shows up against the others. It is an oral error-correcting code, three thousand years old.',
+  'Ramman is practised in two villages — Saloor-Dungra in Chamoli district — and nowhere else. Specific families hold specific roles, so out-migration is an existential threat rather than a general one.',
+  'Chhau has three regional styles. Seraikela and Purulia use masks; Mayurbhanj does not.',
+  'The Kalbelia were snake handlers until the Wildlife Protection Act, 1972 ended that livelihood. Their songs and dances became both a cultural continuity and an economic one.',
+  'The Thatheras of Jandiala Guru are India\'s only craft inscription — and what is inscribed is the skill and its transmission, not the utensils.',
+  'Yoga was inscribed under "knowledge and practices concerning nature and the universe", not under performing arts. The category reflects what was actually nominated.',
+  'Nowruz is a multinational inscription shared by twelve countries. ICH elements are not required to stop at borders, and the Convention has a mechanism for that.',
+  'Durga Puja is inscribed specifically as practised in Kolkata, not as a general festival — for its function as citywide public art and its collapsing of class and religious boundaries in public space.',
+  'Garba, inscribed in December 2023, is India\'s most recent element. The name comes from garbha, meaning womb, referring to the lamp at the centre of the circle.',
+  'Inscription confers no legal protection, no funding by default, no ownership and no exclusivity. It is recognition. What actually safeguards a tradition is somebody teaching it to somebody younger.',
+];
+
+/* ----------------------------------------------------------------- quiz */
+const ICH_QUIZ = [
+  {
+    q: 'What is the difference between a UNESCO World Heritage Site and an intangible cultural heritage element?',
+    options: [
+      'One is natural and the other is cultural',
+      'They fall under two different conventions — 1972 covers places, 2003 covers practices',
+      'One is permanent and the other is reviewed every ten years',
+      'There is no difference; they are two names for the same list',
+    ],
+    answer: 1,
+    explain: 'Two separate conventions with separate lists and separate criteria. The 1972 Convention covers monuments, sites and natural properties; the 2003 Convention covers living practices.',
+  },
+  {
+    q: 'How many Indian elements are on the UNESCO Representative List of Intangible Cultural Heritage?',
+    options: ['10', '15', '25', '40'],
+    answer: 1,
+    explain: 'Fifteen, from Kutiyattam in 2008 to Garba of Gujarat in 2023.',
+  },
+  {
+    q: 'What does inscription on the Representative List actually do?',
+    options: [
+      'It legally protects the tradition under Indian law',
+      'It provides recognition and visibility — no legal force, no automatic funding, no exclusivity',
+      'It grants India ownership of the practice',
+      'It requires the tradition to be performed in its documented form',
+    ],
+    answer: 1,
+    explain: 'Inscription is recognition. It carries no legal force, no default funding and no ownership. What safeguards a tradition is transmission.',
+  },
+  {
+    q: 'Which Indian element is practised in only two villages?',
+    options: ['Mudiyettu', 'Ramman', 'Chhau', 'Sankirtana'],
+    answer: 1,
+    explain: 'Ramman, in the twin villages of Saloor-Dungra in Chamoli district, Uttarakhand. Specific families hold specific roles.',
+  },
+  {
+    q: 'Under which ICH domain was Yoga inscribed?',
+    options: [
+      'Performing arts',
+      'Knowledge and practices concerning nature and the universe',
+      'Social practices, rituals and festive events',
+      'Traditional craftsmanship',
+    ],
+    answer: 1,
+    explain: 'Knowledge and practices concerning nature and the universe — reflecting yoga as a system of thought rather than as physical exercise.',
+  },
+  {
+    q: 'What makes Vedic chanting methods such as ghana-patha remarkable?',
+    options: [
+      'They are sung to a fixed melody preserved unchanged',
+      'They recite words in permuted orders so that errors become detectable',
+      'They are performed only by a single family',
+      'They were written down in the second century BCE',
+    ],
+    answer: 1,
+    explain: 'The permutation acts as an oral error-correcting mechanism — an error in one recitation is exposed by comparison with the others.',
+  },
+  {
+    q: 'Which is India\'s only inscribed traditional craft?',
+    options: [
+      'Kalbelia embroidery',
+      'The brass and copper utensil craft of the Thatheras of Jandiala Guru',
+      'Kumartuli idol-making',
+      'Chhau mask-making',
+    ],
+    answer: 1,
+    explain: 'The Thatheras of Jandiala Guru in Punjab, inscribed in 2014 — and what is inscribed is the skill and its transmission, not the objects.',
+  },
+  {
+    q: 'Why is Nowruz a multinational inscription?',
+    options: [
+      'Because it is celebrated on the same date everywhere',
+      'Because it is practised across many countries and no single state can claim it',
+      'Because UNESCO requires all festivals to be jointly nominated',
+      'Because India nominated it on behalf of the region',
+    ],
+    answer: 1,
+    explain: 'Twelve countries are party to it. The multinational format exists precisely so that shared practices need not be claimed by one state.',
+  },
+  {
+    q: 'What is the kalam in Mudiyettu?',
+    options: [
+      'A ritual drum',
+      'A large drawing of the goddess made on the temple floor in coloured powders',
+      'The mask worn by the performer playing Kali',
+      'The temple hall where the performance takes place',
+    ],
+    answer: 1,
+    explain: 'It is created, worshipped and then deliberately erased as part of the ritual.',
+  },
+  {
+    q: 'Which body is India\'s nodal agency for intangible cultural heritage?',
+    options: [
+      'Archaeological Survey of India',
+      'Sangeet Natak Akademi',
+      'Indira Gandhi National Centre for the Arts',
+      'National Museum',
+    ],
+    answer: 1,
+    explain: 'The Sangeet Natak Akademi maintains the National ICH Inventory and prepares nomination files. The ASI handles tangible heritage.',
+  },
+  {
+    q: 'Why must a nomination have community consent?',
+    options: [
+      'To confirm the tradition is old enough to qualify',
+      'Because the heritage belongs to the community, and free prior informed consent is a Convention requirement',
+      'To establish who owns the copyright',
+      'It is recommended but not required',
+    ],
+    answer: 1,
+    explain: 'The Convention requires free, prior and informed consent. A nomination made over a community\'s head does not meet its requirements.',
+  },
+  {
+    q: 'Which is India\'s most recent inscription?',
+    options: ['Durga Puja in Kolkata (2021)', 'Garba of Gujarat (2023)', 'Kumbh Mela (2017)', 'Yoga (2016)'],
+    answer: 1,
+    explain: 'Garba of Gujarat, inscribed in December 2023 — the fifteenth Indian element on the Representative List.',
+  },
+];

--- a/frontend/intangible-heritage-explorer/index.html
+++ b/frontend/intangible-heritage-explorer/index.html
@@ -1,0 +1,288 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Explore India's 15 UNESCO Intangible Cultural Heritage inscriptions — Kutiyattam, Vedic chanting, Ramlila, Chhau, Kalbelia, Yoga, Kumbh Mela, Durga Puja, Garba and more — under the 2003 Convention." />
+  <title>UNESCO Intangible Cultural Heritage of India | Incredible India</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="../../styles.css" />
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <script>
+    (function () {
+      const theme = localStorage.getItem('theme') || 'dark';
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+
+  <header class="navbar scrolled" id="navbar">
+    <div class="nav-container">
+      <a href="../../index.html#home" class="nav-logo" id="nav-logo"><span class="saffron">Incredible</span> <span class="gold">India</span> <span class="green">Explorer</span></a>
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false"><span class="bar"></span><span class="bar"></span><span class="bar"></span></button>
+      <nav class="nav-menu" id="nav-menu">
+        <a href="../../index.html#home" class="nav-link">Home</a>
+        <a href="../unesco/unesco.html" class="nav-link">UNESCO Sites</a>
+        <a href="index.html" class="nav-link active" style="color:var(--ic-gold)">Intangible Heritage</a>
+        <div class="nav-dropdown">
+          <button class="nav-link dropdown-toggle" id="link-explore-more">Explore More ▾</button>
+          <div class="dropdown-menu">
+            <a href="../classical-dances/index.html" class="dropdown-item">Classical Dances</a>
+            <a href="../folk-dances/index.html" class="dropdown-item">Folk Dances</a>
+            <a href="../festivals/festivals.html" class="dropdown-item">Festivals</a>
+            <a href="../arts-crafts/arts-crafts.html" class="dropdown-item">Arts &amp; Crafts</a>
+            <a href="../culture/culture.html" class="dropdown-item">Culture</a>
+          </div>
+        </div>
+        <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">☀️</button>
+      </nav>
+    </div>
+  </header>
+
+  <main class="ic-page">
+    <!-- ================= HERO ================= -->
+    <section class="hero-section">
+      <div class="hero-bg"></div>
+      <div class="hero-content">
+        <span class="hero-badge">🎭 The 2003 Convention</span>
+        <h1>Intangible <span>Cultural Heritage of India</span></h1>
+        <p>UNESCO runs two entirely separate conventions. The 1972 one lists places. The 2003 one lists practices — performance, ritual, oral tradition, craft skill. India has fifteen elements on the second list, and almost nobody distinguishes it from the first. This page does.</p>
+        <div class="hero-stats">
+          <div class="hero-stat"><span class="number" id="stat-elements">15</span><span class="label">Inscribed Elements</span></div>
+          <div class="hero-stat"><span class="number" id="stat-domains">5</span><span class="label">ICH Domains</span></div>
+          <div class="hero-stat"><span class="number" id="stat-first">2008</span><span class="label">First Inscriptions</span></div>
+          <div class="hero-stat"><span class="number" id="stat-latest">2023</span><span class="label">Most Recent</span></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ================= THE TWO CONVENTIONS ================= -->
+    <section class="section-container" id="overview">
+      <div class="section-header">
+        <span class="section-badge">Two Different Things</span>
+        <h2>Places vs Practices</h2>
+        <p class="section-subtitle">The site already has pages for World Heritage Sites. This is the other list, and it works on entirely different principles.</p>
+      </div>
+      <div class="content-section glass-card">
+        <div class="content-text">
+          <p>The <strong>World Heritage Convention of 1972</strong> lists properties — the Taj Mahal, Hampi, the Western Ghats. It judges them against <em>Outstanding Universal Value</em>, which is an explicitly comparative standard, and it places conservation obligations on the state that owns them.</p>
+          <p>The <strong>Convention for the Safeguarding of the Intangible Cultural Heritage, 2003</strong> does none of that. It lists living practices, and it makes no comparative judgment at all — the list is called <em>Representative</em>, not "best of". What it asks a state to safeguard is not fabric but <strong>transmission</strong>: whether the practice is still being passed to the next generation. A perfectly documented tradition that nobody is learning has not been safeguarded.</p>
+          <p>The most important consequence is about ownership. A World Heritage property belongs to the State Party. An intangible element belongs to <strong>the community that practises it</strong>. The state nominates; it does not acquire. That is why Nowruz is inscribed jointly by twelve countries — no one of them can claim it, and the Convention has a mechanism for exactly that situation.</p>
+          <ul>
+            <li>Two conventions, two lists, two sets of criteria — routinely conflated</li>
+            <li>No ranking: the Representative List makes no "better than" judgment</li>
+            <li>Safeguarding means transmission, not documentation</li>
+            <li>The heritage belongs to the community, not to the nominating state</li>
+          </ul>
+        </div>
+        <div class="side-note">
+          <div class="big-icon">📜</div>
+          <h3>Why Only Fifteen?</h3>
+          <p>India's National ICH Inventory lists hundreds of elements. Fifteen are on the UNESCO list because States Parties may submit only a limited number of files per cycle, and files are frequently referred back for more information. <em>The list reflects nomination capacity as much as cultural significance</em> — an element not on it is not thereby less important.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- ================= COMPARISON TABLE ================= -->
+    <section class="section-container" id="compare">
+      <div class="section-header">
+        <span class="section-badge">Side by Side</span>
+        <h2>The 1972 and 2003 Conventions</h2>
+        <p class="section-subtitle">Eight differences, of which the last three are the ones that get missed.</p>
+      </div>
+      <div class="table-wrap glass-card">
+        <table class="compare-table">
+          <caption class="sr-only">Comparison of the 1972 World Heritage Convention and the 2003 Intangible Cultural Heritage Convention</caption>
+          <thead>
+            <tr>
+              <th scope="col">Aspect</th>
+              <th scope="col">World Heritage (1972)</th>
+              <th scope="col">Intangible Heritage (2003)</th>
+            </tr>
+          </thead>
+          <tbody id="compare-body"><!-- populated by script.js --></tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- ================= DOMAINS ================= -->
+    <section class="section-container" id="domains">
+      <div class="section-header">
+        <span class="section-badge">Five Domains</span>
+        <h2>What Counts as Intangible Heritage</h2>
+        <p class="section-subtitle">The Convention's five domains. Click a card to filter the elements below.</p>
+      </div>
+      <div class="domain-grid" id="domain-grid"><!-- populated by script.js --></div>
+    </section>
+
+    <!-- ================= EXPLORER ================= -->
+    <section class="section-container" id="explorer">
+      <div class="section-header">
+        <span class="section-badge">Browse</span>
+        <h2>The Fifteen Elements</h2>
+        <p class="section-subtitle">Search by name, state or community. Filter by domain or region, and sort by year or name. Each card names the community that holds the practice.</p>
+      </div>
+
+      <div class="filter-bar glass-card">
+        <div class="search-row">
+          <label class="sr-only" for="ic-search">Search inscribed elements</label>
+          <input type="search" id="ic-search" class="ic-search" placeholder="Search an element, state or community…" autocomplete="off" />
+          <button type="button" id="reset-filters" class="btn-reset">Reset</button>
+        </div>
+        <div class="filter-row">
+          <span class="filter-label">Domain</span>
+          <div class="chip-group" id="domain-chips" role="group" aria-label="Filter by ICH domain"><!-- populated by script.js --></div>
+        </div>
+        <div class="filter-row">
+          <span class="filter-label">Region</span>
+          <div class="chip-group" id="region-chips" role="group" aria-label="Filter by region"><!-- populated by script.js --></div>
+        </div>
+        <div class="filter-row sort-row">
+          <span class="filter-label">Sort by</span>
+          <div class="chip-group" id="sort-chips" role="group" aria-label="Sort elements">
+            <button type="button" class="chip active" data-sort="year">Year inscribed</button>
+            <button type="button" class="chip" data-sort="name">Name</button>
+            <button type="button" class="chip" data-sort="state">State</button>
+          </div>
+        </div>
+        <p class="result-count" id="result-count" aria-live="polite"></p>
+      </div>
+
+      <div class="element-grid" id="element-grid"><!-- populated by script.js --></div>
+      <div class="empty-state" id="empty-state" hidden>
+        <div class="big-icon">🔍</div>
+        <h3>No elements match those filters</h3>
+        <p>Try a different domain, or clear the search box.</p>
+      </div>
+    </section>
+
+    <!-- ================= TIMELINE ================= -->
+    <section class="section-container" id="timeline">
+      <div class="section-header">
+        <span class="section-badge">2001 to 2023</span>
+        <h2>Inscription Timeline</h2>
+        <p class="section-subtitle">Three of India's elements were recognised before the Convention that governs them existed.</p>
+      </div>
+      <div class="timeline" id="timeline-track"><!-- populated by script.js --></div>
+    </section>
+
+    <!-- ================= NOMINATION PROCESS ================= -->
+    <section class="section-container" id="process">
+      <div class="section-header">
+        <span class="section-badge">How It Works</span>
+        <h2>The Nomination Process</h2>
+        <p class="section-subtitle">Six steps. The first one — community consent — is a hard requirement, not a formality.</p>
+      </div>
+      <div class="process-grid" id="process-grid"><!-- populated by script.js --></div>
+    </section>
+
+    <!-- ================= MYTHS ================= -->
+    <section class="section-container" id="myths">
+      <div class="section-header">
+        <span class="section-badge">Setting It Straight</span>
+        <h2>What Inscription Does Not Do</h2>
+        <p class="section-subtitle">Six things routinely claimed about UNESCO inscription that are not true.</p>
+      </div>
+      <div class="myth-grid" id="myth-grid"><!-- populated by script.js --></div>
+    </section>
+
+    <!-- ================= SAFEGUARDING ================= -->
+    <section class="section-container" id="safeguarding">
+      <div class="section-header">
+        <span class="section-badge">Living Traditions</span>
+        <h2>Safeguarding &amp; Transmission</h2>
+        <p class="section-subtitle">What actually keeps a practice alive, and where the pressure on these fifteen currently sits.</p>
+      </div>
+      <div class="safeguard-grid" id="safeguard-grid"><!-- populated by script.js --></div>
+    </section>
+
+    <!-- ================= QUIZ ================= -->
+    <section class="section-container" id="quiz">
+      <div class="section-header">
+        <span class="section-badge">Test Yourself</span>
+        <h2>Intangible Heritage Quiz</h2>
+        <p class="section-subtitle">Twelve questions on the Convention and the fifteen elements.</p>
+      </div>
+      <div class="quiz-section glass-card" id="quiz-section"><!-- populated by script.js --></div>
+    </section>
+
+    <!-- ================= GALLERY ================= -->
+    <section class="section-container" id="gallery">
+      <div class="section-header">
+        <span class="section-badge">Visual Journey</span>
+        <h2>Gallery</h2>
+        <p class="section-subtitle">Ten things worth picturing.</p>
+      </div>
+      <div class="gallery-grid" id="gallery-grid"><!-- populated by script.js --></div>
+    </section>
+
+    <!-- ================= FACTS ================= -->
+    <section class="section-container" id="facts">
+      <div class="section-header">
+        <span class="section-badge">Did You Know?</span>
+        <h2>Interesting Facts</h2>
+        <p class="section-subtitle">Twelve things about India's living heritage.</p>
+      </div>
+      <div class="facts-grid" id="facts-grid"><!-- populated by script.js --></div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-container">
+      <div class="footer-section">
+        <h3>Incredible India Explorer</h3>
+        <p>An interactive digital guide to the ecology, culture and natural heritage of India.</p>
+      </div>
+      <div class="footer-links">
+        <h3>Quick Navigation</h3>
+        <ul>
+          <li><a href="../../index.html#home">Home</a></li>
+          <li><a href="../unesco/unesco.html">UNESCO World Heritage</a></li>
+          <li><a href="../classical-dances/index.html">Classical Dances</a></li>
+          <li><a href="../festivals/festivals.html">Festivals</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-credits footer-credits-center">
+      <p>&copy; 2026 Incredible India Explorer. Created with Vanilla HTML, CSS &amp; JavaScript.</p>
+      <p class="footer-note">These are living traditions belonging to the communities that practise them. Inscription is recognition, not ownership.</p>
+    </div>
+  </footer>
+
+  <!-- Element detail modal -->
+  <div class="ic-modal" id="ic-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" hidden>
+    <div class="ic-modal-backdrop" id="modal-backdrop"></div>
+    <div class="ic-modal-card" role="document">
+      <button class="ic-modal-close" id="modal-close" aria-label="Close details">&times;</button>
+      <div class="ic-modal-head">
+        <span class="ic-modal-icon" id="modal-icon">🎭</span>
+        <div>
+          <h3 id="modal-title">Element</h3>
+          <p class="ic-modal-tagline" id="modal-tagline"></p>
+        </div>
+      </div>
+      <div class="ic-modal-meta" id="modal-meta"></div>
+      <p class="ic-modal-desc" id="modal-desc"></p>
+
+      <h4 class="ic-modal-subhead">At a Glance</h4>
+      <dl class="spec-list" id="modal-specs"></dl>
+
+      <h4 class="ic-modal-subhead">Detail</h4>
+      <p class="ic-modal-detail" id="modal-detail"></p>
+
+      <h4 class="ic-modal-subhead">Current Status</h4>
+      <p class="ic-modal-status" id="modal-status"></p>
+    </div>
+  </div>
+
+  <script src="../app.js" defer></script>
+  <script src="data.js" defer></script>
+  <script src="script.js" defer></script>
+  <script type="module" src="../auth.js"></script>
+</body>
+</html>

--- a/frontend/intangible-heritage-explorer/index.html
+++ b/frontend/intangible-heritage-explorer/index.html
@@ -166,7 +166,7 @@
       <div class="section-header">
         <span class="section-badge">2001 to 2023</span>
         <h2>Inscription Timeline</h2>
-        <p class="section-subtitle">Three of India's elements were recognised before the Convention that governs them existed.</p>
+        <p class="section-subtitle">Three of India's elements were proclaimed Masterpieces under the earlier programme, before the Representative List existed, and were folded into it in 2008.</p>
       </div>
       <div class="timeline" id="timeline-track"><!-- populated by script.js --></div>
     </section>

--- a/frontend/intangible-heritage-explorer/index.html
+++ b/frontend/intangible-heritage-explorer/index.html
@@ -145,9 +145,9 @@
         <div class="filter-row sort-row">
           <span class="filter-label">Sort by</span>
           <div class="chip-group" id="sort-chips" role="group" aria-label="Sort elements">
-            <button type="button" class="chip active" data-sort="year">Year inscribed</button>
-            <button type="button" class="chip" data-sort="name">Name</button>
-            <button type="button" class="chip" data-sort="state">State</button>
+            <button type="button" class="chip active" data-sort="year" aria-pressed="true">Year inscribed</button>
+            <button type="button" class="chip" data-sort="name" aria-pressed="false">Name</button>
+            <button type="button" class="chip" data-sort="state" aria-pressed="false">State</button>
           </div>
         </div>
         <p class="result-count" id="result-count" aria-live="polite"></p>

--- a/frontend/intangible-heritage-explorer/script.js
+++ b/frontend/intangible-heritage-explorer/script.js
@@ -1,0 +1,535 @@
+/* ==========================================================================
+   UNESCO INTANGIBLE CULTURAL HERITAGE OF INDIA — INTERACTION LAYER
+   Vanilla JS, no dependencies. Everything renders from data.js.
+   ========================================================================== */
+
+(function () {
+  'use strict';
+
+  const DEFAULT_FILTERS = { search: '', domain: 'all', region: 'all', sort: 'year' };
+
+  let filters = Object.assign({}, DEFAULT_FILTERS);
+  let quizState = { current: 0, score: 0, answered: false };
+  let lastFocused = null;
+
+  document.addEventListener('DOMContentLoaded', function () {
+    if (typeof ICH_ELEMENTS === 'undefined') {
+      console.error('intangible-heritage-explorer: data.js failed to load');
+      return;
+    }
+    renderHeroStats();
+    renderComparisonTable();
+    renderDomains();
+    renderChips('domain-chips', 'domain', ICH_DOMAINS.map(toChip));
+    renderChips('region-chips', 'region', ICH_REGIONS.map(toChip));
+    bindSortChips();
+    renderElements();
+    renderTimeline();
+    renderProcess();
+    renderMyths();
+    renderSafeguarding();
+    renderQuiz();
+    renderGallery();
+    renderFacts();
+    bindSearch();
+    bindModal();
+    revealVisible();
+  });
+
+  /* ---------------------------------------------------------------- utils */
+
+  function escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function toChip(item) {
+    return { value: item.key, label: item.name, icon: item.icon };
+  }
+
+  function lookup(list, key, field) {
+    for (let i = 0; i < list.length; i++) {
+      if (list[i].key === key) return list[i][field];
+    }
+    return field === 'icon' ? '' : key;
+  }
+
+  function setText(id, value) {
+    const el = document.getElementById(id);
+    if (el) el.textContent = value;
+  }
+
+  /* ------------------------------------------------------------ hero stats */
+
+  function renderHeroStats() {
+    let earliest = Infinity;
+    let latest = 0;
+
+    ICH_ELEMENTS.forEach(function (element) {
+      if (element.year < earliest) earliest = element.year;
+      if (element.year > latest) latest = element.year;
+    });
+
+    setText('stat-elements', ICH_ELEMENTS.length);
+    setText('stat-domains', ICH_DOMAINS.length);
+    setText('stat-first', earliest);
+    setText('stat-latest', latest);
+  }
+
+  /* ----------------------------------------------------- comparison table */
+
+  function renderComparisonTable() {
+    const body = document.getElementById('compare-body');
+    if (!body) return;
+
+    body.innerHTML = ICH_COMPARISON.map(function (row) {
+      return '<tr>' +
+        '<th scope="row">' + escapeHtml(row.aspect) + '</th>' +
+        '<td>' + escapeHtml(row.tangible) + '</td>' +
+        '<td class="cell-intangible">' + escapeHtml(row.intangible) + '</td>' +
+        '</tr>';
+    }).join('');
+  }
+
+  /* ---------------------------------------------------------- domain cards */
+
+  function renderDomains() {
+    const grid = document.getElementById('domain-grid');
+    if (!grid) return;
+
+    grid.innerHTML = ICH_DOMAINS.map(function (domain) {
+      const count = ICH_ELEMENTS.filter(function (element) {
+        return element.domain === domain.key;
+      }).length;
+
+      return '<button type="button" class="domain-card animate-on-scroll" data-domain="' +
+          escapeHtml(domain.key) + '">' +
+        '<span class="domain-icon" aria-hidden="true">' + domain.icon + '</span>' +
+        '<h3>' + escapeHtml(domain.name) + '</h3>' +
+        '<p>' + escapeHtml(domain.blurb) + '</p>' +
+        '<span class="domain-count">' + count + (count === 1 ? ' element' : ' elements') + '</span>' +
+        '</button>';
+    }).join('');
+
+    grid.addEventListener('click', function (event) {
+      const card = event.target.closest('.domain-card');
+      if (!card) return;
+      filters.domain = card.getAttribute('data-domain');
+      syncChips();
+      renderElements();
+      const explorer = document.getElementById('explorer');
+      if (explorer) explorer.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  }
+
+  /* ----------------------------------------------------------------- chips */
+
+  function renderChips(containerId, filterKey, items) {
+    const group = document.getElementById(containerId);
+    if (!group) return;
+
+    let html = '<button type="button" class="chip active" data-filter="' + filterKey + '" data-value="all">All</button>';
+    html += items.map(function (item) {
+      const icon = item.icon ? item.icon + ' ' : '';
+      return '<button type="button" class="chip" data-filter="' + filterKey + '" data-value="' +
+        escapeHtml(item.value) + '">' + icon + escapeHtml(item.label) + '</button>';
+    }).join('');
+
+    group.innerHTML = html;
+    group.addEventListener('click', onChipClick);
+  }
+
+  function onChipClick(event) {
+    const chip = event.target.closest('.chip');
+    if (!chip) return;
+    filters[chip.getAttribute('data-filter')] = chip.getAttribute('data-value');
+    syncChips();
+    renderElements();
+  }
+
+  function bindSortChips() {
+    const group = document.getElementById('sort-chips');
+    if (!group) return;
+    group.addEventListener('click', function (event) {
+      const chip = event.target.closest('.chip');
+      if (!chip) return;
+      filters.sort = chip.getAttribute('data-sort');
+      syncChips();
+      renderElements();
+    });
+  }
+
+  function syncChips() {
+    ['domain', 'region'].forEach(function (key) {
+      const chips = document.querySelectorAll('[data-filter="' + key + '"]');
+      Array.prototype.forEach.call(chips, function (chip) {
+        chip.classList.toggle('active', chip.getAttribute('data-value') === filters[key]);
+      });
+    });
+
+    const sortChips = document.querySelectorAll('[data-sort]');
+    Array.prototype.forEach.call(sortChips, function (chip) {
+      chip.classList.toggle('active', chip.getAttribute('data-sort') === filters.sort);
+    });
+  }
+
+  function bindSearch() {
+    const input = document.getElementById('ic-search');
+    const reset = document.getElementById('reset-filters');
+
+    if (input) {
+      input.addEventListener('input', function () {
+        filters.search = input.value.trim().toLowerCase();
+        renderElements();
+      });
+    }
+
+    if (reset) {
+      reset.addEventListener('click', function () {
+        filters = Object.assign({}, DEFAULT_FILTERS);
+        if (input) input.value = '';
+        syncChips();
+        renderElements();
+      });
+    }
+  }
+
+  /* --------------------------------------------------------- element cards */
+
+  function matchesFilters(element) {
+    if (filters.domain !== 'all' && element.domain !== filters.domain) return false;
+    if (filters.region !== 'all' && element.region !== filters.region) return false;
+    if (!filters.search) return true;
+
+    const haystack = [element.name, element.state, element.community,
+      element.tagline, element.desc, element.detail]
+      .join(' ')
+      .toLowerCase();
+
+    return haystack.indexOf(filters.search) !== -1;
+  }
+
+  function sortElements(list) {
+    const sorted = list.slice();
+    sorted.sort(function (a, b) {
+      if (filters.sort === 'name') return a.name.localeCompare(b.name);
+      if (filters.sort === 'state') {
+        const byState = a.state.localeCompare(b.state);
+        return byState !== 0 ? byState : a.year - b.year;
+      }
+      return a.year - b.year;
+    });
+    return sorted;
+  }
+
+  function renderElements() {
+    const grid = document.getElementById('element-grid');
+    const empty = document.getElementById('empty-state');
+    const counter = document.getElementById('result-count');
+    if (!grid) return;
+
+    const matches = sortElements(ICH_ELEMENTS.filter(matchesFilters));
+
+    if (counter) {
+      counter.textContent = matches.length === ICH_ELEMENTS.length
+        ? 'Showing all ' + ICH_ELEMENTS.length + ' elements'
+        : 'Showing ' + matches.length + ' of ' + ICH_ELEMENTS.length + ' elements';
+    }
+    if (empty) empty.hidden = matches.length !== 0;
+
+    grid.innerHTML = matches.map(function (element) {
+      const proclaimed = element.proclaimed
+        ? '<span class="element-proclaimed">Proclaimed a Masterpiece in ' + element.proclaimed + '</span>'
+        : '';
+
+      return '<article class="element-card animate-on-scroll domain-' + escapeHtml(element.domain) + '" ' +
+          'tabindex="0" role="button" data-name="' + escapeHtml(element.name) + '" ' +
+          'aria-label="View details for ' + escapeHtml(element.name) + '">' +
+        '<div class="element-head">' +
+          '<span class="element-icon" aria-hidden="true">' + element.icon + '</span>' +
+          '<span class="element-year">' + element.year + '</span>' +
+        '</div>' +
+        '<h3>' + escapeHtml(element.name) + '</h3>' +
+        '<p class="element-state">📍 ' + escapeHtml(element.state) + '</p>' +
+        '<p class="element-tagline">' + escapeHtml(element.tagline) + '</p>' +
+        '<p class="element-community"><strong>Held by:</strong> ' + escapeHtml(element.community) + '</p>' +
+        proclaimed +
+        '<div class="element-meta">' +
+          '<span class="pill pill-domain">' + lookup(ICH_DOMAINS, element.domain, 'icon') + ' ' +
+            escapeHtml(lookup(ICH_DOMAINS, element.domain, 'name')) + '</span>' +
+        '</div>' +
+        '<span class="element-cta">Full profile →</span>' +
+        '</article>';
+    }).join('');
+
+    revealVisible();
+  }
+
+  /* -------------------------------------------------------------- timeline */
+
+  function renderTimeline() {
+    const track = document.getElementById('timeline-track');
+    if (!track) return;
+
+    track.innerHTML = ICH_TIMELINE.map(function (entry, index) {
+      const side = index % 2 === 0 ? 'left' : 'right';
+      return '<div class="timeline-item timeline-' + side + ' animate-on-scroll">' +
+        '<div class="timeline-dot" aria-hidden="true"></div>' +
+        '<div class="timeline-body">' +
+          '<span class="timeline-year">' + escapeHtml(entry.year) + '</span>' +
+          '<h3>' + escapeHtml(entry.title) + '</h3>' +
+          '<p>' + escapeHtml(entry.desc) + '</p>' +
+        '</div>' +
+        '</div>';
+    }).join('');
+  }
+
+  /* ------------------------------------------------------- static sections */
+
+  function renderProcess() {
+    const grid = document.getElementById('process-grid');
+    if (!grid) return;
+
+    grid.innerHTML = ICH_PROCESS.map(function (item) {
+      return '<article class="process-card animate-on-scroll">' +
+        '<span class="process-step">' + escapeHtml(item.step) + '</span>' +
+        '<span class="process-icon" aria-hidden="true">' + item.icon + '</span>' +
+        '<h3>' + escapeHtml(item.title) + '</h3>' +
+        '<p>' + escapeHtml(item.desc) + '</p>' +
+        '</article>';
+    }).join('');
+  }
+
+  function renderMyths() {
+    const grid = document.getElementById('myth-grid');
+    if (!grid) return;
+
+    grid.innerHTML = ICH_MYTHS.map(function (item) {
+      return '<article class="myth-card animate-on-scroll">' +
+        '<div class="myth-icon">' + item.icon + '</div>' +
+        '<p class="myth-claim"><span class="myth-label">Claim</span>' + escapeHtml(item.myth) + '</p>' +
+        '<p class="myth-reality"><span class="reality-label">Actually</span>' + escapeHtml(item.reality) + '</p>' +
+        '</article>';
+    }).join('');
+  }
+
+  function renderSafeguarding() {
+    const grid = document.getElementById('safeguard-grid');
+    if (!grid) return;
+
+    grid.innerHTML = ICH_SAFEGUARD.map(function (item) {
+      return '<article class="safeguard-card animate-on-scroll">' +
+        '<div class="safeguard-icon">' + item.icon + '</div>' +
+        '<h3>' + escapeHtml(item.title) + '</h3>' +
+        '<p>' + escapeHtml(item.desc) + '</p>' +
+        '</article>';
+    }).join('');
+  }
+
+  function renderGallery() {
+    const grid = document.getElementById('gallery-grid');
+    if (!grid) return;
+
+    grid.innerHTML = ICH_GALLERY.map(function (item) {
+      return '<figure class="gallery-item animate-on-scroll">' +
+        '<div class="gallery-visual" aria-hidden="true">' + item.icon + '</div>' +
+        '<figcaption><strong>' + escapeHtml(item.title) + '</strong><span>' + escapeHtml(item.caption) + '</span></figcaption>' +
+        '</figure>';
+    }).join('');
+  }
+
+  function renderFacts() {
+    const grid = document.getElementById('facts-grid');
+    if (!grid) return;
+
+    grid.innerHTML = ICH_FACTS.map(function (fact, index) {
+      return '<div class="fact-card animate-on-scroll">' +
+        '<span class="fact-number">' + (index + 1) + '</span>' +
+        '<p>' + escapeHtml(fact) + '</p>' +
+        '</div>';
+    }).join('');
+  }
+
+  /* ----------------------------------------------------------------- modal */
+
+  function bindModal() {
+    const grid = document.getElementById('element-grid');
+    const modal = document.getElementById('ic-modal');
+    if (!grid || !modal) return;
+
+    grid.addEventListener('click', function (event) {
+      const card = event.target.closest('.element-card');
+      if (card) openModal(card.getAttribute('data-name'));
+    });
+
+    grid.addEventListener('keydown', function (event) {
+      if (event.key !== 'Enter' && event.key !== ' ') return;
+      const card = event.target.closest('.element-card');
+      if (!card) return;
+      event.preventDefault();
+      openModal(card.getAttribute('data-name'));
+    });
+
+    const close = document.getElementById('modal-close');
+    const backdrop = document.getElementById('modal-backdrop');
+    if (close) close.addEventListener('click', closeModal);
+    if (backdrop) backdrop.addEventListener('click', closeModal);
+
+    document.addEventListener('keydown', function (event) {
+      if (event.key === 'Escape' && !modal.hidden) closeModal();
+    });
+  }
+
+  function openModal(name) {
+    const element = ICH_ELEMENTS.filter(function (item) { return item.name === name; })[0];
+    const modal = document.getElementById('ic-modal');
+    if (!element || !modal) return;
+
+    lastFocused = document.activeElement;
+
+    document.getElementById('modal-icon').textContent = element.icon;
+    document.getElementById('modal-title').textContent = element.name;
+    document.getElementById('modal-tagline').textContent = element.tagline;
+    document.getElementById('modal-desc').textContent = element.desc;
+    document.getElementById('modal-detail').textContent = element.detail;
+    document.getElementById('modal-status').textContent = element.status;
+
+    document.getElementById('modal-meta').innerHTML =
+      '<span class="pill pill-year">Inscribed ' + element.year + '</span>' +
+      '<span class="pill pill-domain">' + lookup(ICH_DOMAINS, element.domain, 'icon') + ' ' +
+        escapeHtml(lookup(ICH_DOMAINS, element.domain, 'name')) + '</span>' +
+      '<span class="pill pill-region">' + lookup(ICH_REGIONS, element.region, 'icon') + ' ' +
+        escapeHtml(lookup(ICH_REGIONS, element.region, 'name')) + '</span>';
+
+    const specs = [
+      { label: 'Year inscribed', value: String(element.year) },
+      { label: 'Domain', value: lookup(ICH_DOMAINS, element.domain, 'name') },
+      { label: 'State / region', value: element.state },
+      { label: 'Community', value: element.community },
+    ];
+
+    if (element.proclaimed) {
+      specs.push({
+        label: 'Earlier recognition',
+        value: 'Proclaimed a Masterpiece of the Oral and Intangible Heritage of Humanity in ' + element.proclaimed,
+      });
+    }
+
+    document.getElementById('modal-specs').innerHTML = specs.map(function (spec) {
+      return '<dt>' + escapeHtml(spec.label) + '</dt><dd>' + escapeHtml(spec.value) + '</dd>';
+    }).join('');
+
+    modal.hidden = false;
+    document.body.classList.add('modal-open');
+    const close = document.getElementById('modal-close');
+    if (close) close.focus();
+  }
+
+  function closeModal() {
+    const modal = document.getElementById('ic-modal');
+    if (!modal) return;
+    modal.hidden = true;
+    document.body.classList.remove('modal-open');
+    if (lastFocused && typeof lastFocused.focus === 'function') lastFocused.focus();
+  }
+
+  /* ------------------------------------------------------------------ quiz */
+
+  function renderQuiz() {
+    const section = document.getElementById('quiz-section');
+    if (!section) return;
+
+    if (quizState.current >= ICH_QUIZ.length) {
+      const pct = Math.round((quizState.score / ICH_QUIZ.length) * 100);
+      const verdict = pct === 100 ? 'Perfect score — including what inscription actually does.'
+        : pct >= 75 ? 'Strong result. The comparison table is worth one more look.'
+        : pct >= 50 ? 'A reasonable start. Try the fifteen element cards again.'
+        : 'Worth another pass through the sections above.';
+
+      section.innerHTML =
+        '<div class="quiz-result">' +
+          '<div class="quiz-score">' + quizState.score + ' / ' + ICH_QUIZ.length + '</div>' +
+          '<p class="quiz-verdict">' + verdict + '</p>' +
+          '<button type="button" class="btn-quiz" id="quiz-restart">Try Again</button>' +
+        '</div>';
+
+      const restart = document.getElementById('quiz-restart');
+      if (restart) {
+        restart.addEventListener('click', function () {
+          quizState = { current: 0, score: 0, answered: false };
+          renderQuiz();
+        });
+      }
+      return;
+    }
+
+    const question = ICH_QUIZ[quizState.current];
+    section.innerHTML =
+      '<div class="quiz-progress">Question ' + (quizState.current + 1) + ' of ' + ICH_QUIZ.length +
+        '<span class="quiz-running-score">Score: ' + quizState.score + '</span></div>' +
+      '<h3 class="quiz-question">' + escapeHtml(question.q) + '</h3>' +
+      '<div class="quiz-options" id="quiz-options">' +
+        question.options.map(function (option, index) {
+          return '<button type="button" class="quiz-option" data-index="' + index + '">' +
+            escapeHtml(option) + '</button>';
+        }).join('') +
+      '</div>' +
+      '<div class="quiz-explain" id="quiz-explain" hidden></div>';
+
+    const options = document.getElementById('quiz-options');
+    options.addEventListener('click', function (event) {
+      const button = event.target.closest('.quiz-option');
+      if (!button || quizState.answered) return;
+      quizState.answered = true;
+
+      const chosen = parseInt(button.getAttribute('data-index'), 10);
+      const correct = question.answer;
+      if (chosen === correct) quizState.score++;
+
+      Array.prototype.forEach.call(options.querySelectorAll('.quiz-option'), function (opt, index) {
+        opt.disabled = true;
+        if (index === correct) opt.classList.add('correct');
+        else if (index === chosen) opt.classList.add('wrong');
+      });
+
+      const explain = document.getElementById('quiz-explain');
+      explain.hidden = false;
+      explain.innerHTML = '<p>' + escapeHtml(question.explain) + '</p>' +
+        '<button type="button" class="btn-quiz" id="quiz-next">' +
+        (quizState.current === ICH_QUIZ.length - 1 ? 'See Result' : 'Next Question') + '</button>';
+
+      document.getElementById('quiz-next').addEventListener('click', function () {
+        quizState.current++;
+        quizState.answered = false;
+        renderQuiz();
+      });
+    });
+  }
+
+  /* ------------------------------------------------------------ animations */
+
+  function revealVisible() {
+    const targets = document.querySelectorAll('.animate-on-scroll:not(.animate-visible)');
+    if (!targets.length) return;
+
+    if (!('IntersectionObserver' in window)) {
+      Array.prototype.forEach.call(targets, function (el) { el.classList.add('animate-visible'); });
+      return;
+    }
+
+    const observer = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('animate-visible');
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.08, rootMargin: '0px 0px -40px 0px' });
+
+    Array.prototype.forEach.call(targets, function (el) { observer.observe(el); });
+  }
+})();

--- a/frontend/intangible-heritage-explorer/script.js
+++ b/frontend/intangible-heritage-explorer/script.js
@@ -132,11 +132,11 @@
     const group = document.getElementById(containerId);
     if (!group) return;
 
-    let html = '<button type="button" class="chip active" data-filter="' + filterKey + '" data-value="all">All</button>';
+    let html = '<button type="button" class="chip active" data-filter="' + filterKey + '" data-value="all" aria-pressed="true">All</button>';
     html += items.map(function (item) {
       const icon = item.icon ? item.icon + ' ' : '';
       return '<button type="button" class="chip" data-filter="' + filterKey + '" data-value="' +
-        escapeHtml(item.value) + '">' + icon + escapeHtml(item.label) + '</button>';
+        escapeHtml(item.value) + '" aria-pressed="false">' + icon + escapeHtml(item.label) + '</button>';
     }).join('');
 
     group.innerHTML = html;
@@ -167,13 +167,17 @@
     ['domain', 'region'].forEach(function (key) {
       const chips = document.querySelectorAll('[data-filter="' + key + '"]');
       Array.prototype.forEach.call(chips, function (chip) {
-        chip.classList.toggle('active', chip.getAttribute('data-value') === filters[key]);
+        const active = chip.getAttribute('data-value') === filters[key];
+        chip.classList.toggle('active', active);
+        chip.setAttribute('aria-pressed', String(active));
       });
     });
 
     const sortChips = document.querySelectorAll('[data-sort]');
     Array.prototype.forEach.call(sortChips, function (chip) {
-      chip.classList.toggle('active', chip.getAttribute('data-sort') === filters.sort);
+      const active = chip.getAttribute('data-sort') === filters.sort;
+      chip.classList.toggle('active', active);
+      chip.setAttribute('aria-pressed', String(active));
     });
   }
 

--- a/frontend/intangible-heritage-explorer/style.css
+++ b/frontend/intangible-heritage-explorer/style.css
@@ -1,0 +1,1263 @@
+/* ==========================================================================
+   UNESCO INTANGIBLE CULTURAL HERITAGE OF INDIA — PAGE STYLES
+   Scoped under .ic-page with page-local custom properties.
+   ========================================================================== */
+
+:root {
+  --ic-gold: #fbbf24;
+  --ic-deep: #b45309;
+  --ic-plum: #a21caf;
+  --ic-indigo: #4f46e5;
+  --ic-alert: #dc2626;
+  --ic-good: #16a34a;
+  --ic-bg: linear-gradient(135deg, #120a16, #1a0f1c, #0c060f);
+  --ic-card: rgba(38, 22, 44, 0.58);
+  --ic-border: rgba(255, 255, 255, 0.09);
+  --ic-text: #fdf4f8;
+  --ic-sub: rgba(253, 244, 248, 0.68);
+}
+
+.light-theme {
+  --ic-bg: linear-gradient(135deg, #fdf4ff, #fff7ed, #faf5ff);
+  --ic-card: rgba(255, 255, 255, 0.87);
+  --ic-border: rgba(162, 28, 175, 0.16);
+  --ic-text: #1a0716;
+  --ic-sub: rgba(26, 7, 22, 0.68);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.ic-page {
+  background: var(--ic-bg);
+  color: var(--ic-text);
+  font-family: 'Outfit', sans-serif;
+  min-height: 100vh;
+  padding-top: 80px;
+  overflow-x: hidden;
+}
+
+body.modal-open {
+  overflow: hidden;
+}
+
+/* -------------------------------------------------------------- sections */
+
+.section-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 60px 20px;
+}
+
+.section-header {
+  text-align: center;
+  margin-bottom: 40px;
+}
+
+.section-badge {
+  display: inline-block;
+  background: linear-gradient(135deg, var(--ic-plum), var(--ic-gold));
+  color: #1a0716;
+  padding: 5px 16px;
+  border-radius: 20px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-bottom: 12px;
+}
+
+.section-header h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: 2.4rem;
+  font-weight: 700;
+  margin-bottom: 12px;
+  letter-spacing: -0.5px;
+}
+
+.section-subtitle {
+  color: var(--ic-sub);
+  font-size: 1.03rem;
+  max-width: 780px;
+  margin: 0 auto;
+  line-height: 1.65;
+}
+
+.glass-card {
+  background: var(--ic-card);
+  border: 1px solid var(--ic-border);
+  border-radius: 18px;
+  backdrop-filter: blur(10px);
+}
+
+/* ------------------------------------------------------------------ hero */
+
+.hero-section {
+  position: relative;
+  min-height: 62vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 90px 20px;
+  overflow: hidden;
+}
+
+.hero-bg {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 18% 22%, rgba(251, 191, 36, 0.2), transparent 55%),
+    radial-gradient(circle at 82% 74%, rgba(162, 28, 175, 0.24), transparent 55%),
+    linear-gradient(135deg, #120a16 0%, #2c1230 50%, #120a16 100%);
+  z-index: 0;
+}
+
+.light-theme .hero-bg {
+  background:
+    radial-gradient(circle at 18% 22%, rgba(254, 240, 138, 0.75), transparent 55%),
+    radial-gradient(circle at 82% 74%, rgba(240, 171, 252, 0.6), transparent 55%),
+    linear-gradient(135deg, #fdf4ff 0%, #fff7ed 50%, #fdf4ff 100%);
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  max-width: 880px;
+}
+
+.hero-badge {
+  display: inline-block;
+  padding: 7px 18px;
+  border-radius: 30px;
+  background: rgba(251, 191, 36, 0.14);
+  border: 1px solid rgba(251, 191, 36, 0.42);
+  color: var(--ic-gold);
+  font-size: 0.84rem;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  margin-bottom: 20px;
+}
+
+.light-theme .hero-badge { color: var(--ic-deep); }
+
+.hero-content h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2rem, 5vw, 3.4rem);
+  font-weight: 800;
+  line-height: 1.14;
+  margin-bottom: 18px;
+}
+
+.hero-content h1 span {
+  background: linear-gradient(135deg, var(--ic-gold), var(--ic-plum));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  display: block;
+}
+
+.light-theme .hero-content h1 span {
+  background: linear-gradient(135deg, var(--ic-deep), var(--ic-plum));
+  -webkit-background-clip: text;
+  background-clip: text;
+}
+
+.hero-content > p {
+  color: var(--ic-sub);
+  font-size: 1.06rem;
+  line-height: 1.72;
+  max-width: 800px;
+  margin: 0 auto 34px;
+}
+
+.hero-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 18px;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.hero-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 16px 10px;
+  border-radius: 14px;
+  background: var(--ic-card);
+  border: 1px solid var(--ic-border);
+}
+
+.hero-stat .number {
+  font-size: 1.7rem;
+  font-weight: 800;
+  color: var(--ic-gold);
+  line-height: 1.1;
+}
+
+.light-theme .hero-stat .number { color: var(--ic-deep); }
+
+.hero-stat .label {
+  font-size: 0.78rem;
+  color: var(--ic-sub);
+  text-transform: uppercase;
+  letter-spacing: 0.6px;
+}
+
+/* -------------------------------------------------------- overview block */
+
+.content-section {
+  display: grid;
+  grid-template-columns: 1.7fr 1fr;
+  gap: 28px;
+  padding: 32px;
+}
+
+.content-text p {
+  color: var(--ic-sub);
+  line-height: 1.78;
+  margin-bottom: 16px;
+  font-size: 1rem;
+}
+
+.content-text strong { color: var(--ic-text); }
+.content-text em { color: var(--ic-gold); font-style: italic; }
+.light-theme .content-text em { color: var(--ic-deep); }
+
+.content-text ul {
+  list-style: none;
+  padding: 0;
+  margin-top: 20px;
+}
+
+.content-text li {
+  position: relative;
+  padding-left: 24px;
+  margin-bottom: 11px;
+  color: var(--ic-sub);
+  line-height: 1.6;
+}
+
+.content-text li::before {
+  content: '◆';
+  position: absolute;
+  left: 3px;
+  top: 0;
+  color: var(--ic-gold);
+  font-size: 0.75rem;
+}
+
+.light-theme .content-text li::before { color: var(--ic-plum); }
+
+.side-note {
+  background: rgba(251, 191, 36, 0.08);
+  border: 1px solid rgba(251, 191, 36, 0.28);
+  border-radius: 16px;
+  padding: 24px;
+  align-self: start;
+}
+
+.side-note .big-icon {
+  font-size: 2.1rem;
+  margin-bottom: 10px;
+}
+
+.side-note h3 {
+  font-size: 1.12rem;
+  margin-bottom: 10px;
+  font-weight: 700;
+}
+
+.side-note p {
+  color: var(--ic-sub);
+  line-height: 1.68;
+  font-size: 0.94rem;
+}
+
+.side-note em { color: var(--ic-gold); font-style: italic; }
+.light-theme .side-note em { color: var(--ic-deep); }
+
+/* ----------------------------------------------------------------- table */
+
+.table-wrap {
+  overflow-x: auto;
+  padding: 8px;
+}
+
+.compare-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+}
+
+.compare-table th,
+.compare-table td {
+  text-align: left;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--ic-border);
+  font-size: 0.92rem;
+  line-height: 1.58;
+  vertical-align: top;
+}
+
+.compare-table thead th {
+  color: var(--ic-gold);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.7px;
+  font-size: 0.76rem;
+}
+
+.light-theme .compare-table thead th { color: var(--ic-deep); }
+
+.compare-table tbody th {
+  color: var(--ic-text);
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.compare-table td { color: var(--ic-sub); }
+
+.compare-table .cell-intangible {
+  color: var(--ic-text);
+  background: rgba(162, 28, 175, 0.09);
+}
+
+.compare-table tbody tr:last-child th,
+.compare-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+/* ---------------------------------------------------------- domain cards */
+
+.domain-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+}
+
+.domain-card {
+  background: var(--ic-card);
+  border: 1px solid var(--ic-border);
+  border-radius: 16px;
+  padding: 24px 20px;
+  text-align: left;
+  color: inherit;
+  font-family: inherit;
+  cursor: pointer;
+  transition: transform 0.22s ease, border-color 0.22s ease;
+}
+
+.domain-card:hover,
+.domain-card:focus-visible {
+  transform: translateY(-4px);
+  border-color: var(--ic-gold);
+  outline: none;
+}
+
+.domain-icon {
+  font-size: 1.9rem;
+  display: block;
+  margin-bottom: 10px;
+}
+
+.domain-card h3 {
+  font-size: 1rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+  line-height: 1.38;
+}
+
+.domain-card p {
+  color: var(--ic-sub);
+  font-size: 0.88rem;
+  line-height: 1.6;
+  margin-bottom: 12px;
+}
+
+.domain-count {
+  display: inline-block;
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: var(--ic-gold);
+  letter-spacing: 0.3px;
+}
+
+.light-theme .domain-count { color: var(--ic-deep); }
+
+/* ------------------------------------------------------------ filter bar */
+
+.filter-bar {
+  padding: 22px 24px;
+  margin-bottom: 28px;
+}
+
+.search-row {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.ic-search {
+  flex: 1;
+  padding: 12px 18px;
+  border-radius: 30px;
+  border: 1px solid var(--ic-border);
+  background: rgba(0, 0, 0, 0.22);
+  color: var(--ic-text);
+  font-family: inherit;
+  font-size: 0.95rem;
+}
+
+.light-theme .ic-search { background: rgba(255, 255, 255, 0.75); }
+
+.ic-search:focus {
+  outline: none;
+  border-color: var(--ic-gold);
+  box-shadow: 0 0 0 3px rgba(251, 191, 36, 0.2);
+}
+
+.btn-reset {
+  padding: 12px 22px;
+  border-radius: 30px;
+  border: 1px solid var(--ic-border);
+  background: transparent;
+  color: var(--ic-sub);
+  font-family: inherit;
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.btn-reset:hover {
+  color: var(--ic-gold);
+  border-color: var(--ic-gold);
+}
+
+.filter-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.filter-label {
+  font-size: 0.76rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-weight: 700;
+  color: var(--ic-sub);
+  padding-top: 8px;
+  min-width: 62px;
+}
+
+.chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  flex: 1;
+}
+
+.chip {
+  padding: 7px 15px;
+  border-radius: 20px;
+  border: 1px solid var(--ic-border);
+  background: transparent;
+  color: var(--ic-sub);
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.chip:hover {
+  border-color: var(--ic-gold);
+  color: var(--ic-text);
+}
+
+.chip.active {
+  background: linear-gradient(135deg, var(--ic-plum), var(--ic-gold));
+  border-color: transparent;
+  color: #1a0716;
+  font-weight: 700;
+}
+
+.result-count {
+  margin-top: 10px;
+  font-size: 0.86rem;
+  color: var(--ic-sub);
+  font-style: italic;
+}
+
+/* --------------------------------------------------------- element cards */
+
+.element-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(310px, 1fr));
+  gap: 20px;
+}
+
+.element-card {
+  background: var(--ic-card);
+  border: 1px solid var(--ic-border);
+  border-radius: 18px;
+  padding: 22px;
+  cursor: pointer;
+  display: flex;
+  flex-direction: column;
+  border-left: 4px solid var(--ic-border);
+  transition: transform 0.24s ease, border-color 0.24s ease, box-shadow 0.24s ease;
+}
+
+.element-card.domain-oral { border-left-color: var(--ic-indigo); }
+.element-card.domain-performing { border-left-color: var(--ic-plum); }
+.element-card.domain-social { border-left-color: var(--ic-gold); }
+.element-card.domain-nature { border-left-color: var(--ic-good); }
+.element-card.domain-craft { border-left-color: var(--ic-deep); }
+
+.element-card:hover,
+.element-card:focus-visible {
+  transform: translateY(-5px);
+  box-shadow: 0 16px 34px rgba(0, 0, 0, 0.34);
+  outline: none;
+}
+
+.element-card:focus-visible { border-color: var(--ic-gold); }
+
+.element-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.element-icon { font-size: 2rem; }
+
+.element-year {
+  font-size: 0.86rem;
+  font-weight: 800;
+  letter-spacing: 0.4px;
+  color: var(--ic-gold);
+  border: 1px solid rgba(251, 191, 36, 0.4);
+  border-radius: 20px;
+  padding: 4px 13px;
+}
+
+.light-theme .element-year { color: var(--ic-deep); }
+
+.element-card h3 {
+  font-size: 1.05rem;
+  font-weight: 700;
+  line-height: 1.34;
+  margin-bottom: 5px;
+}
+
+.element-state {
+  font-size: 0.83rem;
+  color: var(--ic-sub);
+  margin-bottom: 10px;
+}
+
+.element-tagline {
+  font-size: 0.92rem;
+  color: var(--ic-gold);
+  font-style: italic;
+  line-height: 1.5;
+  margin-bottom: 12px;
+}
+
+.light-theme .element-tagline { color: var(--ic-deep); }
+
+.element-community {
+  font-size: 0.85rem;
+  color: var(--ic-sub);
+  line-height: 1.58;
+  margin-bottom: 10px;
+}
+
+.element-community strong { color: var(--ic-text); }
+
+.element-proclaimed {
+  display: inline-block;
+  font-size: 0.73rem;
+  padding: 3px 11px;
+  border-radius: 20px;
+  background: rgba(79, 70, 229, 0.16);
+  border: 1px solid rgba(79, 70, 229, 0.36);
+  color: var(--ic-sub);
+  margin-bottom: 12px;
+}
+
+.element-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-bottom: 14px;
+  margin-top: auto;
+}
+
+.pill {
+  font-size: 0.73rem;
+  padding: 4px 11px;
+  border-radius: 20px;
+  border: 1px solid var(--ic-border);
+  color: var(--ic-sub);
+  white-space: nowrap;
+}
+
+.pill-domain { border-color: rgba(162, 28, 175, 0.42); }
+.pill-region { border-color: rgba(22, 163, 74, 0.4); }
+.pill-year { border-color: rgba(251, 191, 36, 0.42); }
+
+.element-cta {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--ic-gold);
+}
+
+.light-theme .element-cta { color: var(--ic-deep); }
+
+.empty-state {
+  text-align: center;
+  padding: 60px 20px;
+  color: var(--ic-sub);
+}
+
+.empty-state .big-icon {
+  font-size: 2.6rem;
+  margin-bottom: 12px;
+}
+
+.empty-state h3 {
+  font-size: 1.2rem;
+  margin-bottom: 8px;
+  color: var(--ic-text);
+}
+
+/* -------------------------------------------------------------- timeline */
+
+.timeline {
+  position: relative;
+  max-width: 940px;
+  margin: 0 auto;
+  padding: 10px 0;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  margin-left: -1px;
+  background: linear-gradient(180deg, transparent, var(--ic-gold), transparent);
+}
+
+.timeline-item {
+  position: relative;
+  width: 50%;
+  padding: 0 34px 30px;
+}
+
+.timeline-left { left: 0; text-align: right; }
+.timeline-right { left: 50%; text-align: left; }
+
+.timeline-dot {
+  position: absolute;
+  top: 6px;
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background: var(--ic-gold);
+  border: 3px solid var(--ic-bg);
+  box-shadow: 0 0 0 2px var(--ic-gold);
+}
+
+.timeline-left .timeline-dot { right: -7px; }
+.timeline-right .timeline-dot { left: -6px; }
+
+.timeline-body {
+  background: var(--ic-card);
+  border: 1px solid var(--ic-border);
+  border-radius: 14px;
+  padding: 18px 20px;
+}
+
+.timeline-year {
+  display: inline-block;
+  font-size: 0.82rem;
+  font-weight: 800;
+  color: var(--ic-gold);
+  letter-spacing: 1px;
+  margin-bottom: 6px;
+}
+
+.light-theme .timeline-year { color: var(--ic-deep); }
+
+.timeline-body h3 {
+  font-size: 1.03rem;
+  font-weight: 700;
+  margin-bottom: 7px;
+}
+
+.timeline-body p {
+  color: var(--ic-sub);
+  font-size: 0.91rem;
+  line-height: 1.62;
+}
+
+/* ---------------------------------------------------------- process grid */
+
+.process-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 18px;
+}
+
+.process-card {
+  position: relative;
+  background: var(--ic-card);
+  border: 1px solid var(--ic-border);
+  border-radius: 16px;
+  padding: 26px 22px 22px;
+}
+
+.process-step {
+  position: absolute;
+  top: -12px;
+  left: 20px;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--ic-plum), var(--ic-gold));
+  color: #1a0716;
+  font-weight: 800;
+  font-size: 0.88rem;
+}
+
+.process-icon {
+  font-size: 1.7rem;
+  display: block;
+  margin: 6px 0 10px;
+}
+
+.process-card h3 {
+  font-size: 1.02rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.process-card p {
+  color: var(--ic-sub);
+  font-size: 0.92rem;
+  line-height: 1.66;
+}
+
+/* ------------------------------------------------------------- myth cards */
+
+.myth-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 18px;
+}
+
+.myth-card {
+  background: var(--ic-card);
+  border: 1px solid var(--ic-border);
+  border-radius: 16px;
+  padding: 24px 22px;
+}
+
+.myth-icon {
+  font-size: 1.8rem;
+  margin-bottom: 12px;
+}
+
+.myth-claim,
+.myth-reality {
+  font-size: 0.93rem;
+  line-height: 1.68;
+}
+
+.myth-claim {
+  color: var(--ic-sub);
+  margin-bottom: 14px;
+  text-decoration-line: line-through;
+  text-decoration-color: rgba(220, 38, 38, 0.55);
+  text-decoration-thickness: 1px;
+}
+
+.myth-reality { color: var(--ic-text); }
+
+.myth-label,
+.reality-label {
+  display: block;
+  font-size: 0.68rem;
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-bottom: 5px;
+  text-decoration: none;
+}
+
+.myth-label { color: var(--ic-alert); }
+.reality-label { color: var(--ic-good); }
+
+/* -------------------------------------------------------- safeguard grid */
+
+.safeguard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 18px;
+}
+
+.safeguard-card {
+  background: var(--ic-card);
+  border: 1px solid var(--ic-border);
+  border-radius: 16px;
+  padding: 24px 22px;
+}
+
+.safeguard-icon {
+  font-size: 1.8rem;
+  margin-bottom: 10px;
+}
+
+.safeguard-card h3 {
+  font-size: 1.03rem;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.safeguard-card p {
+  color: var(--ic-sub);
+  font-size: 0.92rem;
+  line-height: 1.68;
+}
+
+/* ------------------------------------------------------------------ quiz */
+
+.quiz-section {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 30px;
+}
+
+.quiz-progress {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+  color: var(--ic-sub);
+  font-weight: 700;
+  margin-bottom: 16px;
+}
+
+.quiz-running-score { color: var(--ic-gold); }
+.light-theme .quiz-running-score { color: var(--ic-deep); }
+
+.quiz-question {
+  font-size: 1.15rem;
+  font-weight: 700;
+  line-height: 1.48;
+  margin-bottom: 20px;
+}
+
+.quiz-options {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.quiz-option {
+  text-align: left;
+  padding: 14px 18px;
+  border-radius: 12px;
+  border: 1px solid var(--ic-border);
+  background: rgba(0, 0, 0, 0.18);
+  color: var(--ic-text);
+  font-family: inherit;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.light-theme .quiz-option { background: rgba(255, 255, 255, 0.7); }
+
+.quiz-option:hover:not(:disabled) {
+  border-color: var(--ic-gold);
+  transform: translateX(4px);
+}
+
+.quiz-option:disabled { cursor: default; }
+
+.quiz-option.correct {
+  border-color: var(--ic-good);
+  background: rgba(22, 163, 74, 0.18);
+}
+
+.quiz-option.wrong {
+  border-color: var(--ic-alert);
+  background: rgba(220, 38, 38, 0.16);
+}
+
+.quiz-explain {
+  margin-top: 18px;
+  padding: 16px 18px;
+  border-radius: 12px;
+  background: rgba(251, 191, 36, 0.09);
+  border: 1px solid rgba(251, 191, 36, 0.3);
+}
+
+.quiz-explain p {
+  color: var(--ic-sub);
+  line-height: 1.66;
+  font-size: 0.93rem;
+  margin-bottom: 14px;
+}
+
+.btn-quiz {
+  padding: 10px 24px;
+  border-radius: 25px;
+  border: none;
+  background: linear-gradient(135deg, var(--ic-plum), var(--ic-gold));
+  color: #1a0716;
+  font-family: inherit;
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.btn-quiz:hover { transform: translateY(-2px); }
+
+.quiz-result { text-align: center; }
+
+.quiz-score {
+  font-size: 2.8rem;
+  font-weight: 800;
+  color: var(--ic-gold);
+  margin-bottom: 10px;
+}
+
+.light-theme .quiz-score { color: var(--ic-deep); }
+
+.quiz-verdict {
+  color: var(--ic-sub);
+  margin-bottom: 20px;
+  font-size: 1rem;
+}
+
+/* --------------------------------------------------------------- gallery */
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+}
+
+.gallery-item {
+  background: var(--ic-card);
+  border: 1px solid var(--ic-border);
+  border-radius: 16px;
+  overflow: hidden;
+  margin: 0;
+}
+
+.gallery-visual {
+  height: 110px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.6rem;
+  background: linear-gradient(135deg, rgba(162, 28, 175, 0.2), rgba(251, 191, 36, 0.12));
+}
+
+.gallery-item figcaption {
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.gallery-item figcaption strong {
+  font-size: 0.94rem;
+  font-weight: 700;
+}
+
+.gallery-item figcaption span {
+  font-size: 0.85rem;
+  color: var(--ic-sub);
+  line-height: 1.55;
+}
+
+/* ----------------------------------------------------------------- facts */
+
+.facts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 16px;
+}
+
+.fact-card {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  background: var(--ic-card);
+  border: 1px solid var(--ic-border);
+  border-radius: 14px;
+  padding: 18px 20px;
+}
+
+.fact-number {
+  flex-shrink: 0;
+  width: 30px;
+  height: 30px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--ic-plum), var(--ic-gold));
+  color: #1a0716;
+  font-weight: 800;
+  font-size: 0.85rem;
+}
+
+.fact-card p {
+  color: var(--ic-sub);
+  font-size: 0.93rem;
+  line-height: 1.65;
+}
+
+.footer-note {
+  font-size: 0.82rem;
+  opacity: 0.75;
+  margin-top: 6px;
+}
+
+/* ----------------------------------------------------------------- modal */
+
+.ic-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 4000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.ic-modal[hidden] { display: none; }
+
+.ic-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.74);
+  backdrop-filter: blur(4px);
+}
+
+.ic-modal-card {
+  position: relative;
+  z-index: 1;
+  width: min(680px, 100%);
+  max-height: 86vh;
+  overflow-y: auto;
+  background: var(--ic-bg);
+  border: 1px solid var(--ic-border);
+  border-radius: 20px;
+  padding: 32px;
+  animation: modal-rise 0.28s ease;
+}
+
+@keyframes modal-rise {
+  from { opacity: 0; transform: translateY(18px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.ic-modal-close {
+  position: absolute;
+  top: 14px;
+  right: 16px;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid var(--ic-border);
+  background: transparent;
+  color: var(--ic-sub);
+  font-size: 1.4rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.ic-modal-close:hover {
+  color: var(--ic-gold);
+  border-color: var(--ic-gold);
+}
+
+.ic-modal-head {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  margin-bottom: 16px;
+  padding-right: 40px;
+}
+
+.ic-modal-icon { font-size: 2.6rem; }
+
+.ic-modal-head h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.45rem;
+  font-weight: 700;
+  line-height: 1.28;
+}
+
+.ic-modal-tagline {
+  color: var(--ic-gold);
+  font-size: 0.92rem;
+  font-style: italic;
+  margin-top: 4px;
+}
+
+.light-theme .ic-modal-tagline { color: var(--ic-deep); }
+
+.ic-modal-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 18px;
+}
+
+.ic-modal-desc,
+.ic-modal-detail,
+.ic-modal-status {
+  color: var(--ic-sub);
+  line-height: 1.76;
+  font-size: 0.96rem;
+}
+
+.ic-modal-subhead {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  font-weight: 700;
+  color: var(--ic-gold);
+  margin: 24px 0 12px;
+}
+
+.light-theme .ic-modal-subhead { color: var(--ic-deep); }
+
+.spec-list {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px 18px;
+  margin: 0;
+}
+
+.spec-list dt {
+  font-size: 0.85rem;
+  color: var(--ic-sub);
+  font-weight: 600;
+}
+
+.spec-list dd {
+  font-size: 0.9rem;
+  color: var(--ic-text);
+  margin: 0;
+  line-height: 1.55;
+}
+
+/* ------------------------------------------------------------ animations */
+
+.animate-on-scroll {
+  opacity: 0;
+  transform: translateY(22px);
+  transition: opacity 0.55s ease, transform 0.55s ease;
+}
+
+.animate-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-on-scroll,
+  .animate-visible,
+  .element-card,
+  .domain-card,
+  .quiz-option,
+  .btn-quiz {
+    transition: none !important;
+    animation: none !important;
+    transform: none !important;
+    opacity: 1 !important;
+  }
+}
+
+/* ----------------------------------------------------------- responsive */
+
+@media (max-width: 1024px) {
+  .content-section { grid-template-columns: 1fr; }
+  .section-header h2 { font-size: 2.05rem; }
+}
+
+@media (max-width: 768px) {
+  .timeline::before { left: 18px; }
+
+  .timeline-item,
+  .timeline-left,
+  .timeline-right {
+    width: 100%;
+    left: 0;
+    text-align: left;
+    padding: 0 0 26px 46px;
+  }
+
+  .timeline-left .timeline-dot,
+  .timeline-right .timeline-dot {
+    left: 12px;
+    right: auto;
+  }
+
+  .filter-row {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .filter-label { padding-top: 0; }
+
+  .ic-modal-card { padding: 26px 20px; }
+}
+
+@media (max-width: 640px) {
+  .section-container { padding: 44px 16px; }
+  .section-header h2 { font-size: 1.75rem; }
+  .hero-content h1 { font-size: 1.85rem; }
+  .element-grid { grid-template-columns: 1fr; }
+  .search-row { flex-direction: column; }
+
+  .spec-list {
+    grid-template-columns: 1fr;
+    gap: 3px 0;
+  }
+
+  .spec-list dd { margin-bottom: 10px; }
+}

--- a/frontend/unesco/unesco.html
+++ b/frontend/unesco/unesco.html
@@ -53,6 +53,7 @@
                 <a href="../../index.html#map" class="nav-link">Interactive Map</a>
                 <a href="../heritage/heritage.html" class="nav-link">Heritage</a>
                 <a href="unesco.html" class="nav-link" style="color: var(--saffron)">UNESCO Sites</a>
+                <a href="../intangible-heritage-explorer/index.html" class="nav-link">Intangible Heritage</a>
                 <div class="journey-nav-search">
                     <input type="search" id="journey-search-input" class="journey-search-input" placeholder="Search all explorers…" aria-label="Search across all explorers" autocomplete="off">
                     <div id="journey-search-results" class="journey-search-results" hidden></div>


### PR DESCRIPTION
## Description

Closes #1440

Adds a self-contained explorer module at `frontend/intangible-heritage-explorer/` covering India's 15 UNESCO Intangible Cultural Heritage inscriptions.

`frontend/unesco/` and `frontend/unesco-sites/` both cover the **World Heritage List** — that is the 1972 Convention, and it lists *places*. There is a second, entirely separate UNESCO instrument: the **2003 Convention for the Safeguarding of the Intangible Cultural Heritage**, which lists *practices*. India has 15 elements on its Representative List, from Kutiyattam (2008) to Garba of Gujarat (2023), and nothing on the site covered any of it.

The two are conflated constantly, which is itself a reason to have the page. They work on different principles:

- World Heritage is judged against **Outstanding Universal Value** — an explicitly comparative standard. The Representative List makes **no comparative judgment at all**
- A World Heritage property belongs to the **State Party**. An intangible element belongs to the **community that practises it** — the state nominates, it does not acquire
- World Heritage protects physical fabric. The 2003 Convention protects **transmission**. A perfectly documented tradition nobody is learning has not been safeguarded

## What's included

| Section | Description |
|---|---|
| **Hero + stats** | 15 elements, 5 domains, first and most recent inscription years |
| **Places vs practices** | The two conventions set against each other, and why the ownership difference is the one that matters |
| **Comparison table** | 8 rows — convention, coverage, list, India's entries, criterion, who holds it, what is protected, danger listing |
| **Five ICH domains** | Oral traditions, performing arts, social practices, knowledge concerning nature, traditional craftsmanship — each card filters the browser below |
| **Element explorer** | All **15 inscriptions** with live search + domain chips + region chips + 3 sort modes. Every card names the **community that holds the practice** |
| **Timeline** | 14 entries — including that Kutiyattam (2001), Vedic chanting (2003) and Ramlila (2005) were proclaimed Masterpieces *before* the Convention that now governs them existed |
| **Nomination process** | 6 steps, leading with free, prior and informed community consent as a hard requirement |
| **Myth vs reality** | 6 cards on what inscription does **not** do — no legal protection, no ownership, no ranking, no exclusivity, no freezing of the practice, and no implication that uninscribed traditions matter less |
| **Safeguarding** | 6 cards on transmission, where the pressure currently sits, the Sangeet Natak Akademi's role, scheme funding, commercialisation, and why documentation is not preservation |
| **Quiz** | 12 questions with per-answer explanations |
| **Gallery & facts** | 10 gallery cards, 12 facts |
| **Detail modal** | Year, domain, state, community, earlier Masterpiece proclamation where applicable, plus detail and current transmission status |

## Files

```
frontend/intangible-heritage-explorer/index.html    288 lines
frontend/intangible-heritage-explorer/data.js       532 lines
frontend/intangible-heritage-explorer/script.js     535 lines
frontend/intangible-heritage-explorer/style.css   1,263 lines
                                                 ─────────────
                                                  2,618 lines
```

Plus a one-line nav addition in `frontend/unesco/unesco.html`, so the tangible and intangible lists sit next to each other and stop being conflated.

## On the editorial requirement in the issue

The issue asked that communities be named, that nothing be written in the past tense unless it genuinely has ceased, and that inscription not be presented as conferring ownership. Concretely:

- **Every** element carries a `community` field, surfaced on the card as "Held by:" and again in the modal — Chakyar and Nambiar families for Kutiyattam, the villages of Saloor-Dungra for Ramman, the Thathera community of Jandiala Guru, Kumartuli's idol-makers for Durga Puja
- Each element has a **current status** field written in the present tense, distinguishing "actively performed" from "highly vulnerable" — Ramman's dependence on specific families staying in two villages is stated plainly, as is Kutiyattam's small teacher base
- Two of the six myth cards address ownership directly, and Nowruz's twelve-country inscription is used as the worked example of why no state can claim a practice
- One myth card addresses the freezing problem: the Convention explicitly expects living heritage to be recreated by its community
- The footer carries the same point

## Technical notes

- **Vanilla HTML/CSS/JS only**, no build step, no external libraries — follows the `frontend/gi-tags-explorer/` module pattern
- `const`/`let` throughout, IIFE-wrapped, `function` declarations for page logic
- All content in `data.js`; adding an element is one object
- Dark/light theme via `.light-theme`; XSS-safe via `escapeHtml()` on every interpolation
- Accessibility — `role="button"` + `tabindex` + Enter/Space on element cards, `aria-modal` dialog with Escape and focus restore, `aria-live` result count, `sr-only` table caption, `prefers-reduced-motion` respected
- Responsive at 1024 / 768 / 640
- CSS scoped under `.ic-page` with page-local custom properties

## Testing

Headless jsdom harness — loads `index.html`, injects `data.js` and `script.js`, fires `DOMContentLoaded` with a stubbed `IntersectionObserver`:

```
ok  #compare-body    (8)     ok  #process-grid    (6)
ok  #domain-grid     (5)     ok  #myth-grid       (6)
ok  #domain-chips    (6)     ok  #safeguard-grid  (6)
ok  #region-chips    (7)     ok  #quiz-section    (4)
ok  #element-grid    (15)    ok  #gallery-grid    (10)
ok  #timeline-track  (14)    ok  #facts-grid      (12)

PASS frontend/intangible-heritage-explorer
```

No `jsdomError`, no `console.error`. `node --check` passes on both JS files, and every internal link added by this PR was checked against the filesystem — two dropdown links (Classical Dances, Folk Dances) were corrected to `index.html` after that check found the `*-dances.html` filenames don't exist.

**Not verified:** no browser in this environment, so visual rendering — theming, breakpoints, hover/focus states, modal animation — has not been checked live. Worth a look before merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive UNESCO Intangible Cultural Heritage explorer focused on India.
  * Browse 15 heritage elements by search, domain, region, and sort options.
  * Explore timelines, convention comparisons, nomination steps, safeguarding guidance, myths, galleries, and cultural facts.
  * Added an interactive 12-question quiz with explanations, scoring, and restart support.
  * Added accessible heritage detail modals, responsive layouts, light/dark themes, and mobile navigation access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->