### PR TITLE
feat: Add Kozhikode (Calicut) Ancient Port Explorer page

### DIFF
--- a/frontend/assets/kozhikode_calico_weaving.svg
+++ b/frontend/assets/kozhikode_calico_weaving.svg
@@ -1,0 +1,31 @@
+<svg viewBox="0 0 800 500" xmlns="http://www.w3.org/2000/svg">
+  <rect width="800" height="500" fill="#0a1930"/>
+  <!-- loom frame -->
+  <g stroke="#f0c674" stroke-width="4" fill="none">
+    <rect x="150" y="80" width="500" height="340" rx="4"/>
+    <line x1="150" y1="160" x2="650" y2="160"/>
+    <line x1="150" y1="340" x2="650" y2="340"/>
+  </g>
+  <!-- woven cloth pattern -->
+  <g stroke="#d4952f" stroke-width="2" opacity="0.85">
+    <line x1="190" y1="170" x2="190" y2="330"/>
+    <line x1="230" y1="170" x2="230" y2="330"/>
+    <line x1="270" y1="170" x2="270" y2="330"/>
+    <line x1="310" y1="170" x2="310" y2="330"/>
+    <line x1="350" y1="170" x2="350" y2="330"/>
+    <line x1="390" y1="170" x2="390" y2="330"/>
+    <line x1="430" y1="170" x2="430" y2="330"/>
+    <line x1="470" y1="170" x2="470" y2="330"/>
+    <line x1="510" y1="170" x2="510" y2="330"/>
+    <line x1="550" y1="170" x2="550" y2="330"/>
+    <line x1="590" y1="170" x2="590" y2="330"/>
+    <line x1="610" y1="170" x2="610" y2="330"/>
+  </g>
+  <g stroke="#0e5c5c" stroke-width="6" opacity="0.9">
+    <line x1="170" y1="190" x2="630" y2="190"/>
+    <line x1="170" y1="230" x2="630" y2="230"/>
+    <line x1="170" y1="270" x2="630" y2="270"/>
+    <line x1="170" y1="310" x2="630" y2="310"/>
+  </g>
+  <text x="400" y="470" text-anchor="middle" font-family="Georgia, serif" font-size="20" fill="#f0c674" opacity="0.6" font-style="italic">Calico — Cotton Cloth that Named Itself After the Port</text>
+</svg>

--- a/frontend/assets/kozhikode_port_banner.svg
+++ b/frontend/assets/kozhikode_port_banner.svg
@@ -1,0 +1,41 @@
+<svg viewBox="0 0 800 500" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0a1930"/>
+      <stop offset="100%" stop-color="#0e5c5c"/>
+    </linearGradient>
+    <linearGradient id="sea" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0e5c5c"/>
+      <stop offset="100%" stop-color="#050d1c"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="500" fill="url(#sky)"/>
+  <circle cx="640" cy="120" r="70" fill="#d4952f" opacity="0.85"/>
+  <circle cx="640" cy="120" r="100" fill="#f0c674" opacity="0.12"/>
+  <rect y="300" width="800" height="200" fill="url(#sea)"/>
+  <path d="M0 300 Q200 280 400 300 T800 300 V500 H0 Z" fill="#0a1930" opacity="0.6"/>
+  <!-- Kappad shoreline -->
+  <path d="M0 340 Q150 320 320 345 Q480 368 650 340 Q740 325 800 335 V500 H0 Z" fill="#050d1c"/>
+  <!-- dhows -->
+  <g transform="translate(150,250)">
+    <path d="M0 40 L60 40 L45 55 L15 55 Z" fill="#0a1930" stroke="#f0c674" stroke-width="1.5"/>
+    <line x1="30" y1="40" x2="30" y2="0" stroke="#f0c674" stroke-width="2"/>
+    <path d="M30 2 L30 34 L62 26 Z" fill="#d4952f" opacity="0.9"/>
+  </g>
+  <g transform="translate(320,270)">
+    <path d="M0 34 L50 34 L38 47 L12 47 Z" fill="#0a1930" stroke="#f0c674" stroke-width="1.5"/>
+    <line x1="25" y1="34" x2="25" y2="0" stroke="#f0c674" stroke-width="2"/>
+    <path d="M25 2 L25 28 L50 22 Z" fill="#f0c674" opacity="0.85"/>
+  </g>
+  <g transform="translate(470,255)">
+    <path d="M0 42 L64 42 L48 58 L16 58 Z" fill="#0a1930" stroke="#f0c674" stroke-width="1.5"/>
+    <line x1="32" y1="42" x2="32" y2="2" stroke="#f0c674" stroke-width="2"/>
+    <path d="M32 4 L32 36 L66 28 Z" fill="#d4952f" opacity="0.9"/>
+  </g>
+  <!-- waves -->
+  <g stroke="#f0c674" stroke-width="1.5" opacity="0.35" fill="none">
+    <path d="M0 400 Q40 390 80 400 T160 400 T240 400 T320 400 T400 400 T480 400 T560 400 T640 400 T720 400 T800 400"/>
+    <path d="M0 440 Q40 430 80 440 T160 440 T240 440 T320 440 T400 440 T480 440 T560 440 T640 440 T720 440 T800 440"/>
+  </g>
+  <text x="40" y="470" font-family="Georgia, serif" font-size="20" fill="#f0c674" opacity="0.6" font-style="italic">Kappad · Coast of the Zamorins</text>
+</svg>

