### PR TITLE
Add Reo Purgyil Mountain Page

### DIFF
--- a/frontend/mountains/script.js
+++ b/frontend/mountains/script.js
@@ -187,6 +187,24 @@ document.addEventListener("DOMContentLoaded", () => {
       tags: []
     },
     {
+      id: "reo-purgyil",
+      name: "Reo Purgyil",
+      height: 6816,
+      heightDisplay: "6,816 m",
+      range: "Himalayas",
+      subrange: "Zanskar Range",
+      state: "Himachal Pradesh",
+      region: "north",
+      difficulty: "Hard",
+      image: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/59/Peaks_of_Mt_Leo_Purgyil_and_Reo_Purgyil.jpg/960px-Peaks_of_Mt_Leo_Purgyil_and_Reo_Purgyil.jpg",
+      firstAscent: "1971",
+      description: "The highest peak in Himachal Pradesh, a dome-shaped massif at the southern end of the Zanskar Range rising above the Sutlej on the India–Tibet border.",
+      fact: "Reo Purgyil forms a striking twin-peak massif with its neighbour Leo Pargial (6,791 m), and is often shrouded in clouds.",
+      link: "../reo-purgyil/reo-purgyil.html",
+      linkLabel: "Explore Peak",
+      tags: ["state-high-point"]
+    },
+    {
       id: "satopanth",
       name: "Satopanth",
       height: 7075,

--- a/frontend/reo-purgyil/reo-purgyil.css
+++ b/frontend/reo-purgyil/reo-purgyil.css
@@ -1,0 +1,547 @@
+.reo-purgyil-page {
+  padding-top: var(--navbar-height);
+  overflow-x: hidden;
+}
+
+.reo-purgyil-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.reo-purgyil-hero {
+  position: relative;
+  padding: 90px 24px 70px;
+  text-align: center;
+  background:
+    linear-gradient(180deg, rgba(15, 23, 42, 0.6) 0%, rgba(15, 23, 42, 0.95) 100%),
+    url("../assets/travel_mountains.png") center/cover no-repeat;
+}
+
+.reo-purgyil-hero-content {
+  max-width: 780px;
+  margin: 0 auto;
+}
+
+.reo-purgyil-back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: var(--primary-saffron);
+  text-decoration: none;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 14px;
+  transition: var(--transition-snappy);
+}
+
+.reo-purgyil-back-link:hover {
+  text-decoration: underline;
+  transform: translateX(-3px);
+}
+
+.reo-purgyil-hero-kicker {
+  display: inline-block;
+  padding: 6px 16px;
+  border-radius: 999px;
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  color: var(--primary-saffron);
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  margin-bottom: 20px;
+}
+
+.reo-purgyil-hero h1 {
+  font-family: var(--font-heading);
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  line-height: 1.15;
+  margin-bottom: 18px;
+  color: var(--text-light);
+}
+
+.reo-purgyil-hero h1 span {
+  background: var(--gradient-saffron-gold);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.reo-purgyil-hero p {
+  color: var(--text-secondary);
+  font-size: 1.08rem;
+  line-height: 1.7;
+  margin-bottom: 36px;
+}
+
+.reo-purgyil-hero-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+
+.reo-purgyil-stat-box {
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 18px 12px;
+  transition: var(--transition-snappy);
+}
+
+.reo-purgyil-stat-box:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-glow);
+}
+
+.reo-purgyil-stat-box strong {
+  display: block;
+  font-family: var(--font-heading);
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--primary-saffron);
+}
+
+.reo-purgyil-stat-box span {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.reo-purgyil-section {
+  padding: 70px 0;
+}
+
+.reo-purgyil-section:nth-of-type(even) {
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.reo-purgyil-section-heading {
+  text-align: center;
+  max-width: 680px;
+  margin: 0 auto 44px;
+}
+
+.reo-purgyil-section-badge {
+  display: inline-block;
+  color: var(--primary-gold);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+
+.reo-purgyil-section-heading h2 {
+  font-family: var(--font-heading);
+  font-size: clamp(1.7rem, 3.5vw, 2.4rem);
+  color: var(--text-light);
+  margin-bottom: 14px;
+}
+
+.reo-purgyil-section-heading p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+.reo-purgyil-overview-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 36px;
+  align-items: start;
+}
+
+.reo-purgyil-overview-text h3 {
+  font-family: var(--font-heading);
+  color: var(--primary-gold);
+  margin-bottom: 16px;
+  font-size: 1.4rem;
+}
+
+.reo-purgyil-overview-text p {
+  color: var(--text-secondary);
+  line-height: 1.8;
+  margin-bottom: 16px;
+}
+
+.reo-purgyil-overview-spec-card {
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 24px 28px;
+  box-shadow: var(--shadow-soft);
+}
+
+.reo-purgyil-overview-spec-card h3 {
+  font-family: var(--font-heading);
+  color: var(--primary-gold);
+  margin-bottom: 18px;
+  font-size: 1.2rem;
+  border-bottom: 1px dashed var(--glass-border);
+  padding-bottom: 10px;
+}
+
+.spec-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.spec-list li {
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  font-size: 0.95rem;
+}
+
+.spec-list li:last-child {
+  border-bottom: none;
+}
+
+.spec-list li strong {
+  color: var(--text-muted);
+}
+
+.spec-list li {
+  color: var(--text-light);
+}
+
+/* ---------- Trekking Information Section ---------- */
+.reo-purgyil-trekking-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+
+.reo-purgyil-trek-card {
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 28px 24px;
+  transition: var(--transition-snappy);
+}
+
+.reo-purgyil-trek-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-glow);
+  border-color: var(--primary-saffron);
+}
+
+.reo-purgyil-trek-icon {
+  font-size: 2rem;
+  margin-bottom: 14px;
+}
+
+.reo-purgyil-trek-card h3 {
+  font-family: var(--font-heading);
+  color: var(--primary-gold);
+  font-size: 1.15rem;
+  margin-bottom: 12px;
+}
+
+.reo-purgyil-trek-card p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+  font-size: 0.92rem;
+}
+
+@media (max-width: 900px) {
+  .reo-purgyil-trekking-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  .reo-purgyil-trekking-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.reo-purgyil-fact-panel {
+  max-width: 760px;
+  margin: 0 auto;
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-lg);
+  padding: 40px 36px;
+  text-align: center;
+  box-shadow: var(--shadow-soft);
+}
+
+.reo-purgyil-fact-icon {
+  font-size: 2.2rem;
+  margin-bottom: 14px;
+}
+
+#reo-purgyil-fact-text {
+  font-family: var(--font-heading);
+  font-size: 1.15rem;
+  color: var(--text-light);
+  line-height: 1.6;
+  transition: opacity 0.2s ease;
+  min-height: 84px;
+}
+
+.reo-purgyil-fact-dots {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-top: 20px;
+}
+
+.reo-purgyil-fact-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  border: none;
+  background: var(--glass-border);
+  cursor: pointer;
+  transition: var(--transition-snappy);
+}
+
+.reo-purgyil-fact-dot.active {
+  background: var(--primary-saffron);
+  width: 22px;
+  border-radius: 4px;
+}
+
+.reo-purgyil-map-wrap {
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow-soft);
+}
+
+#reo-purgyil-map {
+  height: 440px;
+  width: 100%;
+  background: var(--bg-dark-deep);
+}
+
+.leaflet-popup-content-wrapper {
+  background: var(--bg-dark-modal, #0f172a) !important;
+  color: var(--text-light) !important;
+  border: 1px solid var(--glass-border) !important;
+  border-radius: 8px !important;
+  font-family: var(--font-body), sans-serif !important;
+}
+
+.leaflet-popup-tip {
+  background: var(--bg-dark-modal, #0f172a) !important;
+}
+
+.reo-purgyil-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 18px;
+}
+
+.reo-purgyil-gallery-item {
+  margin: 0;
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+  cursor: pointer;
+  border: 1px solid var(--glass-border);
+  transition: var(--transition-snappy);
+  position: relative;
+}
+
+.reo-purgyil-gallery-item:hover {
+  transform: translateY(-4px);
+  border-color: var(--primary-saffron);
+  box-shadow: var(--shadow-glow);
+}
+
+.reo-purgyil-gallery-item img {
+  width: 100%;
+  height: 190px;
+  object-fit: cover;
+  display: block;
+}
+
+.reo-purgyil-gallery-item figcaption {
+  padding: 10px 14px;
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  background: var(--bg-dark-card);
+  border-top: 1px solid var(--glass-border);
+}
+
+.reo-purgyil-faq-container {
+  max-width: 800px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.reo-purgyil-faq-item {
+  background: var(--bg-dark-card);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--border-radius-sm);
+  overflow: hidden;
+  transition: var(--transition-snappy);
+}
+
+.reo-purgyil-faq-question {
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 20px 24px;
+  text-align: left;
+  font-family: var(--font-body);
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text-light);
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  transition: var(--transition-snappy);
+}
+
+.reo-purgyil-faq-question:hover {
+  color: var(--primary-saffron);
+}
+
+.reo-purgyil-faq-question::after {
+  content: "▼";
+  font-size: 0.8rem;
+  transition: transform 0.25s ease;
+  color: var(--text-muted);
+}
+
+.reo-purgyil-faq-item.active {
+  border-color: var(--primary-saffron);
+  box-shadow: var(--shadow-glow);
+}
+
+.reo-purgyil-faq-item.active .reo-purgyil-faq-question::after {
+  transform: rotate(-180deg);
+  color: var(--primary-saffron);
+}
+
+.reo-purgyil-faq-answer {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s cubic-bezier(0, 1, 0, 1), padding 0.3s ease;
+  padding: 0 24px;
+}
+
+.reo-purgyil-faq-item.active .reo-purgyil-faq-answer {
+  max-height: 500px;
+  padding-bottom: 20px;
+}
+
+.reo-purgyil-faq-answer p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+  font-size: 0.95rem;
+}
+
+.reo-purgyil-lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(10, 18, 30, 0.92);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  padding: 24px;
+  backdrop-filter: blur(8px);
+}
+
+.reo-purgyil-lightbox-overlay[hidden] {
+  display: none;
+}
+
+.reo-purgyil-lightbox-content {
+  max-width: 800px;
+  width: 100%;
+  text-align: center;
+  position: relative;
+}
+
+.reo-purgyil-lightbox-content img {
+  width: 100%;
+  max-height: 65vh;
+  object-fit: contain;
+  border-radius: var(--border-radius-lg);
+  border: 1px solid var(--glass-border);
+  box-shadow: var(--shadow-soft);
+}
+
+.reo-purgyil-lightbox-caption {
+  color: var(--text-light);
+  margin-top: 14px;
+  font-size: 0.95rem;
+}
+
+.reo-purgyil-lightbox-close {
+  position: absolute;
+  top: -44px;
+  right: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-light);
+  font-size: 1.4rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: var(--transition-snappy);
+}
+
+.reo-purgyil-lightbox-close:hover {
+  background: rgba(255, 255, 255, 0.2);
+  color: var(--primary-saffron);
+}
+
+.reo-purgyil-lightbox-nav {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.1);
+  color: var(--text-light);
+  font-size: 1.3rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: var(--transition-snappy);
+}
+
+.reo-purgyil-lightbox-nav:hover {
+  background: rgba(255, 255, 255, 0.2);
+  color: var(--primary-saffron);
+}
+
+.reo-purgyil-lightbox-nav.prev { left: -20px; }
+.reo-purgyil-lightbox-nav.next { right: -20px; }
+
+@media (max-width: 900px) {
+  .reo-purgyil-overview-grid {
+    grid-template-columns: 1fr;
+    gap: 28px;
+  }
+}
+
+@media (max-width: 768px) {
+  .reo-purgyil-hero-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  #reo-purgyil-map {
+    height: 320px;
+  }
+
+  .reo-purgyil-lightbox-nav.prev { left: 4px; }
+  .reo-purgyil-lightbox-nav.next { right: 4px; }
+}

