### PR TITLE
feat: Create Sahitya Akademi Award Explorer

### DIFF
--- a/frontend/awards-of-india-explorer/index.html
+++ b/frontend/awards-of-india-explorer/index.html
@@ -374,14 +374,14 @@
                         </div>
                         <h3 class="award-name">Sahitya Akademi Award</h3>
                         <div class="award-meta">
-                            <span class="award-year">Instituted: 1954</span>
-                            <span class="award-tier">Literary Honour</span>
+                            <span class="award-year">Instituted: 1955</span>
+                            <span class="award-tier">India's Premier Literary Honour</span>
                         </div>
                         <p class="award-description">
-                            A literary honour conferred annually on outstanding books in 24 major Indian languages recognized by the National Academy of Letters.
+                            India's premier literary honour, presented annually by the National Academy of Letters to the most outstanding books published in 24 Indian languages since 1955.
                         </p>
                         <div class="card-footer">
-                            <a href="../../index.html" class="award-btn">Explore Literature &rarr;</a>
+                            <a href="../sahitya-akademi-award-explorer/index.html" class="award-btn">Explore Sahitya Akademi &rarr;</a>
                         </div>
                     </div>
 

--- a/frontend/sahitya-akademi-award-explorer/index.html
+++ b/frontend/sahitya-akademi-award-explorer/index.html
@@ -1,0 +1,793 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Sahitya Akademi Award Explorer - Discover India's National Academy of Letters and its annual honours for the most outstanding books in 24 Indian languages, covering history, eligibility, languages covered, selection process, categories, awardees, timeline, facts, and gallery.">
+    <title>Sahitya Akademi Award Explorer | Incredible India Explorer</title>
+    <link rel="icon" href="data:,">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="style.css">
+
+    <!-- Open Graph / Social Media Tags -->
+    <meta property="og:title" content="Sahitya Akademi Award Explorer | Incredible India Explorer">
+    <meta property="og:description" content="Explore India's National Academy of Letters - honours recognising the most outstanding books in 24 Indian languages, with history, eligibility, languages, selection process, categories, awardees, timeline, facts and gallery.">
+    <meta property="og:type" content="website">
+    <meta property="og:locale" content="en_IN">
+</head>
+
+<body class="sah-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <!-- Navbar Header -->
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html#home" class="nav-link">Home</a>
+                <a href="../learn/learn.html" class="nav-link">Learn</a>
+                <a href="../national-awards/national-awards.html" class="nav-link">National Awards</a>
+                <a href="../../index.html" class="nav-link active" style="color: #D4AF37">Sahitya Akademi</a>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+            </nav>
+        </div>
+    </header>
+
+    <main class="sah-main">
+        <!-- Hero Banner -->
+        <section class="sah-hero">
+            <div class="sah-hero-bg" aria-hidden="true"></div>
+            <div class="sah-hero-overlay" aria-hidden="true"></div>
+            <div class="sah-hero-particles" aria-hidden="true">
+                <span></span><span></span><span></span><span></span><span></span><span></span>
+            </div>
+            <div class="sah-hero-content">
+                <span class="sah-kicker">📚 National Academy of Letters</span>
+                <h1>Sahitya Akademi <span>Award</span> Explorer</h1>
+                <p>Discover the Sahitya Akademi (National Academy of Letters), India's premier institution for literature — and the annual national honours that celebrate the most outstanding books in every major Indian language.</p>
+                <p class="sah-type-line">Honouring the finest writing in <span class="sah-type" data-words='["Hindi","Bengali","Tamil","Urdu","Malayalam","English","24 Languages"]'></span></p>
+
+                <div class="sah-hero-stats">
+                    <div class="sah-hero-stat">
+                        <strong><span class="sah-count" data-target="1954">0</span></strong>
+                        <span>Akademi Inaugurated</span>
+                    </div>
+                    <div class="sah-hero-stat">
+                        <strong><span class="sah-count" data-target="24">0</span></strong>
+                        <span>Languages Recognised</span>
+                    </div>
+                    <div class="sah-hero-stat">
+                        <strong><span class="sah-count" data-target="1955">0</span></strong>
+                        <span>First Award Conferred</span>
+                    </div>
+                    <div class="sah-hero-stat">
+                        <strong>₹<span class="sah-count" data-target="100000">0</span></strong>
+                        <span>Akademi Award Purse</span>
+                    </div>
+                </div>
+            </div>
+            <a href="#history" class="sah-scroll-hint" aria-label="Scroll to explore"></a>
+        </section>
+
+        <!-- Marquee Strip -->
+        <div class="sah-marquee" aria-hidden="true">
+            <div class="sah-marquee-track">
+                <span>📖 POETRY</span><span>📕 NOVELS</span><span>🎭 PLAYS</span><span>✍️ ESSAYS</span><span>📜 BIOGRAPHY</span><span>🔁 TRANSLATIONS</span>
+                <span>📖 POETRY</span><span>📕 NOVELS</span><span>🎭 PLAYS</span><span>✍️ ESSAYS</span><span>📜 BIOGRAPHY</span><span>🔁 TRANSLATIONS</span>
+            </div>
+        </div>
+
+        <!-- Navigation Tabs -->
+        <div class="sah-nav-tabs">
+            <button class="sah-tab active" data-tab="history">📜 History</button>
+            <button class="sah-tab" data-tab="year-instituted">📅 Year Instituted</button>
+            <button class="sah-tab" data-tab="eligibility">📋 Eligibility</button>
+            <button class="sah-tab" data-tab="languages">🌐 Languages</button>
+            <button class="sah-tab" data-tab="selection">🎯 Selection</button>
+            <button class="sah-tab" data-tab="categories">🗂️ Categories</button>
+            <button class="sah-tab" data-tab="awardees">🏆 Awardees</button>
+            <button class="sah-tab" data-tab="timeline">⏳ Timeline</button>
+            <button class="sah-tab" data-tab="facts">💡 Facts</button>
+            <button class="sah-tab" data-tab="gallery">🖼️ Gallery</button>
+        </div>
+
+        <!-- History Section -->
+        <section id="history" class="sah-section active">
+            <div class="sah-content-card">
+                <h2>📜 History of the Sahitya Akademi</h2>
+                <div class="sah-split">
+                    <div class="sah-split-text">
+                        <p>The <strong>Sahitya Akademi</strong> (National Academy of Letters) is India's national academy for literature. The idea of a National Cultural Trust for India was first accepted in principle in <strong>1944</strong>, on a proposal from the Royal Asiatic Society of Bengal, envisaging three academies — one for letters, one for the visual arts, and one for dance, drama and music.</p>
+
+                        <p>After Independence, the Government of India constituted the <strong>Sahitya Akademi</strong> by a resolution dated <strong>15 December 1952</strong>, and it was <strong>formally inaugurated on 12 March 1954</strong> in the Central Hall of Parliament, New Delhi. Maulana Abul Kalam Azad welcomed the gathering, and Dr. S. Radhakrishnan, then Vice President of India, delivered the inaugural address.</p>
+
+                        <p>The first General Council was presided over by <strong>Prime Minister Jawaharlal Nehru</strong>, the Akademi's first Chairman, with Dr. Radhakrishnan elected its Vice-Chairman. The Government explained that Nehru was chosen "not because he is Prime Minister, but because he has carved out for himself a distinctive place as a writer and author." The Akademi was registered as a society on <strong>7 January 1956</strong> under the Societies Registration Act, 1860, and functions as an autonomous body of the Ministry of Culture, headquartered at <strong>Rabindra Bhavan, 35 Ferozeshah Road, New Delhi</strong>.</p>
+                    </div>
+                    <figure class="sah-figure float-slow">
+                        <img src="https://images.unsplash.com/photo-1481627834876-b7833e8f5570?auto=format&fit=crop&q=80&w=800" alt="A shelf lined with books" loading="lazy">
+                        <figcaption>India's letters — a national academy for every Indian language</figcaption>
+                    </figure>
+                </div>
+
+                <h3>Mandate &amp; Objectives</h3>
+                <ul class="sah-list">
+                    <li>To work actively for the development of Indian letters and to set high literary standards.</li>
+                    <li>To foster and co-ordinate literary activities in all the Indian languages.</li>
+                    <li>To promote, through literature, the cultural unity of the country.</li>
+                    <li>To honour outstanding books of literary merit with the annual Sahitya Akademi Awards.</li>
+                    <li>To publish original works, translations, and reference books, and to document Indian literature.</li>
+                </ul>
+
+                <h3>Headquarters &amp; National Presence</h3>
+                <p>The Akademi is headquartered at <strong>Rabindra Bhavan, New Delhi</strong> — the same complex that houses the Sangeet Natak Akademi and the Lalit Kala Akademi. It works through a General Council, an Executive Board, and a Finance Committee representing every region of India, maintains regional offices, and has published over <strong>7,000 books</strong> across its 24 recognized languages.</p>
+
+                <h3>Flagship Honours</h3>
+                <p>The Akademi confers the <strong>Sahitya Akademi Fellowship</strong> — its highest honour, reserved for the "immortals of literature" — the <strong>Sahitya Akademi Award</strong> for the most outstanding books published each year, and, since the 1980s and 2010s, the <strong>Prize for Translation</strong>, the <strong>Yuva Puraskar</strong>, the <strong>Bal Sahitya Puraskar</strong>, and the <strong>Bhasha Samman</strong>.</p>
+            </div>
+        </section>
+
+        <!-- Year Instituted Section -->
+        <section id="year-instituted" class="sah-section">
+            <div class="sah-content-card">
+                <h2>📅 Year Instituted</h2>
+                <figure class="sah-banner">
+                    <img src="https://images.unsplash.com/photo-1457369804613-52c61a468e7d?auto=format&fit=crop&q=80&w=1200" alt="Vast library reading hall" loading="lazy">
+                </figure>
+                <div class="sah-content">
+                    <p>The <strong>Sahitya Akademi</strong> was constituted by a Government of India resolution on <strong>15 December 1952</strong> and formally inaugurated on <strong>12 March 1954</strong>. The <strong>Sahitya Akademi Award</strong> itself was first conferred in <strong>1955</strong>, and has been given every year since to the most outstanding books of literary merit published in the languages recognized by the Akademi.</p>
+
+                    <div class="eligibility-grid">
+                        <div class="eligibility-item">
+                            <h3>📅 Akademi Established</h3>
+                            <p>Constituted by Government resolution dated <strong>15 December 1952</strong>; formally inaugurated on <strong>12 March 1954</strong> in the Central Hall of Parliament, New Delhi.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>🏅 First Awards</h3>
+                            <p>The first Sahitya Akademi Awards were conferred in <strong>1955</strong>, honouring outstanding books published in the preceding year in languages such as Hindi, Bengali, and Assamese.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>💵 Purse Today</h3>
+                            <p>Each Award carries an engraved copper plaque, a shawl, and a cash purse of <strong>₹1,00,000</strong> — raised progressively from ₹5,000 at inception to the present amount in 2009.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>🖋️ The Plaque</h3>
+                            <p>The award plaque was designed by the renowned filmmaker <strong>Satyajit Ray</strong>, and today holds an engraved citation to the winning book and author.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Eligibility Section -->
+        <section id="eligibility" class="sah-section">
+            <div class="sah-content-card">
+                <h2>📋 Eligibility &amp; Award Details</h2>
+                <figure class="sah-banner">
+                    <img src="https://images.unsplash.com/photo-1519682337058-a94d519337bc?auto=format&fit=crop&q=80&w=1200" alt="Open books on a reading desk" loading="lazy">
+                </figure>
+                <div class="sah-content">
+                    <p>The Sahitya Akademi Award recognizes the most outstanding book of literary merit published in any of the 24 languages recognized by the Akademi. The award honours the book itself, and hence the author who wrote it.</p>
+
+                    <div class="eligibility-grid">
+                        <div class="eligibility-item">
+                            <h3>🏅 What is Honoured</h3>
+                            <p>The most outstanding <strong>original book of literary merit</strong> published during the year preceding the award, in any of the 24 recognized Indian languages.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>📚 Eligible Genres</h3>
+                            <p>Fiction, poetry, drama, essays and literary criticism, biography and autobiography, travel literature, and other creative and scholarly prose of high literary merit.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>👥 The Jury</h3>
+                            <p>Each language has a <strong>three-member jury</strong> of eminent writers and scholars who screen the books and make unanimous or majority selections.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>🗳️ Final Approval</h3>
+                            <p>Jury selections are placed before the Akademi's <strong>Executive Board</strong>, which declares the awards on the basis of the jury's unanimous or majority recommendations.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>🎁 Award Components</h3>
+                            <p>A casket containing an <strong>engraved copper plaque</strong> designed by Satyajit Ray, a shawl, and a cheque for <strong>₹1,00,000</strong> — the amount in force since 2009.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>🌍 No Barriers of Creed</h3>
+                            <p>The Award is open to writers of Indian nationality in the recognized languages, without distinction of caste, creed, religion, or region.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Languages Covered Section -->
+        <section id="languages" class="sah-section">
+            <div class="sah-content-card">
+                <h2>🌐 Languages Covered</h2>
+                <div class="sah-content">
+                    <p>The Sahitya Akademi recognizes <strong>24 languages</strong> — the 22 languages of the Eighth Schedule of the Constitution of India, together with <strong>English</strong> and <strong>Rajasthani</strong>. Awards are conferred for the most outstanding book published in each language.</p>
+
+                    <div class="language-grid">
+                        <div class="language-chip">Assamese</div>
+                        <div class="language-chip">Bengali</div>
+                        <div class="language-chip">Bodo <span>since 2005</span></div>
+                        <div class="language-chip">Dogri <span>since 1970</span></div>
+                        <div class="language-chip">English</div>
+                        <div class="language-chip">Gujarati</div>
+                        <div class="language-chip">Hindi</div>
+                        <div class="language-chip">Kannada</div>
+                        <div class="language-chip">Kashmiri</div>
+                        <div class="language-chip">Konkani <span>since 1977</span></div>
+                        <div class="language-chip">Maithili <span>since 1966</span></div>
+                        <div class="language-chip">Malayalam</div>
+                        <div class="language-chip">Manipuri <span>since 1973</span></div>
+                        <div class="language-chip">Marathi</div>
+                        <div class="language-chip">Nepali <span>since 1977</span></div>
+                        <div class="language-chip">Odia</div>
+                        <div class="language-chip">Punjabi</div>
+                        <div class="language-chip">Rajasthani <span>since 1974</span></div>
+                        <div class="language-chip">Sanskrit</div>
+                        <div class="language-chip">Santhali <span>since 2005</span></div>
+                        <div class="language-chip">Sindhi <span>since 1959</span></div>
+                        <div class="language-chip">Tamil</div>
+                        <div class="language-chip">Telugu</div>
+                        <div class="language-chip">Urdu</div>
+                    </div>
+
+                    <div class="media-highlights">
+                        <h3>Growing the Family of Languages</h3>
+                        <ul>
+                            <li>From the original languages at inception, the Akademi has steadily added Dogri, Maithili, Manipuri, Rajasthani, Konkani, Nepali, and Sindhi over the decades.</li>
+                            <li><strong>Bodo</strong> and <strong>Santhali</strong> were the most recent additions, completing the 24 languages in <strong>2005</strong>.</li>
+                            <li>English has been honoured since <strong>1960</strong>, when R. K. Narayan's The Guide became the first English book to win.</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Selection Process Section -->
+        <section id="selection" class="sah-section">
+            <div class="sah-content-card">
+                <h2>🎯 Selection Process</h2>
+                <div class="sah-content">
+                    <p>The selection of the Sahitya Akademi Awards is a disciplined, multi-tier annual process that moves from publication to presentation, guided by three-member juries in each language.</p>
+
+                    <div class="selection-timeline">
+                        <div class="selection-step">
+                            <div class="step-number">1</div>
+                            <h3>Publication</h3>
+                            <p>Books of literary merit published in the preceding year in the 24 recognized languages are brought into consideration by the Akademi.</p>
+                        </div>
+
+                        <div class="selection-step">
+                            <div class="step-number">2</div>
+                            <h3>Submission &amp; Collection</h3>
+                            <p>Authors and publishers submit copies of eligible books, and the Akademi collects the year's significant publications in each language.</p>
+                        </div>
+
+                        <div class="selection-step">
+                            <div class="step-number">3</div>
+                            <h3>Language Juries</h3>
+                            <p>A <strong>three-member jury</strong> of eminent writers and scholars in each language screens the books and recommends the most outstanding work.</p>
+                        </div>
+
+                        <div class="selection-step">
+                            <div class="step-number">4</div>
+                            <h3>Executive Board Approval</h3>
+                            <p>The selections — made unanimously or by majority vote — are placed before the Akademi's Executive Board, which approves and declares the awards.</p>
+                        </div>
+
+                        <div class="selection-step">
+                            <div class="step-number">5</div>
+                            <h3>Festival of Letters</h3>
+                            <p>The awards are presented at the Akademi's annual <strong>Festival of Letters</strong> (Akhil Bharatiya Sahityotsav), where the engraved plaque, shawl, and cheque are conferred.</p>
+                        </div>
+                    </div>
+
+                    <div class="evaluation-criteria">
+                        <h3>Evaluation Focus Areas</h3>
+                        <ul>
+                            <li><strong>Literary Merit:</strong> Distinction of language, craft, and imagination</li>
+                            <li><strong>Originality:</strong> Freshness of form, thought, and expression</li>
+                            <li><strong>Linguistic Excellence:</strong> Mastery of the language of the work</li>
+                            <li><strong>New Trends:</strong> Works that acknowledge and shape new literary directions</li>
+                            <li><strong>National Significance:</strong> Contribution to the literature of India as a whole</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Categories Section -->
+        <section id="categories" class="sah-section">
+            <div class="sah-content-card">
+                <h2>🗂️ Categories &amp; Honours</h2>
+                <div class="sah-content">
+                    <p>Beyond the flagship Sahitya Akademi Award, the Akademi confers a family of honours recognizing writers, translators, young authors, children's literature, and languages beyond the recognized 24.</p>
+
+                    <div class="category-cards">
+                        <div class="category-card">
+                            <div class="category-img">
+                                <img src="https://images.unsplash.com/photo-1474932430478-367dbb6832c1?auto=format&fit=crop&q=80&w=800" alt="Rows of books in a library" loading="lazy">
+                            </div>
+                            <h3>📖 Sahitya Akademi Award</h3>
+                            <p>The flagship honour since <strong>1955</strong> — given annually to the most outstanding book in each of the 24 recognized languages, carrying a plaque, shawl, and ₹1,00,000.</p>
+                        </div>
+                        <div class="category-card">
+                            <div class="category-img">
+                                <img src="https://images.unsplash.com/photo-1524995997946-a1c2e315a42f?auto=format&fit=crop&q=80&w=800" alt="A stack of books" loading="lazy">
+                            </div>
+                            <h3>💎 Sahitya Akademi Fellowship</h3>
+                            <p>The <strong>highest honour</strong> of the Akademi — reserved for the "immortals of literature", and limited to <strong>twenty-one Fellows</strong> at any given time.</p>
+                        </div>
+                        <div class="category-card">
+                            <div class="category-img">
+                                <img src="https://images.unsplash.com/photo-1455390582262-044cdead277a?auto=format&fit=crop&q=80&w=800" alt="A hand writing with a fountain pen" loading="lazy">
+                            </div>
+                            <h3>🔁 Prize for Translation</h3>
+                            <p>Instituted in <strong>1989</strong> for outstanding translations among the 24 languages, carrying a purse of <strong>₹50,000</strong> — celebrating the bridges between India's literatures.</p>
+                        </div>
+                        <div class="category-card">
+                            <div class="category-img">
+                                <img src="https://images.unsplash.com/photo-1488190211105-8b0e65b80b4e?auto=format&fit=crop&q=80&w=800" alt="A writer's desk with notebooks" loading="lazy">
+                            </div>
+                            <h3>🌱 Yuva Puraskar</h3>
+                            <p>Instituted in <strong>2011</strong> for writers aged <strong>35 and below</strong>, nurturing the next generation of Indian writers with a plaque and ₹50,000.</p>
+                        </div>
+                        <div class="category-card">
+                            <div class="category-img">
+                                <img src="https://images.unsplash.com/photo-1543002588-bfa74002ed7e?auto=format&fit=crop&q=80&w=800" alt="Open book being read" loading="lazy">
+                            </div>
+                            <h3>🧒 Bal Sahitya Puraskar</h3>
+                            <p>Instituted in <strong>2010</strong> for outstanding contributions to <strong>children's literature</strong>, encouraging the earliest readers of Indian languages.</p>
+                        </div>
+                        <div class="category-card">
+                            <div class="category-img">
+                                <img src="https://images.unsplash.com/photo-1526243741027-444d633d7365?auto=format&fit=crop&q=80&w=800" alt="An open vintage book" loading="lazy">
+                            </div>
+                            <h3>🗣️ Bhasha Samman</h3>
+                            <p>Instituted in <strong>1996</strong> for writers and scholars contributing to <strong>languages beyond the recognized 24</strong>, and to classical and medieval literature — carrying ₹1,00,000.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Awardees Section -->
+        <section id="awardees" class="sah-section">
+            <div class="sah-content-card">
+                <h2>🏆 Notable Awardees</h2>
+                <div class="sah-content">
+                    <p>Since 1955, the Sahitya Akademi Award has crowned the greatest names in Indian writing — from the first pioneers to the modern masters of every language.</p>
+
+                    <h3>📜 The First Honourees</h3>
+                    <div class="awardees-gallery">
+                        <div class="awardee-card">
+                            <div class="awardee-avatar">📖</div>
+                            <h3>Makhanlal Chaturvedi</h3>
+                            <p class="awardee-year">Award · 1955 · Hindi</p>
+                            <p>The first Hindi writer to win, honoured for his poetry collection <em>Him Tarangini</em>.</p>
+                        </div>
+
+                        <div class="awardee-card">
+                            <div class="awardee-avatar">📜</div>
+                            <h3>Jibanananda Das</h3>
+                            <p class="awardee-year">Award · 1955 · Bengali</p>
+                            <p>One of Bengal's greatest modern poets, honoured for his selected verse <em>Shreshtha Kavita</em>.</p>
+                        </div>
+
+                        <div class="awardee-card">
+                            <div class="awardee-avatar">🌙</div>
+                            <h3>Amrita Pritam</h3>
+                            <p class="awardee-year">Award · 1956 · Punjabi</p>
+                            <p>The voice of Punjab's soul, honoured for her poetry collection <em>Sunehade</em>, who also became a Jnanpith laureate.</p>
+                        </div>
+                    </div>
+
+                    <h3>🌏 Masters of English</h3>
+                    <div class="awardees-gallery">
+                        <div class="awardee-card">
+                            <div class="awardee-avatar">🏛️</div>
+                            <h3>R. K. Narayan</h3>
+                            <p class="awardee-year">Award · 1960 · English</p>
+                            <p>The first English winner, honoured for his classic novel <em>The Guide</em> — the world of Malgudi.</p>
+                        </div>
+
+                        <div class="awardee-card">
+                            <div class="awardee-avatar">🪢</div>
+                            <h3>Raja Rao</h3>
+                            <p class="awardee-year">Award · 1964 · English</p>
+                            <p>Honoured for his philosophical masterpiece <em>The Serpent and the Rope</em>.</p>
+                        </div>
+
+                        <div class="awardee-card">
+                            <div class="awardee-avatar">🌅</div>
+                            <h3>Mulk Raj Anand</h3>
+                            <p class="awardee-year">Award · 1971 · English</p>
+                            <p>The pioneer of the Indian English novel, honoured for <em>Morning Face</em>.</p>
+                        </div>
+
+                        <div class="awardee-card">
+                            <div class="awardee-avatar">🎼</div>
+                            <h3>Vikram Seth</h3>
+                            <p class="awardee-year">Award · 1988 · English</p>
+                            <p>Honoured for his celebrated novel in verse, <em>The Golden Gate</em>.</p>
+                        </div>
+                    </div>
+
+                    <h3>🎨 Voices of the Regions</h3>
+                    <div class="awardees-gallery">
+                        <div class="awardee-card">
+                            <div class="awardee-avatar">🪔</div>
+                            <h3>M. T. Vasudevan Nair</h3>
+                            <p class="awardee-year">Award · 1978 · Malayalam</p>
+                            <p>The giant of Malayalam letters, honoured for his novel <em>Randamoozham</em>, later a Jnanpith laureate.</p>
+                        </div>
+
+                        <div class="awardee-card">
+                            <div class="awardee-avatar">🌳</div>
+                            <h3>Mahasweta Devi</h3>
+                            <p class="awardee-year">Award · 1979 · Bengali</p>
+                            <p>Honoured for her tribal saga <em>Aranyer Adhikar</em> — a novelist-activist of extraordinary force.</p>
+                        </div>
+
+                        <div class="awardee-card">
+                            <div class="awardee-avatar">🎭</div>
+                            <h3>Girish Karnad</h3>
+                            <p class="awardee-year">Award · 1994 · Kannada</p>
+                            <p>The Kannada playwright of <em>Tughlaq</em> and <em>Naga-Mandala</em>, honoured among the Akademi's distinguished writers.</p>
+                        </div>
+                    </div>
+
+                    <div class="notable-achievements">
+                        <h3>Impact of the Honours</h3>
+                        <ul>
+                            <li>The Sahitya Akademi Award is considered India's most prestigious literary award after the Jnanpith</li>
+                            <li>Awards are conferred for books in 24 languages — 22 Eighth Schedule languages plus English and Rajasthani</li>
+                            <li>Each Award carries a plaque, shawl, and ₹1,00,000 purse</li>
+                            <li>Honourees include poets, novelists, playwrights, and scholars of every Indian region</li>
+                            <li>The honours connect India's regional literatures into a single national conversation</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Timeline Section -->
+        <section id="timeline" class="sah-section">
+            <div class="sah-content-card">
+                <h2>⏳ Timeline</h2>
+                <div class="sah-content">
+                    <p>A journey through the milestones of India's national academy of letters.</p>
+
+                    <div class="timeline-container">
+                        <div class="timeline-item">
+                            <div class="timeline-year">1944</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Seed of an Idea</h3>
+                                <p>The Royal Asiatic Society of Bengal proposes a National Cultural Trust; the Government accepts the idea of a National Academy of Letters in principle.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1952</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Constituted</h3>
+                                <p>The Government of India constitutes the Sahitya Akademi by a resolution dated <strong>15 December 1952</strong>.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1954</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Inauguration</h3>
+                                <p>Formally inaugurated on <strong>12 March 1954</strong> in the Central Hall of Parliament; PM Jawaharlal Nehru chairs the first General Council as the first Chairman.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1955</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>First Awards</h3>
+                                <p>The first Sahitya Akademi Awards are conferred for outstanding books published in the preceding year.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1956</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Registered as a Society</h3>
+                                <p>The Akademi is registered under the Societies Registration Act, 1860, on <strong>7 January 1956</strong>, cementing its autonomy.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1959–1977</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Family of Languages Grows</h3>
+                                <p>Sindhi (1959), Maithili (1966), Dogri (1970), Manipuri (1973), Rajasthani (1974), and Konkani and Nepali (1977) are brought into the awards.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1989</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Prize for Translation</h3>
+                                <p>The Akademi institutes an annual Prize for Translation for outstanding translations among the 24 recognized languages.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1996</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Bhasha Samman</h3>
+                                <p>The Bhasha Samman is instituted for contribution to languages beyond the recognized 24, and to classical and medieval literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2005</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>24 Languages Complete</h3>
+                                <p><strong>Bodo</strong> and <strong>Santhali</strong> are added, completing the 24 recognized languages of the Akademi.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2009</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Purse Raised to ₹1 Lakh</h3>
+                                <p>The Award purse is raised to <strong>₹1,00,000</strong>, up from ₹5,000 at inception in 1955.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2010–2011</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>New Honours for New Readers</h3>
+                                <p>The <strong>Bal Sahitya Puraskar</strong> (2010) for children's literature and the <strong>Yuva Puraskar</strong> (2011) for writers under 35 are instituted.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Interesting Facts Section -->
+        <section id="facts" class="sah-section">
+            <div class="sah-content-card">
+                <h2>💡 Interesting Facts</h2>
+                <div class="sah-content">
+                    <p>Curious corners of the Sahitya Akademi's story — from wartime plaques to the pen behind the awards.</p>
+
+                    <div class="eligibility-grid">
+                        <div class="eligibility-item">
+                            <h3>🖋️ Designed by Satyajit Ray</h3>
+                            <p>The award plaque was designed by the legendary filmmaker and writer <strong>Satyajit Ray</strong>.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>💼 Plaques of Marble</h3>
+                            <p>Early plaques were occasionally made of marble, a practice discontinued because of their excessive weight.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>🪖 Savings Bonds in Wartime</h3>
+                            <p>During the <strong>Indo-Pakistan War of 1965</strong>, the plaque was substituted with national savings bonds.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>👑 A Prime Minister First</h3>
+                            <p>PM Jawaharlal Nehru was the first Chairman — chosen, in the Government's words, for being a writer, not a Prime Minister.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>💎 Twenty-One Immortals</h3>
+                            <p>The Sahitya Akademi Fellowship — the highest honour — is limited to just <strong>21 Fellows</strong> at any time.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>🎪 Festival of Letters</h3>
+                            <p>Awards are presented each year at the <strong>Akhil Bharatiya Sahityotsav</strong> (Festival of Letters) in New Delhi.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>🏛️ Three Academies, One Roof</h3>
+                            <p>Rabindra Bhavan houses all three national academies — Sahitya, Sangeet Natak, and Lalit Kala.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>📚 7,000 Books and Counting</h3>
+                            <p>The Akademi has published over 7,000 books and produced over 145 documentaries on eminent Indian writers.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Gallery Section -->
+        <section id="gallery" class="sah-section">
+            <div class="sah-content-card">
+                <h2>🖼️ Gallery</h2>
+                <div class="sah-content">
+                    <p>A visual journey through the world of Indian letters — the books, libraries, and words the Akademi celebrates.</p>
+
+                    <div class="gallery-grid">
+                        <figure class="gallery-item">
+                            <div class="gallery-img">
+                                <img src="https://images.unsplash.com/photo-1481627834876-b7833e8f5570?auto=format&fit=crop&q=80&w=600" alt="A shelf lined with hardbound books" loading="lazy">
+                            </div>
+                            <figcaption>
+                                <h3>The Written Word</h3>
+                                <p>Books honoured since the first awards of 1955.</p>
+                            </figcaption>
+                        </figure>
+
+                        <figure class="gallery-item">
+                            <div class="gallery-img">
+                                <img src="https://images.unsplash.com/photo-1524995997946-a1c2e315a42f?auto=format&fit=crop&q=80&w=600" alt="A neat stack of books" loading="lazy">
+                            </div>
+                            <figcaption>
+                                <h3>24 Languages</h3>
+                                <p>From Assamese to Urdu — one award, one language.</p>
+                            </figcaption>
+                        </figure>
+
+                        <figure class="gallery-item">
+                            <div class="gallery-img">
+                                <img src="https://images.unsplash.com/photo-1455390582262-044cdead277a?auto=format&fit=crop&q=80&w=600" alt="A hand writing with a fountain pen" loading="lazy">
+                            </div>
+                            <figcaption>
+                                <h3>Ink &amp; Paper</h3>
+                                <p>The craft celebrated at every Festival of Letters.</p>
+                            </figcaption>
+                        </figure>
+
+                        <figure class="gallery-item">
+                            <div class="gallery-img">
+                                <img src="https://images.unsplash.com/photo-1488190211105-8b0e65b80b4e?auto=format&fit=crop&q=80&w=600" alt="A writer's desk with notebooks and papers" loading="lazy">
+                            </div>
+                            <figcaption>
+                                <h3>Writers at Work</h3>
+                                <p>Original works of literary merit, honoured each year.</p>
+                            </figcaption>
+                        </figure>
+
+                        <figure class="gallery-item">
+                            <div class="gallery-img">
+                                <img src="https://images.unsplash.com/photo-1457369804613-52c61a468e7d?auto=format&fit=crop&q=80&w=600" alt="The grand reading hall of a library" loading="lazy">
+                            </div>
+                            <figcaption>
+                                <h3>Rabindra Bhavan</h3>
+                                <p>Home to the three national academies of India.</p>
+                            </figcaption>
+                        </figure>
+
+                        <figure class="gallery-item">
+                            <div class="gallery-img">
+                                <img src="https://images.unsplash.com/photo-1543002588-bfa74002ed7e?auto=format&fit=crop&q=80&w=600" alt="An open book being read closely" loading="lazy">
+                            </div>
+                            <figcaption>
+                                <h3>New Readers</h3>
+                                <p>The Bal Sahitya Puraskar nurtures the youngest readers.</p>
+                            </figcaption>
+                        </figure>
+
+                        <figure class="gallery-item">
+                            <div class="gallery-img">
+                                <img src="https://images.unsplash.com/photo-1526243741027-444d633d7365?auto=format&fit=crop&q=80&w=600" alt="An open vintage book with printed pages" loading="lazy">
+                            </div>
+                            <figcaption>
+                                <h3>Classics &amp; Medieval</h3>
+                                <p>Bhasha Samman honours scholarship in classical literature.</p>
+                            </figcaption>
+                        </figure>
+
+                        <figure class="gallery-item">
+                            <div class="gallery-img">
+                                <img src="https://images.unsplash.com/photo-1474932430478-367dbb6832c1?auto=format&fit=crop&q=80&w=600" alt="Rows of books stretching across library shelves" loading="lazy">
+                            </div>
+                            <figcaption>
+                                <h3>Voices of India</h3>
+                                <p>From R. K. Narayan to Mahasweta Devi — voices that defined an era.</p>
+                            </figcaption>
+                        </figure>
+                    </div>
+
+                    <div class="media-highlights">
+                        <h3>Recognition &amp; Legacy</h3>
+                        <ul>
+                            <li>India's National Academy of Letters, inaugurated 12 March 1954</li>
+                            <li>Registered office at Rabindra Bhavan, 35 Ferozeshah Road, New Delhi</li>
+                            <li>The Award carries a ₹1,00,000 purse, plaque, and shawl</li>
+                            <li>The Fellowship (Akademi Ratna) is the highest honour, limited to 21 Fellows</li>
+                            <li>Awards honour books in 24 languages, including English and Rajasthani</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div class="sah-scroll-progress" id="scroll-progress" aria-hidden="true"></div>
+
+    <footer class="sah-footer">
+        <div class="sah-footer-container">
+            <div class="sah-footer-brand">
+                <h3><span class="saffron">Incredible</span> <span class="gold">India</span> <span class="green">Explorer</span></h3>
+                <p>An interactive digital guide to the geography, food, festivals, and cultural heritage of India — built with passion and pure vanilla web technologies.</p>
+                <p class="sah-footer-tagline">📚 Celebrating India's literature and letters.</p>
+            </div>
+            <div class="sah-footer-links">
+                <h4>Explore the Akademi</h4>
+                <ul>
+                    <li><a href="#" class="sah-footer-tab" data-footer-tab="history">📜 History</a></li>
+                    <li><a href="#" class="sah-footer-tab" data-footer-tab="year-instituted">📅 Year Instituted</a></li>
+                    <li><a href="#" class="sah-footer-tab" data-footer-tab="eligibility">📋 Eligibility</a></li>
+                    <li><a href="#" class="sah-footer-tab" data-footer-tab="languages">🌐 Languages</a></li>
+                    <li><a href="#" class="sah-footer-tab" data-footer-tab="selection">🎯 Selection</a></li>
+                    <li><a href="#" class="sah-footer-tab" data-footer-tab="categories">🗂️ Categories</a></li>
+                    <li><a href="#" class="sah-footer-tab" data-footer-tab="awardees">🏆 Awardees</a></li>
+                    <li><a href="#" class="sah-footer-tab" data-footer-tab="timeline">⏳ Timeline</a></li>
+                    <li><a href="#" class="sah-footer-tab" data-footer-tab="facts">💡 Facts</a></li>
+                    <li><a href="#" class="sah-footer-tab" data-footer-tab="gallery">🖼️ Gallery</a></li>
+                </ul>
+            </div>
+            <div class="sah-footer-links">
+                <h4>Discover More</h4>
+                <ul>
+                    <li><a href="../../index.html#home">🏠 Home</a></li>
+                    <li><a href="../../frontend/national-awards/national-awards.html">🏅 National Awards</a></li>
+                    <li><a href="../../frontend/culture/culture.html">🪔 Culture</a></li>
+                    <li><a href="../../frontend/learn/learn.html">📚 Learn</a></li>
+                    <li><a href="../../frontend/literature/literature.html">📖 Literature</a></li>
+                </ul>
+            </div>
+            <div class="sah-footer-links">
+                <h4>About the Project</h4>
+                <ul>
+                    <li><a href="../../frontend/about/about.html">ℹ️ About</a></li>
+                    <li><a href="../../frontend/privacy/privacy.html">🔒 Privacy Policy</a></li>
+                    <li><a href="../../index.html#map">🗺️ Interactive Map</a></li>
+                    <li><a href="../../index.html#quiz">🧠 Quiz</a></li>
+                    <li><a href="../../index.html#home">🏠 Back to Home</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="sah-footer-bottom">
+            <p>&copy; 2026 Incredible India Explorer · Created with Vanilla HTML, CSS &amp; JavaScript</p>
+            <p>Sahitya Akademi (National Academy of Letters) · Inaugurated 1954 · Rabindra Bhavan, New Delhi</p>
+        </div>
+    </footer>
+
+    <button class="sah-scroll-top" id="btn-scroll-top" aria-label="Scroll back to top">↑</button>
+
+    <!-- Client Script -->
+    <script type="module" src="script.js"></script>
+</body>
+</html>

