### PR TITLE
feat: Create Jnanpith Award Explorer

### DIFF
--- a/frontend/awards-of-india-explorer/index.html
+++ b/frontend/awards-of-india-explorer/index.html
@@ -385,6 +385,25 @@
                         </div>
                     </div>
 
+                    <!-- Jnanpith Award Card -->
+                    <div class="award-card glass-card" data-category="Literature &amp; Arts">
+                        <div class="card-header">
+                            <span class="award-icon">🏆</span>
+                            <span class="award-category">Literature &amp; Arts</span>
+                        </div>
+                        <h3 class="award-name">Jnanpith Award</h3>
+                        <div class="award-meta">
+                            <span class="award-year">Instituted: 1961</span>
+                            <span class="award-tier">India's Highest Literary Honour</span>
+                        </div>
+                        <p class="award-description">
+                            India's highest literary honour, conferred by the Bharatiya Jnanpith trust since 1965 for outstanding contribution to Indian literature across 16 languages.
+                        </p>
+                        <div class="card-footer">
+                            <a href="../jnanpith-award-explorer/index.html" class="award-btn">Explore Jnanpith &rarr;</a>
+                        </div>
+                    </div>
+
                     <!-- National Film Awards Card -->
                     <div class="award-card glass-card" data-category="Literature &amp; Arts">
                         <div class="card-header">