--- a/frontend/reo-purgyil/reo-purgyil.html
+++ b/frontend/reo-purgyil/reo-purgyil.html
@@ -1,0 +1,291 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Explore Reo Purgyil Mountain, a 6,816 m high peak in the Zanskar Range of Himachal Pradesh. Discover facts, map locations, image gallery, and climb details.">
+    <title>Reo Purgyil Mountain Explorer | Incredible India</title>
+    <link rel="icon" href="data:,">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap" rel="stylesheet">
+
+    <!-- Leaflet CSS for Map -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="reo-purgyil.css">
+
+    <!-- Open Graph / Social Media Tags -->
+    <meta property="og:title" content="Reo Purgyil Mountain Explorer | Incredible India Explorer">
+    <meta property="og:description" content="Explore Reo Purgyil Mountain, a 6,816 m high peak in the Zanskar Range of Himachal Pradesh. Discover facts, map locations, image gallery, and climb details.">
+    <meta property="og:image" content="https://upload.wikimedia.org/wikipedia/commons/thumb/5/59/Peaks_of_Mt_Leo_Purgyil_and_Reo_Purgyil.jpg/960px-Peaks_of_Mt_Leo_Purgyil_and_Reo_Purgyil.jpg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/reo-purgyil/reo-purgyil.html">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Incredible India Explorer">
+    <meta property="og:locale" content="en_IN">
+
+    <!-- Twitter Card Meta Tags -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Reo Purgyil Mountain Explorer | Incredible India Explorer">
+    <meta name="twitter:description" content="Explore Reo Purgyil Mountain, a 6,816 m high peak in the Zanskar Range of Himachal Pradesh. Discover facts, map locations, image gallery, and climb details.">
+    <meta name="twitter:image" content="https://upload.wikimedia.org/wikipedia/commons/thumb/5/59/Peaks_of_Mt_Leo_Purgyil_and_Reo_Purgyil.jpg/960px-Peaks_of_Mt_Leo_Purgyil_and_Reo_Purgyil.jpg">
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/reo-purgyil/reo-purgyil.html">
+</head>
+
+<body class="reo-purgyil-body-wrapper">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html#home" class="nav-link" id="link-home">Home</a>
+                <a href="../../index.html#map" class="nav-link" id="link-map">Interactive Map</a>
+                <a href="../travel/travel.html" class="nav-link" id="link-travel">Travel</a>
+                <a href="reo-purgyil.html" class="nav-link active" style="color: var(--saffron)">Reo Purgyil</a>
+
+                <div class="nav-dropdown">
+                    <button class="nav-link dropdown-toggle" id="link-explore-more">
+                        Explore More ▾
+                    </button>
+                    <div class="dropdown-menu">
+                        <a href="../travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                        <a href="../wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                        <a href="../coastal-india/coastal-india.html" class="dropdown-item">Coastal India</a>
+                        <a href="../heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    </div>
+                </div>
+
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
+                    ☀️
+                </button>
+                <a href="../login.html" class="nav-link" id="link-login">Login</a>
+            </nav>
+        </div>
+    </header>
+
+    <main class="reo-purgyil-page" id="app-root">
+        <!-- Hero Section -->
+        <section class="reo-purgyil-hero">
+            <div class="reo-purgyil-hero-content">
+                <a href="../../index.html" class="reo-purgyil-back-link">← Back to Mountains Explorer</a>
+                <span class="reo-purgyil-hero-kicker">🏔️ Zanskar Range</span>
+                <h1>Reo Purgyil <span>Explorer</span></h1>
+                <p>Standing majestically at 6,816 meters, Reo Purgyil is the highest peak in Himachal Pradesh. This dome-shaped giant of the Zanskar Range rises above the Sutlej on the India–Tibet border, guarding a landscape of dramatic gorges, high-altitude villages, and ancient monasteries.</p>
+
+                <div class="reo-purgyil-hero-stats">
+                    <div class="reo-purgyil-stat-box">
+                        <strong>6,816 m</strong>
+                        <span>Peak Elevation</span>
+                    </div>
+                    <div class="reo-purgyil-stat-box">
+                        <strong>Himachal Pradesh</strong>
+                        <span>State Location</span>
+                    </div>
+                    <div class="reo-purgyil-stat-box">
+                        <strong>Zanskar Range</strong>
+                        <span>Mountain Range</span>
+                    </div>
+                    <div class="reo-purgyil-stat-box">
+                        <strong>Highest in HP</strong>
+                        <span>State High Point</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Overview Section -->
+        <section class="reo-purgyil-section" id="reo-purgyil-overview">
+            <div class="reo-purgyil-container">
+                <div class="reo-purgyil-section-heading">
+                    <span class="reo-purgyil-section-badge">Peak Profile</span>
+                    <h2>Geography, History &amp; Significance</h2>
+                </div>
+                
+                <div class="reo-purgyil-overview-grid">
+                    <div class="reo-purgyil-overview-text">
+                        <h3>The Guardian of the Upper Sutlej</h3>
+                        <p>Reo Purgyil (6,816 m) and its slightly shorter twin Leo Pargial (6,791 m) form a striking twin-peak massif at the southern end of the Zanskar Range in the Western Himalaya, in the Kinnaur district of Himachal Pradesh. Rising directly from the banks of the Sutlej River, the massif marks the border between India and the Tibet region of China.</p>
+                        <p>The mountain's name means 'the mountain that guards' — a fitting description, for this dome-shaped peak is often cloaked in swirling clouds and has long been venerated by the local people. The Spiti River, a right-bank tributary of the Sutlej, drains the northern face of the massif, carving one of the most dramatic river valleys in the Himalaya.</p>
+                        <p>Geologically a dome structure, Reo Purgyil overlooks the western valleys of Tibet and the ancient trade routes of Kinnaur. Its remote, high-altitude setting and the lingering mystery around its early ascents have made it one of the most fascinating — and least visited — high peaks of the Indian Himalaya.</p>
+                    </div>
+                    <div class="reo-purgyil-overview-spec-card">
+                        <h3>Technical Specifications</h3>
+                        <ul class="spec-list">
+                            <li><strong>Elevation:</strong> 6,816 m (22,362 ft)</li>
+                            <li><strong>Prominence:</strong> 1,978 m (6,490 ft)</li>
+                            <li><strong>Coordinates:</strong> 31°53'02"N 78°43'53"E</li>
+                            <li><strong>Climbing Difficulty:</strong> Hard / Technical</li>
+                            <li><strong>First Ascent:</strong> 1971</li>
+                            <li><strong>Ascent Team:</strong> Indo-Tibetan Border Police</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Trekking Information Section -->
+        <section class="reo-purgyil-section" id="reo-purgyil-trekking-section">
+            <div class="reo-purgyil-container">
+                <div class="reo-purgyil-section-heading">
+                    <span class="reo-purgyil-section-badge">Trekking Information</span>
+                    <h2>Plan Your Reo Purgyil Expedition</h2>
+                    <p>Essential details for trekkers and mountaineers planning to explore the Reo Purgyil massif region.</p>
+                </div>
+                <div class="reo-purgyil-trekking-grid">
+                    <div class="reo-purgyil-trek-card">
+                        <div class="reo-purgyil-trek-icon">🗓️</div>
+                        <h3>Best Season</h3>
+                        <p>June to September. Summer months offer the most stable conditions, though the massif frequently shrouds itself in cloud. Late September provides the clearest views of the twin peaks.</p>
+                    </div>
+                    <div class="reo-purgyil-trek-card">
+                        <div class="reo-purgyil-trek-icon">🥾</div>
+                        <h3>Trek Difficulty</h3>
+                        <p>Very Difficult. The approach involves high-altitude hiking above 4,500 m with exposed, technical sections. This is an expedition-grade peak for experienced mountaineers only.</p>
+                    </div>
+                    <div class="reo-purgyil-trek-card">
+                        <div class="reo-purgyil-trek-icon">⏱️</div>
+                        <h3>Duration</h3>
+                        <p>A full expedition typically takes 2–3 weeks round trip from Kaza or Nako, including acclimatization at the high camps on the glacier plateau south of the peak.</p>
+                    </div>
+                    <div class="reo-purgyil-trek-card">
+                        <div class="reo-purgyil-trek-icon">🏕️</div>
+                        <h3>Base Camp</h3>
+                        <p>Nako (3,620 m) serves as the primary gateway in Kinnaur. The trek follows the Spiti River valley, passing through the villages of Leo and Pooh before establishing base camp near the massif.</p>
+                    </div>
+                    <div class="reo-purgyil-trek-card">
+                        <div class="reo-purgyil-trek-icon">📋</div>
+                        <h3>Permits</h3>
+                        <p>Special inner-line and Protected Area Permits are required due to the proximity of the international border. Trekking agencies and the ITBP coordinate clearance in advance.</p>
+                    </div>
+                    <div class="reo-purgyil-trek-card">
+                        <div class="reo-purgyil-trek-icon">🏔️</div>
+                        <h3>Key Highlights</h3>
+                        <p>Panoramic views of the Zanskar Range, the twin summits of Reo Purgyil and Leo Pargial, the Sutlej gorges, and the ancient monasteries of Nako with their cliff-side Tibetan settlements.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Facts Section -->
+        <section class="reo-purgyil-section" id="reo-purgyil-facts-section">
+            <div class="reo-purgyil-container">
+                <div class="reo-purgyil-section-heading">
+                    <span class="reo-purgyil-section-badge">Did You Know?</span>
+                    <h2>Interesting Facts</h2>
+                </div>
+                <div class="reo-purgyil-fact-panel">
+                    <div class="reo-purgyil-fact-icon">💡</div>
+                    <p id="reo-purgyil-fact-text" aria-live="polite">Loading fact...</p>
+                    <div class="reo-purgyil-fact-dots" id="reo-purgyil-fact-dots"></div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Interactive Map Section -->
+        <section class="reo-purgyil-section" id="reo-purgyil-map-section">
+            <div class="reo-purgyil-container">
+                <div class="reo-purgyil-section-heading">
+                    <span class="reo-purgyil-section-badge">Interactive Map</span>
+                    <h2>Key Locations Around Reo Purgyil</h2>
+                    <p>Click on any marker to learn about that geographic landmark.</p>
+                </div>
+                <div class="reo-purgyil-map-wrap">
+                    <div id="reo-purgyil-map" aria-label="Interactive Leaflet Map showing Reo Purgyil and surrounding landmarks"></div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Image Gallery Section -->
+        <section class="reo-purgyil-section" id="reo-purgyil-gallery-section">
+            <div class="reo-purgyil-container">
+                <div class="reo-purgyil-section-heading">
+                    <span class="reo-purgyil-section-badge">Image Gallery</span>
+                    <h2>Views of the Massif &amp; Kinnaur Range</h2>
+                    <p>Explore the stunning peaks and valleys of Himachal Pradesh. Click an image to view it larger.</p>
+                </div>
+                <div id="reo-purgyil-gallery-grid" class="reo-purgyil-gallery-grid"></div>
+            </div>
+        </section>
+
+        <!-- FAQs Section -->
+        <section class="reo-purgyil-section" id="reo-purgyil-faq-section">
+            <div class="reo-purgyil-container">
+                <div class="reo-purgyil-section-heading">
+                    <span class="reo-purgyil-section-badge">FAQ</span>
+                    <h2>Frequently Asked Questions</h2>
+                </div>
+                <div class="reo-purgyil-faq-container" id="reo-purgyil-faq-accordion">
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <!-- Lightbox Modal -->
+    <div class="reo-purgyil-lightbox-overlay" id="reo-purgyil-lightbox" hidden role="dialog" aria-modal="true" aria-label="Image Lightbox">
+        <div class="reo-purgyil-lightbox-content">
+            <button class="reo-purgyil-lightbox-close" data-close-lightbox="true" aria-label="Close Lightbox">&times;</button>
+            <button class="reo-purgyil-lightbox-nav prev" id="reo-purgyil-lightbox-prev" aria-label="Previous image">‹</button>
+            <img id="reo-purgyil-lightbox-image" src="" alt="">
+            <button class="reo-purgyil-lightbox-nav next" id="reo-purgyil-lightbox-next" aria-label="Next image">›</button>
+            <p class="reo-purgyil-lightbox-caption" id="reo-purgyil-lightbox-caption"></p>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <footer class="site-footer">
+        <div class="footer-container">
+            <div class="footer-brand">
+                <a href="../../index.html#home" class="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <p>Highlighting and documenting India's magnificent geography, mountains, and cultural heritage.</p>
+            </div>
+            <div class="footer-links">
+                <h4>Quick Links</h4>
+                <a href="../../index.html#home">Home</a>
+                <a href="../../index.html">Mountains Explorer</a>
+                <a href="../travel/travel.html">Travel &amp; Destinations</a>
+                <a href="reo-purgyil.html">Reo Purgyil Explorer</a>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2026 Incredible India Explorer. Developed with Vanilla Web Tech.</p>
+        </div>
+    </footer>
+
+    <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+
+    <!-- Leaflet JS for Map -->
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+    
+    <!-- Local Javascript Module -->
+    <script type="module" src="reo-purgyil.js"></script>
+    <script src="../pages-common.js"></script>
+</body>
+</html>