--- a/frontend/sahitya-akademi-award-explorer/script.js
+++ b/frontend/sahitya-akademi-award-explorer/script.js
@@ -1,0 +1,387 @@
+/**
+ * Sahitya Akademi Award Explorer - Interactive Script
+ * Handles tab navigation, theme toggle, smooth scrolling, and scroll animations
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    initTabNavigation();
+    initThemeToggle();
+    initSmoothScroll();
+    initMobileMenu();
+    initScrollAnimations();
+    initCountUp();
+    initScrollUI();
+    initFooterTabs();
+    initCardTilt();
+    initTyping();
+    initHeroParallax();
+});
+
+/**
+ * Activate a tab section by its id (shared by tab bar and footer links)
+ */
+function activateTab(targetTab) {
+    const tabs = document.querySelectorAll('.sah-tab');
+    const sections = document.querySelectorAll('.sah-section');
+    if (!tabs.length || !sections.length) return;
+
+    tabs.forEach(t => t.classList.remove('active'));
+    sections.forEach(s => s.classList.remove('active'));
+
+    const tab = document.querySelector(`.sah-tab[data-tab="${targetTab}"]`);
+    const section = document.getElementById(targetTab);
+    if (tab) tab.classList.add('active');
+    if (section) {
+        section.classList.add('active');
+        section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+}
+
+/**
+ * Initialize tab navigation for different sections
+ */
+function initTabNavigation() {
+    document.querySelectorAll('.sah-tab').forEach(tab => {
+        tab.addEventListener('click', () => activateTab(tab.dataset.tab));
+    });
+}
+
+/**
+ * Initialize theme toggle functionality
+ */
+function initThemeToggle() {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+
+    // Set initial icon based on current theme
+    const currentTheme = localStorage.getItem('theme') || 'dark';
+    updateThemeIcon(currentTheme);
+
+    themeToggle.addEventListener('click', () => {
+        const body = document.body;
+        const isLight = body.classList.contains('light-theme');
+
+        if (isLight) {
+            body.classList.remove('light-theme');
+            localStorage.setItem('theme', 'dark');
+            updateThemeIcon('dark');
+        } else {
+            body.classList.add('light-theme');
+            localStorage.setItem('theme', 'light');
+            updateThemeIcon('light');
+        }
+    });
+}
+
+/**
+ * Update theme toggle icon
+ */
+function updateThemeIcon(theme) {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+
+    if (theme === 'light') {
+        themeToggle.textContent = '🌙';
+    } else {
+        themeToggle.textContent = '☀️';
+    }
+}
+
+/**
+ * Initialize smooth scroll for internal links
+ */
+function initSmoothScroll() {
+    document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+        anchor.addEventListener('click', function (e) {
+            e.preventDefault();
+            const target = document.querySelector(this.getAttribute('href'));
+            if (target) {
+                target.scrollIntoView({
+                    behavior: 'smooth',
+                    block: 'start'
+                });
+            }
+        });
+    });
+}
+
+/**
+ * Initialize mobile menu toggle
+ */
+function initMobileMenu() {
+    const menuToggle = document.getElementById('menu-toggle');
+    const navMenu = document.getElementById('nav-menu');
+
+    if (menuToggle && navMenu) {
+        menuToggle.addEventListener('click', () => {
+            const isExpanded = menuToggle.getAttribute('aria-expanded') === 'true';
+            menuToggle.setAttribute('aria-expanded', !isExpanded);
+            navMenu.classList.toggle('active');
+        });
+
+        // Close menu when clicking outside
+        document.addEventListener('click', (e) => {
+            if (!menuToggle.contains(e.target) && !navMenu.contains(e.target)) {
+                navMenu.classList.remove('active');
+                menuToggle.setAttribute('aria-expanded', 'false');
+            }
+        });
+    }
+}
+
+/**
+ * Add animation on scroll for elements
+ */
+function initScrollAnimations() {
+    const observerOptions = {
+        threshold: 0.1,
+        rootMargin: '0px 0px -50px 0px'
+    };
+
+    const observer = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                entry.target.classList.add('animate-in');
+                const el = entry.target;
+                setTimeout(() => {
+                    el.style.transitionDelay = '0ms';
+                    el.classList.remove('animate-on-scroll');
+                }, 700);
+                observer.unobserve(entry.target);
+            }
+        });
+    }, observerOptions);
+
+    const revealVariant = (el) => {
+        if (el.classList.contains('gallery-item')) {
+            const siblings = Array.from(el.parentNode.children).filter(s => s.classList.contains('gallery-item'));
+            return (siblings.indexOf(el) % 2 === 0) ? 'reveal-left' : 'reveal-right';
+        }
+        if (el.classList.contains('awardee-card') || el.classList.contains('category-card')) return 'reveal-scale';
+        if (el.classList.contains('selection-step')) return 'reveal-right';
+        if (el.classList.contains('eligibility-item') || el.classList.contains('timeline-item')) return 'reveal-left';
+        return 'reveal-up';
+    };
+
+    // Observe cards and sections with a staggered reveal delay
+    const targets = document.querySelectorAll('.eligibility-item, .category-card, .selection-step, .awardee-card, .gallery-item, .timeline-item, .sah-banner, .sah-content-card');
+    targets.forEach(el => {
+        el.classList.add('animate-on-scroll', revealVariant(el));
+        const siblings = Array.from(el.parentNode.children).filter(s => s.classList.contains('animate-on-scroll'));
+        const index = siblings.indexOf(el);
+        el.style.transitionDelay = (index % 6) * 70 + 'ms';
+        observer.observe(el);
+    });
+}
+
+/**
+ * Scroll progress bar and back-to-top button
+ */
+function initScrollUI() {
+    const progress = document.getElementById('scroll-progress');
+    const btn = document.getElementById('btn-scroll-top');
+    if (!progress && !btn) return;
+
+    const update = () => {
+        const doc = document.documentElement;
+        const scrollTop = window.pageYOffset || doc.scrollTop;
+        const max = doc.scrollHeight - window.innerHeight;
+        if (progress) progress.style.width = (max > 0 ? (scrollTop / max) * 100 : 0) + '%';
+        if (btn) btn.classList.toggle('visible', scrollTop > 400);
+    };
+
+    window.addEventListener('scroll', update, { passive: true });
+    update();
+
+    if (btn) {
+        btn.addEventListener('click', () => {
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+        });
+    }
+}
+
+/**
+ * Footer quick links activate the matching section tab
+ */
+function initFooterTabs() {
+    document.querySelectorAll('.sah-footer-tab').forEach(link => {
+        link.addEventListener('click', (e) => {
+            e.preventDefault();
+            activateTab(link.dataset.footerTab);
+        });
+    });
+}
+
+/**
+ * Subtle 3D tilt on hover for cards (skipped for touch & reduced-motion)
+ */
+function initCardTilt() {
+    const cards = document.querySelectorAll('.category-card, .awardee-card, .gallery-item');
+    if (!cards.length) return;
+
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const coarse = window.matchMedia('(pointer: coarse)').matches;
+    if (reduced || coarse) return;
+
+    cards.forEach(card => {
+        card.addEventListener('mousemove', (e) => {
+            if (!card.classList.contains('animate-in')) return;
+            const rect = card.getBoundingClientRect();
+            const x = e.clientX - rect.left;
+            const y = e.clientY - rect.top;
+            card.style.setProperty('--spot-x', x + 'px');
+            card.style.setProperty('--spot-y', y + 'px');
+            const px = x / rect.width;
+            const py = y / rect.height;
+            const rx = (0.5 - py) * 8;
+            const ry = (px - 0.5) * 10;
+            card.classList.add('sah-card-tilt');
+            card.style.transform = `perspective(600px) rotateX(${rx.toFixed(2)}deg) rotateY(${ry.toFixed(2)}deg) translateY(-4px)`;
+        });
+
+        card.addEventListener('mouseleave', () => {
+            card.style.transform = '';
+        });
+    });
+}
+
+/**
+ * Typewriter effect for the rotating art-form words in the hero
+ */
+function initTyping() {
+    const el = document.querySelector('.sah-type[data-words]');
+    if (!el) return;
+
+    let words = [];
+    try {
+        words = JSON.parse(el.dataset.words);
+    } catch (err) {
+        return;
+    }
+    if (!Array.isArray(words) || !words.length) return;
+
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+        el.textContent = words[0];
+        return;
+    }
+
+    let wordIdx = 0;
+    let charIdx = 0;
+    let deleting = false;
+
+    const tick = () => {
+        const word = words[wordIdx];
+        el.textContent = word.slice(0, charIdx);
+
+        if (!deleting && charIdx < word.length) {
+            charIdx++;
+            setTimeout(tick, 90);
+        } else if (!deleting && charIdx === word.length) {
+            setTimeout(() => {
+                deleting = true;
+                tick();
+            }, 1700);
+        } else if (deleting && charIdx > 0) {
+            charIdx--;
+            setTimeout(tick, 45);
+        } else {
+            deleting = false;
+            wordIdx = (wordIdx + 1) % words.length;
+            setTimeout(tick, 350);
+        }
+    };
+
+    tick();
+}
+
+/**
+ * Gentle parallax drift for the hero backdrop while scrolling past the top
+ */
+function initHeroParallax() {
+    const bg = document.querySelector('.sah-hero-bg');
+    if (!bg) return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    let ticking = false;
+    const update = () => {
+        const y = window.pageYOffset;
+        if (y < window.innerHeight) {
+            bg.style.backgroundPosition = `center calc(50% + ${y * 0.35}px)`;
+        }
+    };
+
+    window.addEventListener('scroll', () => {
+        if (ticking) return;
+        ticking = true;
+        requestAnimationFrame(() => {
+            update();
+            ticking = false;
+        });
+    }, { passive: true });
+
+    update();
+}
+
+/**
+ * Animate count-up numbers when the hero enters the viewport
+ */
+function initCountUp() {
+    const counters = document.querySelectorAll('.sah-count');
+    if (!counters.length) return;
+
+    const duration = 1600;
+    const hero = document.querySelector('.sah-hero');
+
+    const animate = (counter) => {
+        const target = parseInt(counter.dataset.target, 10);
+        if (isNaN(target)) return;
+        const startTime = performance.now();
+
+        const tick = (now) => {
+            const progress = Math.min((now - startTime) / duration, 1);
+            const eased = 1 - Math.pow(1 - progress, 3);
+            const value = Math.round(target * eased);
+            counter.textContent = value.toLocaleString('en-IN');
+            if (progress < 1) {
+                requestAnimationFrame(tick);
+            } else {
+                counter.textContent = target.toLocaleString('en-IN');
+            }
+        };
+        requestAnimationFrame(tick);
+    };
+
+    const trigger = (entries, observer) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                counters.forEach(animate);
+                observer.disconnect();
+            }
+        });
+    };
+
+    if (hero) {
+        const observer = new IntersectionObserver(trigger, { threshold: 0.2 });
+        observer.observe(hero);
+    } else {
+        counters.forEach(animate);
+    }
+}
+
+/**
+ * Export functions for potential external use
+ */
+export {
+    initTabNavigation,
+    activateTab,
+    initThemeToggle,
+    initSmoothScroll,
+    initMobileMenu,
+    initScrollAnimations,
+    initCountUp,
+    initScrollUI,
+    initFooterTabs,
+    initCardTilt,
+    initTyping,
+    initHeroParallax
+};