--- a/frontend/assets/kozhikode_spice_trade.svg
+++ b/frontend/assets/kozhikode_spice_trade.svg
@@ -1,0 +1,26 @@
+<svg viewBox="0 0 800 500" xmlns="http://www.w3.org/2000/svg">
+  <rect width="800" height="500" fill="#0a1930"/>
+  <!-- sacks -->
+  <g>
+    <ellipse cx="180" cy="410" rx="90" ry="30" fill="#050d1c" opacity="0.6"/>
+    <path d="M110 260 Q95 350 130 410 Q180 435 230 410 Q265 350 250 260 Q180 235 110 260 Z" fill="#d4952f" opacity="0.9"/>
+    <path d="M120 265 Q180 245 240 265" fill="none" stroke="#0a1930" stroke-width="3"/>
+  </g>
+  <g transform="translate(260,40)">
+    <ellipse cx="180" cy="410" rx="80" ry="26" fill="#050d1c" opacity="0.6"/>
+    <path d="M120 270 Q108 350 138 408 Q180 430 222 408 Q252 350 240 270 Q180 248 120 270 Z" fill="#0e5c5c" opacity="0.9"/>
+    <path d="M128 275 Q180 255 232 275" fill="none" stroke="#0a1930" stroke-width="3"/>
+  </g>
+  <g transform="translate(480,10)">
+    <ellipse cx="180" cy="410" rx="95" ry="32" fill="#050d1c" opacity="0.6"/>
+    <path d="M105 258 Q90 350 128 412 Q180 438 232 412 Q270 350 255 258 Q180 232 105 258 Z" fill="#f0c674" opacity="0.9"/>
+    <path d="M115 263 Q180 240 245 263" fill="none" stroke="#0a1930" stroke-width="3"/>
+  </g>
+  <!-- scattered peppercorns -->
+  <g fill="#050d1c">
+    <circle cx="150" cy="330" r="5"/><circle cx="170" cy="345" r="4"/><circle cx="200" cy="325" r="5"/>
+    <circle cx="420" cy="360" r="5"/><circle cx="450" cy="340" r="4"/><circle cx="480" cy="365" r="5"/>
+    <circle cx="620" cy="330" r="5"/><circle cx="650" cy="350" r="4"/><circle cx="600" cy="360" r="5"/>
+  </g>
+  <text x="400" y="470" text-anchor="middle" font-family="Georgia, serif" font-size="20" fill="#f0c674" opacity="0.6" font-style="italic">Pepper, Ginger, Cinnamon — Bound for the World</text>
+</svg>

--- a/frontend/assets/kozhikode_zamorin_court.svg
+++ b/frontend/assets/kozhikode_zamorin_court.svg
@@ -1,0 +1,34 @@
+<svg viewBox="0 0 800 500" xmlns="http://www.w3.org/2000/svg">
+  <rect width="800" height="500" fill="#0a1930"/>
+  <rect width="800" height="500" fill="url(#g)" opacity="0.5"/>
+  <defs>
+    <radialGradient id="g" cx="50%" cy="30%" r="70%">
+      <stop offset="0%" stop-color="#d4952f" stop-opacity="0.18"/>
+      <stop offset="100%" stop-color="#0a1930" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <!-- palace pillars -->
+  <g fill="#0e5c5c" stroke="#f0c674" stroke-width="1.5">
+    <rect x="90" y="140" width="26" height="280"/>
+    <rect x="230" y="120" width="26" height="300"/>
+    <rect x="370" y="100" width="30" height="320"/>
+    <rect x="520" y="120" width="26" height="300"/>
+    <rect x="660" y="140" width="26" height="280"/>
+  </g>
+  <!-- roofline -->
+  <path d="M60 140 L400 60 L740 140 L720 160 L400 90 L80 160 Z" fill="#d4952f" opacity="0.85"/>
+  <!-- throne dais -->
+  <rect x="330" y="330" width="140" height="90" rx="6" fill="#0e5c5c" stroke="#f0c674" stroke-width="1.5"/>
+  <path d="M355 330 L355 260 Q400 230 445 260 L445 330 Z" fill="#d4952f" opacity="0.9" stroke="#f0c674" stroke-width="1.5"/>
+  <circle cx="400" cy="300" r="16" fill="#f5f0e6" opacity="0.9"/>
+  <!-- attendants -->
+  <g fill="#f0c674" opacity="0.75">
+    <rect x="230" y="360" width="14" height="60" rx="6"/>
+    <circle cx="237" cy="352" r="10"/>
+    <rect x="556" y="360" width="14" height="60" rx="6"/>
+    <circle cx="563" cy="352" r="10"/>
+  </g>
+  <!-- floor -->
+  <rect x="0" y="420" width="800" height="80" fill="#050d1c"/>
+  <text x="400" y="470" text-anchor="middle" font-family="Georgia, serif" font-size="20" fill="#f0c674" opacity="0.6" font-style="italic">Samoothiri — Lord of the Sea and Mountains</text>
+</svg>

