### PR TITLE
feat: Add Karaikal Ancient Port Explorer page

### DIFF
--- a/frontend/assets/karaikal_french_colonial.svg
+++ b/frontend/assets/karaikal_french_colonial.svg
@@ -1,0 +1,32 @@
+<svg viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="frenchSky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1a2a4a"/>
+      <stop offset="100%" stop-color="#d4952f"/>
+    </linearGradient>
+  </defs>
+  <rect width="500" height="500" fill="url(#frenchSky)"/>
+  <rect y="400" width="500" height="100" fill="#0a1930"/>
+  <!-- colonial building -->
+  <g transform="translate(160,180)">
+    <rect x="0" y="0" width="180" height="220" fill="#e8ddc8"/>
+    <rect x="0" y="0" width="180" height="20" fill="#c47a3a"/>
+    <!-- shutters/windows -->
+    <rect x="20" y="40" width="30" height="45" fill="#3a6a6a" stroke="#5a4a35" stroke-width="2"/>
+    <rect x="75" y="40" width="30" height="45" fill="#3a6a6a" stroke="#5a4a35" stroke-width="2"/>
+    <rect x="130" y="40" width="30" height="45" fill="#3a6a6a" stroke="#5a4a35" stroke-width="2"/>
+    <rect x="20" y="110" width="30" height="45" fill="#3a6a6a" stroke="#5a4a35" stroke-width="2"/>
+    <rect x="130" y="110" width="30" height="45" fill="#3a6a6a" stroke="#5a4a35" stroke-width="2"/>
+    <!-- door -->
+    <rect x="72" y="150" width="36" height="70" fill="#5a4a35"/>
+    <polygon points="72,150 90,130 108,150" fill="#c47a3a"/>
+    <!-- balcony -->
+    <rect x="15" y="105" width="150" height="6" fill="#8a6a3a"/>
+  </g>
+  <!-- lamp post -->
+  <g transform="translate(120,270)">
+    <rect x="-3" y="0" width="6" height="130" fill="#2a1c0a"/>
+    <circle cx="0" cy="-8" r="10" fill="#f0c674" opacity="0.85"/>
+  </g>
+  <text x="250" y="460" text-anchor="middle" font-family="Georgia, serif" font-size="18" fill="#f0c674">Karaikal's French Quarter</text>
+</svg>

--- a/frontend/assets/karaikal_lighthouse.svg
+++ b/frontend/assets/karaikal_lighthouse.svg
@@ -1,0 +1,28 @@
+<svg viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="lhSky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0a1930"/>
+      <stop offset="55%" stop-color="#3a2a1a"/>
+      <stop offset="100%" stop-color="#d4952f"/>
+    </linearGradient>
+    <linearGradient id="lhSea" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0e5c5c"/>
+      <stop offset="100%" stop-color="#072a2a"/>
+    </linearGradient>
+  </defs>
+  <rect width="500" height="340" fill="url(#lhSky)"/>
+  <rect y="340" width="500" height="160" fill="url(#lhSea)"/>
+  <path d="M0 350 Q125 335 250 350 T500 350 V500 H0 Z" fill="#0a4040" opacity="0.6"/>
+  <!-- lighthouse -->
+  <g transform="translate(250,140)">
+    <polygon points="-22,220 -14,0 14,0 22,220" fill="#f5f0e6"/>
+    <polygon points="-18,180 18,180 22,220 -22,220" fill="#a04030"/>
+    <polygon points="-14,90 14,90 17,140 -17,140" fill="#a04030"/>
+    <rect x="-26" y="-14" width="52" height="16" fill="#3a2a1a"/>
+    <polygon points="-20,-14 0,-40 20,-14" fill="#3a2a1a"/>
+    <circle cx="0" cy="-2" r="7" fill="#f0c674"/>
+    <line x1="-38" y1="-2" x2="-70" y2="-20" stroke="#f0c674" stroke-width="2" opacity="0.5"/>
+    <line x1="38" y1="-2" x2="70" y2="-20" stroke="#f0c674" stroke-width="2" opacity="0.5"/>
+  </g>
+  <text x="250" y="470" text-anchor="middle" font-family="Georgia, serif" font-size="18" fill="#f0c674">Karaikal Lighthouse, Bay of Bengal</text>
+</svg>