--- a/frontend/jnanpith-award-explorer/index.html
+++ b/frontend/jnanpith-award-explorer/index.html
@@ -1,0 +1,1216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Jnanpith Award Explorer - Discover India's highest literary honour, awarded by the Bharatiya Jnanpith trust since 1965, covering history, year instituted, eligibility, selection process, languages covered, medal and citation, complete winners timeline, notable laureates, facts, and gallery.">
+    <title>Jnanpith Award Explorer | Incredible India Explorer</title>
+    <link rel="icon" href="data:,">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="style.css">
+
+    <!-- Open Graph / Social Media Tags -->
+    <meta property="og:title" content="Jnanpith Award Explorer | Incredible India Explorer">
+    <meta property="og:description" content="Explore India's highest literary honour - the Jnanpith Award, conferred by the Bharatiya Jnanpith trust since 1965, with history, eligibility, selection process, languages, medal and citation, winners timeline, laureates, facts and gallery.">
+    <meta property="og:type" content="website">
+    <meta property="og:locale" content="en_IN">
+</head>
+
+<body class="jn-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <!-- Navbar Header -->
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html#home" class="nav-link">Home</a>
+                <a href="../learn/learn.html" class="nav-link">Learn</a>
+                <a href="../national-awards/national-awards.html" class="nav-link">National Awards</a>
+                <a href="../../index.html" class="nav-link active" style="color: #D4AF37">Jnanpith Award</a>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+            </nav>
+        </div>
+    </header>
+
+    <main class="jn-main">
+        <!-- Hero Banner -->
+        <section class="jn-hero">
+            <div class="jn-hero-bg" aria-hidden="true"></div>
+            <div class="jn-hero-overlay" aria-hidden="true"></div>
+            <div class="jn-hero-particles" aria-hidden="true">
+                <span></span><span></span><span></span><span></span><span></span><span></span>
+            </div>
+            <div class="jn-hero-content">
+                <span class="jn-kicker">🏆 India's Highest Literary Honour</span>
+                <h1>Jnanpith <span>Award</span> Explorer</h1>
+                <p>Discover the Jnanpith — the highest literary honour conferred in India — awarded by the Bharatiya Jnanpith trust since 1965 to the most outstanding writers in the languages of India, celebrating a lifetime devoted to the written word.</p>
+                <p class="jn-type-line">Honouring India's finest writers in <span class="jn-type" data-words='["Hindi","Kannada","Malayalam","Tamil","Urdu","English","16 Languages"]'></span></p>
+
+                <div class="jn-hero-stats">
+                    <div class="jn-hero-stat">
+                        <strong><span class="jn-count" data-target="1961">0</span></strong>
+                        <span>Award Instituted</span>
+                    </div>
+                    <div class="jn-hero-stat">
+                        <strong><span class="jn-count" data-target="1965">0</span></strong>
+                        <span>First Award Conferred</span>
+                    </div>
+                    <div class="jn-hero-stat">
+                        <strong><span class="jn-count" data-target="66">0</span></strong>
+                        <span>Laureates Honoured</span>
+                    </div>
+                    <div class="jn-hero-stat">
+                        <strong><span class="jn-count" data-target="16">0</span></strong>
+                        <span>Languages Represented</span>
+                    </div>
+                </div>
+            </div>
+            <a href="#history" class="jn-scroll-hint" aria-label="Scroll to explore"></a>
+        </section>
+
+        <!-- Marquee Strip -->
+        <div class="jn-marquee" aria-hidden="true">
+            <div class="jn-marquee-track">
+                <span>📜 POETRY</span><span>📕 NOVELS</span><span>🎭 PLAYS</span><span>✍️ ESSAYS</span><span>📖 MEMOIRS</span><span>🔁 TRANSLATIONS</span>
+                <span>📜 POETRY</span><span>📕 NOVELS</span><span>🎭 PLAYS</span><span>✍️ ESSAYS</span><span>📖 MEMOIRS</span><span>🔁 TRANSLATIONS</span>
+            </div>
+        </div>
+
+        <!-- Navigation Tabs -->
+        <div class="jn-nav-tabs">
+            <button class="jn-tab active" data-tab="history">📜 History</button>
+            <button class="jn-tab" data-tab="year-instituted">📅 Year Instituted</button>
+            <button class="jn-tab" data-tab="eligibility">📋 Eligibility</button>
+            <button class="jn-tab" data-tab="languages">🌐 Languages</button>
+            <button class="jn-tab" data-tab="selection">🎯 Selection</button>
+            <button class="jn-tab" data-tab="medal-citation">🎖️ Medal &amp; Citation</button>
+            <button class="jn-tab" data-tab="winners">⏳ Winners Timeline</button>
+            <button class="jn-tab" data-tab="awardees">🏆 Notable Laureates</button>
+            <button class="jn-tab" data-tab="facts">💡 Facts</button>
+            <button class="jn-tab" data-tab="gallery">🖼️ Gallery</button>
+        </div>
+
+        <!-- History Section -->
+        <section id="history" class="jn-section active">
+            <div class="jn-content-card">
+                <h2>📜 History of the Jnanpith Award</h2>
+                <div class="jn-split">
+                    <div class="jn-split-text">
+                        <p>The <strong>Jnanpith Award</strong> (ज्ञानपीठ) is India's highest literary honour, presented to writers for their outstanding contribution to Indian literature. The award was instituted by the <strong>Bharatiya Jnanpith</strong> trust, which was founded in <strong>1944</strong> by <strong>Sahu Shanti Prasad Jain</strong>, of the celebrated Jain family associated with the <em>Times of India</em> group, as a private cultural trust devoted to Indian literature, philosophy, and the arts.</p>
+
+                        <p>The trust established the Jnanpith Award on <strong>22 May 1961</strong>, and the first award was conferred in <strong>1965</strong> upon <strong>G. Sankara Kurup</strong> for his Malayalam poetry collection <em>Odakkuzhal</em>. Unlike the national academies, the Jnanpith is <strong>not a Government award</strong> — it is the crowning honour of a private trust, administered with complete independence since its foundation.</p>
+
+                        <p>Originally given for a single outstanding work, the award was restructured in <strong>1982</strong> to honour a writer's <strong>complete contribution</strong> to literature over a lifetime. Today the Jnanpith is widely regarded as India's most prestigious literary prize — the Indian equivalent of a Nobel Prize for literature, and a point of immense national pride for every language community it touches.</p>
+                    </div>
+                    <figure class="jn-figure float-slow">
+                        <img src="https://images.unsplash.com/photo-1519682337058-a94d519337bc?auto=format&fit=crop&q=80&w=800" alt="Open books resting on a reading desk" loading="lazy">
+                        <figcaption>A prize for the written word — India's highest literary honour</figcaption>
+                    </figure>
+                </div>
+
+                <h3>The Trust Behind the Prize</h3>
+                <ul class="jn-list">
+                    <li>Founded in <strong>1944</strong> by Sahu Shanti Prasad Jain, continuing a tradition of literary patronage.</li>
+                    <li>Named after the Sanskrit concept of <em>jñāna</em> (knowledge) and <em>pīṭha</em> (seat) — the seat of knowledge.</li>
+                    <li>Beyond the award, the trust publishes Indian classics, runs a journal, and supports literary research.</li>
+                    <li>The award is funded and administered by the trust, independent of the Government of India.</li>
+                </ul>
+
+                <h3>Why It Matters</h3>
+                <p>Since 1965, the Jnanpith has crowned poets, novelists, and playwrights writing in India's regional languages — from Malayalam and Kannada to Kashmiri and Konkani — reminding the nation that its literature lives and breathes in <strong>every one of its languages</strong>. Winning the Jnanpith places an author in the company of India's literary immortals.</p>
+            </div>
+        </section>
+
+        <!-- Year Instituted Section -->
+        <section id="year-instituted" class="jn-section">
+            <div class="jn-content-card">
+                <h2>📅 Year Instituted</h2>
+                <figure class="jn-banner">
+                    <img src="https://images.unsplash.com/photo-1457369804613-52c61a468e7d?auto=format&fit=crop&q=80&w=1200" alt="The grand reading hall of a library" loading="lazy">
+                </figure>
+                <div class="jn-content">
+                    <p>The <strong>Bharatiya Jnanpith</strong> trust founded the award on <strong>22 May 1961</strong>, and the <strong>first Jnanpith Award</strong> was conferred in <strong>1965</strong> upon G. Sankara Kurup. It has since been given almost every year, honouring India's finest literary voices from across the subcontinent.</p>
+
+                    <div class="eligibility-grid">
+                        <div class="eligibility-item">
+                            <h3>🏛️ Trust Founded</h3>
+                            <p>The Bharatiya Jnanpith trust was founded in <strong>1944</strong> by <strong>Sahu Shanti Prasad Jain</strong> of the Times of India family.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>📅 Award Instituted</h3>
+                            <p>The Jnanpith Award was instituted on <strong>22 May 1961</strong>, a decade and a half before the first prize was presented.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>🏅 First Award</h3>
+                            <p>The first Jnanpith was conferred in <strong>1965</strong> upon <strong>G. Sankara Kurup</strong> for his Malayalam poetry collection <em>Odakkuzhal</em>.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>🔄 Rule Change of 1982</h3>
+                            <p>From <strong>1982</strong> the award shifted from honouring a single work to recognising a writer's <strong>complete contribution</strong> to literature.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Eligibility Section -->
+        <section id="eligibility" class="jn-section">
+            <div class="jn-content-card">
+                <h2>📋 Eligibility &amp; Award Details</h2>
+                <figure class="jn-banner">
+                    <img src="https://images.unsplash.com/photo-1481627834876-b7833e8f5570?auto=format&fit=crop&q=80&w=1200" alt="A shelf lined with books" loading="lazy">
+                </figure>
+                <div class="jn-content">
+                    <p>The Jnanpith Award is open to <strong>citizens of India</strong> who write in any of the languages of India, and is conferred for the most outstanding contribution to Indian literature — since 1982, for the writer's <strong>complete body of work</strong>.</p>
+
+                    <div class="eligibility-grid">
+                        <div class="eligibility-item">
+                            <h3>🇮🇳 Indian Citizenship</h3>
+                            <p>The award is reserved for <strong>Indian citizens</strong>, ensuring the honour stays within the nation's own literary community.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>🗣️ Languages of India</h3>
+                            <p>Writers composing in any of the <strong>22 Eighth-Schedule languages</strong> of the Constitution, as well as <strong>English</strong>, are eligible for consideration.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>🪞 Complete Contribution</h3>
+                            <p>Since <strong>1982</strong> the award honours the writer's overall contribution to literature rather than a single published work.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>🏆 The Prize</h3>
+                            <p>The winner receives a bronze statuette of <strong>Vagdevi</strong>, the goddess of learning, a cash prize of <strong>₹11 lakh</strong>, and a citation.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>🎭 Any Genre</h3>
+                            <p>Poetry, fiction, drama, criticism, biography, and essay — the Jnanpith has honoured masters of every literary form.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>⚖️ No Restriction of School</h3>
+                            <p>Writers of every school, generation, and region compete on equal terms — merit alone decides the laureate.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Languages Covered Section -->
+        <section id="languages" class="jn-section">
+            <div class="jn-content-card">
+                <h2>🌐 Languages Covered</h2>
+                <div class="jn-content">
+                    <p>The Jnanpith is open to writers in the <strong>22 languages of the Eighth Schedule</strong> of the Indian Constitution, together with <strong>English</strong>. To date, laureates have come from <strong>16 of these languages</strong> — a testimony to the depth of India's multilingual literature.</p>
+
+                    <div class="language-grid">
+                        <div class="language-chip">Hindi <span>12 wins</span></div>
+                        <div class="language-chip">Kannada <span>8 wins</span></div>
+                        <div class="language-chip">Bengali <span>6 wins</span></div>
+                        <div class="language-chip">Malayalam <span>6 wins</span></div>
+                        <div class="language-chip">Urdu <span>5 wins</span></div>
+                        <div class="language-chip">Gujarati <span>4 wins</span></div>
+                        <div class="language-chip">Marathi <span>4 wins</span></div>
+                        <div class="language-chip">Odia <span>4 wins</span></div>
+                        <div class="language-chip">Assamese <span>3 wins</span></div>
+                        <div class="language-chip">Tamil <span>3 wins</span></div>
+                        <div class="language-chip">Telugu <span>3 wins</span></div>
+                        <div class="language-chip">Konkani <span>2 wins</span></div>
+                        <div class="language-chip">Punjabi <span>2 wins</span></div>
+                        <div class="language-chip">Sanskrit <span>2 wins</span></div>
+                        <div class="language-chip">English <span>1 win</span></div>
+                        <div class="language-chip">Kashmiri <span>1 win</span></div>
+                    </div>
+
+                    <div class="media-highlights">
+                        <h3>First in Each Language</h3>
+                        <ul>
+                            <li><strong>Malayalam</strong> (1965) — G. Sankara Kurup, the first laureate of the award.</li>
+                            <li><strong>Kannada</strong> (1967) — Kuvempu, for his epic <em>Sri Ramayana Darshanam</em>.</li>
+                            <li><strong>Gujarati</strong> (1967) — Umashankar Joshi, for <em>Nishitha</em>.</li>
+                            <li><strong>Punjabi</strong> (1981) — Amrita Pritam, the first woman laureate.</li>
+                            <li><strong>Kashmiri</strong> (2004) — Rehman Rahi, the first Kashmiri winner.</li>
+                            <li><strong>English</strong> (2018) — Amitav Ghosh, the first English-language winner.</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Selection Process Section -->
+        <section id="selection" class="jn-section">
+            <div class="jn-content-card">
+                <h2>🎯 Selection Process</h2>
+                <div class="jn-content">
+                    <p>The Jnanpith selection is a rigorous, multi-stage process conducted by the Bharatiya Jnanpith trust, guided by a jury of the country's most eminent writers, critics, and academics.</p>
+
+                    <div class="selection-timeline">
+                        <div class="selection-step">
+                            <div class="step-number">1</div>
+                            <h3>Nominations</h3>
+                            <p>The trust invites nominations from literary experts, academic institutions, publishers, and former laureates across India's languages.</p>
+                        </div>
+
+                        <div class="selection-step">
+                            <div class="step-number">2</div>
+                            <h3>Language Scrutiny</h3>
+                            <p>Distinguished scholars and critics in each language screen the nominated writers and forward the most outstanding names.</p>
+                        </div>
+
+                        <div class="selection-step">
+                            <div class="step-number">3</div>
+                            <h3>Jury Deliberation</h3>
+                            <p>A high-level jury of eminent litterateurs reviews the shortlist, weighing each writer's complete contribution to Indian literature.</p>
+                        </div>
+
+                        <div class="selection-step">
+                            <div class="step-number">4</div>
+                            <h3>Final Selection</h3>
+                            <p>The jury's recommendation is placed before the trust, which formally announces the laureate of the Jnanpith Award.</p>
+                        </div>
+
+                        <div class="selection-step">
+                            <div class="step-number">5</div>
+                            <h3>Presentation</h3>
+                            <p>The award — the Vagdevi statuette, cash prize, and citation — is presented to the laureate in a national ceremony, often by the President of India.</p>
+                        </div>
+                    </div>
+
+                    <div class="evaluation-criteria">
+                        <h3>What the Jury Looks For</h3>
+                        <ul>
+                            <li><strong>Literary Excellence:</strong> The highest order of craft, imagination, and language</li>
+                            <li><strong>Contribution:</strong> A body of work that has shaped Indian literature</li>
+                            <li><strong>Linguistic Mastery:</strong> Deep command of the language of composition</li>
+                            <li><strong>Cultural Significance:</strong> Work that carries the voice of its people and region</li>
+                            <li><strong>Enduring Relevance:</strong> Writing that speaks across generations and borders</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Medal & Citation Section -->
+        <section id="medal-citation" class="jn-section">
+            <div class="jn-content-card">
+                <h2>🎖️ Medal &amp; Citation</h2>
+                <div class="jn-split">
+                    <div class="jn-split-text">
+                        <p>Every Jnanpith laureate receives the award's signature trophy — a <strong>bronze statuette of Vagdevi</strong>, the goddess of learning — along with a cash prize and an engraved citation read aloud at the ceremony.</p>
+                        <p>The <strong>Vagdevi</strong> (or Saraswati) statuette embodies the award's deepest idea: that knowledge, wisdom, and the spoken word are India's most treasured possessions. The bronze idol has become one of the most recognizable symbols of literary achievement in the country.</p>
+                        <p>The accompanying <strong>citation</strong> is composed in tribute to the laureate's life and work, tracing their journey through the languages and literatures of India, and is formally presented by a dignitary of the state — historically the President of India has conferred the honour.</p>
+                    </div>
+                    <figure class="jn-figure float-slow">
+                        <img src="https://images.unsplash.com/photo-1526243741027-444d633d7365?auto=format&fit=crop&q=80&w=800" alt="An open vintage book with printed pages" loading="lazy">
+                        <figcaption>The Vagdevi statuette — the goddess of learning, and the award's lasting symbol</figcaption>
+                    </figure>
+                </div>
+
+                <h3>Components of the Honour</h3>
+                <div class="eligibility-grid">
+                    <div class="eligibility-item">
+                        <h3>🗿 Vagdevi Statuette</h3>
+                        <p>A <strong>bronze statuette of Vagdevi</strong>, the goddess of learning — the award's enduring symbol of knowledge and wisdom.</p>
+                    </div>
+                    <div class="eligibility-item">
+                        <h3>💵 Cash Prize</h3>
+                        <p>A cash prize of <strong>₹11 lakh</strong>, raised over the years as the award's prestige has grown.</p>
+                    </div>
+                    <div class="eligibility-item">
+                        <h3>📜 Citation</h3>
+                        <p>An engraved citation celebrating the laureate's complete contribution to Indian literature, read aloud at the ceremony.</p>
+                    </div>
+                    <div class="eligibility-item">
+                        <h3>👑 Presentation</h3>
+                        <p>Traditionally presented by the <strong>President of India</strong> or a national dignitary, underlining the honour's stature.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Complete Winners Timeline Section -->
+        <section id="winners" class="jn-section">
+            <div class="jn-content-card">
+                <h2>⏳ Complete Winners Timeline</h2>
+                <div class="jn-content">
+                    <p>Every Jnanpith laureate from the first award in 1965 to the most recent — a complete roll of honour spanning six decades of Indian literature.</p>
+
+                    <div class="timeline-container">
+                        <div class="timeline-item">
+                            <div class="timeline-year">1965</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>G. Sankara Kurup · Malayalam</h3>
+                                <p>First laureate of the Jnanpith, honoured for his poetry collection <em>Odakkuzhal</em>.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1966</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Tarasankar Bandyopadhyay · Bengali</h3>
+                                <p>The grand old master of the Bengali novel, honoured for <em>Ganadevata</em>.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1967</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Kuvempu · Kannada &amp; Umashankar Joshi · Gujarati</h3>
+                                <p>K. V. Puttappa's epic <em>Sri Ramayana Darshanam</em> and Joshi's <em>Nishitha</em> — two laureates, two languages.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1968</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Sumitranandan Pant · Hindi</h3>
+                                <p>One of the four pillars of the Chhayavaad (romantic) school of Hindi poetry.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1969</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Firaq Gorakhpuri · Urdu</h3>
+                                <p>Raghupati Sahay, the celebrated Urdu poet of love and beauty, honoured for <em>Gul-e-Naghma</em>.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1970</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Viswanatha Satyanarayana · Telugu</h3>
+                                <p>Honoured for his monumental <em>Ramayana Kalpavrikshamu</em> — the Kavi Samrat of Telugu.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1971</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Bishnu Dey · Bengali</h3>
+                                <p>The modernist Bengali poet and critic, honoured for <em>Smriti Satta Bhavishyat</em>.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1972</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Ramdhari Singh 'Dinkar' · Hindi</h3>
+                                <p>The poet of nationalism and revolt, honoured for <em>Urvashi</em>.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1973</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>D. R. Bendre · Kannada &amp; Gopinath Mohanty · Odia</h3>
+                                <p>Da Ra Bendre's <em>Nakutanti</em> and Mohanty's <em>Mattimatal</em> — two regions, one honour.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1974</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Vishnu Sakharam Khandekar · Marathi</h3>
+                                <p>Honoured for his celebrated novel <em>Yayati</em>, a modern retelling of the Puranic king.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1975</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Akilan · Tamil</h3>
+                                <p>P. V. Akilandam, honoured for his novel <em>Chittirappavai</em>.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1976</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Ashapoorna Devi · Bengali</h3>
+                                <p>The chronicler of Bengali women's lives, honoured for <em>Pratham Pratisruti</em>.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1977</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>K. Shivaram Karanth · Kannada</h3>
+                                <p>Honoured for <em>Mukajjiya Kanasugalu</em>, a novel of the Karnataka coast.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1978</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>S. H. Vatsyayan 'Agyeya' · Hindi</h3>
+                                <p>The pioneer of Hindi modernism, honoured for <em>Kitni Navon Mein Kitni Baar</em>.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1979</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Birendra Kumar Bhattacharya · Assamese</h3>
+                                <p>Honoured for his novel <em>Mrityunjay</em> — the first Assamese laureate.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1980</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>S. K. Pottekkatt · Malayalam</h3>
+                                <p>Honoured for <em>Oru Desathinte Katha</em> — the story of a village and its people.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1981</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Amrita Pritam · Punjabi</h3>
+                                <p>The <strong>first woman laureate</strong>, honoured for her collection <em>Kagaz te Canvas</em>.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1982</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Mahadevi Varma · Hindi</h3>
+                                <p>The great Chhayavaad poet, honoured for her complete contribution to Hindi literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1983</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Masti Venkatesha Iyengar · Kannada</h3>
+                                <p>Masti, the dean of Kannada letters, honoured for his lifetime of writing.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1984</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Thakazhi Sivasankara Pillai · Malayalam</h3>
+                                <p>The chronicler of Kerala, honoured for works like <em>Kayar</em> and <em>Chemmeen</em>.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1985</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Pannalal Patel · Gujarati</h3>
+                                <p>The novelist of rural Gujarat, honoured for his village chronicles.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1986</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Sachidananda Routray · Odia</h3>
+                                <p>The rebel poet of Odisha, honoured for his complete contribution to Odia poetry.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1987</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>V. V. Shirwadkar 'Kusumagraj' · Marathi</h3>
+                                <p>The people's poet of Maharashtra, honoured for his lifetime of writing.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1988</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>C. Narayana Reddy · Telugu</h3>
+                                <p>The Janapriya Kavi, honoured for his complete contribution to Telugu poetry.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1989</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Qurratulain Hyder · Urdu</h3>
+                                <p>The great Urdu novelist, honoured for works including <em>Aag Ka Darya</em>.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1990</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Vinayaka Krishna Gokak · Kannada</h3>
+                                <p>The poet-critic who introduced blank verse to Kannada, honoured for his lifetime's work.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1991</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Subhas Mukhopadhyay · Bengali</h3>
+                                <p>The revolutionary Bengali poet, honoured for his complete contribution to literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1992</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Naresh Mehta · Hindi</h3>
+                                <p>The experimental Hindi poet, honoured for his complete contribution to literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1993</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Sitakant Mahapatra · Odia</h3>
+                                <p>The poet and administrator, honoured for his complete contribution to Indian literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1994</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>U. R. Ananthamurthy · Kannada</h3>
+                                <p>The novelist of <em>Samskara</em>, honoured for his complete contribution to Indian literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1995</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>M. T. Vasudevan Nair · Malayalam</h3>
+                                <p>The giant of Malayalam fiction, honoured for works like <em>Randamoozham</em>.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1996</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Mahasweta Devi · Bengali</h3>
+                                <p>The novelist-activist of subaltern India, honoured for her lifetime's work.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1997</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Ali Sardar Jafri · Urdu</h3>
+                                <p>The progressive Urdu poet, honoured for his complete contribution to literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1998</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Girish Karnad · Kannada</h3>
+                                <p>The playwright of <em>Tughlaq</em> and <em>Naga-Mandala</em>, honoured for his lifetime's work.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">1999</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Nirmal Verma · Hindi &amp; Gurdial Singh · Punjabi</h3>
+                                <p>Two masters of fiction, honoured together for their complete contributions to literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2000</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Mamoni Raisom Goswami · Assamese</h3>
+                                <p>Indira Goswami, the voice of Assam's margins, honoured for her lifetime's work.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2001</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Rajendra Shah · Gujarati</h3>
+                                <p>The lyric poet of Gujarat, honoured for his complete contribution to literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2002</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>D. Jayakanthan · Tamil</h3>
+                                <p>The chronicler of Tamil working-class life, honoured for his complete contribution.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2003</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Vinda Karandikar · Marathi</h3>
+                                <p>The modernist Marathi poet, honoured for his complete contribution to literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2004</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Rehman Rahi · Kashmiri</h3>
+                                <p>The <strong>first Kashmiri laureate</strong>, honoured for his complete contribution to Kashmiri literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2005</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Kunwar Narayan · Hindi</h3>
+                                <p>The meditative Hindi poet, honoured for his complete contribution to literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2006</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Ravindra Kelekar · Konkani &amp; Satya Vrat Shastri · Sanskrit</h3>
+                                <p>Two firsts together — Konkani and Sanskrit joined the Jnanpith family.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2007</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>O. N. V. Kurup · Malayalam</h3>
+                                <p>The people's poet of Kerala, honoured for his complete contribution to literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2008</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Shahryar · Urdu</h3>
+                                <p>Akhlaq Mohammed Khan, the ghazal poet and lyricist, honoured for his complete contribution.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2009</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Amarkant &amp; Shrilal Shukla · Hindi</h3>
+                                <p>Two masters of the Hindi novel, honoured together for their complete contributions.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2010</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Chandrashekhara Kambara · Kannada</h3>
+                                <p>The folklorist-poet of Karnataka, honoured for his complete contribution to literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2011</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Pratibha Ray · Odia</h3>
+                                <p>The novelist of <em>Yajnaseni</em>, honoured for her complete contribution to literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2012</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Ravuri Bharadhwaja · Telugu</h3>
+                                <p>The Telugu novelist, honoured for his complete contribution to literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2013</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Kedarnath Singh · Hindi</h3>
+                                <p>The poet of the people, honoured for his complete contribution to Hindi literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2014</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Bhalchandra Nemade · Marathi</h3>
+                                <p>The novelist of <em>Kosala</em>, honoured for his complete contribution to literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2015</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Raghuveer Chaudhari · Gujarati</h3>
+                                <p>The versatile Gujarati writer, honoured for his complete contribution to literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2016</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Shankha Ghosh · Bengali</h3>
+                                <p>The great Bengali poet, honoured for his complete contribution to literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2017</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Krishna Sobti · Hindi</h3>
+                                <p>The grande dame of modern Hindi prose, honoured for her complete contribution.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2018</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Amitav Ghosh · English</h3>
+                                <p>The <strong>first English-language winner</strong>, honoured for his complete contribution to literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2019</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Akkitham Achuthan Namboothiri · Malayalam</h3>
+                                <p>The visionary modernist poet of Kerala, honoured for his complete contribution.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2021</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Nilamani Phookan · Assamese</h3>
+                                <p>The modernist Assamese poet, honoured for his complete contribution to literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2022</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Damodar Mauzo · Konkani</h3>
+                                <p>The chronicler of Goan lives, honoured for his complete contribution to literature.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2023</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Rambhadracharya · Sanskrit &amp; Gulzar · Urdu</h3>
+                                <p>The Sanskrit scholar and the celebrated Urdu poet-lyricist, honoured together.</p>
+                            </div>
+                        </div>
+
+                        <div class="timeline-item">
+                            <div class="timeline-year">2024</div>
+                            <div class="timeline-dot"></div>
+                            <div class="timeline-body">
+                                <h3>Vinod Kumar Shukla · Hindi</h3>
+                                <p>The poet of ordinary lives, honoured for his complete contribution to Hindi literature.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Notable Laureates Section -->
+        <section id="awardees" class="jn-section">
+            <div class="jn-content-card">
+                <h2>🏆 Notable Laureates</h2>
+                <div class="jn-content">
+                    <p>Six decades of Jnanpith laureates include the giants of modern Indian letters — poets, novelists, and playwrights whose names echo across every Indian language.</p>
+
+                    <h3>👑 The Founders of the Honour</h3>
+                    <div class="awardees-gallery">
+                        <div class="awardee-card">
+                            <div class="awardee-avatar">📜</div>
+                            <h3>G. Sankara Kurup</h3>
+                            <p class="awardee-year">Jnanpith · 1965 · Malayalam</p>
+                            <p>The first laureate of the award, honoured for his poetry collection <em>Odakkuzhal</em>.</p>
+                        </div>
+
+                        <div class="awardee-card">
+                            <div class="awardee-avatar">🌄</div>
+                            <h3>Kuvempu</h3>
+                            <p class="awardee-year">Jnanpith · 1967 · Kannada</p>
+                            <p>K. V. Puttappa, honoured for his epic <em>Sri Ramayana Darshanam</em> — Kannada's first laureate.</p>
+                        </div>
+
+                        <div class="awardee-card">
+                            <div class="awardee-avatar">🪖</div>
+                            <h3>Ramdhari Singh 'Dinkar'</h3>
+                            <p class="awardee-year">Jnanpith · 1972 · Hindi</p>
+                            <p>The poet of nationalism and revolt, honoured for <em>Urvashi</em>.</p>
+                        </div>
+                    </div>
+
+                    <h3>🪞 Voices That Redefined Prose</h3>
+                    <div class="awardees-gallery">
+                        <div class="awardee-card">
+                            <div class="awardee-avatar">🌙</div>
+                            <h3>Amrita Pritam</h3>
+                            <p class="awardee-year">Jnanpith · 1981 · Punjabi</p>
+                            <p>The <strong>first woman laureate</strong>, honoured for her collection <em>Kagaz te Canvas</em>.</p>
+                        </div>
+
+                        <div class="awardee-card">
+                            <div class="awardee-avatar">🪔</div>
+                            <h3>Mahadevi Varma</h3>
+                            <p class="awardee-year">Jnanpith · 1982 · Hindi</p>
+                            <p>The great Chhayavaad poet of Hindi, honoured for her complete contribution to literature.</p>
+                        </div>
+
+                        <div class="awardee-card">
+                            <div class="awardee-avatar">🪢</div>
+                            <h3>U. R. Ananthamurthy</h3>
+                            <p class="awardee-year">Jnanpith · 1994 · Kannada</p>
+                            <p>The novelist of <em>Samskara</em>, a master of modern Kannada fiction.</p>
+                        </div>
+                    </div>
+
+                    <h3>🎭 The Modern Masters</h3>
+                    <div class="awardees-gallery">
+                        <div class="awardee-card">
+                            <div class="awardee-avatar">🏛️</div>
+                            <h3>M. T. Vasudevan Nair</h3>
+                            <p class="awardee-year">Jnanpith · 1995 · Malayalam</p>
+                            <p>The giant of Malayalam letters, honoured for works like <em>Randamoozham</em>.</p>
+                        </div>
+
+                        <div class="awardee-card">
+                            <div class="awardee-avatar">🌳</div>
+                            <h3>Mahasweta Devi</h3>
+                            <p class="awardee-year">Jnanpith · 1996 · Bengali</p>
+                            <p>The novelist-activist of subaltern India, honoured for her lifetime's work.</p>
+                        </div>
+
+                        <div class="awardee-card">
+                            <div class="awardee-avatar">🎭</div>
+                            <h3>Girish Karnad</h3>
+                            <p class="awardee-year">Jnanpith · 1998 · Kannada</p>
+                            <p>The playwright of <em>Tughlaq</em> and <em>Naga-Mandala</em>.</p>
+                        </div>
+                    </div>
+
+                    <h3>🌏 The New Century</h3>
+                    <div class="awardees-gallery">
+                        <div class="awardee-card">
+                            <div class="awardee-avatar">🌊</div>
+                            <h3>O. N. V. Kurup</h3>
+                            <p class="awardee-year">Jnanpith · 2007 · Malayalam</p>
+                            <p>The people's poet of Kerala, a voice of the sea and the land.</p>
+                        </div>
+
+                        <div class="awardee-card">
+                            <div class="awardee-avatar">🌅</div>
+                            <h3>Amitav Ghosh</h3>
+                            <p class="awardee-year">Jnanpith · 2018 · English</p>
+                            <p>The <strong>first English-language winner</strong>, honoured for his complete contribution to literature.</p>
+                        </div>
+
+                        <div class="awardee-card">
+                            <div class="awardee-avatar">🎬</div>
+                            <h3>Gulzar</h3>
+                            <p class="awardee-year">Jnanpith · 2023 · Urdu</p>
+                            <p>The poet, lyricist, and filmmaker honoured for his five decades of evocative verse.</p>
+                        </div>
+                    </div>
+
+                    <div class="notable-achievements">
+                        <h3>Impact of the Honour</h3>
+                        <ul>
+                            <li>The Jnanpith is regarded as India's highest literary honour, equivalent in stature to a Nobel Prize for literature</li>
+                            <li>Conferred by the Bharatiya Jnanpith trust since 1965, not by the Government of India</li>
+                            <li>Since 1982, awarded for a writer's complete contribution to Indian literature</li>
+                            <li>Winners have come from 16 of India's languages, from Hindi and Kannada to Kashmiri and Konkani</li>
+                            <li>The Vagdevi statuette and ₹11 lakh prize accompany the citation</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Interesting Facts Section -->
+        <section id="facts" class="jn-section">
+            <div class="jn-content-card">
+                <h2>💡 Interesting Facts</h2>
+                <div class="jn-content">
+                    <p>Curious corners of the Jnanpith's story — from a private trust's dream to the goddess of learning cast in bronze.</p>
+
+                    <div class="eligibility-grid">
+                        <div class="eligibility-item">
+                            <h3>🏛️ Not a Government Award</h3>
+                            <p>The Jnanpith is conferred by the <strong>Bharatiya Jnanpith</strong> trust, founded by the Jain family of the <em>Times of India</em> — not by the Government of India.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>📜 First Laureate</h3>
+                            <p>The first Jnanpith in <strong>1965</strong> went to <strong>G. Sankara Kurup</strong> for his Malayalam poetry collection <em>Odakkuzhal</em>.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>🌹 First Woman Winner</h3>
+                            <p><strong>Amrita Pritam</strong> (1981) was the first woman to receive the Jnanpith, for <em>Kagaz te Canvas</em>.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>🔄 The 1982 Change</h3>
+                            <p>From <strong>1982</strong>, the award honours a writer's complete contribution rather than a single published work.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>🗿 The Vagdevi Statuette</h3>
+                            <p>Each laureate receives a bronze statuette of <strong>Vagdevi</strong>, the goddess of learning — the award's signature trophy.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>💵 Rising Purse</h3>
+                            <p>The cash prize has grown to <strong>₹11 lakh</strong>, reflecting the award's towering status in Indian letters.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>🌏 English Joins Late</h3>
+                            <p><strong>Amitav Ghosh</strong> (2018) was the first English-language writer to win the Jnanpith, 53 years after the first award.</p>
+                        </div>
+                        <div class="eligibility-item">
+                            <h3>📊 Hindi Leads</h3>
+                            <p>Hindi has produced the most laureates with <strong>12 awards</strong>, followed by Kannada with eight.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Gallery Section -->
+        <section id="gallery" class="jn-section">
+            <div class="jn-content-card">
+                <h2>🖼️ Gallery</h2>
+                <div class="jn-content">
+                    <p>A visual journey through the world of the Jnanpith — the books, libraries, and words that India's highest literary honour celebrates.</p>
+
+                    <div class="gallery-grid">
+                        <figure class="gallery-item">
+                            <div class="gallery-img">
+                                <img src="https://images.unsplash.com/photo-1481627834876-b7833e8f5570?auto=format&fit=crop&q=80&w=600" alt="A shelf lined with hardbound books" loading="lazy">
+                            </div>
+                            <figcaption>
+                                <h3>The Written Word</h3>
+                                <p>Books crowned by the Jnanpith since the first award of 1965.</p>
+                            </figcaption>
+                        </figure>
+
+                        <figure class="gallery-item">
+                            <div class="gallery-img">
+                                <img src="https://images.unsplash.com/photo-1524995997946-a1c2e315a42f?auto=format&fit=crop&q=80&w=600" alt="A neat stack of books" loading="lazy">
+                            </div>
+                            <figcaption>
+                                <h3>16 Languages</h3>
+                                <p>From Malayalam to Konkani — one honour, many tongues.</p>
+                            </figcaption>
+                        </figure>
+
+                        <figure class="gallery-item">
+                            <div class="gallery-img">
+                                <img src="https://images.unsplash.com/photo-1455390582262-044cdead277a?auto=format&fit=crop&q=80&w=600" alt="A hand writing with a fountain pen" loading="lazy">
+                            </div>
+                            <figcaption>
+                                <h3>Ink &amp; Paper</h3>
+                                <p>The craft celebrated by India's highest literary honour.</p>
+                            </figcaption>
+                        </figure>
+
+                        <figure class="gallery-item">
+                            <div class="gallery-img">
+                                <img src="https://images.unsplash.com/photo-1488190211105-8b0e65b80b4e?auto=format&fit=crop&q=80&w=600" alt="A writer's desk with notebooks and papers" loading="lazy">
+                            </div>
+                            <figcaption>
+                                <h3>Laureates at Work</h3>
+                                <p>Complete contributions, honoured since 1982.</p>
+                            </figcaption>
+                        </figure>
+
+                        <figure class="gallery-item">
+                            <div class="gallery-img">
+                                <img src="https://images.unsplash.com/photo-1457369804613-52c61a468e7d?auto=format&fit=crop&q=80&w=600" alt="The grand reading hall of a library" loading="lazy">
+                            </div>
+                            <figcaption>
+                                <h3>The Seat of Knowledge</h3>
+                                <p>Jñāna-pīṭha — the seat of knowledge itself.</p>
+                            </figcaption>
+                        </figure>
+
+                        <figure class="gallery-item">
+                            <div class="gallery-img">
+                                <img src="https://images.unsplash.com/photo-1543002588-bfa74002ed7e?auto=format&fit=crop&q=80&w=600" alt="An open book being read closely" loading="lazy">
+                            </div>
+                            <figcaption>
+                                <h3>New Readers</h3>
+                                <p>Every laureate inspires the next generation of Indian writers.</p>
+                            </figcaption>
+                        </figure>
+
+                        <figure class="gallery-item">
+                            <div class="gallery-img">
+                                <img src="https://images.unsplash.com/photo-1526243741027-444d633d7365?auto=format&fit=crop&q=80&w=600" alt="An open vintage book with printed pages" loading="lazy">
+                            </div>
+                            <figcaption>
+                                <h3>Classics &amp; Moderns</h3>
+                                <p>From Kuvempu's epic to Amitav Ghosh's novels.</p>
+                            </figcaption>
+                        </figure>
+
+                        <figure class="gallery-item">
+                            <div class="gallery-img">
+                                <img src="https://images.unsplash.com/photo-1474932430478-367dbb6832c1?auto=format&fit=crop&q=80&w=600" alt="Rows of books stretching across library shelves" loading="lazy">
+                            </div>
+                            <figcaption>
+                                <h3>Voices of India</h3>
+                                <p>From Amrita Pritam to Mahasweta Devi — voices that defined an era.</p>
+                            </figcaption>
+                        </figure>
+                    </div>
+
+                    <div class="media-highlights">
+                        <h3>Recognition &amp; Legacy</h3>
+                        <ul>
+                            <li>India's highest literary honour, conferred since 1965</li>
+                            <li>Administered by the Bharatiya Jnanpith trust, founded 1944</li>
+                            <li>The prize carries a bronze Vagdevi statuette, ₹11 lakh, and citation</li>
+                            <li>Winners write in 16 languages, from Hindi to Kashmiri</li>
+                            <li>The 60th Jnanpith (2025) went to Tamil lyricist Vairamuthu</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div class="jn-scroll-progress" id="scroll-progress" aria-hidden="true"></div>
+
+    <footer class="jn-footer">
+        <div class="jn-footer-container">
+            <div class="jn-footer-brand">
+                <h3><span class="saffron">Incredible</span> <span class="gold">India</span> <span class="green">Explorer</span></h3>
+                <p>An interactive digital guide to the geography, food, festivals, and cultural heritage of India — built with passion and pure vanilla web technologies.</p>
+                <p class="jn-footer-tagline">🏆 Celebrating India's highest literary honour.</p>
+            </div>
+            <div class="jn-footer-links">
+                <h4>Explore the Award</h4>
+                <ul>
+                    <li><a href="#" class="jn-footer-tab" data-footer-tab="history">📜 History</a></li>
+                    <li><a href="#" class="jn-footer-tab" data-footer-tab="year-instituted">📅 Year Instituted</a></li>
+                    <li><a href="#" class="jn-footer-tab" data-footer-tab="eligibility">📋 Eligibility</a></li>
+                    <li><a href="#" class="jn-footer-tab" data-footer-tab="languages">🌐 Languages</a></li>
+                    <li><a href="#" class="jn-footer-tab" data-footer-tab="selection">🎯 Selection</a></li>
+                    <li><a href="#" class="jn-footer-tab" data-footer-tab="medal-citation">🎖️ Medal &amp; Citation</a></li>
+                    <li><a href="#" class="jn-footer-tab" data-footer-tab="winners">⏳ Winners Timeline</a></li>
+                    <li><a href="#" class="jn-footer-tab" data-footer-tab="awardees">🏆 Notable Laureates</a></li>
+                    <li><a href="#" class="jn-footer-tab" data-footer-tab="facts">💡 Facts</a></li>
+                    <li><a href="#" class="jn-footer-tab" data-footer-tab="gallery">🖼️ Gallery</a></li>
+                </ul>
+            </div>
+            <div class="jn-footer-links">
+                <h4>Discover More</h4>
+                <ul>
+                    <li><a href="../../index.html#home">🏠 Home</a></li>
+                    <li><a href="../../frontend/national-awards/national-awards.html">🏅 National Awards</a></li>
+                    <li><a href="../../frontend/culture/culture.html">🪔 Culture</a></li>
+                    <li><a href="../../frontend/learn/learn.html">📚 Learn</a></li>
+                    <li><a href="../../frontend/literature/literature.html">📖 Literature</a></li>
+                </ul>
+            </div>
+            <div class="jn-footer-links">
+                <h4>About the Project</h4>
+                <ul>
+                    <li><a href="../../frontend/about/about.html">ℹ️ About</a></li>
+                    <li><a href="../../frontend/privacy/privacy.html">🔒 Privacy Policy</a></li>
+                    <li><a href="../../index.html#map">🗺️ Interactive Map</a></li>
+                    <li><a href="../../index.html#quiz">🧠 Quiz</a></li>
+                    <li><a href="../../index.html#home">🏠 Back to Home</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="jn-footer-bottom">
+            <p>&copy; 2026 Incredible India Explorer · Created with Vanilla HTML, CSS &amp; JavaScript</p>
+            <p>Jnanpith Award · Instituted 1961 · First Conferred 1965 · Bharatiya Jnanpith, New Delhi</p>
+        </div>
+    </footer>
+
+    <button class="jn-scroll-top" id="btn-scroll-top" aria-label="Scroll back to top">↑</button>
+
+    <!-- Client Script -->
+    <script type="module" src="script.js"></script>
+</body>
+</html>