--- a/frontend/reo-purgyil/reo-purgyil.js
+++ b/frontend/reo-purgyil/reo-purgyil.js
@@ -1,0 +1,288 @@
+const REO_PURGYIL_LOCATIONS = [
+  {
+    name: "Reo Purgyil Peak",
+    lat: 31.884,
+    lng: 78.7314,
+    description: "The highest peak in Himachal Pradesh, standing at 6,816 meters. Also known as Leo Pargial on older maps."
+  },
+  {
+    name: "Leo Pargial Twin Peak",
+    lat: 31.902,
+    lng: 78.73,
+    description: "The 6,791 m northern twin of Reo Purgyil, together forming the twin-peak massif of the southern Zanskar Range."
+  },
+  {
+    name: "Nako Village",
+    lat: 31.8839,
+    lng: 78.6239,
+    description: "A high-altitude village in Kinnaur at 3,620 m, the primary gateway to the Reo Purgyil massif and home to ancient gompas."
+  },
+  {
+    name: "Spiti River Valley",
+    lat: 31.976,
+    lng: 78.606,
+    description: "The Spiti River drains the northern face of the massif, carving one of the deepest valleys in the Himalaya."
+  },
+  {
+    name: "Shipki La",
+    lat: 31.8333,
+    lng: 78.7447,
+    description: "A historic high pass on the India–Tibet border to the south of Reo Purgyil, once part of the old Sutlej trade route."
+  }
+];
+
+const REO_PURGYIL_GALLERY = [
+  { src: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/59/Peaks_of_Mt_Leo_Purgyil_and_Reo_Purgyil.jpg/960px-Peaks_of_Mt_Leo_Purgyil_and_Reo_Purgyil.jpg", caption: "The twin peaks of the Reo Purgyil massif towering over the Zanskar Range." },
+  { src: "https://upload.wikimedia.org/wikipedia/commons/thumb/9/96/LeoPargial.jpg/960px-LeoPargial.jpg", caption: "Reo Purgyil as seen across the dramatic valleys of Kinnaur." },
+  { src: "../../assets/travel_mountains.png", caption: "The Himalayan crest above the Sutlej gorges near the massif." },
+  { src: "../../assets/Hemis_Monastery.png", caption: "Ancient monasteries and high-altitude villages dotting the Kinnaur region." },
+  { src: "../../assets/Shimlakaza.png", caption: "Sunrise over the Zanskar Range from the eastern ridgelines." },
+  { src: "../../assets/Manalileh.png", caption: "Scenic high passes and valleys surrounding the Reo Purgyil massif." }
+];
+
+const REO_PURGYIL_FACTS = [
+  "Reo Purgyil (6,816 m) is the highest mountain peak in the entire state of Himachal Pradesh.",
+  "Its name means 'the mountain that guards', and the local people have long venerated this dome-shaped peak.",
+  "The mountain is often cloaked in swirling clouds, earning it a mysterious, shrouded reputation among mountaineers.",
+  "The first official ascent was made in 1971 by a team of the Indo-Tibetan Border Police (ITBP).",
+  "Reo Purgyil forms a striking twin-peak massif with its neighbour Leo Pargial (6,791 m), a name born from a colonial-era mix-up of 'Reo' and the nearby village of Leo.",
+  "The Spiti River, a right-bank tributary of the Sutlej, drains the northern face of the massif.",
+  "Geologically, the peak is a dome structure that rises directly from the banks of the Sutlej River on the India–Tibet border."
+];
+
+const REO_PURGYIL_FAQS = [
+  {
+    question: "Where is Reo Purgyil located?",
+    answer: "Reo Purgyil is located at the southern end of the Zanskar Range in the Western Himalaya, in the Kinnaur district of Himachal Pradesh, India, on the border with the Tibet region of China."
+  },
+  {
+    question: "Why is it also called Leo Pargial?",
+    answer: "Leo Pargial is a corruption of 'Reo Purgyil' that arose when early surveyors mistook 'Reo' for the nearby village of Leo. The name is now used for the 6,791 m northern twin of the massif."
+  },
+  {
+    question: "What is the elevation of Reo Purgyil?",
+    answer: "Reo Purgyil stands at 6,816 meters (22,362 feet) above sea level, making it the highest peak in Himachal Pradesh."
+  },
+  {
+    question: "What is the historical significance of Reo Purgyil?",
+    answer: "The first official ascent was achieved in 1971 by the Indo-Tibetan Border Police. The second ascent followed in 1991 by an Indian team led by E. Theophilus."
+  },
+  {
+    question: "How can trekkers experience Reo Purgyil?",
+    answer: "The region around Reo Purgyil can be experienced via high-altitude treks in Kinnaur around Nako and the Spiti valley. Climbing the peak itself is an expedition-grade undertaking requiring special permits."
+  }
+];
+
+let map = null;
+let currentGalleryIndex = 0;
+let factIndex = 0;
+let factIntervalId = null;
+
+function init() {
+  initAccordion();
+  initGallery();
+  initFactsRotator();
+  initMap();
+  initLightbox();
+}
+
+if (document.readyState !== "loading") {
+  init();
+} else {
+  document.addEventListener("DOMContentLoaded", init);
+}
+
+if (window.appLifecycle) {
+  window.appLifecycle.registerCleanup(() => {
+    if (factIntervalId) {
+      clearInterval(factIntervalId);
+      factIntervalId = null;
+    }
+  });
+}
+
+function initAccordion() {
+  const container = document.getElementById("reo-purgyil-faq-accordion");
+  if (!container) return;
+
+  container.innerHTML = "";
+  REO_PURGYIL_FAQS.forEach((faq, index) => {
+    const item = document.createElement("div");
+    item.className = "reo-purgyil-faq-item";
+    
+    item.innerHTML = `
+      <button class="reo-purgyil-faq-question" id="faq-q-${index}" aria-expanded="false" aria-controls="faq-a-${index}">
+        ${faq.question}
+      </button>
+      <div class="reo-purgyil-faq-answer" id="faq-a-${index}" role="region" aria-labelledby="faq-q-${index}">
+        <p>${faq.answer}</p>
+      </div>
+    `;
+
+    const button = item.querySelector(".reo-purgyil-faq-question");
+    button.addEventListener("click", () => {
+      const isActive = item.classList.contains("active");
+
+      container.querySelectorAll(".reo-purgyil-faq-item").forEach((otherItem) => {
+        otherItem.classList.remove("active");
+        otherItem.querySelector(".reo-purgyil-faq-question").setAttribute("aria-expanded", "false");
+      });
+
+      if (!isActive) {
+        item.classList.add("active");
+        button.setAttribute("aria-expanded", "true");
+      }
+    });
+
+    container.appendChild(item);
+  });
+}
+
+function initGallery() {
+  const grid = document.getElementById("reo-purgyil-gallery-grid");
+  if (!grid) return;
+
+  grid.innerHTML = "";
+  REO_PURGYIL_GALLERY.forEach((item, index) => {
+    const figure = document.createElement("figure");
+    figure.className = "reo-purgyil-gallery-item";
+    figure.setAttribute("tabindex", "0");
+    figure.setAttribute("role", "button");
+    figure.setAttribute("aria-label", `Open image: ${item.caption}`);
+    figure.innerHTML = `
+      <img src="${item.src}" alt="${item.caption}" loading="lazy">
+      <figcaption>${item.caption}</figcaption>
+    `;
+
+    figure.addEventListener("click", () => openLightbox(index));
+    figure.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        openLightbox(index);
+      }
+    });
+
+    grid.appendChild(figure);
+  });
+}
+
+function initLightbox() {
+  const lightbox = document.getElementById("reo-purgyil-lightbox");
+  if (!lightbox) return;
+
+  document.querySelectorAll("[data-close-lightbox]").forEach((el) => {
+    el.addEventListener("click", closeLightbox);
+  });
+
+  const prevBtn = document.getElementById("reo-purgyil-lightbox-prev");
+  const nextBtn = document.getElementById("reo-purgyil-lightbox-next");
+
+  if (prevBtn) prevBtn.addEventListener("click", () => showGalleryImage(currentGalleryIndex - 1));
+  if (nextBtn) nextBtn.addEventListener("click", () => showGalleryImage(currentGalleryIndex + 1));
+
+  document.addEventListener("keydown", (e) => {
+    if (lightbox.hidden) return;
+    if (e.key === "Escape") closeLightbox();
+    if (e.key === "ArrowRight") showGalleryImage(currentGalleryIndex + 1);
+    if (e.key === "ArrowLeft") showGalleryImage(currentGalleryIndex - 1);
+  });
+}
+
+function openLightbox(index) {
+  const lightbox = document.getElementById("reo-purgyil-lightbox");
+  if (!lightbox) return;
+  lightbox.hidden = false;
+  document.body.style.overflow = "hidden";
+  showGalleryImage(index);
+}
+
+function closeLightbox() {
+  const lightbox = document.getElementById("reo-purgyil-lightbox");
+  if (!lightbox) return;
+  lightbox.hidden = true;
+  document.body.style.overflow = "";
+}
+
+function showGalleryImage(index) {
+  const total = REO_PURGYIL_GALLERY.length;
+  currentGalleryIndex = (index + total) % total;
+  const item = REO_PURGYIL_GALLERY[currentGalleryIndex];
+  
+  const img = document.getElementById("reo-purgyil-lightbox-image");
+  const caption = document.getElementById("reo-purgyil-lightbox-caption");
+  
+  if (img) img.src = item.src;
+  if (img) img.alt = item.caption;
+  if (caption) caption.textContent = item.caption;
+}
+
+function initFactsRotator() {
+  const factEl = document.getElementById("reo-purgyil-fact-text");
+  const dotsWrap = document.getElementById("reo-purgyil-fact-dots");
+  if (!factEl) return;
+
+  if (dotsWrap) dotsWrap.innerHTML = "";
+  if (factIntervalId) clearInterval(factIntervalId);
+
+  if (dotsWrap) {
+    REO_PURGYIL_FACTS.forEach((_, i) => {
+      const dot = document.createElement("button");
+      dot.className = "reo-purgyil-fact-dot" + (i === 0 ? " active" : "");
+      dot.setAttribute("aria-label", "Show fact " + (i + 1));
+      dot.addEventListener("click", () => showFact(i));
+      dotsWrap.appendChild(dot);
+    });
+  }
+
+  function showFact(i) {
+    factIndex = i;
+    factEl.style.opacity = "0";
+    setTimeout(() => {
+      factEl.textContent = REO_PURGYIL_FACTS[factIndex];
+      factEl.style.opacity = "1";
+    }, 200);
+    if (dotsWrap) {
+      [...dotsWrap.children].forEach((dot, di) => dot.classList.toggle("active", di === factIndex));
+    }
+  }
+
+  showFact(0);
+  factIntervalId = setInterval(() => showFact((factIndex + 1) % REO_PURGYIL_FACTS.length), 6000);
+}
+
+function initMap() {
+  const mapContainer = document.getElementById("reo-purgyil-map");
+  if (!mapContainer || typeof L === "undefined") return;
+
+  if (map !== null) {
+    try {
+      map.remove();
+    } catch (e) {
+      console.warn("Failed to remove old map instance", e);
+    }
+    map = null;
+  }
+
+  map = L.map("reo-purgyil-map", {
+    scrollWheelZoom: false,
+    minZoom: 6,
+  }).setView([31.884, 78.73], 10);
+
+  L.tileLayer("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png", {
+    attribution: "&copy; OpenStreetMap contributors &copy; CARTO",
+    maxZoom: 18,
+  }).addTo(map);
+
+  REO_PURGYIL_LOCATIONS.forEach((loc) => {
+    const isPeak = loc.name.includes("Peak");
+    const marker = L.circleMarker([loc.lat, loc.lng], {
+      radius: isPeak ? 9 : 7,
+      color: isPeak ? "#ff9933" : "#0284c7",
+      fillColor: isPeak ? "#ffb01f" : "#38bdf8",
+      fillOpacity: 0.85,
+      weight: 2,
+    }).addTo(map);
+
+    marker.bindPopup(`<strong>${loc.name}</strong><br>${loc.description}`);
+  });
+}

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -1345,6 +1345,12 @@ window.indiaSearchIndex = [
     description: "Horizontal filmstrip timeline detailing Indian cinema from 1913 Raja Harishchandra, talkies, parallel cinema, masala era, and diaspora boom to modern global Oscar triumphs.",
     url: "frontend/indian-cinema-timeline/index.html"
   },