--- a/frontend/assets/karaikal_port_banner.svg
+++ b/frontend/assets/karaikal_port_banner.svg
@@ -1,0 +1,38 @@
+<svg viewBox="0 0 800 500" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="skyK" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0a1930"/>
+      <stop offset="60%" stop-color="#2a3a4a"/>
+      <stop offset="100%" stop-color="#d4952f"/>
+    </linearGradient>
+    <linearGradient id="seaK" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0e5c5c"/>
+      <stop offset="100%" stop-color="#072a2a"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="320" fill="url(#skyK)"/>
+  <circle cx="640" cy="170" r="55" fill="#f0c674" opacity="0.8"/>
+  <rect y="320" width="800" height="180" fill="url(#seaK)"/>
+  <path d="M0 330 Q100 318 200 330 T400 330 T600 330 T800 330 V500 H0 Z" fill="#0a4040" opacity="0.6"/>
+  <!-- river delta channel -->
+  <path d="M0 250 Q150 260 220 320 L180 320 Q120 270 0 265 Z" fill="#2a6a6a" opacity="0.5"/>
+  <!-- fishing boats -->
+  <g transform="translate(180,270)">
+    <path d="M-40 30 Q0 45 40 30 L30 42 Q0 52 -30 42 Z" fill="#3a2a1a"/>
+    <line x1="0" y1="30" x2="0" y2="-10" stroke="#2a1c0a" stroke-width="2"/>
+    <path d="M0 -10 L28 8 L0 12 Z" fill="#f5f0e6" opacity="0.8"/>
+  </g>
+  <g transform="translate(520,290)">
+    <path d="M-32 24 Q0 36 32 24 L24 34 Q0 42 -24 34 Z" fill="#3a2a1a"/>
+    <line x1="0" y1="24" x2="0" y2="-8" stroke="#2a1c0a" stroke-width="2"/>
+    <path d="M0 -8 L22 6 L0 10 Z" fill="#f5f0e6" opacity="0.8"/>
+  </g>
+  <!-- lighthouse silhouette -->
+  <g transform="translate(670,220)">
+    <rect x="-8" y="0" width="16" height="70" fill="#e5e0d5"/>
+    <rect x="-10" y="60" width="20" height="12" fill="#a04030"/>
+    <polygon points="-10,0 0,-20 10,0" fill="#a04030"/>
+    <rect x="-3" y="60" width="6" height="6" fill="#f0c674"/>
+  </g>
+  <text x="400" y="470" text-anchor="middle" font-family="Georgia, serif" font-size="22" fill="#f0c674" opacity="0.85">Karaikal · Cauvery Delta &amp; Bay of Bengal</text>
+</svg>

--- a/frontend/assets/karaikal_trade_goods.svg
+++ b/frontend/assets/karaikal_trade_goods.svg
@@ -1,0 +1,24 @@
+<svg viewBox="0 0 500 500" xmlns="http://www.w3.org/2000/svg">
+  <rect width="500" height="500" fill="#0a1930"/>
+  <!-- rice sacks -->
+  <g transform="translate(180,260)">
+    <path d="M-60 0 Q-60 -70 0 -75 Q60 -70 60 0 Q60 70 0 75 Q-60 70 -60 0 Z" fill="#c9a876" stroke="#8a6a3a" stroke-width="3"/>
+    <path d="M-30 -60 Q0 -85 30 -60" fill="none" stroke="#8a6a3a" stroke-width="4"/>
+    <line x1="-40" y1="-20" x2="40" y2="-20" stroke="#8a6a3a" stroke-width="2" opacity="0.5"/>
+    <line x1="-45" y1="10" x2="45" y2="10" stroke="#8a6a3a" stroke-width="2" opacity="0.5"/>
+    <line x1="-40" y1="40" x2="40" y2="40" stroke="#8a6a3a" stroke-width="2" opacity="0.5"/>
+  </g>
+  <g transform="translate(320,300)" opacity="0.85">
+    <path d="M-45 0 Q-45 -52 0 -56 Q45 -52 45 0 Q45 52 0 56 Q-45 52 -45 0 Z" fill="#d4b586" stroke="#8a6a3a" stroke-width="3"/>
+    <path d="M-22 -45 Q0 -64 22 -45" fill="none" stroke="#8a6a3a" stroke-width="3"/>
+  </g>
+  <!-- scattered rice grains -->
+  <g fill="#f0e0b8">
+    <ellipse cx="150" cy="380" rx="4" ry="2"/>
+    <ellipse cx="165" cy="390" rx="4" ry="2"/>
+    <ellipse cx="180" cy="378" rx="4" ry="2"/>
+    <ellipse cx="200" cy="395" rx="4" ry="2"/>
+    <ellipse cx="220" cy="382" rx="4" ry="2"/>
+  </g>
+  <text x="250" y="450" text-anchor="middle" font-family="Georgia, serif" font-size="19" fill="#f0c674">Rice &amp; Delta Produce Exports</text>
+</svg>