--- a/frontend/jnanpith-award-explorer/script.js
+++ b/frontend/jnanpith-award-explorer/script.js
@@ -1,0 +1,387 @@
+/**
+ * Jnanpith Award Explorer - Interactive Script
+ * Handles tab navigation, theme toggle, smooth scrolling, and scroll animations
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    initTabNavigation();
+    initThemeToggle();
+    initSmoothScroll();
+    initMobileMenu();
+    initScrollAnimations();
+    initCountUp();
+    initScrollUI();
+    initFooterTabs();
+    initCardTilt();
+    initTyping();
+    initHeroParallax();
+});
+
+/**
+ * Activate a tab section by its id (shared by tab bar and footer links)
+ */
+function activateTab(targetTab) {
+    const tabs = document.querySelectorAll('.jn-tab');
+    const sections = document.querySelectorAll('.jn-section');
+    if (!tabs.length || !sections.length) return;
+
+    tabs.forEach(t => t.classList.remove('active'));
+    sections.forEach(s => s.classList.remove('active'));
+
+    const tab = document.querySelector(`.jn-tab[data-tab="${targetTab}"]`);
+    const section = document.getElementById(targetTab);
+    if (tab) tab.classList.add('active');
+    if (section) {
+        section.classList.add('active');
+        section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+}
+
+/**
+ * Initialize tab navigation for different sections
+ */
+function initTabNavigation() {
+    document.querySelectorAll('.jn-tab').forEach(tab => {
+        tab.addEventListener('click', () => activateTab(tab.dataset.tab));
+    });
+}
+
+/**
+ * Initialize theme toggle functionality
+ */
+function initThemeToggle() {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+
+    // Set initial icon based on current theme
+    const currentTheme = localStorage.getItem('theme') || 'dark';
+    updateThemeIcon(currentTheme);
+
+    themeToggle.addEventListener('click', () => {
+        const body = document.body;
+        const isLight = body.classList.contains('light-theme');
+
+        if (isLight) {
+            body.classList.remove('light-theme');
+            localStorage.setItem('theme', 'dark');
+            updateThemeIcon('dark');
+        } else {
+            body.classList.add('light-theme');
+            localStorage.setItem('theme', 'light');
+            updateThemeIcon('light');
+        }
+    });
+}
+
+/**
+ * Update theme toggle icon
+ */
+function updateThemeIcon(theme) {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+
+    if (theme === 'light') {
+        themeToggle.textContent = '🌙';
+    } else {
+        themeToggle.textContent = '☀️';
+    }
+}
+
+/**
+ * Initialize smooth scroll for internal links
+ */
+function initSmoothScroll() {
+    document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+        anchor.addEventListener('click', function (e) {
+            e.preventDefault();
+            const target = document.querySelector(this.getAttribute('href'));
+            if (target) {
+                target.scrollIntoView({
+                    behavior: 'smooth',
+                    block: 'start'
+                });
+            }
+        });
+    });
+}
+
+/**
+ * Initialize mobile menu toggle
+ */
+function initMobileMenu() {
+    const menuToggle = document.getElementById('menu-toggle');
+    const navMenu = document.getElementById('nav-menu');
+
+    if (menuToggle && navMenu) {
+        menuToggle.addEventListener('click', () => {
+            const isExpanded = menuToggle.getAttribute('aria-expanded') === 'true';
+            menuToggle.setAttribute('aria-expanded', !isExpanded);
+            navMenu.classList.toggle('active');
+        });
+
+        // Close menu when clicking outside
+        document.addEventListener('click', (e) => {
+            if (!menuToggle.contains(e.target) && !navMenu.contains(e.target)) {
+                navMenu.classList.remove('active');
+                menuToggle.setAttribute('aria-expanded', 'false');
+            }
+        });
+    }
+}
+
+/**
+ * Add animation on scroll for elements
+ */
+function initScrollAnimations() {
+    const observerOptions = {
+        threshold: 0.1,
+        rootMargin: '0px 0px -50px 0px'
+    };
+
+    const observer = new IntersectionObserver((entries) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                entry.target.classList.add('animate-in');
+                const el = entry.target;
+                setTimeout(() => {
+                    el.style.transitionDelay = '0ms';
+                    el.classList.remove('animate-on-scroll');
+                }, 700);
+                observer.unobserve(entry.target);
+            }
+        });
+    }, observerOptions);
+
+    const revealVariant = (el) => {
+        if (el.classList.contains('gallery-item')) {
+            const siblings = Array.from(el.parentNode.children).filter(s => s.classList.contains('gallery-item'));
+            return (siblings.indexOf(el) % 2 === 0) ? 'reveal-left' : 'reveal-right';
+        }
+        if (el.classList.contains('awardee-card') || el.classList.contains('category-card')) return 'reveal-scale';
+        if (el.classList.contains('selection-step')) return 'reveal-right';
+        if (el.classList.contains('eligibility-item') || el.classList.contains('timeline-item')) return 'reveal-left';
+        return 'reveal-up';
+    };
+
+    // Observe cards and sections with a staggered reveal delay
+    const targets = document.querySelectorAll('.eligibility-item, .category-card, .selection-step, .awardee-card, .gallery-item, .timeline-item, .jn-banner, .jn-content-card');
+    targets.forEach(el => {
+        el.classList.add('animate-on-scroll', revealVariant(el));
+        const siblings = Array.from(el.parentNode.children).filter(s => s.classList.contains('animate-on-scroll'));
+        const index = siblings.indexOf(el);
+        el.style.transitionDelay = (index % 6) * 70 + 'ms';
+        observer.observe(el);
+    });
+}
+
+/**
+ * Scroll progress bar and back-to-top button
+ */
+function initScrollUI() {
+    const progress = document.getElementById('scroll-progress');
+    const btn = document.getElementById('btn-scroll-top');
+    if (!progress && !btn) return;
+
+    const update = () => {
+        const doc = document.documentElement;
+        const scrollTop = window.pageYOffset || doc.scrollTop;
+        const max = doc.scrollHeight - window.innerHeight;
+        if (progress) progress.style.width = (max > 0 ? (scrollTop / max) * 100 : 0) + '%';
+        if (btn) btn.classList.toggle('visible', scrollTop > 400);
+    };
+
+    window.addEventListener('scroll', update, { passive: true });
+    update();
+
+    if (btn) {
+        btn.addEventListener('click', () => {
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+        });
+    }
+}
+
+/**
+ * Footer quick links activate the matching section tab
+ */
+function initFooterTabs() {
+    document.querySelectorAll('.jn-footer-tab').forEach(link => {
+        link.addEventListener('click', (e) => {
+            e.preventDefault();
+            activateTab(link.dataset.footerTab);
+        });
+    });
+}
+
+/**
+ * Subtle 3D tilt on hover for cards (skipped for touch & reduced-motion)
+ */
+function initCardTilt() {
+    const cards = document.querySelectorAll('.category-card, .awardee-card, .gallery-item');
+    if (!cards.length) return;
+
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const coarse = window.matchMedia('(pointer: coarse)').matches;
+    if (reduced || coarse) return;
+
+    cards.forEach(card => {
+        card.addEventListener('mousemove', (e) => {
+            if (!card.classList.contains('animate-in')) return;
+            const rect = card.getBoundingClientRect();
+            const x = e.clientX - rect.left;
+            const y = e.clientY - rect.top;
+            card.style.setProperty('--spot-x', x + 'px');
+            card.style.setProperty('--spot-y', y + 'px');
+            const px = x / rect.width;
+            const py = y / rect.height;
+            const rx = (0.5 - py) * 8;
+            const ry = (px - 0.5) * 10;
+            card.classList.add('jn-card-tilt');
+            card.style.transform = `perspective(600px) rotateX(${rx.toFixed(2)}deg) rotateY(${ry.toFixed(2)}deg) translateY(-4px)`;
+        });
+
+        card.addEventListener('mouseleave', () => {
+            card.style.transform = '';
+        });
+    });
+}
+
+/**
+ * Typewriter effect for the rotating art-form words in the hero
+ */
+function initTyping() {
+    const el = document.querySelector('.jn-type[data-words]');
+    if (!el) return;
+
+    let words = [];
+    try {
+        words = JSON.parse(el.dataset.words);
+    } catch (err) {
+        return;
+    }
+    if (!Array.isArray(words) || !words.length) return;
+
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+        el.textContent = words[0];
+        return;
+    }
+
+    let wordIdx = 0;
+    let charIdx = 0;
+    let deleting = false;
+
+    const tick = () => {
+        const word = words[wordIdx];
+        el.textContent = word.slice(0, charIdx);
+
+        if (!deleting && charIdx < word.length) {
+            charIdx++;
+            setTimeout(tick, 90);
+        } else if (!deleting && charIdx === word.length) {
+            setTimeout(() => {
+                deleting = true;
+                tick();
+            }, 1700);
+        } else if (deleting && charIdx > 0) {
+            charIdx--;
+            setTimeout(tick, 45);
+        } else {
+            deleting = false;
+            wordIdx = (wordIdx + 1) % words.length;
+            setTimeout(tick, 350);
+        }
+    };
+
+    tick();
+}
+
+/**
+ * Gentle parallax drift for the hero backdrop while scrolling past the top
+ */
+function initHeroParallax() {
+    const bg = document.querySelector('.jn-hero-bg');
+    if (!bg) return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+
+    let ticking = false;
+    const update = () => {
+        const y = window.pageYOffset;
+        if (y < window.innerHeight) {
+            bg.style.backgroundPosition = `center calc(50% + ${y * 0.35}px)`;
+        }
+    };
+
+    window.addEventListener('scroll', () => {
+        if (ticking) return;
+        ticking = true;
+        requestAnimationFrame(() => {
+            update();
+            ticking = false;
+        });
+    }, { passive: true });
+
+    update();
+}
+
+/**
+ * Animate count-up numbers when the hero enters the viewport
+ */
+function initCountUp() {
+    const counters = document.querySelectorAll('.jn-count');
+    if (!counters.length) return;
+
+    const duration = 1600;
+    const hero = document.querySelector('.jn-hero');
+
+    const animate = (counter) => {
+        const target = parseInt(counter.dataset.target, 10);
+        if (isNaN(target)) return;
+        const startTime = performance.now();
+
+        const tick = (now) => {
+            const progress = Math.min((now - startTime) / duration, 1);
+            const eased = 1 - Math.pow(1 - progress, 3);
+            const value = Math.round(target * eased);
+            counter.textContent = value.toLocaleString('en-IN');
+            if (progress < 1) {
+                requestAnimationFrame(tick);
+            } else {
+                counter.textContent = target.toLocaleString('en-IN');
+            }
+        };
+        requestAnimationFrame(tick);
+    };
+
+    const trigger = (entries, observer) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                counters.forEach(animate);
+                observer.disconnect();
+            }
+        });
+    };
+
+    if (hero) {
+        const observer = new IntersectionObserver(trigger, { threshold: 0.2 });
+        observer.observe(hero);
+    } else {
+        counters.forEach(animate);
+    }
+}
+
+/**
+ * Export functions for potential external use
+ */
+export {
+    initTabNavigation,
+    activateTab,
+    initThemeToggle,
+    initSmoothScroll,
+    initMobileMenu,
+    initScrollAnimations,
+    initCountUp,
+    initScrollUI,
+    initFooterTabs,
+    initCardTilt,
+    initTyping,
+    initHeroParallax
+};