--- a/frontend/kozhikode-port-explorer/index.html
+++ b/frontend/kozhikode-port-explorer/index.html
@@ -1,0 +1,347 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore Kozhikode (Calicut) Ancient Port on the Malabar Coast: the Zamorin's free-trade emporium, its spice and calico trade, Ibn Battuta and Zheng He's visits, and Vasco da Gama's 1498 landing.">
+  <title>Kozhikode (Calicut) Ancient Port Explorer | Incredible India</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="../js-modules/page-progress/page-progress.css">
+
+  <meta property="og:title" content="Kozhikode (Calicut) Ancient Port Explorer | Incredible India Explorer">
+  <meta property="og:description" content="Discover Kozhikode, the Zamorin's free-trade emporium on the Malabar Coast, its spice and calico exports, and its place in the Indian Ocean world before and after Vasco da Gama.">
+  <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/frontend/assets/kozhikode_port_banner.svg">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/kozhikode-port-explorer/index.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Incredible India Explorer">
+  <meta property="og:locale" content="en_IN">
+
+  <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/kozhikode-port-explorer/index.html">
+</head>
+<body>
+  <script>
+    (function() {
+      const theme = localStorage.getItem('theme') || 'dark';
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+
+  <header class="navbar scrolled" id="navbar">
+    <div class="nav-container">
+      <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+        <span class="saffron">Incredible</span><span class="gold">India</span><span class="green">Explorer</span>
+      </a>
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+        <span class="bar"></span><span class="bar"></span><span class="bar"></span>
+      </button>
+      <nav class="nav-menu" id="nav-menu">
+        <a href="../../index.html#home" class="nav-link" id="link-home">Home</a>
+        <a href="../../index.html#map" class="nav-link" id="link-map">Interactive Map</a>
+        <a href="../../frontend/cuisine/cuisine.html" class="nav-link" id="link-cuisine">Cuisine</a>
+        <a href="../../frontend/festivals/festivals.html" class="nav-link" id="link-festivals">Festivals</a>
+        <a href="../../frontend/culture/culture.html" class="nav-link" id="link-culture">Culture</a>
+        <div class="nav-dropdown">
+          <button class="nav-link dropdown-toggle" id="link-explore-more" style="color: var(--saffron)">Explore More ▾</button>
+          <div class="dropdown-menu">
+            <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+            <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+            <a href="../../frontend/personalities/personalities.html" class="dropdown-item">Famous Personalities</a>
+            <a href="../../frontend/spiritual/spiritual.html" class="dropdown-item">Spiritual India</a>
+            <a href="../../frontend/arts-crafts/arts-crafts.html" class="dropdown-item">Arts & Crafts</a>
+            <a href="../../frontend/museums/museums.html" class="dropdown-item">Museums</a>
+            <a href="../mandvi-port-explorer/index.html" class="dropdown-item">Mandvi Port</a>
+            <a href="../honnavar-port-explorer/index.html" class="dropdown-item">Honnavar Port</a>
+            <a href="../kannur-port-explorer/index.html" class="dropdown-item">Kannur Port</a>
+            <a href="../dwarka-port-explorer/index.html" class="dropdown-item">Dwarka Port</a>
+            <a href="../motupalli-port-explorer/index.html" class="dropdown-item">Motupalli Port</a>
+            <a href="../karaikal-port-explorer/index.html" class="dropdown-item">Karaikal Port</a>
+            <a href="index.html" class="dropdown-item" style="color: var(--saffron)">Kozhikode Port</a>
+          </div>
+        </div>
+        <div class="nav-dropdown">
+          <button class="nav-link dropdown-toggle" id="link-learn-data">Learn & Data ▾</button>
+          <div class="dropdown-menu">
+            <a href="../../frontend/smart-cities/smart-cities.html" class="dropdown-item">Smart Cities</a>
+            <a href="../../frontend/languages/languages.html" class="dropdown-item">Languages of India</a>
+            <a href="../../frontend/data-india/data-india.html" class="dropdown-item">Data & Statistics</a>
+            <a href="../../frontend/learn/learn.html" class="dropdown-item">Learn & Quiz</a>
+          </div>
+        </div>
+        <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">☀️</button>
+        <div class="journey-nav-search">
+          <input type="search" id="journey-search-input" class="journey-search-input" placeholder="Search all explorers…" aria-label="Search across all explorers" autocomplete="off">
+          <div id="journey-search-results" class="journey-search-results" hidden></div>
+        </div>
+        <a href="../../frontend/journey/journey.html" class="nav-link" id="link-journey">🧭 My Journey</a>
+        <a href="../../frontend/premium/premium.html" class="nav-link premium-link">★ Premium</a>
+        <a href="../login.html" class="nav-link" id="link-login">Login</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="app-root" class="port-main">
+
+    <section class="port-hero">
+      <div class="port-hero-content">
+        <span class="port-kicker">⚓ Malabar Coast · Kozhikode District, Kerala</span>
+        <h1>Kozhikode (Calicut) Ancient Port <span>Explorer</span></h1>
+        <p>Step into the "City of Spices," the free-trade emporium of the Zamorins where Arab, Chinese, Persian and European merchants once shared the same shore. Discover the port that gave the world calico cloth and drew Vasco da Gama across the ocean.</p>
+        <div class="port-bookmark-container">
+          <button class="port-bookmark-btn journey-bookmark-btn" type="button" data-bookmark-id="kozhikode-port-main" aria-pressed="false" aria-label="Bookmark Kozhikode Port">
+            ♡ Save to Journey
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <section class="port-section" id="overview">
+      <div class="port-container port-grid-2col">
+        <div class="port-text-block">
+          <span class="port-eyebrow">City of Spices</span>
+          <h2>A Free Port on the Malabar Coast</h2>
+          <p>Kozhikode, known to foreign traders for centuries as Calicut, sits on Kerala's Malabar Coast between the Arabian Sea and the Western Ghats. Arab merchants are recorded trading along this coast from around the 7th century CE, and by the 12th century the rising Zamorin dynasty of Nediyiruppu had made Kozhikode its capital and its chief outlet to the sea.</p>
+          <p>What set Kozhikode apart from other medieval ports was its reputation as an open emporium: the Zamorins welcomed traders of every faith and origin, and enforced order strictly enough that merchants moved their business here from older ports along the coast. By the 14th century, the city stood at the centre of the Indian Ocean spice trade, connecting the Malabar coast to Arabia, East Africa, Persia, and as far as China and Southeast Asia.</p>
+        </div>
+        <div class="port-highlight-box">
+          <h3>📜 At a Glance</h3>
+          <ul>
+            <li><strong>Location</strong>: Kozhikode district, Kerala, on the Malabar Coast.</li>
+            <li><strong>Also known as</strong>: Calicut to Arab, Chinese and European traders.</li>
+            <li><strong>Ruled by</strong>: The Zamorins (Samoothiris) of the Nediyiruppu Swaroopam.</li>
+            <li><strong>Golden age</strong>: 13th–16th century CE, as the leading spice port of the Indian Ocean.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="port-section" id="trade">
+      <div class="port-container">
+        <div class="port-section-header">
+          <span class="port-eyebrow">Pepper, Cotton &amp; the Word "Calico"</span>
+          <h2>Maritime Trade Significance</h2>
+          <p>Kozhikode's warehouses moved the produce of the Malabar hills and looms out into the Indian Ocean, making it one of the most cosmopolitan trading cities of the medieval world.</p>
+        </div>
+
+        <div class="port-card-grid">
+          <div class="port-card">
+            <span class="port-card-icon">🌶️</span>
+            <h3>The Spice Trade</h3>
+            <p>Black pepper, ginger, cardamom and cinnamon grown in the Malabar hills passed through Kozhikode's harbour, earning it the title "City of Spices" and making it a magnet for Arab, Persian and later European buyers.</p>
+          </div>
+          <div class="port-card">
+            <span class="port-card-icon">🧵</span>
+            <h3>Calico Cotton Cloth</h3>
+            <p>Fine hand-woven cotton exported from the port became known in Europe as "calico," an anglicised form of the city's name — a rare case of a global textile trade taking its name directly from an Indian port.</p>
+          </div>
+          <div class="port-card">
+            <span class="port-card-icon">🌏</span>
+            <h3>An Indian Ocean Crossroads</h3>
+            <p>Arab and Persian dhows, Chinese junks, and later Portuguese, Dutch, French and English ships all called at Kozhikode, linking it to trade networks stretching from East Africa to the South China Sea.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="port-section" id="zamorin">
+      <div class="port-container port-grid-2col">
+        <div class="port-highlight-box" style="background: rgba(212, 149, 47, 0.06); border-color: rgba(212, 149, 47, 0.22);">
+          <h3>👑 The Zamorins of Calicut</h3>
+          <ul>
+            <li><strong>Title</strong>: Samoothiri, popularly rendered "Zamorin" — traditionally understood as ruler of the sea and the land.</li>
+            <li><strong>Origin</strong>: The Nediyiruppu Swaroopam lineage, which rose to prominence from around the 12th–13th century CE.</li>
+            <li><strong>Policy</strong>: Guaranteed safety and free trade to merchants of every community, which drew Arab, Jewish, Chinese and later European traders to settle at the port.</li>
+          </ul>
+        </div>
+        <div class="port-text-block">
+          <span class="port-eyebrow">Rulers of an Open Port</span>
+          <h2>Foreign Travellers at the Zamorin's Court</h2>
+          <p>The Moroccan traveller Ibn Battuta visited Calicut in the early 1340s and described it as one of the great ports of the Malabar coast, crowded with ships and merchants from across the Indian Ocean world. He would later pass through again by sea on his journey back from China.</p>
+          <p>In the early 15th century, the Ming Chinese admiral Zheng He called at Calicut several times during his voyages between 1405 and 1433, exchanging silk and porcelain for pepper and spices. His interpreter Ma Huan recorded the Zamorin's court and the port's bustling trade in his travel account, describing Calicut as a great emporium of the Western Ocean.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="port-section" id="europeans">
+      <div class="port-container port-grid-2col">
+        <div class="port-text-block">
+          <span class="port-eyebrow">The Sea Route from Europe</span>
+          <h2>Vasco da Gama and the Colonial Era</h2>
+          <p>On 20 May 1498, the Portuguese navigator Vasco da Gama landed at Kappad, near Kozhikode, having sailed around Africa's Cape of Good Hope — opening the first direct sea route between Europe and India. The Zamorin received him, though local Arab merchants, wary of a rival, worked to limit Portuguese access to the pepper trade.</p>
+          <p>Conflict between the Zamorin and the Portuguese followed over the next decades, and a Portuguese fort and trading post operated at Kozhikode from 1511 until its fall in 1525. Later in the 17th and 18th centuries, English, French and Dutch companies each established their own trading posts along the Malabar coast, drawn by the same pepper and spice trade that had built the Zamorin's fortune.</p>
+        </div>
+        <div class="port-highlight-box">
+          <h3>⛵ A Turning Point</h3>
+          <ul>
+            <li><strong>20 May 1498</strong>: Vasco da Gama lands at Kappad, opening a direct sea route from Europe to India.</li>
+            <li><strong>1511–1525</strong>: A Portuguese factory and fort operate at Kozhikode before falling to the Zamorin's forces.</li>
+            <li><strong>1615 onward</strong>: English, French and Dutch trading posts follow, each competing for the Malabar spice trade.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="port-section" id="timeline">
+      <div class="port-container">
+        <div class="port-section-header">
+          <span class="port-eyebrow">Milestones</span>
+          <h2>Chronology of Kozhikode Port</h2>
+          <p>Tracing Kozhikode's rise from an early Malabar anchorage to the Zamorin's free-trade capital, and its transformation after 1498.</p>
+        </div>
+
+        <div class="timeline-flow">
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">c. 7th century CE</span>
+              <h3>Early Arab Trade Contact</h3>
+              <p>Arab merchants begin regularly trading along the Malabar coast, laying the foundation for Kozhikode's later rise as an international port.</p>
+            </div>
+          </div>
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">12th–13th century CE</span>
+              <h3>Rise of the Zamorins</h3>
+              <p>The Nediyiruppu Swaroopam establishes Kozhikode as its capital, and the ruler takes the title Samoothiri, or Zamorin.</p>
+            </div>
+          </div>
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">1341–1343 CE</span>
+              <h3>Ibn Battuta's Visit</h3>
+              <p>The Moroccan traveller Ibn Battuta visits Calicut and describes it as a major and prosperous port of the Malabar coast.</p>
+            </div>
+          </div>
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">1405–1433 CE</span>
+              <h3>Zheng He's Voyages</h3>
+              <p>The Ming Chinese admiral Zheng He calls at Calicut on several of his treasure-fleet voyages, exchanging goods with the Zamorin's court.</p>
+            </div>
+          </div>
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">20 May 1498</span>
+              <h3>Vasco da Gama Lands at Kappad</h3>
+              <p>The Portuguese navigator's arrival opens the first direct sea route between Europe and India, ending Arab and Venetian control of the spice route.</p>
+            </div>
+          </div>
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">1511–1525 CE</span>
+              <h3>Portuguese Factory and Fall</h3>
+              <p>A Portuguese trading factory and fort operate at Kozhikode until they fall to the Zamorin's forces in 1525.</p>
+            </div>
+          </div>
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">17th–18th century CE</span>
+              <h3>English, French &amp; Dutch Trading Posts</h3>
+              <p>Rival European companies establish trading posts along the Malabar coast, competing for control of the pepper and spice trade.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="port-section" id="gallery">
+      <div class="port-container">
+        <div class="port-section-header">
+          <span class="port-eyebrow">Visual Tour</span>
+          <h2>The Shore, the Court &amp; the Trade of Kozhikode</h2>
+          <p>Illustrated impressions of the port's coastline, the Zamorin's court, and the spices and cloth that passed through it.</p>
+        </div>
+
+        <div class="kozhikode-gallery-grid">
+          <div class="kozhikode-gallery-item" data-title="Kappad Coastline" data-desc="A stylised view of the Malabar coastline near Kappad, with trading dhows at anchor — the shore where Vasco da Gama landed in 1498.">
+            <img src="../assets/kozhikode_port_banner.svg" alt="Illustrated Kappad coastline with sailing dhows" loading="lazy">
+            <div class="kozhikode-gallery-overlay">
+              <h4>Kappad Coastline</h4>
+              <p>Where the sea route from Europe arrived</p>
+            </div>
+          </div>
+          <div class="kozhikode-gallery-item" data-title="The Zamorin's Court" data-desc="A stylised depiction of the Zamorin's palace and court, where foreign envoys such as Ibn Battuta and Ma Huan were received.">
+            <img src="../assets/kozhikode_zamorin_court.svg" alt="Illustrated Zamorin's palace court with pillars and throne" loading="lazy">
+            <div class="kozhikode-gallery-overlay">
+              <h4>The Zamorin's Court</h4>
+              <p>Samoothiri — Lord of the Sea and Mountains</p>
+            </div>
+          </div>
+          <div class="kozhikode-gallery-item" data-title="Pepper &amp; Spice Sacks" data-desc="An illustrated impression of the pepper, ginger and cardamom sacks that made Kozhikode the medieval world's leading spice port.">
+            <img src="../assets/kozhikode_spice_trade.svg" alt="Illustrated sacks of pepper and spices at the port" loading="lazy">
+            <div class="kozhikode-gallery-overlay">
+              <h4>Spice Trade</h4>
+              <p>Pepper, ginger &amp; cinnamon exports</p>
+            </div>
+          </div>
+          <div class="kozhikode-gallery-item" data-title="Calico Weaving" data-desc="A stylised impression of the fine hand-woven cotton cloth exported from Kozhikode, which gave the world the word 'calico.'">
+            <img src="../assets/kozhikode_calico_weaving.svg" alt="Illustrated loom weaving calico cotton cloth" loading="lazy">
+            <div class="kozhikode-gallery-overlay">
+              <h4>Calico Weaving</h4>
+              <p>The cloth that named itself after the port</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="port-section" id="references">
+      <div class="port-container">
+        <div class="port-references">
+          <h3>📚 References &amp; Further Reading</h3>
+          <ul>
+            <li><strong>Ibn Battuta (trans. Gibb, H. A. R., 1929)</strong>. <em>Travels in Asia and Africa, 1325–1354</em>. Routledge.</li>
+            <li><strong>Ma Huan (trans. Mills, J. V. G., 1970)</strong>. <em>Ying-yai Sheng-lan: The Overall Survey of the Ocean's Shores</em>. Hakluyt Society, Cambridge University Press.</li>
+            <li><strong>Subrahmanyam, Sanjay (1997)</strong>. <em>The Career and Legend of Vasco da Gama</em>. Cambridge University Press.</li>
+            <li><strong>Panikkar, K. M. (1929)</strong>. <em>Malabar and the Portuguese</em>. Voice of India.</li>
+            <li><strong>Kozhikode District Administration</strong>. <em>History of Kozhikode</em>. Government of Kerala.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <div class="kozhikode-modal" id="kozhikode-modal" role="dialog" aria-modal="true" aria-labelledby="kozhikode-modal-title" aria-hidden="true">
+    <div class="kozhikode-modal-card">
+      <button class="kozhikode-modal-close" id="kozhikode-modal-close" type="button" aria-label="Close details">✕</button>
+      <span class="kozhikode-modal-category" id="kozhikode-modal-category">Gallery Highlight</span>
+      <img class="kozhikode-modal-image" id="kozhikode-modal-image" alt="">
+      <h2 id="kozhikode-modal-title"></h2>
+      <p class="kozhikode-modal-location" id="kozhikode-modal-heading"></p>
+      <div class="kozhikode-modal-divider">
+        <p class="kozhikode-modal-description" id="kozhikode-modal-description"></p>
+      </div>
+    </div>
+  </div>
+
+  <footer class="port-footer">
+    <div class="port-container">
+      <p>Part of <a href="../../index.html">Incredible India Explorer</a> · Explore Kerala's Malabar Coast and the Zamorin's spice and calico trade networks.</p>
+    </div>
+  </footer>
+
+  <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+
+  <script src="../app.js" defer></script>
+  <script src="../../frontend/journey/journey.js" defer></script>
+  <script src="script.js" defer></script>
+  <script type="module" src="../firebase-config.js"></script>
+  <script type="module" src="../auth.js"></script>
+  <script src="../router.js" defer></script>
+  <script src="../js-modules/page-progress/page-progress.js"></script>
+</body>
+</html>

--- a/frontend/kozhikode-port-explorer/script.js
+++ b/frontend/kozhikode-port-explorer/script.js
@@ -1,0 +1,118 @@
+// ===== Kozhikode (Calicut) Port Explorer — Page Script =====
+
+document.addEventListener('DOMContentLoaded', function () {
+
+  // ---------- Gallery Modal ----------
+  const modal = document.getElementById('kozhikode-modal');
+  const modalClose = document.getElementById('kozhikode-modal-close');
+  const modalImage = document.getElementById('kozhikode-modal-image');
+  const modalTitle = document.getElementById('kozhikode-modal-title');
+  const modalCategory = document.getElementById('kozhikode-modal-category');
+  const modalHeading = document.getElementById('kozhikode-modal-heading');
+  const modalDescription = document.getElementById('kozhikode-modal-description');
+  const galleryItems = document.querySelectorAll('.kozhikode-gallery-item');
+
+  function openModal(item) {
+    const image = item.querySelector('img');
+    const title = item.getAttribute('data-title') || '';
+    const desc = item.getAttribute('data-desc') || '';
+
+    if (image && modalImage) {
+      modalImage.src = image.currentSrc || image.src;
+      modalImage.alt = image.alt;
+    }
+
+    modalTitle.textContent = title;
+    modalCategory.textContent = 'Gallery Highlight';
+    modalHeading.textContent = 'Kozhikode Ancient Port';
+    modalDescription.textContent = desc;
+
+    modal.classList.add('active');
+    modal.setAttribute('aria-hidden', 'false');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeModal() {
+    modal.classList.remove('active');
+    modal.setAttribute('aria-hidden', 'true');
+    document.body.style.overflow = '';
+  }
+
+  galleryItems.forEach(function (item) {
+    item.addEventListener('click', function () {
+      openModal(item);
+    });
+    item.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openModal(item);
+      }
+    });
+    item.setAttribute('tabindex', '0');
+    item.setAttribute('role', 'button');
+  });
+
+  if (modalClose) {
+    modalClose.addEventListener('click', closeModal);
+  }
+
+  if (modal) {
+    modal.addEventListener('click', function (e) {
+      if (e.target === modal) closeModal();
+    });
+  }
+
+  document.addEventListener('keydown', function (e) {
+    if (modal && e.key === 'Escape' && modal.classList.contains('active')) {
+      closeModal();
+    }
+  });
+
+  // ---------- Bookmark Button (Journey integration) ----------
+  // NOTE: same assumption as the Motupalli page — Journey.toggle(id, title, thumbnail)
+  // and Journey.isSaved(id) are assumed based on CodeRabbit's review of that PR.
+  // Please share frontend/journey/journey.js so this can be verified/corrected.
+  const bookmarkBtn = document.querySelector('.journey-bookmark-btn[data-bookmark-id="kozhikode-port-main"]');
+
+  if (bookmarkBtn) {
+    const bookmarkId = bookmarkBtn.getAttribute('data-bookmark-id');
+    const bookmarkTitle = 'Kozhikode Ancient Port';
+    const bookmarkThumbnail = '../assets/kozhikode_port_banner.svg';
+
+    function refreshButtonState() {
+      let isSaved = false;
+      if (typeof Journey !== 'undefined' && typeof Journey.isSaved === 'function') {
+        isSaved = Journey.isSaved(bookmarkId);
+      }
+      bookmarkBtn.setAttribute('aria-pressed', isSaved ? 'true' : 'false');
+      bookmarkBtn.textContent = isSaved ? '♥ Saved to Journey' : '♡ Save to Journey';
+    }
+
+    bookmarkBtn.addEventListener('click', function () {
+      if (typeof Journey === 'undefined' || typeof Journey.toggle !== 'function') {
+        console.warn('Journey.toggle() not found — journey.js may not be loaded before script.js, or the shared API differs from what was assumed.');
+        return;
+      }
+      Journey.toggle(bookmarkId, bookmarkTitle, bookmarkThumbnail);
+      refreshButtonState();
+    });
+
+    refreshButtonState();
+  }
+
+  // ---------- Scroll to top button ----------
+  const scrollTopBtn = document.getElementById('btn-scroll-top');
+  if (scrollTopBtn) {
+    function syncScrollTopVisibility() {
+      scrollTopBtn.classList.toggle('visible', window.scrollY > 400);
+    }
+
+    window.addEventListener('scroll', syncScrollTopVisibility);
+    syncScrollTopVisibility();
+
+    scrollTopBtn.addEventListener('click', function () {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  }
+
+});

--- a/frontend/kozhikode-port-explorer/style.css
+++ b/frontend/kozhikode-port-explorer/style.css
@@ -1,0 +1,480 @@
+/* ===== Kozhikode (Calicut) Port Explorer — Page Styles ===== */
+
+:root {
+  --port-navy: #0a1930;
+  --port-gold: #d4952f;
+  --port-gold-light: #f0c674;
+  --port-teal: #0e5c5c;
+}
+
+.port-main {
+  background: #050d1c;
+  color: #f5f0e6;
+}
+.port-section {
+  background: #050d1c;
+}
+
+/* ---------- Hero ---------- */
+.port-hero {
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 140px 24px 80px;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(212, 149, 47, 0.15), transparent 60%),
+    radial-gradient(circle at 80% 80%, rgba(14, 92, 92, 0.25), transparent 60%),
+    #050d1c;
+}
+
+.port-hero-content {
+  max-width: 760px;
+}
+
+.port-kicker {
+  display: inline-block;
+  font-size: 0.85rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--port-gold-light);
+  background: rgba(212, 149, 47, 0.1);
+  border: 1px solid rgba(212, 149, 47, 0.3);
+  padding: 6px 16px;
+  border-radius: 999px;
+  margin-bottom: 20px;
+}
+
+.port-hero h1 {
+  font-family: "Playfair Display", serif;
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  line-height: 1.15;
+  margin: 0 0 18px;
+  color: #f5f0e6;
+}
+
+.port-hero h1 span {
+  color: var(--port-gold);
+  font-style: italic;
+}
+
+.port-hero p {
+  font-size: 1.05rem;
+  line-height: 1.7;
+  opacity: 0.85;
+  margin: 0 auto 28px;
+}
+
+.port-bookmark-btn {
+  font-family: inherit;
+  font-size: 0.95rem;
+  padding: 10px 22px;
+  border-radius: 999px;
+  border: 1px solid var(--port-gold);
+  background: transparent;
+  color: var(--port-gold-light);
+  cursor: pointer;
+  transition: all 0.25s ease;
+}
+
+.port-bookmark-btn:hover {
+  background: var(--port-gold);
+  color: #1a0f00;
+}
+
+.port-bookmark-btn[aria-pressed="true"] {
+  background: var(--port-gold);
+  color: #1a0f00;
+}
+
+/* ---------- Sections ---------- */
+.port-section {
+  padding: 70px 24px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.port-container {
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+.port-section-header {
+  text-align: center;
+  max-width: 620px;
+  margin: 0 auto 44px;
+}
+
+.port-eyebrow {
+  display: block;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #4fd1c5;
+  margin-bottom: 10px;
+}
+
+.port-section-header h2,
+.port-text-block h2 {
+  font-family: "Playfair Display", serif;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  margin: 0 0 14px;
+  color: #f5f0e6;
+}
+
+.port-section-header p,
+.port-text-block p {
+  line-height: 1.75;
+  opacity: 0.85;
+  margin: 0 0 14px;
+}
+
+/* ---------- Two-column grid ---------- */
+.port-grid-2col {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 48px;
+  align-items: start;
+}
+
+@media (max-width: 800px) {
+  .port-grid-2col {
+    grid-template-columns: 1fr;
+  }
+}
+
+.port-highlight-box {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 28px;
+}
+
+.port-highlight-box h3 {
+  margin: 0 0 16px;
+  font-size: 1.15rem;
+  color: #f5f0e6;
+}
+
+.port-highlight-box ul {
+  margin: 0;
+  padding-left: 20px;
+  line-height: 1.9;
+}
+
+/* ---------- Card grid ---------- */
+.port-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+
+@media (max-width: 800px) {
+  .port-card-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.port-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 26px;
+  text-align: left;
+  transition: transform 0.25s ease, border-color 0.25s ease;
+}
+
+.port-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(212, 149, 47, 0.4);
+}
+
+.port-card-icon {
+  font-size: 1.8rem;
+  display: block;
+  margin-bottom: 12px;
+}
+
+.port-card h3 {
+  margin: 0 0 8px;
+  font-size: 1.05rem;
+  color: #f5f0e6;
+}
+
+.port-card p {
+  margin: 0;
+  line-height: 1.6;
+  opacity: 0.8;
+  font-size: 0.95rem;
+}
+
+/* ---------- Timeline ---------- */
+.timeline-flow {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  padding-left: 30px;
+  border-left: 2px solid rgba(212, 149, 47, 0.3);
+}
+
+.timeline-step {
+  position: relative;
+}
+
+.timeline-step-marker {
+  position: absolute;
+  left: -37px;
+  top: 4px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--port-gold);
+  box-shadow: 0 0 0 4px rgba(212, 149, 47, 0.15);
+}
+
+.timeline-step-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 14px;
+  padding: 18px 22px;
+}
+
+.timeline-step-year {
+  display: inline-block;
+  font-size: 0.8rem;
+  color: var(--port-gold-light);
+  margin-bottom: 6px;
+  font-weight: 600;
+}
+
+.timeline-step-card h3 {
+  margin: 0 0 6px;
+  font-size: 1.05rem;
+  color: #f5f0e6;
+}
+
+.timeline-step-card p {
+  margin: 0;
+  line-height: 1.6;
+  opacity: 0.8;
+  font-size: 0.95rem;
+}
+
+/* ---------- Gallery (unique names — no collisions with global site CSS) ---------- */
+.kozhikode-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 18px;
+}
+
+@media (max-width: 900px) {
+  .kozhikode-gallery-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.kozhikode-gallery-item {
+  position: relative;
+  border-radius: 14px;
+  overflow: hidden;
+  cursor: pointer;
+  aspect-ratio: 1 / 1;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: #0a1930;
+}
+
+.kozhikode-gallery-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.4s ease;
+}
+
+.kozhikode-gallery-item:hover img {
+  transform: scale(1.06);
+}
+
+.kozhikode-gallery-overlay {
+  position: absolute;
+  inset: auto 0 0 0;
+  background: linear-gradient(0deg, rgba(0,0,0,0.85) 40%, transparent);
+  padding: 14px;
+  pointer-events: none;
+}
+
+.kozhikode-gallery-overlay h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #ffffff;
+}
+
+.kozhikode-gallery-overlay p {
+  margin: 2px 0 0;
+  font-size: 0.8rem;
+  opacity: 0.85;
+  color: #f5f0e6;
+}
+
+/* ---------- References ---------- */
+.port-references {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 28px;
+}
+
+.port-references h3 {
+  margin: 0 0 14px;
+  color: #f5f0e6;
+}
+
+.port-references ul {
+  margin: 0;
+  padding-left: 20px;
+  line-height: 1.9;
+  font-size: 0.92rem;
+  opacity: 0.85;
+}
+
+/* ---------- Footer ---------- */
+.port-footer {
+  padding: 30px 24px;
+  text-align: center;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  font-size: 0.9rem;
+  opacity: 0.7;
+  background: #050d1c;
+}
+
+.port-footer a {
+  color: var(--port-gold-light);
+}
+
+/* ---------- Kozhikode Modal (self-contained, unique names) ---------- */
+.kozhikode-modal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  z-index: 999;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.kozhikode-modal.active {
+  display: flex;
+}
+
+.kozhikode-modal-card {
+  position: relative;
+  background: #0a1930;
+  border: 1px solid rgba(212, 149, 47, 0.3);
+  border-radius: 16px;
+  padding: 32px;
+  max-width: 480px;
+  width: 100%;
+  color: #f5f0e6;
+}
+
+.kozhikode-modal-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  background: transparent;
+  border: none;
+  color: #f5f0e6;
+  font-size: 1.2rem;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.kozhikode-modal-category {
+  display: inline-block;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--port-gold-light);
+  margin-bottom: 10px;
+}
+
+.kozhikode-modal-image {
+  display: block;
+  width: 100%;
+  max-height: min(55vh, 360px);
+  margin: 0 0 18px;
+  border-radius: 10px;
+  object-fit: contain;
+}
+
+.kozhikode-modal-card h2 {
+  margin: 0 0 6px;
+  font-family: "Playfair Display", serif;
+  font-size: 1.4rem;
+}
+
+.kozhikode-modal-location {
+  color: var(--port-gold-light);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.kozhikode-modal-divider {
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  margin-top: 15px;
+  padding-top: 15px;
+}
+
+.kozhikode-modal-description {
+  margin: 0;
+  line-height: 1.7;
+  opacity: 0.9;
+}
+
+/* ---------- Scroll to top button ---------- */
+.btn-scroll-top {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid rgba(212, 149, 47, 0.4);
+  background: #0a1930;
+  color: var(--port-gold-light);
+  font-size: 1.2rem;
+  cursor: pointer;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.25s ease, visibility 0.25s ease;
+  z-index: 90;
+}
+
+.btn-scroll-top.visible {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* ---------- Light theme overrides: force this page to stay dark ---------- */
+body.light-theme .port-main,
+body.light-theme .port-hero,
+body.light-theme .port-section,
+body.light-theme .port-footer {
+  background: #050d1c !important;
+  color: #f5f0e6 !important;
+}
+
+body.light-theme .port-card,
+body.light-theme .port-highlight-box,
+body.light-theme .timeline-step-card,
+body.light-theme .port-references {
+  background: rgba(255, 255, 255, 0.04) !important;
+  border-color: rgba(255, 255, 255, 0.1) !important;
+  color: #f5f0e6 !important;
+}
+
+body.light-theme .kozhikode-gallery-item {
+  background: #0a1930 !important;
+}


### PR DESCRIPTION


## Description
Adds a dedicated explorer page for Kozhikode (Calicut), the Zamorin dynasty's free-trade emporium on Kerala's Malabar Coast — a port that welcomed Arab, Chinese, Persian and later European merchants, and whose cotton exports gave the world the word "calico."

## Changes
- Created `frontend/kozhikode-port-explorer/index.html` with:
  - Historical overview (Arab trade contact from the 7th century, rise of the Zamorins)
  - Maritime and trade significance (pepper, ginger, cardamom, calico cotton)
  - Dedicated section on the Zamorins and foreign travellers (Ibn Battuta, Zheng He/Ma Huan)
  - Section on Vasco da Gama's 1498 landing and the colonial-era trading posts
  - Chronology timeline (7th century to 18th century CE)
  - Image gallery with modal viewer
  - References and further reading
- Added `style.css` and `script.js` for page-specific styling and interactivity
- Added 4 custom SVG illustrations in `frontend/assets/`
- Added Kozhikode link to the port explorer navigation dropdown (also added the previously-missing Karaikal link)

## Requirements fulfilled
- [x] Historical overview
- [x] Spice trade history
- [x] International trade connections
- [x] Timeline
- [x] Gallery
- [x] References
- [x] Proper navigation
- [x] Responsive UI
- [ ] Landing page card — pending, needs the landing page file to add consistently with other port cards

## Screenshots
<img width="1440" height="852" alt="Screenshot 2026-08-04 133419" src="https://github.com/user-attachments/assets/a8af295d-962b-4361-a6dd-2303c17327d1" />
<img width="1440" height="852" alt="Screenshot 2026-08-04 133424" src="https://github.com/user-attachments/assets/84aa043d-1019-4425-b3e5-e94a11c29c52" />

<img width="1440" height="852" alt="Screenshot 2026-08-04 133413" src="https://github.com/user-attachments/assets/52b02d0e-b11e-4af2-a973-0c23449768dc" />

Closes #1417