### PR TITLE
feat: Create Ranthambore Fort Explorer page and add it to Indian Forts Explorer landing page

### DIFF
--- a/frontend/forts/ranthambore-fort.css
+++ b/frontend/forts/ranthambore-fort.css
@@ -1,0 +1,239 @@
+/* ==========================================================================
+   RANTHAMBORE FORT EXPLORER - STYLES
+   ========================================================================== */
+
+.hero-section {
+    position: relative;
+    height: 60vh;
+    min-height: 400px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    color: var(--text-light);
+    overflow: hidden;
+}
+
+.hero-bg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+}
+
+.hero-image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+.hero-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(to bottom, rgba(0, 0, 0, 0.35) 0%, rgba(0, 0, 0, 0.8) 100%);
+}
+
+.hero-content {
+    z-index: 1;
+    max-width: 800px;
+    padding: 2rem;
+}
+
+.hero-content .badge {
+    background-color: var(--saffron);
+    color: #fff;
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 1rem;
+    display: inline-block;
+}
+
+.hero-content .title {
+    font-size: clamp(2.5rem, 5vw, 4.5rem);
+    font-family: var(--font-heading);
+    margin: 0.5rem 0;
+    text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
+}
+
+.hero-content .subtitle {
+    font-size: 1.2rem;
+    margin-bottom: 2rem;
+    opacity: 0.95;
+}
+
+.hero-meta {
+    display: flex;
+    justify-content: center;
+    gap: 2rem;
+    flex-wrap: wrap;
+}
+
+.meta-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 500;
+}
+
+.main-content-wrapper {
+    display: grid;
+    grid-template-columns: 250px 1fr;
+    gap: 3rem;
+    padding: 4rem 2rem;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.sticky-nav {
+    position: sticky;
+    top: 100px;
+}
+
+.sticky-nav ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.sticky-nav li {
+    margin-bottom: 1rem;
+}
+
+.sticky-nav a {
+    color: var(--text-muted);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.3s ease;
+    display: block;
+    padding: 0.5rem;
+    border-left: 2px solid transparent;
+}
+
+.sticky-nav a:hover,
+.sticky-nav a.active {
+    color: var(--saffron);
+    border-left-color: var(--saffron);
+}
+
+.content-sections {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.content-section {
+    padding: 2rem;
+    border-radius: 12px;
+}
+
+.glass-panel {
+    background: var(--bg-dark-card);
+    backdrop-filter: blur(10px);
+    border: 1px solid var(--glass-border);
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.content-section h2 {
+    font-family: var(--font-heading);
+    color: var(--saffron);
+    margin-top: 0;
+    margin-bottom: 1.5rem;
+    font-size: 2rem;
+    border-bottom: 1px solid var(--glass-border);
+    padding-bottom: 0.5rem;
+}
+
+.content-section p {
+    line-height: 1.8;
+    margin-bottom: 1rem;
+    color: var(--text-light);
+}
+
+.content-section ul {
+    padding-left: 1.5rem;
+    margin-bottom: 1rem;
+    color: var(--text-light);
+    line-height: 1.7;
+}
+
+.content-section li {
+    margin-bottom: 0.5rem;
+}
+
+.content-section strong {
+    color: var(--gold);
+}
+
+.highlight-panel {
+    background: linear-gradient(135deg, rgba(255, 153, 51, 0.1), rgba(19, 136, 8, 0.1));
+    border-left: 4px solid var(--saffron);
+}
+
+.facts-list {
+    list-style: disc;
+}
+
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.gallery-item {
+    border-radius: 8px;
+    overflow: hidden;
+    height: 200px;
+    border: 1px solid var(--glass-border);
+}
+
+.gallery-item img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.3s ease;
+}
+
+.gallery-item img:hover {
+    transform: scale(1.05);
+}
+
+.map-placeholder {
+    margin-top: 1rem;
+}
+
+.map-mockup {
+    height: 300px;
+    background: var(--bg-dark-card);
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px dashed var(--glass-border);
+    color: var(--text-muted);
+    text-align: center;
+    padding: 1rem;
+}
+
+.reference-list {
+    list-style: disc;
+}
+
+@media (max-width: 768px) {
+    .main-content-wrapper {
+        grid-template-columns: 1fr;
+        padding: 2rem 1rem;
+    }
+
+    .sidebar-nav {
+        display: none;
+    }
+}

--- a/frontend/forts/ranthambore-fort.html
+++ b/frontend/forts/ranthambore-fort.html
@@ -1,0 +1,233 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Explore Ranthambore Fort - a historic hill fort inside Ranthambore National Park, famous for its temples, architecture, and wildlife connection.">
+    <title>Ranthambore Fort Explorer | Incredible India</title>
+    <meta property="og:title" content="Ranthambore Fort Explorer | Incredible India">
+    <meta property="og:description" content="Discover Ranthambore Fort - an ancient hill fort standing at the heart of a tiger reserve, and a UNESCO World Heritage Site.">
+    <meta property="og:type" content="website">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="ranthambore-fort.css">
+</head>
+<body>
+    <header class="navbar" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html" class="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">☰</button>
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html" class="nav-link">Home</a>
+                <a href="index.html" class="nav-link">Forts</a>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Light/Dark Mode">☀️</button>
+            </nav>
+        </div>
+    </header>
+
+    <main>
+        <!-- Overview / Hero -->
+        <section class="hero-section" id="overview">
+            <div class="hero-bg">
+                <img src="https://images.unsplash.com/photo-1561361513-2d000a50f0dc?w=1600&q=80" alt="Ranthambore Fort amid the forest" class="hero-image">
+                <div class="hero-overlay"></div>
+            </div>
+            <div class="hero-content">
+                <span class="badge">Sawai Madhopur, Rajasthan</span>
+                <h1 class="title">Ranthambore Fort</h1>
+                <p class="subtitle">An ancient hill fort rising above the wilderness of Ranthambore National Park, home to history, temples, and tigers alike.</p>
+                <div class="hero-meta">
+                    <div class="meta-item">
+                        <span class="icon">📍</span>
+                        <span>Ranthambore National Park</span>
+                    </div>
+                    <div class="meta-item">
+                        <span class="icon">🏆</span>
+                        <span>UNESCO World Heritage Site</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <div class="container main-content-wrapper">
+            <!-- Sidebar Navigation -->
+            <aside class="sidebar-nav">
+                <nav class="sticky-nav">
+                    <ul>
+                        <li><a href="#overview">Overview</a></li>
+                        <li><a href="#history">History</a></li>
+                        <li><a href="#architecture">Architecture</a></li>
+                        <li><a href="#unesco">UNESCO Status</a></li>
+                        <li><a href="#wildlife">Wildlife Connection</a></li>
+                        <li><a href="#temples">Temples</a></li>
+                        <li><a href="#facts">Interesting Facts</a></li>
+                        <li><a href="#gallery">Gallery</a></li>
+                        <li><a href="#location">Location & Map</a></li>
+                        <li><a href="#references">References</a></li>
+                    </ul>
+                </nav>
+            </aside>
+
+            <!-- Main Content Area -->
+            <div class="content-sections">
+                <!-- Overview -->
+                <section id="overview-text" class="content-section glass-panel">
+                    <h2>Overview</h2>
+                    <p>Ranthambore Fort stands on a rocky hill within <strong>Ranthambore National Park</strong> in the Sawai Madhopur district of Rajasthan. It is one of the oldest and largest forts in Rajasthan, and one of the few forts in the world located inside an active tiger reserve.</p>
+                    <p>The fort's massive walls, ancient temples, and commanding views over the surrounding forest make it both a historical landmark and a striking backdrop to the wildlife that now roams its grounds.</p>
+                </section>
+
+                <!-- History -->
+                <section id="history" class="content-section glass-panel">
+                    <h2>History</h2>
+                    <p>The fort is believed to have been built in the <strong>10th century</strong> by the Chauhan (Chahamana) rulers, and it went on to become one of the most strategically important strongholds in the region due to its rugged, hard-to-access location.</p>
+                    <p>Over the centuries, Ranthambore Fort was contested by the Chauhans, the Delhi Sultanate, and the Mughals. It witnessed sieges by rulers such as Alauddin Khilji in the early 14th century, and later passed into the control of the Kachwaha rulers of Jaipur before eventually coming under British paramountcy along with the wider region.</p>
+                </section>
+
+                <!-- Architecture -->
+                <section id="architecture" class="content-section glass-panel">
+                    <h2>Architecture</h2>
+                    <p>Ranthambore Fort follows classic Rajput military architecture, built to exploit the natural defences of the hill it stands on.</p>
+                    <ul>
+                        <li><strong>Massive Walls & Gates:</strong> A series of fortified gateways lead up through the hillside to the main fort complex.</li>
+                        <li><strong>Battlements & Watchtowers:</strong> Elevated positions once used to observe approaching threats across the surrounding plains and forest.</li>
+                        <li><strong>Hammir Court:</strong> The remains of a royal court associated with Rana Hammir Dev, one of the fort's most celebrated rulers.</li>
+                        <li><strong>Step Wells & Water Tanks:</strong> Structures built to store water and sustain the fort during long sieges.</li>
+                    </ul>
+                </section>
+
+                <!-- UNESCO Status -->
+                <section id="unesco" class="content-section glass-panel highlight-panel">
+                    <h2>UNESCO Status</h2>
+                    <p>Ranthambore Fort was inscribed as a <strong>UNESCO World Heritage Site in 2013</strong>, as part of the serial listing <strong>"Hill Forts of Rajasthan"</strong>, which also includes Chittorgarh, Kumbhalgarh, Jaisalmer, Amber, and Gagron forts.</p>
+                    <ul>
+                        <li>Recognised for its representation of Rajput hill-fort military architecture.</li>
+                        <li>Valued for its integration with the surrounding forested landscape.</li>
+                        <li>Noted for its long, layered history spanning multiple ruling dynasties.</li>
+                    </ul>
+                </section>
+
+                <!-- Wildlife Connection -->
+                <section id="wildlife" class="content-section glass-panel highlight-panel">
+                    <h2>Wildlife Connection</h2>
+                    <p>What makes Ranthambore Fort truly unique is its setting inside <strong>Ranthambore National Park</strong>, one of India's premier tiger reserves.</p>
+                    <ul>
+                        <li>The fort sits at the heart of a landscape famous for its <strong>Bengal tiger</strong> population.</li>
+                        <li>Tigers, leopards, and other wildlife are frequently spotted roaming near the fort's ancient walls and lakes.</li>
+                        <li>The park's lakes, including Padam Talao, lie at the foot of the fort and are popular wildlife-viewing spots.</li>
+                        <li>The fort's presence within the reserve makes it one of the rare places where heritage tourism and wildlife tourism directly overlap.</li>
+                    </ul>
+                </section>
+
+                <!-- Temples -->
+                <section id="temples" class="content-section glass-panel">
+                    <h2>Temples</h2>
+                    <p>The fort complex houses several ancient temples that remain active pilgrimage sites to this day.</p>
+                    <ul>
+                        <li><strong>Trinetra Ganesh Temple:</strong> One of the most revered Ganesh temples in India, believed to be over 1,000 years old and visited by pilgrims from across the country, especially before weddings.</li>
+                        <li><strong>Ramlalaji Temple:</strong> A temple dedicated to Lord Rama, located within the fort premises.</li>
+                        <li><strong>Shiva Temple:</strong> An ancient stone temple dedicated to Lord Shiva, reflecting the fort's long religious history.</li>
+                    </ul>
+                </section>
+
+                <!-- Interesting Facts -->
+                <section id="facts" class="content-section glass-panel">
+                    <h2>Interesting Facts</h2>
+                    <ul class="facts-list">
+                        <li>Ranthambore Fort is one of the <strong>oldest forts in Rajasthan</strong>, with origins dating to the 10th century.</li>
+                        <li>It is one of the very few forts in the world situated inside an <strong>active tiger reserve</strong>.</li>
+                        <li>The Trinetra Ganesh Temple inside the fort receives letters and wedding invitations addressed directly to the deity.</li>
+                        <li>The fort was the site of a famous siege by Alauddin Khilji in <strong>1301</strong>.</li>
+                        <li>Ranthambore Fort forms part of the UNESCO "Hill Forts of Rajasthan" listing, inscribed in 2013.</li>
+                        <li>The fort's elevated ramparts offer sweeping views over the forest and lakes of Ranthambore National Park.</li>
+                    </ul>
+                </section>
+
+                <!-- Gallery -->
+                <section id="gallery" class="content-section glass-panel">
+                    <h2>Gallery</h2>
+                    <div class="gallery-grid">
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1561361513-2d000a50f0dc?w=500&q=80" alt="Ranthambore Fort ramparts" loading="lazy">
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1548013146-72479768bada?w=500&q=80" alt="Forest surrounding Ranthambore Fort" loading="lazy">
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1599661046289-e31897846e41?w=500&q=80" alt="Ancient temple within Ranthambore Fort" loading="lazy">
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1596176530529-78163a4f7af2?w=500&q=80" alt="View from Ranthambore Fort walls" loading="lazy">
+                        </div>
+                    </div>
+                </section>
+
+                <!-- Location / Map -->
+                <section id="location" class="content-section glass-panel">
+                    <h2>Location & Map</h2>
+                    <p>Ranthambore Fort is located inside Ranthambore National Park, about 13 km from Sawai Madhopur town in eastern Rajasthan, on the edge of the Aravalli and Vindhya hill ranges.</p>
+                    <div class="map-placeholder">
+                        <div class="map-mockup">
+                            <span>🗺️ Map View of Ranthambore Fort, Sawai Madhopur, Rajasthan</span>
+                        </div>
+                    </div>
+                </section>
+
+                <!-- References -->
+                <section id="references" class="content-section glass-panel">
+                    <h2>References</h2>
+                    <ul class="reference-list">
+                        <li>UNESCO World Heritage Centre - "Hill Forts of Rajasthan"</li>
+                        <li>Archaeological Survey of India (ASI) - Jaipur Circle</li>
+                        <li>Rajasthan Tourism Development Corporation (RTDC)</li>
+                        <li>Ranthambore National Park, Forest Department, Government of Rajasthan</li>
+                    </ul>
+                </section>
+            </div>
+        </div>
+    </main>
+
+    <footer class="footer">
+        <div class="footer-container">
+            <div class="footer-brand">
+                <h3>Incredible India Explorer</h3>
+                <p>An interactive digital guide to the geography, food, festivals, wildlife, and cultural heritage of India.</p>
+            </div>
+            <div class="footer-links">
+                <h3>Quick Navigation</h3>
+                <ul>
+                    <li><a href="../../index.html">Home</a></li>
+                    <li><a href="index.html">Indian Forts Explorer</a></li>
+                    <li><a href="ranthambore-fort.html">Ranthambore Fort</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="footer-credits footer-credits-center">
+            <p>&copy; 2026 Incredible India Explorer. Ranthambore Fort Explorer.</p>
+        </div>
+    </footer>
+
+    <!-- Scroll To Top Button -->
+    <button class="btn-scroll-top" id="btn-scroll-top" aria-label="Scroll to Top">&#8593;</button>
+
+    <script src="../../app.js" defer></script>
+    <script src="../../router.js" defer></script>
+    <script type="module" src="../../auth.js"></script>
+</body>
+</html>

--- a/frontend/forts/script.js
+++ b/frontend/forts/script.js
@@ -349,9 +349,27 @@ const fortsData = [
             "Hidden 1.4 km underwater wall",
             "Kanhoji Angre's headquarters"
         ],
-customUrl: "vijaydurg-fort.html"
+ customUrl: "vijaydurg-fort.html"
     },
     {
+        id: "ranthambore-fort",
+        name: "Ranthambore Fort",
+        location: "Sawai Madhopur",
+        state: "Rajasthan",
+        built: "10th Century",
+        builtBy: "Chauhan (Chahamana) Dynasty",
+        era: "Rajput Era",
+        architecture: "Rajput Hill Fort Architecture",
+        image: "https://images.unsplash.com/photo-1561361513-2d000a50f0dc?w=800&q=80",
+        history: "An ancient hill fort standing inside Ranthambore National Park, famous for its Trinetra Ganesh Temple, its role in the sieges of medieval Rajasthan, and its unique setting within a tiger reserve.",
+        highlights: [
+            "UNESCO World Heritage Site",
+            "Located inside a tiger reserve",
+            "Trinetra Ganesh Temple",
+            "Site of Alauddin Khilji's 1301 siege"
+        ],
+        customUrl: "ranthambore-fort.html"
+    },    {
         id: "gagron-fort",
         name: "Gagron Fort",
         location: "Jhalawar",


### PR DESCRIPTION
## Description
This PR adds a new "Ranthambore Fort Explorer" page to the Indian Forts Explorer section, closing #1171.

Ranthambore Fort (Sawai Madhopur, Rajasthan) is an ancient hill fort located inside Ranthambore National Park, one of India's premier tiger reserves. It is famous for the Trinetra Ganesh Temple, its long history under the Chauhan dynasty and Delhi Sultanate, and its rare overlap of heritage and wildlife tourism. It is part of the UNESCO World Heritage "Hill Forts of Rajasthan" listing (2013).

## Changes
- Added `frontend/forts/ranthambore-fort.html`: new fort page covering History, Architecture, UNESCO Status, Wildlife Connection, Temples, Interesting Facts, Gallery, Location & Map, and References.
- Added `frontend/forts/ranthambore-fort.css`: stylesheet reusing the shared fort-page layout used by other fort pages (e.g. Vijaydurg Fort).
- Updated `frontend/forts/script.js`: added a Ranthambore Fort entry to `fortsData` with `customUrl: "ranthambore-fort.html"` so it appears as a card on the Indian Forts Explorer landing page and links to the new page.

## Testing
- Verified the new card appears on the Indian Forts Explorer landing page grid.
- Verified clicking the Ranthambore Fort card navigates to `ranthambore-fort.html`.
- Verified all sidebar anchor links on the new page scroll to the correct sections.
- Verified the page matches the layout, theming, and responsive behavior of existing fort pages.

Closes #1171 

@Eshajha19 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.