--- a/frontend/jnanpith-award-explorer/style.css
+++ b/frontend/jnanpith-award-explorer/style.css
@@ -1,0 +1,1741 @@
+/* ==========================================================================
+   Jnanpith Award Explorer Styling
+   India's highest literary honour - conferred by the Bharatiya Jnanpith since 1965
+   ========================================================================== */
+
+.jn-page-body {
+    background-color: var(--bg-primary, #111827);
+    color: var(--text-primary, #E2E8F0);
+    font-family: 'Inter', system-ui, -apple-system, sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+}
+
+body.jn-page-body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    background:
+        radial-gradient(620px circle at 12% 18%, rgba(255, 153, 51, 0.12), transparent 60%),
+        radial-gradient(720px circle at 88% 78%, rgba(212, 175, 55, 0.12), transparent 60%),
+        radial-gradient(520px circle at 62% 40%, rgba(19, 136, 8, 0.1), transparent 60%);
+    animation: jn-aurora 20s ease-in-out infinite alternate;
+}
+
+@keyframes jn-aurora {
+    0% {
+        transform: translate(0, 0) scale(1);
+    }
+    50% {
+        transform: translate(18px, -18px) scale(1.06);
+    }
+    100% {
+        transform: translate(-18px, 14px) scale(1.12);
+    }
+}
+
+.jn-main {
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: 80px 20px 60px;
+    animation: jn-page-in 0.7s ease-out both;
+}
+
+@keyframes jn-page-in {
+    from {
+        opacity: 0;
+        transform: translateY(18px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* --- Hero Banner --- */
+.jn-hero {
+    text-align: center;
+    padding: 48px 24px;
+    background: linear-gradient(135deg, rgba(17, 24, 39, 0.95) 0%, rgba(30, 12, 34, 0.92) 100%);
+    border: 1px solid rgba(255, 176, 31, 0.3);
+    border-radius: 16px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+    margin-bottom: 32px;
+    position: relative;
+    overflow: hidden;
+}
+
+.jn-hero::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: linear-gradient(90deg, #FF9933 0%, #D4AF37 50%, #138808 100%);
+    z-index: 5;
+}
+
+.jn-hero-bg {
+    position: absolute;
+    inset: 0;
+    background-image: url('https://images.unsplash.com/photo-1507842217343-583bb7270b66?auto=format&fit=crop&q=80&w=1600');
+    background-size: cover;
+    background-position: center;
+    z-index: 0;
+    animation: jn-kenburns 26s ease-in-out infinite alternate;
+}
+
+.jn-hero-overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, rgba(11, 17, 30, 0.86) 0%, rgba(30, 12, 34, 0.8) 55%, rgba(11, 17, 30, 0.92) 100%);
+    z-index: 1;
+}
+
+.jn-hero-particles {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    z-index: 2;
+}
+
+.jn-hero-particles span {
+    position: absolute;
+    bottom: -20px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: rgba(255, 176, 31, 0.55);
+    box-shadow: 0 0 12px rgba(255, 153, 51, 0.5);
+    animation: jn-rise linear infinite;
+}
+
+.jn-hero-particles span:nth-child(1) { left: 8%; width: 6px; height: 6px; animation-duration: 9s; animation-delay: 0s; }
+.jn-hero-particles span:nth-child(2) { left: 22%; width: 10px; height: 10px; animation-duration: 12s; animation-delay: 2s; }
+.jn-hero-particles span:nth-child(3) { left: 38%; width: 7px; height: 7px; animation-duration: 10s; animation-delay: 4s; }
+.jn-hero-particles span:nth-child(4) { left: 55%; width: 11px; height: 11px; animation-duration: 14s; animation-delay: 1s; }
+.jn-hero-particles span:nth-child(5) { left: 72%; width: 6px; height: 6px; animation-duration: 11s; animation-delay: 5s; }
+.jn-hero-particles span:nth-child(6) { left: 88%; width: 9px; height: 9px; animation-duration: 13s; animation-delay: 3s; }
+
+@keyframes jn-rise {
+    0% {
+        transform: translateY(0) translateX(0) scale(0.5);
+        opacity: 0;
+    }
+    15% {
+        opacity: 0.85;
+    }
+    100% {
+        transform: translateY(-520px) translateX(18px) scale(1.15);
+        opacity: 0;
+    }
+}
+
+.jn-hero-content {
+    position: relative;
+    z-index: 3;
+    animation: jn-hero-rise 0.9s ease-out both;
+}
+
+@keyframes jn-hero-rise {
+    from {
+        opacity: 0;
+        transform: translateY(24px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes jn-kenburns {
+    from {
+        transform: scale(1) translateX(0);
+    }
+    to {
+        transform: scale(1.14) translateX(2%);
+    }
+}
+
+.jn-kicker {
+    display: inline-block;
+    padding: 6px 16px;
+    background: rgba(255, 176, 31, 0.15);
+    color: #F0C04D;
+    border: 1px solid rgba(255, 176, 31, 0.4);
+    border-radius: 20px;
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 16px;
+    position: relative;
+    overflow: hidden;
+}
+
+.jn-kicker::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 45%;
+    background: linear-gradient(105deg, transparent, rgba(255, 255, 255, 0.35), transparent);
+    transform: translateX(-140%);
+    animation: jn-badge-shine 3.6s ease-in-out infinite;
+}
+
+@keyframes jn-badge-shine {
+    0% {
+        transform: translateX(-140%);
+    }
+    60%,
+    100% {
+        transform: translateX(320%);
+    }
+}
+
+.jn-hero h1 {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 2.6rem;
+    font-weight: 800;
+    margin: 0 0 12px;
+    background: linear-gradient(90deg, #FFB01F, #F8FAFC, #FF9933, #F8FAFC, #FFB01F);
+    background-size: 200% auto;
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+    animation: jn-shimmer 7s linear infinite;
+}
+
+@keyframes jn-shimmer {
+    to {
+        background-position: -200% center;
+    }
+}
+
+@supports not (background-clip: text) {
+    .jn-hero h1 {
+        background: none;
+        color: var(--text-heading, #F8FAFC);
+    }
+}
+
+.jn-hero p {
+    font-size: 1.1rem;
+    color: var(--text-secondary, #94A3B8);
+    max-width: 850px;
+    margin: 0 auto 24px;
+}
+
+.jn-type-line {
+    font-size: 1.15rem;
+    font-weight: 600;
+}
+
+.jn-type {
+    color: #F0C04D;
+    font-weight: 800;
+}
+
+.jn-type::after {
+    content: '';
+    display: inline-block;
+    width: 3px;
+    height: 1em;
+    margin-left: 4px;
+    background: #F0C04D;
+    vertical-align: -0.12em;
+    animation: jn-blink 0.85s step-end infinite;
+}
+
+@keyframes jn-blink {
+    0%,
+    100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0;
+    }
+}
+
+.jn-hero-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 16px;
+    margin-top: 24px;
+}
+
+.jn-hero-stat {
+    background: rgba(15, 23, 42, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 14px;
+    padding: 22px 16px 18px;
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+    transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.jn-hero-stat::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, #FF9933 0%, #D4AF37 50%, #138808 100%);
+    border-radius: 14px 14px 0 0;
+}
+
+.jn-hero-stat:hover {
+    transform: translateY(-5px);
+    border-color: rgba(255, 176, 31, 0.55);
+    box-shadow: 0 12px 28px rgba(0, 0, 0, 0.4);
+}
+
+.jn-hero-stat:hover strong {
+    animation: jn-pop 0.4s ease;
+}
+
+@keyframes jn-pop {
+    0% {
+        transform: scale(1);
+    }
+    50% {
+        transform: scale(1.18);
+    }
+    100% {
+        transform: scale(1);
+    }
+}
+
+.jn-hero-stat strong {
+    font-size: clamp(1.9rem, 4.5vw, 2.6rem);
+    font-family: 'Playfair Display', Georgia, serif;
+    font-weight: 800;
+    line-height: 1.1;
+    color: #FF9933;
+    display: block;
+    margin-bottom: 8px;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+    animation: jn-glow 3s ease-in-out infinite;
+}
+
+@keyframes jn-glow {
+    0%,
+    100% {
+        text-shadow: 0 0 6px rgba(255, 153, 51, 0.35);
+    }
+    50% {
+        text-shadow: 0 0 20px rgba(255, 153, 51, 0.75);
+    }
+}
+
+.jn-hero-stat span {
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: #94A3B8;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    display: block;
+}
+
+/* --- Scroll Down Hint --- */
+.jn-scroll-hint {
+    position: relative;
+    z-index: 3;
+    display: block;
+    width: 26px;
+    height: 42px;
+    margin: 10px auto 0;
+    border: 2px solid rgba(240, 192, 77, 0.8);
+    border-radius: 16px;
+    animation: jn-hint-bob 2s ease-in-out infinite;
+}
+
+.jn-scroll-hint::after {
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: 8px;
+    width: 5px;
+    height: 5px;
+    margin-left: -2.5px;
+    border-radius: 50%;
+    background: #F0C04D;
+    animation: jn-hint-dot 2s ease-in-out infinite;
+}
+
+@keyframes jn-hint-bob {
+    0%,
+    100% {
+        transform: translateY(0);
+    }
+    50% {
+        transform: translateY(6px);
+    }
+}
+
+@keyframes jn-hint-dot {
+    0% {
+        opacity: 0;
+        transform: translateY(0);
+    }
+    30% {
+        opacity: 1;
+    }
+    100% {
+        opacity: 0;
+        transform: translateY(16px);
+    }
+}
+
+/* --- Marquee Strip --- */
+.jn-marquee {
+    overflow: hidden;
+    background: linear-gradient(90deg, #FF9933 0%, #D4AF37 50%, #138808 100%);
+    padding: 10px 0;
+    border-radius: 10px;
+    margin-bottom: 24px;
+    box-shadow: 0 4px 18px rgba(0, 0, 0, 0.25);
+}
+
+.jn-marquee-track {
+    display: flex;
+    gap: 56px;
+    width: max-content;
+    animation: jn-marquee-scroll 30s linear infinite;
+}
+
+.jn-marquee-track span {
+    color: #111827;
+    font-weight: 800;
+    font-size: 0.85rem;
+    letter-spacing: 1.5px;
+    white-space: nowrap;
+}
+
+@keyframes jn-marquee-scroll {
+    from {
+        transform: translateX(0);
+    }
+    to {
+        transform: translateX(-50%);
+    }
+}
+
+.jn-marquee:hover .jn-marquee-track {
+    animation-play-state: paused;
+}
+
+/* --- Navigation Tabs --- */
+.jn-nav-tabs {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-bottom: 32px;
+    padding: 16px;
+    background: rgba(15, 23, 42, 0.6);
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.jn-tab {
+    background: rgba(15, 23, 42, 0.8);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    color: var(--text-secondary, #94A3B8);
+    padding: 10px 18px;
+    border-radius: 8px;
+    font-size: 0.88rem;
+    font-weight: 600;
+    cursor: pointer;
+    position: relative;
+    overflow: hidden;
+    transition: all 0.25s ease;
+}
+
+.jn-tab::after {
+    content: '';
+    position: absolute;
+    left: 14%;
+    right: 14%;
+    bottom: 5px;
+    height: 2px;
+    border-radius: 2px;
+    background: currentColor;
+    transform: scaleX(0);
+    transform-origin: center;
+    transition: transform 0.3s ease;
+}
+
+.jn-tab:hover::after {
+    transform: scaleX(1);
+}
+
+.jn-tab:hover {
+    background: rgba(255, 176, 31, 0.15);
+    color: #F0C04D;
+    border-color: rgba(255, 176, 31, 0.4);
+    transform: translateY(-2px);
+}
+
+.jn-tab.active {
+    background: linear-gradient(135deg, #D4AF37 0%, #FF9933 100%);
+    color: #111827;
+    border-color: transparent;
+    box-shadow: 0 4px 16px rgba(255, 153, 51, 0.3);
+    animation: jn-tab-pulse 2.6s ease-in-out infinite;
+}
+
+@keyframes jn-tab-pulse {
+    0%,
+    100% {
+        box-shadow: 0 4px 16px rgba(255, 153, 51, 0.3);
+    }
+    50% {
+        box-shadow: 0 6px 28px rgba(255, 153, 51, 0.6);
+    }
+}
+
+/* --- Sections --- */
+.jn-section {
+    display: none;
+}
+
+.jn-section.active {
+    display: block;
+    animation: jn-fade-in 0.4s ease;
+}
+
+@keyframes jn-fade-in {
+    from {
+        opacity: 0;
+        transform: translateY(18px) scale(0.985);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0) scale(1);
+    }
+}
+
+.jn-content-card {
+    background: var(--bg-dark-card, rgba(30, 41, 59, 0.5));
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 16px;
+    padding: 32px;
+    margin-bottom: 24px;
+    backdrop-filter: blur(8px);
+}
+
+.jn-content-card h2 {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 1.8rem;
+    color: #FF9933;
+    margin: 0 0 20px;
+    border-bottom: 1px solid rgba(255, 176, 31, 0.2);
+    padding-bottom: 12px;
+    position: relative;
+}
+
+.jn-content-card h2::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: -1px;
+    height: 3px;
+    width: 60px;
+    border-radius: 3px;
+    background: linear-gradient(90deg, #FF9933 0%, #D4AF37 100%);
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform 0.55s ease;
+}
+
+.jn-content-card.animate-in h2::after {
+    transform: scaleX(1);
+}
+
+.jn-content p {
+    color: var(--text-secondary, #94A3B8);
+    margin-bottom: 16px;
+    font-size: 1rem;
+}
+
+.jn-content h3 {
+    color: #F0C04D;
+    font-size: 1.15rem;
+    margin: 24px 0 12px;
+}
+
+/* --- Split Layout (Text + Figure) --- */
+.jn-split {
+    display: grid;
+    grid-template-columns: 1.35fr 1fr;
+    gap: 32px;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.jn-figure {
+    margin: 0;
+    position: relative;
+    border-radius: 16px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 16px 40px rgba(0, 0, 0, 0.35);
+    min-height: 260px;
+}
+
+.jn-figure img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.6s ease;
+}
+
+.jn-figure:hover img {
+    transform: scale(1.05);
+}
+
+.jn-figure figcaption {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 30px 16px 14px;
+    background: linear-gradient(transparent, rgba(8, 12, 22, 0.85));
+    color: #F8FAFC;
+    font-size: 0.82rem;
+    text-align: center;
+}
+
+@keyframes jn-float {
+    0%,
+    100% {
+        transform: translateY(0);
+    }
+    50% {
+        transform: translateY(-10px);
+    }
+}
+
+.float-slow {
+    animation: jn-float 5s ease-in-out infinite;
+}
+
+/* --- Banner Figure --- */
+.jn-banner {
+    margin: 0 0 20px;
+    border-radius: 16px;
+    overflow: hidden;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.jn-banner img {
+    display: block;
+    width: 100%;
+    height: 300px;
+    object-fit: cover;
+    transition: transform 0.6s ease;
+}
+
+.jn-banner:hover img {
+    transform: scale(1.04);
+}
+
+.jn-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 16px;
+}
+
+.jn-list li {
+    position: relative;
+    padding-left: 28px;
+    margin-bottom: 10px;
+    color: var(--text-secondary, #94A3B8);
+    transition: transform 0.22s ease, color 0.22s ease;
+}
+
+.jn-list li:hover {
+    transform: translateX(6px);
+    color: #F0C04D;
+}
+
+.jn-list li::before {
+    content: '🏆';
+    position: absolute;
+    left: 0;
+    top: 0;
+    transition: transform 0.25s ease;
+}
+
+.jn-list li:hover::before {
+    transform: scale(1.25) rotate(-8deg);
+}
+
+/* --- Eligibility Grid --- */
+.eligibility-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 16px;
+    margin-top: 8px;
+}
+
+.eligibility-item {
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    padding: 20px;
+    transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.eligibility-item:hover {
+    transform: translateY(-4px);
+    border-color: rgba(255, 176, 31, 0.4);
+}
+
+.eligibility-item h3 {
+    color: #F0C04D;
+    font-size: 1.05rem;
+    margin: 0 0 10px;
+}
+
+.eligibility-item p {
+    color: var(--text-secondary, #94A3B8);
+    font-size: 0.92rem;
+    margin: 0;
+}
+
+/* --- Category Cards (Painting/Sculpture/Printmaking/Ceramics) --- */
+.category-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 16px;
+    margin-top: 16px;
+}
+
+.category-card {
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    padding: 20px;
+    text-align: left;
+    position: relative;
+    overflow: hidden;
+    transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.category-card:hover {
+    transform: translateY(-4px);
+    border-color: rgba(255, 176, 31, 0.4);
+}
+
+.category-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(320px circle at var(--spot-x, 50%) var(--spot-y, 50%), rgba(255, 176, 31, 0.18), transparent 65%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+    z-index: 1;
+}
+
+.category-card:hover::before {
+    opacity: 1;
+}
+
+.category-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 1px;
+    background: linear-gradient(120deg, transparent 20%, #FF9933 40%, #D4AF37 50%, #138808 60%, transparent 80%);
+    background-size: 250% 250%;
+    -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    opacity: 0;
+    transition: opacity 0.35s ease;
+    pointer-events: none;
+    z-index: 2;
+    animation: jn-border-shimmer 2.5s linear infinite;
+}
+
+.category-card:hover::after {
+    opacity: 1;
+}
+
+@keyframes jn-border-shimmer {
+    to {
+        background-position: 250% 0;
+    }
+}
+
+.category-img {
+    height: 150px;
+    border-radius: 10px;
+    overflow: hidden;
+    margin-bottom: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    position: relative;
+}
+
+.category-img img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.5s ease;
+}
+
+.category-card:hover .category-img img {
+    transform: scale(1.08);
+}
+
+.category-img::before {
+    content: '↗';
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(8, 12, 22, 0.4);
+    color: #F0C04D;
+    font-size: 1.8rem;
+    font-weight: 700;
+    opacity: 0;
+    transition: opacity 0.35s ease;
+    z-index: 1;
+}
+
+.category-card:hover .category-img::before {
+    opacity: 1;
+}
+
+.category-img::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(105deg, transparent 40%, rgba(255, 255, 255, 0.28) 50%, transparent 60%);
+    transform: translateX(-130%);
+    transition: transform 0.6s ease;
+    z-index: 1;
+}
+
+.category-card:hover .category-img::after {
+    transform: translateX(130%);
+}
+
+.category-card:hover .category-icon {
+    animation: jn-bounce 0.5s ease;
+}
+
+@keyframes jn-bounce {
+    0%,
+    100% {
+        transform: translateY(0);
+    }
+    40% {
+        transform: translateY(-8px) rotate(-6deg);
+    }
+}
+
+.category-card h3 {
+    color: #F0C04D;
+    font-size: 1.05rem;
+    margin: 0 0 10px;
+}
+
+.category-card p {
+    color: var(--text-secondary, #94A3B8);
+    font-size: 0.92rem;
+    margin: 0;
+}
+
+/* --- Selection Timeline --- */
+.selection-timeline {
+    margin: 20px 0;
+}
+
+.selection-step {
+    position: relative;
+    padding: 0 0 24px 56px;
+}
+
+.selection-step:last-child {
+    padding-bottom: 0;
+}
+
+.selection-step::before {
+    content: '';
+    position: absolute;
+    left: 24px;
+    top: 42px;
+    bottom: 0;
+    width: 2px;
+    background: rgba(255, 176, 31, 0.3);
+}
+
+.selection-step:last-child::before {
+    display: none;
+}
+
+.step-number {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #D4AF37 0%, #FF9933 100%);
+    color: #111827;
+    font-weight: 800;
+    font-size: 1.1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 4px 14px rgba(255, 153, 51, 0.35);
+}
+
+.selection-step h3 {
+    color: #F0C04D;
+    font-size: 1.05rem;
+    margin: 0 0 6px;
+}
+
+.selection-step:hover .step-number {
+    transform: scale(1.15) rotate(8deg);
+    box-shadow: 0 6px 20px rgba(255, 153, 51, 0.5);
+}
+
+.step-number {
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.selection-step p {
+    color: var(--text-secondary, #94A3B8);
+    font-size: 0.95rem;
+    margin: 0;
+}
+
+.evaluation-criteria {
+    background: rgba(255, 176, 31, 0.06);
+    border: 1px solid rgba(255, 176, 31, 0.25);
+    border-radius: 12px;
+    padding: 20px;
+    margin-top: 24px;
+}
+
+.evaluation-criteria h3 {
+    color: #F0C04D;
+    margin: 0 0 12px;
+}
+
+.evaluation-criteria ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.evaluation-criteria li {
+    color: var(--text-secondary, #94A3B8);
+    margin-bottom: 8px;
+    font-size: 0.95rem;
+    transition: transform 0.22s ease, color 0.22s ease;
+}
+
+.evaluation-criteria li:hover {
+    color: #F0C04D;
+    transform: translateX(6px);
+}
+
+/* --- Awardees --- */
+.awardees-gallery {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 16px;
+    margin-top: 16px;
+}
+
+.awardee-card {
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    padding: 20px;
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+    transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.awardee-card:hover {
+    transform: translateY(-4px);
+    border-color: rgba(255, 176, 31, 0.4);
+}
+
+.awardee-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(300px circle at var(--spot-x, 50%) var(--spot-y, 50%), rgba(255, 176, 31, 0.16), transparent 65%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+    z-index: 1;
+}
+
+.awardee-card:hover::before {
+    opacity: 1;
+}
+
+.awardee-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 1px;
+    background: linear-gradient(120deg, transparent 20%, #FF9933 40%, #D4AF37 50%, #138808 60%, transparent 80%);
+    background-size: 250% 250%;
+    -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    opacity: 0;
+    transition: opacity 0.35s ease;
+    pointer-events: none;
+    z-index: 2;
+    animation: jn-border-shimmer 2.5s linear infinite;
+}
+
+.awardee-card:hover::after {
+    opacity: 1;
+}
+
+.awardee-avatar {
+    font-size: 2.2rem;
+    margin-bottom: 8px;
+    display: inline-block;
+}
+
+.awardee-card:hover .awardee-avatar {
+    animation: jn-bounce 0.5s ease;
+}
+
+.awardee-card h3 {
+    color: #F8FAFC;
+    font-size: 1.05rem;
+    margin: 0 0 4px;
+}
+
+.awardee-year {
+    display: inline-block;
+    background: rgba(255, 153, 51, 0.15);
+    color: #FFB01F;
+    font-size: 0.78rem;
+    font-weight: 600;
+    padding: 4px 10px;
+    border-radius: 20px;
+    margin-bottom: 10px;
+    animation: jn-year-pulse 3s ease-in-out infinite;
+}
+
+@keyframes jn-year-pulse {
+    0%,
+    100% {
+        box-shadow: 0 0 0 0 rgba(255, 153, 51, 0.4);
+    }
+    50% {
+        box-shadow: 0 0 0 6px rgba(255, 153, 51, 0);
+    }
+}
+
+.awardee-card p:last-child {
+    color: var(--text-secondary, #94A3B8);
+    font-size: 0.88rem;
+    margin: 0;
+}
+
+.notable-achievements {
+    background: rgba(255, 176, 31, 0.06);
+    border: 1px solid rgba(255, 176, 31, 0.25);
+    border-radius: 12px;
+    padding: 20px;
+    margin-top: 24px;
+}
+
+.notable-achievements h3 {
+    color: #F0C04D;
+    margin: 0 0 12px;
+}
+
+.notable-achievements ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.notable-achievements li {
+    color: var(--text-secondary, #94A3B8);
+    margin-bottom: 8px;
+    font-size: 0.95rem;
+    padding-left: 24px;
+    position: relative;
+}
+
+.notable-achievements li::before {
+    content: '🏅';
+    position: absolute;
+    left: 0;
+    top: 0;
+}
+
+/* --- Gallery --- */
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 16px;
+    margin-top: 16px;
+}
+
+.gallery-item {
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    overflow: hidden;
+    text-align: center;
+    position: relative;
+    transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.gallery-item:hover {
+    transform: translateY(-4px);
+    border-color: rgba(255, 176, 31, 0.4);
+}
+
+.gallery-item::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(320px circle at var(--spot-x, 50%) var(--spot-y, 50%), rgba(255, 176, 31, 0.18), transparent 65%);
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
+    z-index: 2;
+}
+
+.gallery-item:hover::before {
+    opacity: 1;
+}
+
+.gallery-item::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 1px;
+    background: linear-gradient(120deg, transparent 20%, #FF9933 40%, #D4AF37 50%, #138808 60%, transparent 80%);
+    background-size: 250% 250%;
+    -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    opacity: 0;
+    transition: opacity 0.35s ease;
+    pointer-events: none;
+    z-index: 3;
+    animation: jn-border-shimmer 2.5s linear infinite;
+}
+
+.gallery-item:hover::after {
+    opacity: 1;
+}
+
+.gallery-img {
+    height: 170px;
+    overflow: hidden;
+    position: relative;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.gallery-img img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.5s ease;
+}
+
+.gallery-item:hover .gallery-img img {
+    transform: scale(1.08);
+}
+
+.gallery-img::before {
+    content: '↗';
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(8, 12, 22, 0.4);
+    color: #F0C04D;
+    font-size: 1.8rem;
+    font-weight: 700;
+    opacity: 0;
+    transition: opacity 0.35s ease;
+    z-index: 1;
+}
+
+.gallery-item:hover .gallery-img::before {
+    opacity: 1;
+}
+
+.gallery-img::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(105deg, transparent 40%, rgba(255, 255, 255, 0.28) 50%, transparent 60%);
+    transform: translateX(-130%);
+    transition: transform 0.6s ease;
+    z-index: 1;
+}
+
+.gallery-item:hover .gallery-img::after {
+    transform: translateX(130%);
+}
+
+.gallery-item figcaption {
+    position: relative;
+    z-index: 4;
+}
+
+.gallery-item h3 {
+    color: #F8FAFC;
+    font-size: 1rem;
+    margin: 12px 0 4px;
+}
+
+.gallery-item p {
+    color: var(--text-secondary, #94A3B8);
+    font-size: 0.85rem;
+    padding: 0 14px 14px;
+    margin: 0;
+}
+
+.media-highlights {
+    background: rgba(255, 176, 31, 0.06);
+    border: 1px solid rgba(255, 176, 31, 0.25);
+    border-radius: 12px;
+    padding: 20px;
+    margin-top: 24px;
+}
+
+.media-highlights h3 {
+    color: #F0C04D;
+    margin: 0 0 12px;
+}
+
+.media-highlights ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.media-highlights li {
+    color: var(--text-secondary, #94A3B8);
+    margin-bottom: 8px;
+    font-size: 0.95rem;
+}
+
+/* --- Language Chips --- */
+.language-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(170px, 1fr));
+    gap: 14px;
+    margin: 28px 0;
+}
+
+.language-chip {
+    position: relative;
+    background: rgba(255, 153, 51, 0.08);
+    border: 1px solid rgba(212, 175, 55, 0.35);
+    border-radius: 14px;
+    padding: 14px 18px;
+    color: #F0C04D;
+    font-weight: 600;
+    font-size: 0.98rem;
+    text-align: center;
+    transition: transform 0.25s ease, border-color 0.25s ease, background 0.25s ease;
+}
+
+.language-chip:hover {
+    transform: translateY(-4px);
+    border-color: #D4AF37;
+    background: rgba(255, 153, 51, 0.15);
+}
+
+.language-chip span {
+    display: block;
+    margin-top: 4px;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--text-secondary, #94A3B8);
+    letter-spacing: 0.4px;
+}
+
+/* --- Akademi Timeline --- */
+.timeline-container {
+    position: relative;
+    margin: 24px 0 8px;
+    padding-left: 24px;
+}
+
+.timeline-container::before {
+    content: '';
+    position: absolute;
+    left: 10px;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: linear-gradient(180deg, #FF9933 0%, #D4AF37 55%, #138808 100%);
+    border-radius: 2px;
+}
+
+.timeline-item {
+    position: relative;
+    padding: 0 0 28px 22px;
+}
+
+.timeline-item:last-child {
+    padding-bottom: 0;
+}
+
+.timeline-dot {
+    position: absolute;
+    left: -22px;
+    top: 6px;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #D4AF37 0%, #FF9933 100%);
+    box-shadow: 0 0 0 4px rgba(255, 153, 51, 0.18);
+    animation: jn-dot-pulse 3s ease-in-out infinite;
+}
+
+@keyframes jn-dot-pulse {
+    0%,
+    100% {
+        box-shadow: 0 0 0 4px rgba(255, 153, 51, 0.18);
+    }
+    50% {
+        box-shadow: 0 0 0 8px rgba(255, 153, 51, 0.05);
+    }
+}
+
+.timeline-item:hover .timeline-dot {
+    transform: scale(1.25);
+}
+
+.timeline-dot {
+    transition: transform 0.25s ease;
+}
+
+.timeline-year {
+    display: inline-block;
+    background: rgba(255, 153, 51, 0.15);
+    color: #FFB01F;
+    font-size: 0.82rem;
+    font-weight: 700;
+    padding: 4px 12px;
+    border-radius: 20px;
+    margin-bottom: 8px;
+    letter-spacing: 0.5px;
+}
+
+.timeline-body h3 {
+    color: #F0C04D;
+    font-size: 1.08rem;
+    margin: 0 0 6px;
+}
+
+.timeline-body p {
+    color: var(--text-secondary, #94A3B8);
+    font-size: 0.95rem;
+    margin: 0;
+}
+
+/* --- Footer --- */
+.jn-footer {
+    margin-top: 48px;
+    border-top: 3px solid;
+    border-image: linear-gradient(90deg, #FF9933 0%, #D4AF37 50%, #138808 100%) 1;
+    background: rgba(11, 17, 30, 0.55);
+    color: var(--text-secondary, #94A3B8);
+    font-size: 0.9rem;
+}
+
+.jn-footer-container {
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: 48px 24px 32px;
+    display: grid;
+    grid-template-columns: 1.6fr 1fr 1fr 1fr;
+    gap: 40px;
+}
+
+.jn-footer-brand h3 {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 1.3rem;
+    margin: 0 0 12px;
+    color: #F8FAFC;
+}
+
+.jn-footer-brand p {
+    font-size: 0.88rem;
+    line-height: 1.7;
+    margin: 0 0 10px;
+    color: var(--text-secondary, #94A3B8);
+}
+
+.jn-footer-tagline {
+    color: #F0C04D;
+    font-weight: 600;
+}
+
+.jn-footer-links h4 {
+    color: #F0C04D;
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 1rem;
+    margin: 0 0 16px;
+}
+
+.jn-footer-links ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.jn-footer-links li {
+    margin-bottom: 10px;
+}
+
+.jn-footer-links a {
+    color: var(--text-secondary, #94A3B8);
+    text-decoration: none;
+    font-size: 0.9rem;
+    transition: color 0.25s ease, transform 0.25s ease;
+    display: inline-block;
+    position: relative;
+}
+
+.jn-footer-links a::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    bottom: -2px;
+    height: 2px;
+    width: 100%;
+    background: linear-gradient(90deg, #FF9933 0%, #D4AF37 100%);
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform 0.3s ease;
+}
+
+.jn-footer-links a:hover::after {
+    transform: scaleX(1);
+}
+
+.jn-footer-links a:hover {
+    color: #FF9933;
+    transform: translateX(4px);
+}
+
+.jn-footer-bottom {
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 18px 24px;
+    text-align: center;
+    font-size: 0.82rem;
+    color: var(--text-secondary, #94A3B8);
+}
+
+.jn-footer-bottom p {
+    margin: 4px 0;
+}
+
+/* --- Scroll Progress --- */
+.jn-scroll-progress {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 3px;
+    width: 0;
+    background: linear-gradient(90deg, #FF9933 0%, #D4AF37 50%, #138808 100%);
+    z-index: 1000;
+    transition: width 0.1s linear;
+}
+
+/* --- Scroll to Top --- */
+.jn-scroll-top {
+    position: fixed;
+    bottom: 24px;
+    right: 24px;
+    width: 46px;
+    height: 46px;
+    border-radius: 50%;
+    border: none;
+    background: linear-gradient(135deg, #D4AF37 0%, #FF9933 100%);
+    color: #111827;
+    font-size: 1.2rem;
+    font-weight: 800;
+    cursor: pointer;
+    box-shadow: 0 6px 18px rgba(255, 153, 51, 0.4);
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(12px);
+    transition: opacity 0.3s ease, transform 0.3s ease, visibility 0.3s ease;
+    z-index: 900;
+}
+
+.jn-scroll-top.visible {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
+.jn-scroll-top:hover {
+    transform: translateY(-3px) scale(1.05);
+}
+
+/* --- Scroll Animations --- */
+.animate-on-scroll {
+    opacity: 0;
+    transform: translateY(24px);
+    transition: opacity 0.6s ease, transform 0.6s ease;
+}
+
+.reveal-left {
+    transform: translateX(-30px);
+}
+
+.reveal-right {
+    transform: translateX(30px);
+}
+
+.reveal-scale {
+    transform: scale(0.9);
+}
+
+.animate-in {
+    opacity: 1;
+    transform: none;
+}
+
+/* Card 3D tilt (transform set inline via JS on hover) */
+.jn-card-tilt {
+    transition: transform 0.2s ease-out, box-shadow 0.3s ease, border-color 0.3s ease !important;
+    transform-style: preserve-3d;
+    will-change: transform;
+}
+
+.category-card:hover,
+.awardee-card:hover,
+.gallery-item:hover {
+    box-shadow: 0 16px 36px rgba(0, 0, 0, 0.4);
+}
+
+/* --- Light Theme Overrides --- */
+.light-theme .jn-page-body {
+    background-color: #F8FAFC;
+}
+
+.light-theme .jn-hero {
+    background: linear-gradient(135deg, rgba(255, 248, 235, 0.95) 0%, rgba(250, 240, 255, 0.92) 100%);
+    border-color: rgba(255, 153, 51, 0.35);
+}
+
+.light-theme .jn-hero h1 {
+    background-image: linear-gradient(90deg, #B45309, #1E293B, #B45309, #1E293B, #B45309);
+}
+
+.light-theme .jn-footer {
+    background: rgba(255, 255, 255, 0.78);
+}
+
+.light-theme body.jn-page-body::before {
+    background:
+        radial-gradient(620px circle at 12% 18%, rgba(255, 153, 51, 0.16), transparent 60%),
+        radial-gradient(720px circle at 88% 78%, rgba(212, 175, 55, 0.16), transparent 60%),
+        radial-gradient(520px circle at 62% 40%, rgba(19, 136, 8, 0.12), transparent 60%);
+}
+
+.light-theme .jn-type {
+    color: #B45309;
+}
+
+.light-theme .jn-type::after {
+    background: #B45309;
+}
+
+.light-theme .jn-footer-brand h3,
+.light-theme .jn-footer-links h4 {
+    color: #1E293B;
+}
+
+.light-theme .jn-footer-tagline {
+    color: #B45309;
+}
+
+.light-theme .jn-scroll-top {
+    color: #ffffff;
+}
+
+.light-theme .jn-hero-overlay {
+    background: linear-gradient(180deg, rgba(255, 248, 235, 0.9) 0%, rgba(250, 240, 255, 0.84) 55%, rgba(255, 248, 235, 0.94) 100%);
+}
+
+.light-theme .jn-figure figcaption {
+    background: linear-gradient(transparent, rgba(30, 41, 59, 0.85));
+}
+
+.light-theme .jn-hero-stat {
+    background: rgba(255, 255, 255, 0.8);
+    border-color: rgba(255, 153, 51, 0.2);
+}
+
+.light-theme .jn-hero-stat span {
+    color: #64748B;
+}
+
+.light-theme .jn-nav-tabs,
+.light-theme .jn-content-card {
+    background: rgba(255, 255, 255, 0.85);
+    border-color: rgba(203, 213, 225, 0.6);
+}
+
+.light-theme .jn-tab {
+    background: rgba(255, 255, 255, 0.8);
+    border-color: rgba(203, 213, 225, 0.7);
+    color: #475569;
+}
+
+.light-theme .jn-content p,
+.light-theme .jn-list li,
+.light-theme .eligibility-item p,
+.light-theme .category-card p,
+.light-theme .selection-step p,
+.light-theme .evaluation-criteria li,
+.light-theme .awardee-card p:last-child,
+.light-theme .gallery-item p,
+.light-theme .media-highlights li,
+.light-theme .notable-achievements li,
+.light-theme .timeline-body p,
+.light-theme .language-chip span,
+.light-theme .jn-footer {
+    color: #475569;
+}
+
+.light-theme .jn-hero p {
+    color: #475569;
+}
+
+.light-theme .eligibility-item,
+.light-theme .category-card,
+.light-theme .awardee-card,
+.light-theme .gallery-item,
+.light-theme .language-chip {
+    background: rgba(255, 255, 255, 0.9);
+    border-color: rgba(203, 213, 225, 0.6);
+}
+
+.light-theme .awardee-card h3,
+.light-theme .gallery-item h3,
+.light-theme .timeline-body h3,
+.light-theme .language-chip {
+    color: #1E293B;
+}
+
+/* --- Responsive --- */
+@media (max-width: 768px) {
+    .jn-main {
+        padding: 60px 14px 40px;
+    }
+
+    .jn-hero h1 {
+        font-size: 1.9rem;
+    }
+
+    .jn-hero p {
+        font-size: 1rem;
+    }
+
+    .jn-content-card {
+        padding: 20px;
+    }
+
+    .jn-content-card h2 {
+        font-size: 1.45rem;
+    }
+
+    .jn-split {
+        grid-template-columns: 1fr;
+    }
+
+    .jn-banner img {
+        height: 200px;
+    }
+
+    .jn-footer-container {
+        grid-template-columns: 1fr;
+        gap: 32px;
+        padding: 36px 20px 24px;
+    }
+
+    .jn-scroll-top {
+        bottom: 16px;
+        right: 16px;
+        width: 42px;
+        height: 42px;
+    }
+}
+
+/* --- Reduced Motion --- */
+@media (prefers-reduced-motion: reduce) {
+    .jn-hero-bg,
+    .jn-marquee-track,
+    .float-slow,
+    .jn-hero-content,
+    .jn-hero-particles span,
+    .jn-hero h1,
+    .jn-hero-stat strong,
+    body.jn-page-body::before,
+    .jn-tab.active,
+    .jn-type::after {
+        animation: none;
+    }
+
+    .category-card::after,
+    .awardee-card::after,
+    .gallery-item::after,
+    .jn-kicker::after,
+    .jn-scroll-hint,
+    .jn-scroll-hint::after,
+    .awardee-year {
+        animation: none;
+    }
+
+    .jn-main,
+    .jn-section.active {
+        animation: none;
+    }
+}

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -1715,6 +1715,13 @@ window.indiaSearchIndex = [
     description: "Explore India's highest national honour for the performing arts — history since 1952, eligibility, dance, music and theatre categories, selection process, awardees, timeline, and gallery.",
     url: "frontend/sangeet-natak-akademi-award-explorer/index.html"
   },
+  // --- Jnanpith Award Explorer ---
+  {
+    title: "Jnanpith Award Explorer",
+    category: "Awards & Honours",
+    description: "Explore India's highest literary honour — history since 1961, year instituted, eligibility, selection process, languages covered, medal and citation, complete winners timeline, notable laureates, facts, and gallery.",
+    url: "frontend/jnanpith-award-explorer/index.html"
+  },
   // --- Mandvi Port Explorer ---
   {
     title: "Mandvi Ancient Port Explorer",

--- a/tests/unit/jnanpith-award-explorer.test.js
+++ b/tests/unit/jnanpith-award-explorer.test.js
@@ -1,0 +1,135 @@
+/**
+ * jnanpith-award-explorer.test.js
+ * Unit tests for the Jnanpith Award Explorer page.
+ * Validates required sections, tab navigation, accessibility, image URLs,
+ * and landing page card integration on the Awards of India landing page.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function readExplorerFile(file) {
+    return readFileSync(
+        resolve(__dirname, '../../frontend/jnanpith-award-explorer', file),
+        'utf-8'
+    );
+}
+
+function readLandingPage() {
+    return readFileSync(
+        resolve(__dirname, '../../frontend/awards-of-india-explorer/index.html'),
+        'utf-8'
+    );
+}
+
+describe('Jnanpith Award Explorer — Page Structure', () => {
+    let html;
+
+    beforeAll(() => {
+        html = readExplorerFile('index.html');
+    });
+
+    it('contains a hero section with page title and kicker', () => {
+        expect(html).toContain('class="jn-hero"');
+        expect(html).toContain('<h1>');
+        expect(html).toContain('Jnanpith Award');
+        expect(html).toContain('India\'s Highest Literary Honour');
+        expect(html).toContain('First Award Conferred');
+        expect(html).toContain('1965');
+    });
+
+    it('contains all required content sections from the issue', () => {
+        const sections = ['history', 'year-instituted', 'eligibility', 'languages', 'selection', 'medal-citation', 'winners', 'awardees', 'facts', 'gallery'];
+        sections.forEach(id => {
+            expect(html).toContain(`id="${id}"`);
+            expect(html).toContain(`data-tab="${id}"`);
+        });
+    });
+
+    it('contains all required categories as tab buttons', () => {
+        ['History', 'Year Instituted', 'Eligibility', 'Languages', 'Selection', 'Medal & Citation', 'Winners Timeline', 'Notable Laureates', 'Facts', 'Gallery'].forEach(category => {
+            expect(html).toContain(category);
+        });
+    });
+
+    it('contains the key historical and structural details', () => {
+        expect(html).toContain('22 May 1961');
+        expect(html).toContain('Sahu Shanti Prasad Jain');
+        expect(html).toContain('Bharatiya Jnanpith');
+        expect(html).toContain('Vagdevi');
+        expect(html).toContain('11 lakh');
+        expect(html).toContain('Odakkuzhal');
+    });
+
+    it('covers the languages represented among laureates', () => {
+        ['Hindi', 'Kannada', 'Malayalam', 'Tamil', 'Urdu', 'English', 'Kashmiri', 'Konkani', 'Sanskrit', 'Punjabi'].forEach(language => {
+            expect(html).toContain(language);
+        });
+    });
+
+    it('has a semantic heading hierarchy (single h1, section h2s)', () => {
+        const h1Count = (html.match(/<h1[\s>]/g) || []).length;
+        const h2Count = (html.match(/<h2[\s>]/g) || []).length;
+        expect(h1Count).toBe(1);
+        expect(h2Count).toBeGreaterThanOrEqual(10);
+    });
+
+    it('uses HTTPS image sources with alt attributes', () => {
+        const imgTags = html.match(/<img [^>]*>/g) || [];
+        expect(imgTags.length).toBeGreaterThanOrEqual(6);
+        imgTags.forEach(tag => {
+            expect(tag).toMatch(/src="https:\/\//);
+            expect(tag).toMatch(/alt="/);
+            expect(tag).not.toMatch(/src="http:\/\//);
+        });
+    });
+
+    it('links the shared stylesheet, page stylesheet, and script', () => {
+        expect(html).toContain('href="../../styles.css"');
+        expect(html).toContain('href="style.css"');
+        expect(html).toContain('src="script.js"');
+    });
+});
+
+describe('Jnanpith Award Explorer — Assets', () => {
+    it('includes a non-empty stylesheet', () => {
+        const css = readExplorerFile('style.css');
+        expect(css.length).toBeGreaterThan(1000);
+        expect(css).toContain('.jn-hero');
+        expect(css).toContain('.timeline-container');
+        expect(css).toContain('.language-chip');
+    });
+
+    it('includes a valid interactive script with required functions', () => {
+        const js = readExplorerFile('script.js');
+        expect(js).toContain('initTabNavigation');
+        expect(js).toContain('activateTab');
+        expect(js).toContain('initCountUp');
+        expect(js).toContain('initTyping');
+        expect(js).toContain("document.addEventListener('DOMContentLoaded'");
+    });
+});
+
+describe('Jnanpith Award — Landing Page Integration', () => {
+    it('is listed as a card on the Awards of India Explorer landing page', () => {
+        const index = readLandingPage();
+        expect(index).toContain('Jnanpith Award');
+        expect(index).toContain('../jnanpith-award-explorer/index.html');
+    });
+
+    it('matches the existing award card pattern (icon, category, stats, button)', () => {
+        const index = readLandingPage();
+        const cardStart = index.indexOf('Jnanpith Award Card');
+        expect(cardStart).toBeGreaterThan(-1);
+        const card = index.slice(cardStart, cardStart + 1200);
+        expect(card).toContain('award-icon');
+        expect(card).toContain('award-category');
+        expect(card).toContain('award-year');
+        expect(card).toContain('award-btn');
+        expect(card).toContain('class="award-card glass-card"');
+    });
+});


### PR DESCRIPTION
Fixes #1097

## Summary
Adds a dedicated **Jnanpith Award Explorer** page celebrating India's highest literary honour, conferred by the Bharatiya Jnanpith trust since 1965.

## Include
- History
- Year Instituted
- Eligibility
- Selection Process
- Languages Covered
- Medal & Citation
- Complete Winners Timeline (1965–2024)
- Notable Laureates
- Interesting Facts
- Image Gallery

## Landing Page Integration
Adds a Jnanpith Award card to the **Awards of India Explorer** landing page, plus a search index entry.

## Files
- `frontend/jnanpith-award-explorer/index.html`
- `frontend/jnanpith-award-explorer/style.css`
- `frontend/jnanpith-award-explorer/script.js`
- `frontend/awards-of-india-explorer/index.html` (landing card)
- `frontend/search-index.js` (search entry)
- `tests/unit/jnanpith-award-explorer.test.js`

## Tests
`npm run test:unit` — new test file passes (12 tests).