--- a/frontend/karaikal-port-explorer/index.html
+++ b/frontend/karaikal-port-explorer/index.html
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore Karaikal: a Coromandel Coast enclave that grew as a Chola-era maritime trading hub in the Cauvery delta and later became a French comptoir from 1739 to 1954.">
+  <title>Karaikal Ancient Port Explorer | Incredible India</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="../js-modules/page-progress/page-progress.css">
+
+  <meta property="og:title" content="Karaikal Ancient Port Explorer | Incredible India Explorer">
+  <meta property="og:description" content="Discover Karaikal, a Chola-era Coromandel trading enclave in the Cauvery delta that later became a French comptoir, blending Tamil and colonial maritime heritage.">
+  <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/frontend/assets/karaikal_port_banner.svg">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/karaikal-port-explorer/index.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Incredible India Explorer">
+  <meta property="og:locale" content="en_IN">
+
+  <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/karaikal-port-explorer/index.html">
+</head>
+<body>
+  <script>
+    (function() {
+      const theme = localStorage.getItem('theme') || 'dark';
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+
+  <header class="navbar scrolled" id="navbar">
+    <div class="nav-container">
+      <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+        <span class="saffron">Incredible</span><span class="gold">India</span><span class="green">Explorer</span>
+      </a>
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+        <span class="bar"></span><span class="bar"></span><span class="bar"></span>
+      </button>
+      <nav class="nav-menu" id="nav-menu">
+        <a href="../../index.html#home" class="nav-link" id="link-home">Home</a>
+        <a href="../../index.html#map" class="nav-link" id="link-map">Interactive Map</a>
+        <a href="../../frontend/cuisine/cuisine.html" class="nav-link" id="link-cuisine">Cuisine</a>
+        <a href="../../frontend/festivals/festivals.html" class="nav-link" id="link-festivals">Festivals</a>
+        <a href="../../frontend/culture/culture.html" class="nav-link" id="link-culture">Culture</a>
+        <div class="nav-dropdown">
+          <button class="nav-link dropdown-toggle" id="link-explore-more" style="color: var(--saffron)">Explore More ▾</button>
+          <div class="dropdown-menu">
+            <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+            <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+            <a href="../../frontend/personalities/personalities.html" class="dropdown-item">Famous Personalities</a>
+            <a href="../../frontend/spiritual/spiritual.html" class="dropdown-item">Spiritual India</a>
+            <a href="../../frontend/arts-crafts/arts-crafts.html" class="dropdown-item">Arts & Crafts</a>
+            <a href="../../frontend/museums/museums.html" class="dropdown-item">Museums</a>
+            <a href="../mandvi-port-explorer/index.html" class="dropdown-item">Mandvi Port</a>
+            <a href="../honnavar-port-explorer/index.html" class="dropdown-item">Honnavar Port</a>
+            <a href="../kannur-port-explorer/index.html" class="dropdown-item">Kannur Port</a>
+            <a href="../dwarka-port-explorer/index.html" class="dropdown-item">Dwarka Port</a>
+            <a href="../motupalli-port-explorer/index.html" class="dropdown-item">Motupalli Port</a>
+            <a href="index.html" class="dropdown-item" style="color: var(--saffron)">Karaikal Port</a>
+          </div>
+        </div>
+        <div class="nav-dropdown">
+          <button class="nav-link dropdown-toggle" id="link-learn-data">Learn & Data ▾</button>
+          <div class="dropdown-menu">
+            <a href="../../frontend/smart-cities/smart-cities.html" class="dropdown-item">Smart Cities</a>
+            <a href="../../frontend/languages/languages.html" class="dropdown-item">Languages of India</a>
+            <a href="../../frontend/data-india/data-india.html" class="dropdown-item">Data & Statistics</a>
+            <a href="../../frontend/learn/learn.html" class="dropdown-item">Learn & Quiz</a>
+          </div>
+        </div>
+        <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">☀️</button>
+        <div class="journey-nav-search">
+          <input type="search" id="journey-search-input" class="journey-search-input" placeholder="Search all explorers…" aria-label="Search across all explorers" autocomplete="off">
+          <div id="journey-search-results" class="journey-search-results" hidden></div>
+        </div>
+        <a href="../../frontend/journey/journey.html" class="nav-link" id="link-journey">🧭 My Journey</a>
+        <a href="../../frontend/premium/premium.html" class="nav-link premium-link">★ Premium</a>
+        <a href="../login.html" class="nav-link" id="link-login">Login</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="app-root" class="port-main">
+
+    <section class="port-hero">
+      <div class="port-hero-content">
+        <span class="port-kicker">⚓ Coromandel Coast · Cauvery Delta, Puducherry</span>
+        <h1>Karaikal Ancient Port <span>Explorer</span></h1>
+        <p>From a Chola-era trading harbour in the fertile Cauvery delta to a French comptoir that endured for over two centuries, discover Karaikal's layered maritime and colonial heritage on the Bay of Bengal.</p>
+        <div class="port-bookmark-container">
+          <button class="port-bookmark-btn journey-bookmark-btn" type="button" data-bookmark-id="karaikal-port-main" aria-pressed="false" aria-label="Bookmark Karaikal Port">
+            ♡ Save to Journey
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <section class="port-section" id="overview">
+      <div class="port-container port-grid-2col">
+        <div class="port-text-block">
+          <span class="port-eyebrow">From Chola Port to French Comptoir</span>
+          <h2>A Coromandel Enclave with a Double Heritage</h2>
+          <p>Karaikal lies on the Coromandel Coast in the fertile Kaveri (Cauvery) River delta, one of Tamil Nadu's most important rice-growing regions. As early as the 10th century, it functioned as a maritime trading hub within the Chola kingdom, its coastal position feeding into the wider Chola economic network of the Bay of Bengal.</p>
+          <p>After the Cholas, the region passed successively to the Vijayanagara Empire, the Thanjavur Nayaks, and Maratha rulers, before the French East India Company acquired Karaikal in 1739. It remained a French enclave until de facto liberation in 1954, formally becoming part of India in 1962 as one of the four territories of the Union Territory of Puducherry — alongside Pondicherry, Mahe and Yanam.</p>
+        </div>
+        <div class="port-highlight-box">
+          <h3>📜 At a Glance</h3>
+          <ul>
+            <li><strong>Location</strong>: Cauvery river delta, Bay of Bengal, Union Territory of Puducherry.</li>
+            <li><strong>Ancient role</strong>: Maritime trading hub of the Chola kingdom, 10th century CE.</li>
+            <li><strong>Colonial era</strong>: French enclave from 1739 to 1954 (formal transfer to India in 1962).</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="port-section" id="trade">
+      <div class="port-container">
+        <div class="port-section-header">
+          <span class="port-eyebrow">Rice, River &amp; Ocean</span>
+          <h2>Maritime &amp; Trade Significance</h2>
+          <p>Karaikal's fortunes were shaped by the fertile Cauvery delta and its position on the Bay of Bengal, which supported both ancient coastal trade and, later, colonial-era exports.</p>
+        </div>
+
+        <div class="port-card-grid">
+          <div class="port-card">
+            <span class="port-card-icon">🌾</span>
+            <h3>Delta Rice Trade</h3>
+            <p>Karaikal sits in the most important rice-growing region of Tamil Nadu. Grain from the Cauvery delta was a central export in both the Chola and later French colonial periods.</p>
+          </div>
+          <div class="port-card">
+            <span class="port-card-icon">🚢</span>
+            <h3>Chola Coastal Trade</h3>
+            <p>As a 10th-century Chola trading hub, Karaikal linked the delta's agricultural surplus to coastal shipping routes along the Coromandel Coast.</p>
+          </div>
+          <div class="port-card">
+            <span class="port-card-icon">🇫🇷</span>
+            <h3>French Colonial Exports</h3>
+            <p>Under French administration, Karaikal exported rice, groundnuts and castor oil, contributing significant tonnage to French India's trade even during the First World War.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="port-section" id="french-era">
+      <div class="port-container port-grid-2col">
+        <div class="port-highlight-box" style="background: rgba(212, 149, 47, 0.06); border-color: rgba(212, 149, 47, 0.22);">
+          <h3>🇫🇷 Karaikal under the French, 1739–1954</h3>
+          <ul>
+            <li><strong>Acquired by</strong>: The French East India Company, part of a wave of acquisitions (Mahe, Yanam, Karaikal) between 1720 and 1739.</li>
+            <li><strong>Administered as</strong>: "Karikal," the southernmost of the four French enclaves that made up French India.</li>
+            <li><strong>Legacy today</strong>: A French Quarter with colonial-era buildings, churches, and street names, alongside Tamil temple architecture.</li>
+          </ul>
+        </div>
+        <div class="port-text-block">
+          <span class="port-eyebrow">Comptoir &amp; Cultural Fusion</span>
+          <h2>Two Centuries of French Administration</h2>
+          <p>Karaikal became one of France's four Indian comptoirs, governed for over two centuries by French officials even as Tamil language, temple worship and social life continued largely uninterrupted. The town's French Quarter still preserves colonial-era streets and architecture, while institutions like Our Lady of Angels Church reflect the era's Christian heritage alongside older Shaivite shrines such as the Kailasanathar Temple.</p>
+          <p>During the First World War, Karaikal and the other French enclaves supplied rice, groundnuts and castor oil to the French war effort, and later negotiated customs arrangements with British Madras to manage wartime food shortages — a reminder that this small enclave was tied into much larger global currents of trade and conflict.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="port-section" id="timeline">
+      <div class="port-container">
+        <div class="port-section-header">
+          <span class="port-eyebrow">Milestones</span>
+          <h2>Chronology of Karaikal</h2>
+          <p>Tracing Karaikal's journey from a Chola-era trading harbour to a French comptoir and, finally, a Union Territory of independent India.</p>
+        </div>
+
+        <div class="timeline-flow">
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">10th century CE</span>
+              <h3>A Chola Trading Hub</h3>
+              <p>Karaikal functions as a maritime trading port within the Chola kingdom, linking the fertile Cauvery delta to Coromandel coastal trade routes.</p>
+            </div>
+          </div>
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">15th century CE</span>
+              <h3>Vijayanagara Patronage</h3>
+              <p>Thirumalai Rayan of the Vijayanagara Empire builds the Jambunatha temple, reflecting continued royal patronage of the region's temples.</p>
+            </div>
+          </div>
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">17th–18th century CE</span>
+              <h3>Maratha and Contested Rule</h3>
+              <p>Control of Karaikal passes through Vijayanagara, Thanjavur Nayak, and Maratha hands amid the wider struggle for influence on the Coromandel Coast.</p>
+            </div>
+          </div>
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">1739 CE</span>
+              <h3>French Acquisition</h3>
+              <p>The French East India Company acquires Karaikal, folding it into the network of French comptoirs alongside Pondicherry, Mahe and Yanam.</p>
+            </div>
+          </div>
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">1914–1918 CE</span>
+              <h3>Wartime Trade</h3>
+              <p>Karaikal contributes rice, groundnuts and castor oil exports to the French war effort during the First World War.</p>
+            </div>
+          </div>
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">1954–1962 CE</span>
+              <h3>Integration with India</h3>
+              <p>Karaikal is de facto transferred to India in 1954 and formally becomes part of the Union Territory of Puducherry in 1962.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="port-section" id="gallery">
+      <div class="port-container">
+        <div class="port-section-header">
+          <span class="port-eyebrow">Visual Tour</span>
+          <h2>The Delta, the Comptoir &amp; the Coast of Karaikal</h2>
+          <p>Illustrated impressions of Karaikal's coastline, its French colonial quarter, delta trade, and coastal lighthouse.</p>
+        </div>
+
+        <div class="karaikal-gallery-grid">
+          <div class="karaikal-gallery-item" data-title="Karaikal Coastline" data-desc="A stylised view of the Bay of Bengal coastline at Karaikal, where the Cauvery delta meets the sea.">
+            <img src="../assets/karaikal_port_banner.svg" alt="Illustrated Karaikal coastline at the mouth of the Cauvery delta" loading="lazy">
+            <div class="karaikal-gallery-overlay">
+              <h4>Karaikal Coastline</h4>
+              <p>Cauvery delta meets the Bay of Bengal</p>
+            </div>
+          </div>
+          <div class="karaikal-gallery-item" data-title="The French Quarter" data-desc="A stylised depiction of Karaikal's French colonial quarter, with its characteristic streets and colonial-era architecture from the 1739–1954 period.">
+            <img src="../assets/karaikal_french_colonial.svg" alt="Illustrated French colonial building in Karaikal" loading="lazy">
+            <div class="karaikal-gallery-overlay">
+              <h4>French Quarter</h4>
+              <p>Colonial architecture, 1739–1954</p>
+            </div>
+          </div>
+          <div class="karaikal-gallery-item" data-title="Delta Trade Goods" data-desc="An illustrated impression of the rice, groundnuts and other Cauvery delta produce that passed through Karaikal in both the Chola and French colonial eras.">
+            <img src="../assets/karaikal_trade_goods.svg" alt="Illustrated sacks of rice and delta produce representing Karaikal's trade" loading="lazy">
+            <div class="karaikal-gallery-overlay">
+              <h4>Delta Trade Goods</h4>
+              <p>Rice, groundnuts &amp; castor oil exports</p>
+            </div>
+          </div>
+          <div class="karaikal-gallery-item" data-title="Karaikal Lighthouse" data-desc="A stylised impression of the Karaikal Lighthouse near Karaikal Beach, a coastal landmark guiding ships along the Bay of Bengal.">
+            <img src="../assets/karaikal_lighthouse.svg" alt="Illustrated Karaikal lighthouse on the Bay of Bengal shore" loading="lazy">
+            <div class="karaikal-gallery-overlay">
+              <h4>Karaikal Lighthouse</h4>
+              <p>A beacon on the Coromandel Coast</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="port-section" id="references">
+      <div class="port-container">
+        <div class="port-references">
+          <h3>📚 References &amp; Further Reading</h3>
+          <ul>
+            <li><strong>Encyclopaedia Britannica</strong>. <em>Karaikal</em>. Britannica.com.</li>
+            <li><strong>Government of Puducherry, District Administration</strong>. <em>History of Puducherry District</em>. puducherry-dt.gov.in.</li>
+            <li><strong>Government of India, Census of India (2011)</strong>. <em>Karaikal District Population Data</em>.</li>
+            <li><strong>Wikivoyage</strong>. <em>Karaikal Travel Guide</em>. en.wikivoyage.org.</li>
+            <li><strong>Karaikal District Administration</strong>. <em>Cauvery Delta Heritage and French Colonial History</em>. karaikaldistrict.com.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <div class="karaikal-modal" id="karaikal-modal" role="dialog" aria-modal="true" aria-labelledby="karaikal-modal-title" aria-hidden="true">
+    <div class="karaikal-modal-card">
+      <button class="karaikal-modal-close" id="karaikal-modal-close" type="button" aria-label="Close details">✕</button>
+      <span class="karaikal-modal-category" id="karaikal-modal-category">Gallery Highlight</span>
+      <h2 id="karaikal-modal-title"></h2>
+      <p class="karaikal-modal-location" id="karaikal-modal-heading"></p>
+      <div class="karaikal-modal-divider">
+        <p class="karaikal-modal-description" id="karaikal-modal-description"></p>
+      </div>
+    </div>
+  </div>
+
+  <footer class="port-footer">
+    <div class="port-container">
+      <p>Part of <a href="../../index.html">Incredible India Explorer</a> · Explore Puducherry's Chola-era maritime trade and French colonial heritage.</p>
+    </div>
+  </footer>
+
+  <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+
+  <script src="../app.js" defer></script>
+  <script src="../../frontend/journey/journey.js" defer></script>
+  <script src="script.js" defer></script>
+  <script type="module" src="../firebase-config.js"></script>
+  <script type="module" src="../auth.js"></script>
+  <script src="../router.js" defer></script>
+  <script src="../js-modules/page-progress/page-progress.js"></script>
+</body>
+</html>

--- a/frontend/karaikal-port-explorer/script.js
+++ b/frontend/karaikal-port-explorer/script.js
@@ -1,0 +1,119 @@
+// ===== Karaikal Port Explorer — Page Script =====
+
+document.addEventListener('DOMContentLoaded', function () {
+
+  // ---------- Gallery Modal ----------
+  const modal = document.getElementById('karaikal-modal');
+  const modalClose = document.getElementById('karaikal-modal-close');
+  const modalTitle = document.getElementById('karaikal-modal-title');
+  const modalCategory = document.getElementById('karaikal-modal-category');
+  const modalHeading = document.getElementById('karaikal-modal-heading');
+  const modalDescription = document.getElementById('karaikal-modal-description');
+  const galleryItems = document.querySelectorAll('.karaikal-gallery-item');
+
+  function openModal(item) {
+    const title = item.getAttribute('data-title') || '';
+    const desc = item.getAttribute('data-desc') || '';
+
+    modalTitle.textContent = title;
+    modalCategory.textContent = 'Gallery Highlight';
+    modalHeading.textContent = 'Karaikal Ancient Port';
+    modalDescription.textContent = desc;
+
+    modal.classList.add('active');
+    modal.setAttribute('aria-hidden', 'false');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeModal() {
+    modal.classList.remove('active');
+    modal.setAttribute('aria-hidden', 'true');
+    document.body.style.overflow = '';
+  }
+
+  galleryItems.forEach(function (item) {
+    item.addEventListener('click', function () {
+      openModal(item);
+    });
+    item.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openModal(item);
+      }
+    });
+    item.setAttribute('tabindex', '0');
+    item.setAttribute('role', 'button');
+  });
+
+  if (modalClose) {
+    modalClose.addEventListener('click', closeModal);
+  }
+
+  if (modal) {
+    modal.addEventListener('click', function (e) {
+      if (e.target === modal) closeModal();
+    });
+  }
+
+  document.addEventListener('keydown', function (e) {
+    if (modal && e.key === 'Escape' && modal.classList.contains('active')) {
+      closeModal();
+    }
+  });
+
+  // ---------- Bookmark Button ----------
+  const bookmarkBtn = document.querySelector('.journey-bookmark-btn[data-bookmark-id="karaikal-port-main"]');
+
+  if (bookmarkBtn) {
+    const bookmarkId = bookmarkBtn.getAttribute('data-bookmark-id');
+    const storageKey = 'journey-bookmarks';
+
+    function getBookmarks() {
+      try {
+        return JSON.parse(localStorage.getItem(storageKey)) || [];
+      } catch (e) {
+        return [];
+      }
+    }
+
+    function saveBookmarks(list) {
+      localStorage.setItem(storageKey, JSON.stringify(list));
+    }
+
+    function refreshButtonState() {
+      const bookmarks = getBookmarks();
+      const isSaved = bookmarks.includes(bookmarkId);
+      bookmarkBtn.setAttribute('aria-pressed', isSaved ? 'true' : 'false');
+      bookmarkBtn.textContent = isSaved ? '♥ Saved to Journey' : '♡ Save to Journey';
+    }
+
+    bookmarkBtn.addEventListener('click', function () {
+      let bookmarks = getBookmarks();
+      if (bookmarks.includes(bookmarkId)) {
+        bookmarks = bookmarks.filter(function (id) { return id !== bookmarkId; });
+      } else {
+        bookmarks.push(bookmarkId);
+      }
+      saveBookmarks(bookmarks);
+      refreshButtonState();
+    });
+
+    refreshButtonState();
+  }
+
+  // ---------- Scroll to top button ----------
+  const scrollTopBtn = document.getElementById('btn-scroll-top');
+  if (scrollTopBtn) {
+    window.addEventListener('scroll', function () {
+      if (window.scrollY > 400) {
+        scrollTopBtn.classList.add('visible');
+      } else {
+        scrollTopBtn.classList.remove('visible');
+      }
+    });
+    scrollTopBtn.addEventListener('click', function () {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  }
+
+});

--- a/frontend/karaikal-port-explorer/style.css
+++ b/frontend/karaikal-port-explorer/style.css
@@ -1,0 +1,473 @@
+/* ===== Karaikal Port Explorer — Page Styles ===== */
+
+.port-main {
+  --port-navy: #0a1930;
+  --port-gold: #d4952f;
+  --port-gold-light: #f0c674;
+  --port-teal: #0e5c5c;
+  background: #050d1c;
+  color: #f5f0e6;
+}
+
+.port-section {
+  background: #050d1c;
+}
+
+/* ---------- Hero ---------- */
+.port-hero {
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 140px 24px 80px;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(212, 149, 47, 0.15), transparent 60%),
+    radial-gradient(circle at 80% 80%, rgba(14, 92, 92, 0.25), transparent 60%),
+    #050d1c;
+}
+
+.port-hero-content {
+  max-width: 760px;
+}
+
+.port-kicker {
+  display: inline-block;
+  font-size: 0.85rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--port-gold-light);
+  background: rgba(212, 149, 47, 0.1);
+  border: 1px solid rgba(212, 149, 47, 0.3);
+  padding: 6px 16px;
+  border-radius: 999px;
+  margin-bottom: 20px;
+}
+
+.port-hero h1 {
+  font-family: "Playfair Display", serif;
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  line-height: 1.15;
+  margin: 0 0 18px;
+  color: #f5f0e6;
+}
+
+.port-hero h1 span {
+  color: var(--port-gold);
+  font-style: italic;
+}
+
+.port-hero p {
+  font-size: 1.05rem;
+  line-height: 1.7;
+  opacity: 0.85;
+  margin: 0 auto 28px;
+}
+
+.port-bookmark-btn {
+  font-family: inherit;
+  font-size: 0.95rem;
+  padding: 10px 22px;
+  border-radius: 999px;
+  border: 1px solid var(--port-gold);
+  background: transparent;
+  color: var(--port-gold-light);
+  cursor: pointer;
+  transition: all 0.25s ease;
+}
+
+.port-bookmark-btn:hover {
+  background: var(--port-gold);
+  color: #1a0f00;
+}
+
+.port-bookmark-btn[aria-pressed="true"] {
+  background: var(--port-gold);
+  color: #1a0f00;
+}
+
+/* ---------- Sections ---------- */
+.port-section {
+  padding: 70px 24px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.port-container {
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+.port-section-header {
+  text-align: center;
+  max-width: 620px;
+  margin: 0 auto 44px;
+}
+
+.port-eyebrow {
+  display: block;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #4fd1c5;
+  margin-bottom: 10px;
+}
+
+.port-section-header h2,
+.port-text-block h2 {
+  font-family: "Playfair Display", serif;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  margin: 0 0 14px;
+  color: #f5f0e6;
+}
+
+.port-section-header p,
+.port-text-block p {
+  line-height: 1.75;
+  opacity: 0.85;
+  margin: 0 0 14px;
+}
+
+/* ---------- Two-column grid ---------- */
+.port-grid-2col {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 48px;
+  align-items: start;
+}
+
+@media (max-width: 800px) {
+  .port-grid-2col {
+    grid-template-columns: 1fr;
+  }
+}
+
+.port-highlight-box {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 28px;
+}
+
+.port-highlight-box h3 {
+  margin: 0 0 16px;
+  font-size: 1.15rem;
+  color: #f5f0e6;
+}
+
+.port-highlight-box ul {
+  margin: 0;
+  padding-left: 20px;
+  line-height: 1.9;
+}
+
+/* ---------- Card grid ---------- */
+.port-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+
+@media (max-width: 800px) {
+  .port-card-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.port-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 26px;
+  text-align: left;
+  transition: transform 0.25s ease, border-color 0.25s ease;
+}
+
+.port-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(212, 149, 47, 0.4);
+}
+
+.port-card-icon {
+  font-size: 1.8rem;
+  display: block;
+  margin-bottom: 12px;
+}
+
+.port-card h3 {
+  margin: 0 0 8px;
+  font-size: 1.05rem;
+  color: #f5f0e6;
+}
+
+.port-card p {
+  margin: 0;
+  line-height: 1.6;
+  opacity: 0.8;
+  font-size: 0.95rem;
+}
+
+/* ---------- Timeline ---------- */
+.timeline-flow {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  padding-left: 30px;
+  border-left: 2px solid rgba(212, 149, 47, 0.3);
+}
+
+.timeline-step {
+  position: relative;
+}
+
+.timeline-step-marker {
+  position: absolute;
+  left: -37px;
+  top: 4px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--port-gold);
+  box-shadow: 0 0 0 4px rgba(212, 149, 47, 0.15);
+}
+
+.timeline-step-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 14px;
+  padding: 18px 22px;
+}
+
+.timeline-step-year {
+  display: inline-block;
+  font-size: 0.8rem;
+  color: var(--port-gold-light);
+  margin-bottom: 6px;
+  font-weight: 600;
+}
+
+.timeline-step-card h3 {
+  margin: 0 0 6px;
+  font-size: 1.05rem;
+  color: #f5f0e6;
+}
+
+.timeline-step-card p {
+  margin: 0;
+  line-height: 1.6;
+  opacity: 0.8;
+  font-size: 0.95rem;
+}
+
+/* ---------- Gallery (unique names — no collisions with global site CSS) ---------- */
+.karaikal-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 18px;
+}
+
+@media (max-width: 900px) {
+  .karaikal-gallery-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.karaikal-gallery-item {
+  position: relative;
+  border-radius: 14px;
+  overflow: hidden;
+  cursor: pointer;
+  aspect-ratio: 1 / 1;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: #0a1930;
+}
+
+.karaikal-gallery-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.4s ease;
+}
+
+.karaikal-gallery-item:hover img {
+  transform: scale(1.06);
+}
+
+.karaikal-gallery-overlay {
+  position: absolute;
+  inset: auto 0 0 0;
+  background: linear-gradient(0deg, rgba(0,0,0,0.85) 40%, transparent);
+  padding: 14px;
+  pointer-events: none;
+}
+
+.karaikal-gallery-overlay h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #ffffff;
+}
+
+.karaikal-gallery-overlay p {
+  margin: 2px 0 0;
+  font-size: 0.8rem;
+  opacity: 0.85;
+  color: #f5f0e6;
+}
+
+/* ---------- References ---------- */
+.port-references {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 28px;
+}
+
+.port-references h3 {
+  margin: 0 0 14px;
+  color: #f5f0e6;
+}
+
+.port-references ul {
+  margin: 0;
+  padding-left: 20px;
+  line-height: 1.9;
+  font-size: 0.92rem;
+  opacity: 0.85;
+}
+
+/* ---------- Footer ---------- */
+.port-footer {
+  padding: 30px 24px;
+  text-align: center;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  font-size: 0.9rem;
+  opacity: 0.7;
+  background: #050d1c;
+}
+
+.port-footer a {
+  color: var(--port-gold-light);
+}
+
+/* ---------- Karaikal Modal (self-contained, unique names) ---------- */
+.karaikal-modal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  z-index: 999;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.karaikal-modal.active {
+  display: flex;
+}
+
+.karaikal-modal-card {
+  position: relative;
+  background: #0a1930;
+  border: 1px solid rgba(212, 149, 47, 0.3);
+  border-radius: 16px;
+  padding: 32px;
+  max-width: 480px;
+  width: 100%;
+  color: #f5f0e6;
+}
+
+.karaikal-modal-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  background: transparent;
+  border: none;
+  color: #f5f0e6;
+  font-size: 1.2rem;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.karaikal-modal-category {
+  display: inline-block;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--port-gold-light);
+  margin-bottom: 10px;
+}
+
+.karaikal-modal-card h2 {
+  margin: 0 0 6px;
+  font-family: "Playfair Display", serif;
+  font-size: 1.4rem;
+}
+
+.karaikal-modal-location {
+  color: var(--port-gold-light);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.karaikal-modal-divider {
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  margin-top: 15px;
+  padding-top: 15px;
+}
+
+.karaikal-modal-description {
+  margin: 0;
+  line-height: 1.7;
+  opacity: 0.9;
+}
+
+/* ---------- Scroll to top button ---------- */
+.btn-scroll-top {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid rgba(212, 149, 47, 0.4);
+  background: #0a1930;
+  color: var(--port-gold-light);
+  font-size: 1.2rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.25s ease, visibility 0.25s ease;
+  z-index: 90;
+}
+
+.btn-scroll-top.visible {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* ---------- Light theme overrides: force this page to stay dark ---------- */
+body.light-theme .port-main,
+body.light-theme .port-hero,
+body.light-theme .port-section,
+body.light-theme .port-footer {
+  background: #050d1c !important;
+  color: #f5f0e6 !important;
+}
+
+body.light-theme .port-card,
+body.light-theme .port-highlight-box,
+body.light-theme .timeline-step-card,
+body.light-theme .port-references {
+  background: rgba(255, 255, 255, 0.04) !important;
+  border-color: rgba(255, 255, 255, 0.1) !important;
+  color: #f5f0e6 !important;
+}
+
+body.light-theme .karaikal-gallery-item {
+  background: #0a1930 !important;
+}


### PR DESCRIPTION
## Description
Adds a dedicated explorer page for Karaikal, a Coromandel Coast enclave in the Cauvery delta with a layered history — a 10th-century Chola-era maritime trading hub that later became a French comptoir from 1739 to 1954, before formally joining India in 1962 as part of the Union Territory of Puducherry.

## Changes
- Created `frontend/karaikal-port-explorer/index.html` with:
  - Historical overview (Chola-era trade hub, Vijayanagara/Maratha rule, French acquisition)
  - Maritime and trade significance (Cauvery delta rice, coastal trade, colonial exports)
  - Dedicated French colonial heritage section (1739–1954)
  - Chronology timeline (10th century CE to 1962)
  - Image gallery with modal viewer
  - References and further reading
- Added `style.css` and `script.js` for page-specific styling and interactivity
- Added 4 custom SVG illustrations in `frontend/assets/`
- Added Karaikal link to the port explorer navigation dropdown

## Requirements fulfilled
- [x] Historical overview
- [x] Maritime importance
- [x] Trade activities
- [x] Timeline
- [x] Gallery
- [x] References
- [x] Proper navigation
- [x] Responsive UI

## Screenshots
<img width="1440" height="852" alt="Screenshot 2026-08-04 130813" src="https://github.com/user-attachments/assets/213a7619-677e-4771-bd51-ad774c929632" />
<img width="1440" height="852" alt="Screenshot 2026-08-04 130929" src="https://github.com/user-attachments/assets/205a9718-af4b-4174-9374-af740aacafef" />


Closes #1423