--- a/frontend/sahitya-akademi-award-explorer/style.css
+++ b/frontend/sahitya-akademi-award-explorer/style.css
@@ -1,0 +1,1741 @@
+/* ==========================================================================
+   Sahitya Akademi Award Explorer Styling
+   India's National Academy of Letters - honours for Indian literature
+   ========================================================================== */
+
+.sah-page-body {
+    background-color: var(--bg-primary, #111827);
+    color: var(--text-primary, #E2E8F0);
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+}
+
+body.sah-page-body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    background:
+        radial-gradient(620px circle at 12% 18%, rgba(255, 153, 51, 0.12), transparent 60%),
+        radial-gradient(720px circle at 88% 78%, rgba(212, 175, 55, 0.12), transparent 60%),
+        radial-gradient(520px circle at 62% 40%, rgba(19, 136, 8, 0.1), transparent 60%);
+    animation: sah-aurora 20s ease-in-out infinite alternate;
+}
+
+@keyframes sah-aurora {
+    0% {
+        transform: translate(0, 0) scale(1);
+    }
+    50% {
+        transform: translate(18px, -18px) scale(1.06);
+    }
+    100% {
+        transform: translate(-18px, 14px) scale(1.12);
+    }
+}
+
+.sah-main {
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: 80px 20px 60px;
+    animation: sah-page-in 0.7s ease-out both;
+}
+
+@keyframes sah-page-in {
+    from {
+        opacity: 0;
+        transform: translateY(18px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* --- Hero Banner --- */
+.sah-hero {
+    text-align: center;
+    padding: 48px 24px;
+    background: linear-gradient(135deg, rgba(17, 24, 39, 0.95) 0%, rgba(30, 12, 34, 0.92) 100%);
+    border: 1px solid rgba(255, 176, 31, 0.3);
+    border-radius: 16px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+    margin-bottom: 32px;
+    position: relative;
+    overflow: hidden;
+}
+
+.sah-hero::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: linear-gradient(90deg, #FF9933 0%, #D4AF37 50%, #138808 100%);
+    z-index: 5;
+}
+
+.sah-hero-bg {
+    position: absolute;
+    inset: 0;
+    background-image: url('https://images.unsplash.com/photo-1507842217343-583bb7270b66?auto=format&fit=crop&q=80&w=1600');
+    background-size: cover;
+    background-position: center;
+    z-index: 0;
+    animation: sah-kenburns 26s ease-in-out infinite alternate;
+}
+
+.sah-hero-overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, rgba(11, 17, 30, 0.86) 0%, rgba(30, 12, 34, 0.8) 55%, rgba(11, 17, 30, 0.92) 100%);
+    z-index: 1;
+}
+
+.sah-hero-particles {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    z-index: 2;
+}
+
+.sah-hero-particles span {
+    position: absolute;
+    bottom: -20px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: rgba(255, 176, 31, 0.55);
+    box-shadow: 0 0 12px rgba(255, 153, 51, 0.5);
+    animation: sah-rise linear infinite;
+}
+
+.sah-hero-particles span:nth-child(1) { left: 8%; width: 6px; height: 6px; animation-duration: 9s; animation-delay: 0s; }
+.sah-hero-particles span:nth-child(2) { left: 22%; width: 10px; height: 10px; animation-duration: 12s; animation-delay: 2s; }
+.sah-hero-particles span:nth-child(3) { left: 38%; width: 7px; height: 7px; animation-duration: 10s; animation-delay: 4s; }
+.sah-hero-particles span:nth-child(4) { left: 55%; width: 11px; height: 11px; animation-duration: 14s; animation-delay: 1s; }
+.sah-hero-particles span:nth-child(5) { left: 72%; width: 6px; height: 6px; animation-duration: 11s; animation-delay: 5s; }
+.sah-hero-particles span:nth-child(6) { left: 88%; width: 9px; height: 9px; animation-duration: 13s; animation-delay: 3s; }
+
+@keyframes sah-rise {
+    0% {
+        transform: translateY(0) translateX(0) scale(0.5);
+        opacity: 0;
+    }
+    15% {
+        opacity: 0.85;
+    }
+    100% {
+        transform: translateY(-520px) translateX(18px) scale(1.15);
+        opacity: 0;
+    }
+}
+
+.sah-hero-content {
+    position: relative;
+    z-index: 3;
+    animation: sah-hero-rise 0.9s ease-out both;
+}
+
+@keyframes sah-hero-rise {
+    from {
+        opacity: 0;
+        transform: translateY(24px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes sah-kenburns {
+    from {
+        transform: scale(1) translateX(0);
+    }
+    to {
+        transform: scale(1.14) translateX(2%);
+    }
+}
+
+.sah-kicker {
+    display: inline-block;
+    padding: 6px 16px;
+    background: rgba(255, 176, 31, 0.15);
+    color: #F0C04D;
+    border: 1px solid rgba(255, 176, 31, 0.4);
+    border-radius: 20px;
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 16px;
+    position: relative;
+    overflow: hidden;
+}
+
+.sah-kicker::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 45%;
+    background: linear-gradient(105deg, transparent, rgba(255, 255, 255, 0.35), transparent);
+    transform: translateX(-140%);
+    animation: sah-badge-shine 3.6s ease-in-out infinite;
+}
+
+@keyframes sah-badge-shine {
+    0% {
+        transform: translateX(-140%);
+    }
+    60%,
+    100% {
+        transform: translateX(320%);
+    }
+}
+
+.sah-hero h1 {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 2.6rem;
+    font-weight: 800;
+    margin: 0 0 12px;
+    background: linear-gradient(90deg, #FFB01F, #F8FAFC, #FF9933, #F8FAFC, #FFB01F);
+    background-size: 200% auto;
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    animation: sah-shimmer 7s linear infinite;
+}
+
+@keyframes sah-shimmer {
+    to {
+        background-position: -200% center;
+    }
+}
+
+@supports not (background-clip: text) {
+    .sah-hero h1 {
+        background: none;
+        color: var(--text-heading, #F8FAFC);
+    }
+}
+
+.sah-hero p {
+    font-size: 1.1rem;
+    color: var(--text-secondary, #94A3B8);
+    max-width: 850px;
+    margin: 0 auto 24px;
+}
+
+.sah-type-line {
+    font-size: 1.15rem;
+    font-weight: 600;
+}
+
+.sah-type {
+    color: #F0C04D;
+    font-weight: 800;
+}
+
+.sah-type::after {
+    content: '';
+    display: inline-block;
+    width: 3px;
+    height: 1em;
+    margin-left: 4px;
+    background: #F0C04D;
+    vertical-align: -0.12em;
+    animation: sah-blink 0.85s step-end infinite;
+}
+
+@keyframes sah-blink {
+    0%,
+    100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0;
+    }
+}
+
+.sah-hero-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 16px;
+    margin-top: 24px;
+}
+
+.sah-hero-stat {
+    background: rgba(15, 23, 42, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 14px;
+    padding: 22px 16px 18px;
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+    transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.sah-hero-stat::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, #FF9933 0%, #D4AF37 50%, #138808 100%);
+    border-radius: 14px 14px 0 0;
+}
+
+.sah-hero-stat:hover {
+    transform: translateY(-5px);
+    border-color: rgba(255, 176, 31, 0.55);
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.4);
+}
+
+.sah-hero-stat:hover strong {
+    animation: sah-pop 0.4s ease;
+}
+
+@keyframes sah-pop {
+    0% {
+        transform: scale(1);
+    }
+    50% {
+        transform: scale(1.18);
+    }
+    100% {
+        transform: scale(1);
+    }
+}
+
+.sah-hero-stat strong {
+    font-size: clamp(1.9rem, 4.5vw, 2.6rem);
+    font-family: 'Playfair Display', Georgia, serif;
+    font-weight: 800;
+    line-height: 1.1;
+    color: #FF9933;
+    display: block;
+    margin-bottom: 8px;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+    animation: sah-glow 3s ease-in-out infinite;
+}
+
+@keyframes sah-glow {
+    0%,
+    100% {
+        text-shadow: 0 0 6px rgba(255, 153, 51, 0.35);
+    }
+    50% {
+        text-shadow: 0 0 20px rgba(255, 153, 51, 0.75);
+    }
+}
+
+.sah-hero-stat span {
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: #94A3B8;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    display: block;
+}
+
+/* --- Scroll Down Hint --- */
+.sah-scroll-hint {
+    position: relative;
+    z-index: 3;
+    display: block;
+    width: 26px;
+    height: 42px;
+    margin: 10px auto 0;
+    border: 2px solid rgba(240, 192, 77, 0.8);
+    border-radius: 16px;
+    animation: sah-hint-bob 2s ease-in-out infinite;
+}
+
+.sah-scroll-hint::after {
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: 8px;
+    width: 5px;
+    height: 5px;
+    margin-left: -2.5px;
+    border-radius: 50%;
+    background: #F0C04D;
+    animation: sah-hint-dot 2s ease-in-out infinite;
+}
+
+@keyframes sah-hint-bob {
+    0%,
+    100% {
+        transform: translateY(0);
+    }
+    50% {
+        transform: translateY(6px);
+    }
+}
+
+@keyframes sah-hint-dot {
+    0% {
+        opacity: 0;
+        transform: translateY(0);
+    }
+    30% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+        transform: translateY(16px);
+    }
+}
+
+/* --- Marquee Strip --- */
+.sah-marquee {
+    overflow: hidden;
+    background: linear-gradient(90deg, #FF9933 0%, #D4AF37 50%, #138808 100%);
+    padding: 10px 0;
+    border-radius: 10px;
+    margin-bottom: 24px;
+    box-shadow: 0 4px 18px rgba(0, 0, 0, 0.25);
+}
+
+.sah-marquee-track {
+    display: flex;
+    gap: 56px;
+    width: max-content;
+    animation: sah-marquee-scroll 30s linear infinite;
+}
+
+.sah-marquee-track span {
+    color: #111827;
+    font-weight: 800;
+    font-size: 0.85rem;
+    letter-spacing: 1.5px;
+    white-space: nowrap;
+}
+
+@keyframes sah-marquee-scroll {
+    from {
+        transform: translateX(0);
+    }
+    to {
+        transform: translateX(-50%);
+    }
+}
+
+.sah-marquee:hover .sah-marquee-track {
+    animation-play-state: paused;
+}
+
+/* --- Navigation Tabs --- */
+.sah-nav-tabs {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-bottom: 32px;
+    padding: 16px;
+    background: rgba(15, 23, 42, 0.6);
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.sah-tab {
+    background: rgba(15, 23, 42, 0.8);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    color: var(--text-secondary, #94A3B8);
+    padding: 10px 18px;
+    border-radius: 8px;
+    font-size: 0.88rem;
+    font-weight: 600;
+    cursor: pointer;
+    position: relative;
+    overflow: hidden;
+    transition: all 0.25s ease;
+}
+
+.sah-tab::after {
+    content: '';
+    position: absolute;
+    left: 14%;
+    right: 14%;
+    bottom: 5px;
+    height: 2px;
+    border-radius: 2px;
+    background: currentColor;
+    transform: scaleX(0);
+    transform-origin: center;
+    transition: transform 0.3s ease;
+}
+
+.sah-tab:hover::after {
+    transform: scaleX(1);
+}
+
+.sah-tab:hover {
+    background: rgba(255, 176, 31, 0.15);
+    color: #F0C04D;
+    border-color: rgba(255, 176, 31, 0.4);
+    transform: translateY(-2px);
+}
+
+.sah-tab.active {
+    background: linear-gradient(135deg, #D4AF37 0%, #FF9933 100%);
+    color: #111827;
+    border-color: transparent;
+    box-shadow: 0 4px 16px rgba(255, 153, 51, 0.3);
+    animation: sah-tab-pulse 2.6s ease-in-out infinite;
+}
+
+@keyframes sah-tab-pulse {
+    0%,
+    100% {
+        box-shadow: 0 4px 16px rgba(255, 153, 51, 0.3);
+    }
+    50% {
+        box-shadow: 0 6px 28px rgba(255, 153, 51, 0.6);
+    }
+}
+
+/* --- Sections --- */
+.sah-section {
+    display: none;
+}
+
+.sah-section.active {
+    display: block;
+    animation: sah-fade-in 0.4s ease;
+}
+
+@keyframes sah-fade-in {
+    from {
+        opacity: 0;
+        transform: translateY(18px) scale(0.985);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+.sah-content-card {
+    background: var(--bg-dark-card, rgba(30, 41, 59, 0.5));
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 16px;
+    padding: 32px;
+    margin-bottom: 24px;
+    backdrop-filter: blur(8px);
+}
+
+.sah-content-card h2 {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 1.8rem;
+    color: #FF9933;
+    margin: 0 0 20px;
+    border-bottom: 1px solid rgba(255, 176, 31, 0.2);
+    padding-bottom: 12px;
+    position: relative;
+}
+
+.sah-content-card h2::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: -1px;
+    height: 3px;
+    width: 60px;
+    border-radius: 3px;
+    background: linear-gradient(90deg, #FF9933 0%, #D4AF37 100%);
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform 0.55s ease;
+}
+
+.sah-content-card.animate-in h2::after {
+    transform: scaleX(1);
+}
+
+.sah-content p {
+    color: var(--text-secondary, #94A3B8);
+    margin-bottom: 16px;
+    font-size: 1rem;
+}
+
+.sah-content h3 {
+    color: #F0C04D;
+    font-size: 1.15rem;
+    margin: 24px 0 12px;
+}
+
+/* --- Split Layout (Text + Figure) --- */
+.sah-split {
+    display: grid;
+    grid-template-columns: 1.35fr 1fr;
+    gap: 32px;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.sah-figure {
+    margin: 0;
+    position: relative;
+    border-radius: 16px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
+    min-height: 260px;
+}
+
+.sah-figure img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.6s ease;
+}
+
+.sah-figure:hover img {
+    transform: scale(1.05);
+}
+
+.sah-figure figcaption {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 30px 16px 14px;
+    background: linear-gradient(transparent, rgba(8, 12, 22, 0.85));
+    color: #F8FAFC;
+    font-size: 0.82rem;
+    text-align: center;
+}
+
+@keyframes sah-float {
+    0%,
+    100% {
+        transform: translateY(0);
+    }
+    50% {
+        transform: translateY(-10px);
+    }
+}
+
+.float-slow {
+    animation: sah-float 5s ease-in-out infinite;
+}
+
+/* --- Banner Figure --- */
+.sah-banner {
+    margin: 0 0 20px;
+    border-radius: 16px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.sah-banner img {
+    display: block;
+    width: 100%;
+    height: 300px;
+    object-fit: cover;
+    transition: transform 0.6s ease;
+}
+
+.sah-banner:hover img {
+    transform: scale(1.04);
+}
+
+.sah-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 16px;
+}
+
+.sah-list li {
+    position: relative;
+    padding-left: 28px;
+    margin-bottom: 10px;
+    color: var(--text-secondary, #94A3B8);
+    transition: transform 0.22s ease, color 0.22s ease;
+}
+
+.sah-list li:hover {
+    transform: translateX(6px);
+    color: #F0C04D;
+}
+
+.sah-list li::before {
+    content: '📖';
+    position: absolute;
+    left: 0;
+    top: 0;
+    transition: transform 0.25s ease;
+}
+
+.sah-list li:hover::before {
+    transform: scale(1.25) rotate(-8deg);
+}
+
+/* --- Eligibility Grid --- */
+.eligibility-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 16px;
+    margin-top: 8px;
+}
+
+.eligibility-item {
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    padding: 20px;
+    transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.eligibility-item:hover {
+    transform: translateY(-4px);
+    border-color: rgba(255, 176, 31, 0.4);
+}
+
+.eligibility-item h3 {
+    color: #F0C04D;
+    font-size: 1.05rem;
+    margin: 0 0 10px;
+}
+
+.eligibility-item p {
+    color: var(--text-secondary, #94A3B8);
+    font-size: 0.92rem;
+    margin: 0;
+}
+
+/* --- Category Cards (Painting/Sculpture/Printmaking/Ceramics) --- */
+.category-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 16px;
+    margin-top: 16px;
+}
+
+.category-card {
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    padding: 20px;
+    text-align: left;
+    position: relative;
+    overflow: hidden;
+    transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.category-card:hover {
+    transform: translateY(-4px);
+    border-color: rgba(255, 176, 31, 0.4);
+}
+
+.category-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(320px circle at var(--spot-x, 50%) var(--spot-y, 50%), rgba(255, 176, 31, 0.18), transparent 65%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+    z-index: 1;
+}
+
+.category-card:hover::before {
+    opacity: 1;
+}
+
+.category-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 1px;
+    background: linear-gradient(120deg, transparent 20%, #FF9933 40%, #D4AF37 50%, #138808 60%, transparent 80%);
+    background-size: 250% 250%;
+    -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    opacity: 0;
+    transition: opacity 0.35s ease;
+    pointer-events: none;
+    z-index: 2;
+    animation: sah-border-shimmer 2.5s linear infinite;
+}
+
+.category-card:hover::after {
+    opacity: 1;
+}
+
+@keyframes sah-border-shimmer {
+    to {
+        background-position: 250% 0;
+    }
+}
+
+.category-img {
+    height: 150px;
+    border-radius: 10px;
+    overflow: hidden;
+    margin-bottom: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    position: relative;
+}
+
+.category-img img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.5s ease;
+}
+
+.category-card:hover .category-img img {
+    transform: scale(1.08);
+}
+
+.category-img::before {
+    content: '↗';
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(8, 12, 22, 0.4);
+    color: #F0C04D;
+    font-size: 1.8rem;
+    font-weight: 700;
+    opacity: 0;
+    transition: opacity 0.35s ease;
+    z-index: 1;
+}
+
+.category-card:hover .category-img::before {
+    opacity: 1;
+}
+
+.category-img::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(105deg, transparent 40%, rgba(255, 255, 255, 0.28) 50%, transparent 60%);
+    transform: translateX(-130%);
+    transition: transform 0.6s ease;
+    z-index: 1;
+}
+
+.category-card:hover .category-img::after {
+    transform: translateX(130%);
+}
+
+.category-card:hover .category-icon {
+    animation: sah-bounce 0.5s ease;
+}
+
+@keyframes sah-bounce {
+    0%,
+    100% {
+        transform: translateY(0);
+    }
+    40% {
+        transform: translateY(-8px) rotate(-6deg);
+    }
+}
+
+.category-card h3 {
+    color: #F0C04D;
+    font-size: 1.05rem;
+    margin: 0 0 10px;
+}
+
+.category-card p {
+    color: var(--text-secondary, #94A3B8);
+    font-size: 0.92rem;
+    margin: 0;
+}
+
+/* --- Selection Timeline --- */
+.selection-timeline {
+    margin: 20px 0;
+}
+
+.selection-step {
+    position: relative;
+    padding: 0 0 24px 56px;
+}
+
+.selection-step:last-child {
+    padding-bottom: 0;
+}
+
+.selection-step::before {
+    content: '';
+    position: absolute;
+    left: 24px;
+    top: 42px;
+    bottom: 0;
+    width: 2px;
+    background: rgba(255, 176, 31, 0.3);
+}
+
+.selection-step:last-child::before {
+    display: none;
+}
+
+.step-number {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #D4AF37 0%, #FF9933 100%);
+    color: #111827;
+    font-weight: 800;
+    font-size: 1.1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 4px 14px rgba(255, 153, 51, 0.35);
+}
+
+.selection-step h3 {
+    color: #F0C04D;
+    font-size: 1.05rem;
+    margin: 0 0 6px;
+}
+
+.selection-step:hover .step-number {
+    transform: scale(1.15) rotate(8deg);
+    box-shadow: 0 6px 20px rgba(255, 153, 51, 0.5);
+}
+
+.step-number {
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.selection-step p {
+    color: var(--text-secondary, #94A3B8);
+    font-size: 0.95rem;
+    margin: 0;
+}
+
+.evaluation-criteria {
+    background: rgba(255, 176, 31, 0.06);
+    border: 1px solid rgba(255, 176, 31, 0.25);
+    border-radius: 12px;
+    padding: 20px;
+    margin-top: 24px;
+}
+
+.evaluation-criteria h3 {
+    color: #F0C04D;
+    margin: 0 0 12px;
+}
+
+.evaluation-criteria ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.evaluation-criteria li {
+    color: var(--text-secondary, #94A3B8);
+    margin-bottom: 8px;
+    font-size: 0.95rem;
+    transition: transform 0.22s ease, color 0.22s ease;
+}
+
+.evaluation-criteria li:hover {
+    color: #F0C04D;
+    transform: translateX(6px);
+}
+
+/* --- Awardees --- */
+.awardees-gallery {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 16px;
+    margin-top: 16px;
+}
+
+.awardee-card {
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    padding: 20px;
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+    transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.awardee-card:hover {
+    transform: translateY(-4px);
+    border-color: rgba(255, 176, 31, 0.4);
+}
+
+.awardee-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(300px circle at var(--spot-x, 50%) var(--spot-y, 50%), rgba(255, 176, 31, 0.16), transparent 65%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+    z-index: 1;
+}
+
+.awardee-card:hover::before {
+    opacity: 1;
+}
+
+.awardee-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 1px;
+    background: linear-gradient(120deg, transparent 20%, #FF9933 40%, #D4AF37 50%, #138808 60%, transparent 80%);
+    background-size: 250% 250%;
+    -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    opacity: 0;
+    transition: opacity 0.35s ease;
+    pointer-events: none;
+    z-index: 2;
+    animation: sah-border-shimmer 2.5s linear infinite;
+}
+
+.awardee-card:hover::after {
+    opacity: 1;
+}
+
+.awardee-avatar {
+    font-size: 2.2rem;
+    margin-bottom: 8px;
+    display: inline-block;
+}
+
+.awardee-card:hover .awardee-avatar {
+    animation: sah-bounce 0.5s ease;
+}
+
+.awardee-card h3 {
+    color: #F8FAFC;
+    font-size: 1.05rem;
+    margin: 0 0 4px;
+}
+
+.awardee-year {
+    display: inline-block;
+    background: rgba(255, 153, 51, 0.15);
+    color: #FFB01F;
+    font-size: 0.78rem;
+    font-weight: 600;
+    padding: 4px 10px;
+    border-radius: 20px;
+    margin-bottom: 10px;
+    animation: sah-year-pulse 3s ease-in-out infinite;
+}
+
+@keyframes sah-year-pulse {
+    0%,
+    100% {
+        box-shadow: 0 0 0 0 rgba(255, 153, 51, 0.4);
+    }
+    50% {
+        box-shadow: 0 0 0 6px rgba(255, 153, 51, 0);
+    }
+}
+
+.awardee-card p:last-child {
+    color: var(--text-secondary, #94A3B8);
+    font-size: 0.88rem;
+    margin: 0;
+}
+
+.notable-achievements {
+    background: rgba(255, 176, 31, 0.06);
+    border: 1px solid rgba(255, 176, 31, 0.25);
+    border-radius: 12px;
+    padding: 20px;
+    margin-top: 24px;
+}
+
+.notable-achievements h3 {
+    color: #F0C04D;
+    margin: 0 0 12px;
+}
+
+.notable-achievements ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.notable-achievements li {
+    color: var(--text-secondary, #94A3B8);
+    margin-bottom: 8px;
+    font-size: 0.95rem;
+    padding-left: 24px;
+    position: relative;
+}
+
+.notable-achievements li::before {
+    content: '🏅';
+    position: absolute;
+    left: 0;
+    top: 0;
+}
+
+/* --- Gallery --- */
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 16px;
+    margin-top: 16px;
+}
+
+.gallery-item {
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    overflow: hidden;
+    text-align: center;
+    position: relative;
+    transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.gallery-item:hover {
+    transform: translateY(-4px);
+    border-color: rgba(255, 176, 31, 0.4);
+}
+
+.gallery-item::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(320px circle at var(--spot-x, 50%) var(--spot-y, 50%), rgba(255, 176, 31, 0.18), transparent 65%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+    z-index: 2;
+}
+
+.gallery-item:hover::before {
+    opacity: 1;
+}
+
+.gallery-item::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 1px;
+    background: linear-gradient(120deg, transparent 20%, #FF9933 40%, #D4AF37 50%, #138808 60%, transparent 80%);
+    background-size: 250% 250%;
+    -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    opacity: 0;
+    transition: opacity 0.35s ease;
+    pointer-events: none;
+    z-index: 3;
+    animation: sah-border-shimmer 2.5s linear infinite;
+}
+
+.gallery-item:hover::after {
+    opacity: 1;
+}
+
+.gallery-img {
+    height: 170px;
+    overflow: hidden;
+    position: relative;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.gallery-img img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.5s ease;
+}
+
+.gallery-item:hover .gallery-img img {
+    transform: scale(1.08);
+}
+
+.gallery-img::before {
+    content: '↗';
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(8, 12, 22, 0.4);
+    color: #F0C04D;
+    font-size: 1.8rem;
+    font-weight: 700;
+    opacity: 0;
+    transition: opacity 0.35s ease;
+    z-index: 1;
+}
+
+.gallery-item:hover .gallery-img::before {
+    opacity: 1;
+}
+
+.gallery-img::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(105deg, transparent 40%, rgba(255, 255, 255, 0.28) 50%, transparent 60%);
+    transform: translateX(-130%);
+    transition: transform 0.6s ease;
+    z-index: 1;
+}
+
+.gallery-item:hover .gallery-img::after {
+    transform: translateX(130%);
+}
+
+.gallery-item figcaption {
+    position: relative;
+    z-index: 4;
+}
+
+.gallery-item h3 {
+    color: #F8FAFC;
+    font-size: 1rem;
+    margin: 12px 0 4px;
+}
+
+.gallery-item p {
+    color: var(--text-secondary, #94A3B8);
+    font-size: 0.85rem;
+    padding: 0 14px 14px;
+    margin: 0;
+}
+
+.media-highlights {
+    background: rgba(255, 176, 31, 0.06);
+    border: 1px solid rgba(255, 176, 31, 0.25);
+    border-radius: 12px;
+    padding: 20px;
+    margin-top: 24px;
+}
+
+.media-highlights h3 {
+    color: #F0C04D;
+    margin: 0 0 12px;
+}
+
+.media-highlights ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.media-highlights li {
+    color: var(--text-secondary, #94A3B8);
+    margin-bottom: 8px;
+    font-size: 0.95rem;
+}
+
+/* --- Language Chips --- */
+.language-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+    gap: 14px;
+    margin: 28px 0;
+}
+
+.language-chip {
+    position: relative;
+    background: rgba(255, 153, 51, 0.08);
+    border: 1px solid rgba(212, 175, 55, 0.35);
+    border-radius: 14px;
+    padding: 14px 18px;
+    color: #F0C04D;
+    font-weight: 600;
+    font-size: 0.98rem;
+    text-align: center;
+    transition: transform 0.25s ease, border-color 0.25s ease, background 0.25s ease;
+}
+
+.language-chip:hover {
+    transform: translateY(-4px);
+    border-color: #D4AF37;
+    background: rgba(255, 153, 51, 0.15);
+}
+
+.language-chip span {
+    display: block;
+    margin-top: 4px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--text-secondary, #94A3B8);
+    letter-spacing: 0.4px;
+}
+
+/* --- Akademi Timeline --- */
+.timeline-container {
+    position: relative;
+    margin: 24px 0 8px;
+    padding-left: 24px;
+}
+
+.timeline-container::before {
+    content: '';
+    position: absolute;
+    left: 10px;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: linear-gradient(180deg, #FF9933 0%, #D4AF37 55%, #138808 100%);
+    border-radius: 2px;
+}
+
+.timeline-item {
+    position: relative;
+    padding: 0 0 28px 22px;
+}
+
+.timeline-item:last-child {
+    padding-bottom: 0;
+}
+
+.timeline-dot {
+    position: absolute;
+    left: -22px;
+    top: 6px;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #D4AF37 0%, #FF9933 100%);
+    box-shadow: 0 0 0 4px rgba(255, 153, 51, 0.18);
+    animation: sah-dot-pulse 3s ease-in-out infinite;
+}
+
+@keyframes sah-dot-pulse {
+    0%,
+    100% {
+        box-shadow: 0 0 0 4px rgba(255, 153, 51, 0.18);
+    }
+    50% {
+        box-shadow: 0 0 0 8px rgba(255, 153, 51, 0.05);
+    }
+}
+
+.timeline-item:hover .timeline-dot {
+    transform: scale(1.25);
+}
+
+.timeline-dot {
+    transition: transform 0.25s ease;
+}
+
+.timeline-year {
+    display: inline-block;
+    background: rgba(255, 153, 51, 0.15);
+    color: #FFB01F;
+    font-size: 0.82rem;
+    font-weight: 700;
+    padding: 4px 12px;
+    border-radius: 20px;
+    margin-bottom: 8px;
+    letter-spacing: 0.5px;
+}
+
+.timeline-body h3 {
+    color: #F0C04D;
+    font-size: 1.08rem;
+    margin: 0 0 6px;
+}
+
+.timeline-body p {
+    color: var(--text-secondary, #94A3B8);
+    font-size: 0.95rem;
+    margin: 0;
+}
+
+/* --- Footer --- */
+.sah-footer {
+    margin-top: 48px;
+    border-top: 3px solid;
+    border-image: linear-gradient(90deg, #FF9933 0%, #D4AF37 50%, #138808 100%) 1;
+    background: rgba(11, 17, 30, 0.55);
+    color: var(--text-secondary, #94A3B8);
+    font-size: 0.9rem;
+}
+
+.sah-footer-container {
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: 48px 24px 32px;
+    display: grid;
+    grid-template-columns: 1.6fr 1fr 1fr 1fr;
+    gap: 40px;
+}
+
+.sah-footer-brand h3 {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 1.3rem;
+    margin: 0 0 12px;
+    color: #F8FAFC;
+}
+
+.sah-footer-brand p {
+    font-size: 0.88rem;
+    line-height: 1.7;
+    margin: 0 0 10px;
+    color: var(--text-secondary, #94A3B8);
+}
+
+.sah-footer-tagline {
+    color: #F0C04D;
+    font-weight: 600;
+}
+
+.sah-footer-links h4 {
+    color: #F0C04D;
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 1rem;
+    margin: 0 0 16px;
+}
+
+.sah-footer-links ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.sah-footer-links li {
+    margin-bottom: 10px;
+}
+
+.sah-footer-links a {
+    color: var(--text-secondary, #94A3B8);
+    text-decoration: none;
+    font-size: 0.9rem;
+    transition: color 0.25s ease, transform 0.25s ease;
+    display: inline-block;
+    position: relative;
+}
+
+.sah-footer-links a::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: -2px;
+    height: 2px;
+    width: 100%;
+    background: linear-gradient(90deg, #FF9933 0%, #D4AF37 100%);
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform 0.3s ease;
+}
+
+.sah-footer-links a:hover::after {
+    transform: scaleX(1);
+}
+
+.sah-footer-links a:hover {
+    color: #FF9933;
+    transform: translateX(4px);
+}
+
+.sah-footer-bottom {
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 18px 24px;
+    text-align: center;
+    font-size: 0.82rem;
+    color: var(--text-secondary, #94A3B8);
+}
+
+.sah-footer-bottom p {
+    margin: 4px 0;
+}
+
+/* --- Scroll Progress --- */
+.sah-scroll-progress {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 3px;
+    width: 0;
+    background: linear-gradient(90deg, #FF9933 0%, #D4AF37 50%, #138808 100%);
+    z-index: 1000;
+    transition: width 0.1s linear;
+}
+
+/* --- Scroll to Top --- */
+.sah-scroll-top {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    width: 46px;
+    height: 46px;
+    border-radius: 50%;
+    border: none;
+    background: linear-gradient(135deg, #D4AF37 0%, #FF9933 100%);
+    color: #111827;
+    font-size: 1.2rem;
+    font-weight: 800;
+    cursor: pointer;
+    box-shadow: 0 6px 18px rgba(255, 153, 51, 0.4);
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(12px);
+    transition: opacity 0.3s ease, transform 0.3s ease, visibility 0.3s ease;
+    z-index: 900;
+}
+
+.sah-scroll-top.visible {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
+.sah-scroll-top:hover {
+    transform: translateY(-3px) scale(1.05);
+}
+
+/* --- Scroll Animations --- */
+.animate-on-scroll {
+    opacity: 0;
+    transform: translateY(24px);
+    transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.reveal-left {
+    transform: translateX(-30px);
+}
+
+.reveal-right {
+    transform: translateX(30px);
+}
+
+.reveal-scale {
+    transform: scale(0.9);
+}
+
+.animate-in {
+    opacity: 1;
+    transform: none;
+}
+
+/* Card 3D tilt (transform set inline via JS on hover) */
+.sah-card-tilt {
+    transition: transform 0.2s ease-out, box-shadow 0.3s ease, border-color 0.3s ease !important;
+    transform-style: preserve-3d;
+    will-change: transform;
+}
+
+.category-card:hover,
+.awardee-card:hover,
+.gallery-item:hover {
+    box-shadow: 0 16px 36px rgba(0, 0, 0, 0.4);
+}
+
+/* --- Light Theme Overrides --- */
+.light-theme .sah-page-body {
+    background-color: #F8FAFC;
+}
+
+.light-theme .sah-hero {
+    background: linear-gradient(135deg, rgba(255, 248, 235, 0.95) 0%, rgba(250, 240, 255, 0.92) 100%);
+    border-color: rgba(255, 153, 51, 0.35);
+}
+
+.light-theme .sah-hero h1 {
+    background-image: linear-gradient(90deg, #B45309, #1E293B, #B45309, #1E293B, #B45309);
+}
+
+.light-theme .sah-footer {
+    background: rgba(255, 255, 255, 0.78);
+}
+
+.light-theme body.sah-page-body::before {
+    background:
+        radial-gradient(620px circle at 12% 18%, rgba(255, 153, 51, 0.16), transparent 60%),
+        radial-gradient(720px circle at 88% 78%, rgba(212, 175, 55, 0.16), transparent 60%),
+        radial-gradient(520px circle at 62% 40%, rgba(19, 136, 8, 0.12), transparent 60%);
+}
+
+.light-theme .sah-type {
+    color: #B45309;
+}
+
+.light-theme .sah-type::after {
+    background: #B45309;
+}
+
+.light-theme .sah-footer-brand h3,
+.light-theme .sah-footer-links h4 {
+    color: #1E293B;
+}
+
+.light-theme .sah-footer-tagline {
+    color: #B45309;
+}
+
+.light-theme .sah-scroll-top {
+    color: #ffffff;
+}
+
+.light-theme .sah-hero-overlay {
+    background: linear-gradient(180deg, rgba(255, 248, 235, 0.9) 0%, rgba(250, 240, 255, 0.84) 55%, rgba(255, 248, 235, 0.94) 100%);
+}
+
+.light-theme .sah-figure figcaption {
+    background: linear-gradient(transparent, rgba(30, 41, 59, 0.85));
+}
+
+.light-theme .sah-hero-stat {
+    background: rgba(255, 255, 255, 0.8);
+    border-color: rgba(255, 153, 51, 0.2);
+}
+
+.light-theme .sah-hero-stat span {
+    color: #64748B;
+}
+
+.light-theme .sah-nav-tabs,
+.light-theme .sah-content-card {
+    background: rgba(255, 255, 255, 0.85);
+    border-color: rgba(203, 213, 225, 0.6);
+}
+
+.light-theme .sah-tab {
+    background: rgba(255, 255, 255, 0.8);
+    border-color: rgba(203, 213, 225, 0.7);
+    color: #475569;
+}
+
+.light-theme .sah-content p,
+.light-theme .sah-list li,
+.light-theme .eligibility-item p,
+.light-theme .category-card p,
+.light-theme .selection-step p,
+.light-theme .evaluation-criteria li,
+.light-theme .awardee-card p:last-child,
+.light-theme .gallery-item p,
+.light-theme .media-highlights li,
+.light-theme .notable-achievements li,
+.light-theme .timeline-body p,
+.light-theme .language-chip span,
+.light-theme .sah-footer {
+    color: #475569;
+}
+
+.light-theme .sah-hero p {
+    color: #475569;
+}
+
+.light-theme .eligibility-item,
+.light-theme .category-card,
+.light-theme .awardee-card,
+.light-theme .gallery-item,
+.light-theme .language-chip {
+    background: rgba(255, 255, 255, 0.9);
+    border-color: rgba(203, 213, 225, 0.6);
+}
+
+.light-theme .awardee-card h3,
+.light-theme .gallery-item h3,
+.light-theme .timeline-body h3,
+.light-theme .language-chip {
+    color: #1E293B;
+}
+
+/* --- Responsive --- */
+@media (max-width: 768px) {
+    .sah-main {
+        padding: 60px 14px 40px;
+    }
+
+    .sah-hero h1 {
+        font-size: 1.9rem;
+    }
+
+    .sah-hero p {
+        font-size: 1rem;
+    }
+
+    .sah-content-card {
+        padding: 20px;
+    }
+
+    .sah-content-card h2 {
+        font-size: 1.45rem;
+    }
+
+    .sah-split {
+        grid-template-columns: 1fr;
+    }
+
+    .sah-banner img {
+        height: 200px;
+    }
+
+    .sah-footer-container {
+        grid-template-columns: 1fr;
+        gap: 32px;
+        padding: 36px 20px 24px;
+    }
+
+    .sah-scroll-top {
+        bottom: 16px;
+        right: 16px;
+        width: 42px;
+        height: 42px;
+    }
+}
+
+/* --- Reduced Motion --- */
+@media (prefers-reduced-motion: reduce) {
+    .sah-hero-bg,
+    .sah-marquee-track,
+    .float-slow,
+    .sah-hero-content,
+    .sah-hero-particles span,
+    .sah-hero h1,
+    .sah-hero-stat strong,
+    body.sah-page-body::before,
+    .sah-tab.active,
+    .sah-type::after {
+        animation: none;
+    }
+
+    .category-card::after,
+    .awardee-card::after,
+    .gallery-item::after,
+    .sah-kicker::after,
+    .sah-scroll-hint,
+    .sah-scroll-hint::after,
+    .awardee-year {
+        animation: none;
+    }
+
+    .sah-main,
+    .sah-section.active {
+        animation: none;
+    }
+}

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -1702,6 +1702,13 @@ window.indiaSearchIndex = [
     description: "Explore India's most prestigious government-sponsored film awards — history since 1954, the Golden and Silver Lotus, categories, Best Feature Film, acting and technical awards, selection process, timeline, and notable winners.",
     url: "frontend/national-film-awards-explorer/index.html"
   },
+  // --- Sahitya Akademi Award Explorer ---
+  {
+    title: "Sahitya Akademi Award Explorer",
+    category: "Awards & Honours",
+    description: "Explore India's National Academy of Letters and its premier literary honour — history since 1954, year instituted, eligibility, the 24 languages covered, selection process, categories, notable awardees, timeline, facts, and gallery.",
+    url: "frontend/sahitya-akademi-award-explorer/index.html"
+  },
   // --- Mandvi Port Explorer ---
   {
     title: "Mandvi Ancient Port Explorer",

--- a/tests/unit/sahitya-akademi-award-explorer.test.js
+++ b/tests/unit/sahitya-akademi-award-explorer.test.js
@@ -1,0 +1,136 @@
+/**
+ * sahitya-akademi-award-explorer.test.js
+ * Unit tests for the Sahitya Akademi Award Explorer page.
+ * Validates required sections, tab navigation, accessibility, image URLs,
+ * and landing page card integration on the Awards of India landing page.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function readExplorerFile(file) {
+    return readFileSync(
+        resolve(__dirname, '../../frontend/sahitya-akademi-award-explorer', file),
+        'utf-8'
+    );
+}
+
+function readLandingPage() {
+    return readFileSync(
+        resolve(__dirname, '../../frontend/awards-of-india-explorer/index.html'),
+        'utf-8'
+    );
+}
+
+describe('Sahitya Akademi Award Explorer — Page Structure', () => {
+    let html;
+
+    beforeAll(() => {
+        html = readExplorerFile('index.html');
+    });
+
+    it('contains a hero section with page title and kicker', () => {
+        expect(html).toContain('class="sah-hero"');
+        expect(html).toContain('<h1>');
+        expect(html).toContain('Sahitya Akademi Award');
+        expect(html).toContain('National Academy of Letters');
+        expect(html).toContain('First Award Conferred');
+        expect(html).toContain('1955');
+    });
+
+    it('contains all required content sections from the issue', () => {
+        const sections = ['history', 'year-instituted', 'eligibility', 'languages', 'selection', 'categories', 'awardees', 'timeline', 'facts', 'gallery'];
+        sections.forEach(id => {
+            expect(html).toContain(`id="${id}"`);
+            expect(html).toContain(`data-tab="${id}"`);
+        });
+    });
+
+    it('contains all required award categories as tab buttons', () => {
+        ['History', 'Year Instituted', 'Eligibility', 'Languages', 'Selection', 'Categories', 'Awardees', 'Timeline', 'Facts', 'Gallery'].forEach(category => {
+            expect(html).toContain(category);
+        });
+    });
+
+    it('contains the key historical and structural details', () => {
+        expect(html).toContain('15 December 1952');
+        expect(html).toContain('12 March 1954');
+        expect(html).toContain('Jawaharlal Nehru');
+        expect(html).toContain('S. Radhakrishnan');
+        expect(html).toContain('Satyajit Ray');
+        expect(html).toContain('1,00,000');
+        expect(html).toContain('Rabindra Bhavan');
+    });
+
+    it('covers the 24 recognized languages', () => {
+        ['Assamese', 'Bengali', 'Hindi', 'Kannada', 'Malayalam', 'Tamil', 'Telugu', 'Urdu', 'English', 'Rajasthani', 'Sanskrit', 'Santhali'].forEach(language => {
+            expect(html).toContain(language);
+        });
+    });
+
+    it('has a semantic heading hierarchy (single h1, section h2s)', () => {
+        const h1Count = (html.match(/<h1[\s>]/g) || []).length;
+        const h2Count = (html.match(/<h2[\s>]/g) || []).length;
+        expect(h1Count).toBe(1);
+        expect(h2Count).toBeGreaterThanOrEqual(10);
+    });
+
+    it('uses HTTPS image sources with alt attributes', () => {
+        const imgTags = html.match(/<img [^>]*>/g) || [];
+        expect(imgTags.length).toBeGreaterThanOrEqual(6);
+        imgTags.forEach(tag => {
+            expect(tag).toMatch(/src="https:\/\//);
+            expect(tag).toMatch(/alt="/);
+            expect(tag).not.toMatch(/src="http:\/\//);
+        });
+    });
+
+    it('links the shared stylesheet, page stylesheet, and script', () => {
+        expect(html).toContain('href="../../styles.css"');
+        expect(html).toContain('href="style.css"');
+        expect(html).toContain('src="script.js"');
+    });
+});
+
+describe('Sahitya Akademi Award Explorer — Assets', () => {
+    it('includes a non-empty stylesheet', () => {
+        const css = readExplorerFile('style.css');
+        expect(css.length).toBeGreaterThan(1000);
+        expect(css).toContain('.sah-hero');
+        expect(css).toContain('.timeline-container');
+        expect(css).toContain('.language-chip');
+    });
+
+    it('includes a valid interactive script with required functions', () => {
+        const js = readExplorerFile('script.js');
+        expect(js).toContain('initTabNavigation');
+        expect(js).toContain('activateTab');
+        expect(js).toContain('initCountUp');
+        expect(js).toContain('initTyping');
+        expect(js).toContain("document.addEventListener('DOMContentLoaded'");
+    });
+});
+
+describe('Sahitya Akademi Award — Landing Page Integration', () => {
+    it('is listed as a card on the Awards of India Explorer landing page', () => {
+        const index = readLandingPage();
+        expect(index).toContain('Sahitya Akademi Award');
+        expect(index).toContain('../sahitya-akademi-award-explorer/index.html');
+    });
+
+    it('matches the existing award card pattern (icon, category, stats, button)', () => {
+        const index = readLandingPage();
+        const cardStart = index.indexOf('Sahitya Akademi Award Card');
+        expect(cardStart).toBeGreaterThan(-1);
+        const card = index.slice(cardStart, cardStart + 1200);
+        expect(card).toContain('award-icon');
+        expect(card).toContain('award-category');
+        expect(card).toContain('award-year');
+        expect(card).toContain('award-btn');
+        expect(card).toContain('class="award-card glass-card"');
+    });
+});


### PR DESCRIPTION
## Description
Closes #1098

Adds a complete **Sahitya Akademi Award Explorer** page celebrating India's National Academy of Letters and its premier literary honour for the most outstanding books in 24 Indian languages.

## What's included
- **History** — from the 1944 proposal to the 1954 inauguration in the Central Hall of Parliament, Nehru as first Chairman, Rabindra Bhavan headquarters
- **Year Instituted** — resolution of 15 December 1952, inauguration 12 March 1954, first Awards in 1955, purse progression to ₹1,00,000 (2009)
- **Eligibility** — original books of literary merit, eligible genres, three-member juries, award components (Satyajit Ray plaque + shawl + cheque)
- **Languages Covered** — all 24 languages (22 Eighth Schedule + English + Rajasthani) with years of inclusion
- **Selection Process** — publication to Festival of Letters, with evaluation focus areas
- **Categories & Honours** — main Award, Fellowship (21 immortals), Prize for Translation, Yuva Puraskar, Bal Sahitya Puraskar, Bhasha Samman
- **Notable Awardees** — Makhanlal Chaturvedi, Jibanananda Das, Amrita Pritam, R. K. Narayan, Raja Rao, Mulk Raj Anand, Vikram Seth, M. T. Vasudevan Nair, Mahasweta Devi, Girish Karnad
- **Timeline** — 1944 to 2011 milestones
- **Interesting Facts** — wartime savings bonds, marble plaques, Satyajit Ray design, and more
- **Gallery** — visual journey through Indian letters

## Landing Page Integration
- Wired the existing **Sahitya Akademi Award** card on the Awards of India Explorer landing page to the new explorer page (previously pointed to `../../index.html`)
- Added the page to the site-wide **search index** (`frontend/search-index.js`)

## Tests
- Added `tests/unit/sahitya-akademi-award-explorer.test.js` (12 tests) validating page structure, all 10 required sections, category tabs, the 24 languages, semantic hierarchy, HTTPS images with alt text, assets, and landing page card integration — **all passing**

## Checklist
- [x] Page created at `frontend/sahitya-akademi-award-explorer/`
- [x] Landing page card wired up
- [x] Search index entry added
- [x] Unit tests added and passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Sahitya Akademi Award Explorer with historical information, eligibility, languages, selection process, honours, awardees, timeline, facts, and gallery.
  * Added responsive navigation, theme switching, tabbed content, animated statistics, smooth scrolling, and mobile-friendly interactions.
  * Added the explorer to site search and linked it from the Awards of India page.
  * Updated award details, institution date, description, displayed tier, and call-to-action text.

* **Tests**
  * Added coverage for page structure, content, accessibility, assets, and landing-page integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->