+  // --- Reo Purgyil Mountain ---
+  {
+    title: "Reo Purgyil Mountain Explorer",
+    category: "Mountains & Geography",
+    description: "Dedicated explorer for Reo Purgyil, a 6,816 m high peak in the Zanskar Range of Himachal Pradesh, featuring facts, map locations, image gallery, and trivia.",
+    url: "frontend/reo-purgyil/reo-purgyil.html"},
   // --- Saltoro Kangri Mountain ---
   {
     title: "Saltoro Kangri Mountain Explorer",


### PR DESCRIPTION
## Description

Closes #758

Adds a dedicated Reo Purgyil Mountain Explorer page, fully integrated with the Mountains of India landing page.

## What's included

- **New page** `frontend/reo-purgyil/` (HTML + JS + CSS) with all required sections:
  - Hero section (6,816 m, Himachal Pradesh, Zanskar Range, state high point)
  - Overview / Peak profile with technical specifications
  - Quick facts & Interesting facts rotator
  - Trekking information cards
  - Interactive Leaflet map of key locations
  - Image gallery with lightbox
  - FAQ accordion
- **Landing page card**: registered Reo Purgyil in `frontend/mountains/script.js` (Zanskar Range, Himachal Pradesh) with working **Explore Peak** button linking to the new page
- **Search integration**: entry added to `frontend/search-index.js`
- Responsive design reusing the existing mountain page components and styles

## Files changed

- `frontend/reo-purgyil/reo-purgyil.html`
- `frontend/reo-purgyil/reo-purgyil.js`
- `frontend/reo-purgyil/reo-purgyil.css`
- `frontend/mountains/script.js`
- `frontend/search-index.js`

## Quick facts

- **Elevation:** 6,816 m (22,362 ft) — highest peak in Himachal Pradesh
- **Range:** Zanskar Range (Western Himalaya)
- **Location:** Kinnaur district, India–Tibet border
- **First ascent:** 1971 (Indo-Tibetan Border Police)
- **Prominence:** 1,978 m

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Reo Purgyil Mountain Explorer page with overview, elevation, location, trekking information, facts, FAQs, gallery, and interactive map.
  * Added accessible gallery lightbox navigation, responsive layouts, themed map markers, and interactive page controls.
  * Added Reo Purgyil to the mountain directory and site search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->