### PR TITLE
feat: Add Nanda Dynasty Explorer page

### DIFF
--- a/frontend/assets/nanda_army_alexander.svg
+++ b/frontend/assets/nanda_army_alexander.svg
@@ -1,0 +1,36 @@
+<svg viewBox="0 0 800 500" xmlns="http://www.w3.org/2000/svg">
+  <rect width="800" height="500" fill="#0a1930"/>
+  <!-- river Hyphasis/Beas -->
+  <path d="M0 260 Q200 240 400 265 T800 250 V500 H0 Z" fill="#0e5c5c" opacity="0.45"/>
+  <rect y="430" width="800" height="70" fill="#050d1c"/>
+  <!-- elephants (silhouette) representing the Nanda war-elephant corps -->
+  <g fill="#0e5c5c" opacity="0.85">
+    <ellipse cx="200" cy="380" rx="55" ry="34"/>
+    <ellipse cx="200" cy="345" rx="26" ry="24"/>
+    <path d="M180 350 Q165 375 175 400" stroke="#0e5c5c" stroke-width="8" fill="none"/>
+    <rect x="160" y="405" width="10" height="30"/>
+    <rect x="230" y="405" width="10" height="30"/>
+  </g>
+  <g fill="#0e5c5c" opacity="0.85">
+    <ellipse cx="400" cy="390" rx="60" ry="36"/>
+    <ellipse cx="400" cy="352" rx="28" ry="26"/>
+    <path d="M378 358 Q362 384 373 410" stroke="#0e5c5c" stroke-width="9" fill="none"/>
+    <rect x="356" y="414" width="11" height="32"/>
+    <rect x="432" y="414" width="11" height="32"/>
+  </g>
+  <g fill="#0e5c5c" opacity="0.85">
+    <ellipse cx="610" cy="380" rx="55" ry="34"/>
+    <ellipse cx="610" cy="345" rx="26" ry="24"/>
+    <path d="M590 350 Q575 375 585 400" stroke="#0e5c5c" stroke-width="8" fill="none"/>
+    <rect x="570" y="405" width="10" height="30"/>
+    <rect x="640" y="405" width="10" height="30"/>
+  </g>
+  <!-- howdah / banners on elephants -->
+  <g fill="#d4952f" opacity="0.9">
+    <rect x="188" y="320" width="24" height="16" rx="2"/>
+    <rect x="386" y="326" width="28" height="18" rx="2"/>
+    <rect x="598" y="320" width="24" height="16" rx="2"/>
+  </g>
+  <!-- sun -->
+  <circle cx="700" cy="90" r="45" fill="#d4952f" opacity="0.8"/>
+</svg>

--- a/frontend/assets/nanda_mahapadma_conquest.svg
+++ b/frontend/assets/nanda_mahapadma_conquest.svg
@@ -1,0 +1,38 @@
+<svg viewBox="0 0 800 500" xmlns="http://www.w3.org/2000/svg">
+  <rect width="800" height="500" fill="#0a1930"/>
+  <rect width="800" height="500" fill="url(#g)"/>
+  <defs>
+    <radialGradient id="g" cx="50%" cy="30%" r="70%">
+      <stop offset="0%" stop-color="#d4952f" stop-opacity="0.16"/>
+      <stop offset="100%" stop-color="#0a1930" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <!-- throne dais -->
+  <rect x="320" y="330" width="160" height="100" rx="6" fill="#0e5c5c" stroke="#f0c674" stroke-width="1.5"/>
+  <path d="M345 330 L345 250 Q400 215 455 250 L455 330 Z" fill="#d4952f" opacity="0.9" stroke="#f0c674" stroke-width="1.5"/>
+  <circle cx="400" cy="290" r="18" fill="#f5f0e6" opacity="0.9"/>
+  <!-- crown -->
+  <path d="M388 262 L392 250 L400 260 L408 250 L412 262 Z" fill="#f0c674"/>
+  <!-- expanding territory arrows -->
+  <g stroke="#f0c674" stroke-width="2.5" opacity="0.55" fill="none">
+    <path d="M400 300 L250 200" marker-end="url(#arrow)"/>
+    <path d="M400 300 L560 190" marker-end="url(#arrow)"/>
+    <path d="M400 300 L230 380" marker-end="url(#arrow)"/>
+    <path d="M400 300 L580 400" marker-end="url(#arrow)"/>
+  </g>
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#f0c674" opacity="0.6"/>
+    </marker>
+  </defs>
+  <!-- treasury coins -->
+  <g fill="#d4952f" opacity="0.85">
+    <circle cx="180" cy="420" r="14"/>
+    <circle cx="205" cy="425" r="14"/>
+    <circle cx="230" cy="418" r="14"/>
+    <circle cx="600" cy="425" r="14"/>
+    <circle cx="625" cy="418" r="14"/>
+    <circle cx="575" cy="418" r="14"/>
+  </g>
+  <rect y="450" width="800" height="50" fill="#050d1c"/>
+</svg>

--- a/frontend/assets/nanda_pataliputra_banner.svg
+++ b/frontend/assets/nanda_pataliputra_banner.svg
@@ -1,0 +1,45 @@
+<svg viewBox="0 0 800 500" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="sky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0a1930"/>
+      <stop offset="100%" stop-color="#0e5c5c"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="500" fill="url(#sky)"/>
+  <circle cx="640" cy="110" r="65" fill="#d4952f" opacity="0.85"/>
+  <circle cx="640" cy="110" r="95" fill="#f0c674" opacity="0.12"/>
+  <!-- river Ganges -->
+  <path d="M0 380 Q200 360 400 385 T800 375 V500 H0 Z" fill="#0e5c5c" opacity="0.5"/>
+  <rect y="410" width="800" height="90" fill="#050d1c"/>
+  <!-- city ramparts of Pataliputra -->
+  <g fill="#0a1930" stroke="#f0c674" stroke-width="1.5">
+    <rect x="90" y="300" width="620" height="110"/>
+  </g>
+  <g fill="#0a1930" stroke="#f0c674" stroke-width="1.2">
+    <rect x="90" y="280" width="24" height="24"/>
+    <rect x="150" y="280" width="24" height="24"/>
+    <rect x="210" y="280" width="24" height="24"/>
+    <rect x="270" y="280" width="24" height="24"/>
+    <rect x="330" y="280" width="24" height="24"/>
+    <rect x="390" y="280" width="24" height="24"/>
+    <rect x="450" y="280" width="24" height="24"/>
+    <rect x="510" y="280" width="24" height="24"/>
+    <rect x="570" y="280" width="24" height="24"/>
+    <rect x="630" y="280" width="24" height="24"/>
+    <rect x="686" y="280" width="24" height="24"/>
+  </g>
+  <!-- watchtowers -->
+  <g fill="#0e5c5c" stroke="#f0c674" stroke-width="1.5">
+    <rect x="150" y="230" width="30" height="90"/>
+    <rect x="385" y="210" width="34" height="110"/>
+    <rect x="620" y="230" width="30" height="90"/>
+  </g>
+  <g fill="#0a1930">
+    <rect x="145" y="222" width="8" height="10"/>
+    <rect x="167" y="222" width="8" height="10"/>
+    <rect x="380" y="202" width="8" height="10"/>
+    <rect x="405" y="202" width="8" height="10"/>
+    <rect x="615" y="222" width="8" height="10"/>
+    <rect x="637" y="222" width="8" height="10"/>
+  </g>
+</svg>

--- a/frontend/assets/nanda_treasury_administration.svg
+++ b/frontend/assets/nanda_treasury_administration.svg
@@ -1,0 +1,29 @@
+<svg viewBox="0 0 800 500" xmlns="http://www.w3.org/2000/svg">
+  <rect width="800" height="500" fill="#0a1930"/>
+  <!-- stacked treasury coins/ingots -->
+  <g fill="#d4952f" opacity="0.9">
+    <rect x="140" y="330" width="120" height="26" rx="4"/>
+    <rect x="150" y="304" width="100" height="26" rx="4"/>
+    <rect x="160" y="278" width="80" height="26" rx="4"/>
+    <rect x="170" y="252" width="60" height="26" rx="4"/>
+  </g>
+  <g fill="#f0c674" opacity="0.9">
+    <rect x="340" y="350" width="120" height="26" rx="4"/>
+    <rect x="350" y="324" width="100" height="26" rx="4"/>
+    <rect x="360" y="298" width="80" height="26" rx="4"/>
+    <rect x="370" y="272" width="60" height="26" rx="4"/>
+    <rect x="380" y="246" width="40" height="26" rx="4"/>
+  </g>
+  <g fill="#0e5c5c" opacity="0.9" stroke="#f0c674" stroke-width="1">
+    <rect x="540" y="330" width="120" height="26" rx="4"/>
+    <rect x="550" y="304" width="100" height="26" rx="4"/>
+    <rect x="560" y="278" width="80" height="26" rx="4"/>
+    <rect x="570" y="252" width="60" height="26" rx="4"/>
+  </g>
+  <!-- ledger / scroll suggesting taxation records -->
+  <rect x="330" y="400" width="140" height="18" rx="8" fill="#0a1930" stroke="#f0c674" stroke-width="1.5"/>
+  <g stroke="#f0c674" stroke-width="1" opacity="0.5">
+    <line x1="345" y1="409" x2="455" y2="409"/>
+  </g>
+  <rect y="430" width="800" height="70" fill="#050d1c"/>
+</svg>

--- a/frontend/nanda-dynasty-explorer/index.html
+++ b/frontend/nanda-dynasty-explorer/index.html
@@ -1,0 +1,336 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore the Nanda Dynasty of Magadha: Mahapadma Nanda's rise, the empire's vast army and treasury, its administrative innovations, and its fall to Chandragupta Maurya.">
+  <title>Nanda Dynasty Explorer | Incredible India</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="../js-modules/page-progress/page-progress.css">
+
+  <meta property="og:title" content="Nanda Dynasty Explorer | Incredible India Explorer">
+  <meta property="og:description" content="Discover the Nanda Dynasty of Magadha, the empire that preceded the Mauryas, its vast army and treasury, and its administrative innovations.">
+  <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/frontend/assets/nanda_pataliputra_banner.svg">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/nanda-dynasty-explorer/index.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Incredible India Explorer">
+  <meta property="og:locale" content="en_IN">
+
+  <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/nanda-dynasty-explorer/index.html">
+</head>
+<body>
+  <script>
+    (function() {
+      const theme = localStorage.getItem('theme') || 'dark';
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+
+  <header class="navbar scrolled" id="navbar">
+    <div class="nav-container">
+      <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+        <span class="saffron">Incredible</span><span class="gold">India</span><span class="green">Explorer</span>
+      </a>
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+        <span class="bar"></span><span class="bar"></span><span class="bar"></span>
+      </button>
+      <nav class="nav-menu" id="nav-menu">
+        <a href="../../index.html#home" class="nav-link" id="link-home">Home</a>
+        <a href="../../index.html#map" class="nav-link" id="link-map">Interactive Map</a>
+        <a href="../../frontend/cuisine/cuisine.html" class="nav-link" id="link-cuisine">Cuisine</a>
+        <a href="../../frontend/festivals/festivals.html" class="nav-link" id="link-festivals">Festivals</a>
+        <a href="../../frontend/culture/culture.html" class="nav-link" id="link-culture">Culture</a>
+        <div class="nav-dropdown">
+          <button class="nav-link dropdown-toggle" id="link-explore-more" style="color: var(--saffron)">Explore More ▾</button>
+          <div class="dropdown-menu">
+            <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+            <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+            <a href="../../frontend/personalities/personalities.html" class="dropdown-item">Famous Personalities</a>
+            <a href="../../frontend/spiritual/spiritual.html" class="dropdown-item">Spiritual India</a>
+            <a href="../../frontend/arts-crafts/arts-crafts.html" class="dropdown-item">Arts & Crafts</a>
+            <a href="../../frontend/museums/museums.html" class="dropdown-item">Museums</a>
+            <a href="../chandela-dynasty-explorer/index.html" class="dropdown-item">Chandela Dynasty</a>
+            <a href="index.html" class="dropdown-item" style="color: var(--saffron)">Nanda Dynasty</a>
+          </div>
+        </div>
+        <div class="nav-dropdown">
+          <button class="nav-link dropdown-toggle" id="link-learn-data">Learn & Data ▾</button>
+          <div class="dropdown-menu">
+            <a href="../../frontend/smart-cities/smart-cities.html" class="dropdown-item">Smart Cities</a>
+            <a href="../../frontend/languages/languages.html" class="dropdown-item">Languages of India</a>
+            <a href="../../frontend/data-india/data-india.html" class="dropdown-item">Data & Statistics</a>
+            <a href="../../frontend/learn/learn.html" class="dropdown-item">Learn & Quiz</a>
+          </div>
+        </div>
+        <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">☀️</button>
+        <div class="journey-nav-search">
+          <input type="search" id="journey-search-input" class="journey-search-input" placeholder="Search all explorers…" aria-label="Search across all explorers" autocomplete="off">
+          <div id="journey-search-results" class="journey-search-results" hidden></div>
+        </div>
+        <a href="../../frontend/journey/journey.html" class="nav-link" id="link-journey">🧭 My Journey</a>
+        <a href="../../frontend/premium/premium.html" class="nav-link premium-link">★ Premium</a>
+        <a href="../login.html" class="nav-link" id="link-login">Login</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="app-root" class="nanda-main">
+
+    <section class="nanda-hero">
+      <div class="nanda-hero-content">
+        <span class="nanda-kicker">👑 Magadha · Pataliputra, Modern-Day Bihar</span>
+        <h1>Nanda Dynasty <span>Explorer</span></h1>
+        <p>Step into the empire that ruled Magadha before the Mauryas — a dynasty of low-caste origin that raised the largest army in the Indian subcontinent, filled the treasury of Pataliputra, and made even Alexander the Great's soldiers refuse to march further.</p>
+        <div class="nanda-bookmark-container">
+          <button class="nanda-bookmark-btn journey-bookmark-btn" type="button" data-bookmark-id="nanda-dynasty-main" aria-pressed="false" aria-label="Bookmark Nanda Dynasty">
+            ♡ Save to Journey
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <section class="nanda-section" id="overview">
+      <div class="nanda-container nanda-grid-2col">
+        <div class="nanda-text-block">
+          <span class="nanda-eyebrow">From Shishunaga Vassals to Sole Rulers</span>
+          <h2>The First Great Empire of Magadha</h2>
+          <p>The Nanda dynasty ruled the kingdom of Magadha in eastern India for roughly two to three decades in the mid-to-late 4th century BCE, with its capital at Pataliputra, near present-day Patna. It came to power after overthrowing the ruling Shishunaga dynasty, and is remembered as the first dynasty to weld a large part of northern India into a single, centrally administered empire.</p>
+          <p>Puranic tradition holds that the dynasty's founder, Mahapadma Nanda, was the son of the last Shishunaga king and a woman of low social standing — Jain sources and the Greek historian Curtius go further, describing his father as a barber. Whatever the exact truth, ancient texts agree that the Nandas rose from outside the traditional Kshatriya ruling class, which made their conquests all the more remarkable, and earned Mahapadma the title "Sarva-Kshatriyantaka," destroyer of Kshatriyas.</p>
+        </div>
+        <div class="nanda-highlight-box">
+          <h3>📜 At a Glance</h3>
+          <ul>
+            <li><strong>Region</strong>: Magadha, with a capital at Pataliputra (modern Patna, Bihar).</li>
+            <li><strong>Founder</strong>: Mahapadma Nanda, c. mid-4th century BCE.</li>
+            <li><strong>Last ruler</strong>: Dhana Nanda, overthrown c. 321 BCE.</li>
+            <li><strong>Known for</strong>: A vast standing army, centralised taxation, and the empire's fall to Chandragupta Maurya.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="nanda-section" id="rulers">
+      <div class="nanda-container">
+        <div class="nanda-section-header">
+          <span class="nanda-eyebrow">Nine Kings in a Single Line</span>
+          <h2>Major Rulers of the Nanda Dynasty</h2>
+          <p>Ancient sources disagree on the exact number and names of Nanda kings, but Buddhist, Jain and Puranic traditions together describe a short but dominant dynasty bookended by two towering figures.</p>
+        </div>
+
+        <div class="nanda-card-grid">
+          <div class="nanda-card">
+            <span class="nanda-card-icon">🏹</span>
+            <h3>Mahapadma Nanda</h3>
+            <p>The dynasty's founder overthrew the Shishunaga rulers of Magadha and expanded his territory from the Kuru region in the northwest to the Godavari valley in the south, reportedly ruling for around 28 years and unifying much of northern India for the first time.</p>
+          </div>
+          <div class="nanda-card">
+            <span class="nanda-card-icon">👑</span>
+            <h3>The Later Nandas</h3>
+            <p>Buddhist tradition names eight successors after Mahapadma, sometimes called the "Nava Nandas" (nine Nandas) collectively. Their individual reigns are only sketchily recorded, but Puranic and Buddhist sources agree the dynasty as a whole lasted a few decades.</p>
+          </div>
+          <div class="nanda-card">
+            <span class="nanda-card-icon">💰</span>
+            <h3>Dhana Nanda</h3>
+            <p>The last Nanda king was renowned even among the Greeks — recorded as "Agrammes" or "Xandrames" — for his immense wealth and an army so large it reportedly discouraged Alexander's own soldiers from advancing on Magadha. He was eventually deposed by Chandragupta Maurya.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="nanda-section" id="army">
+      <div class="nanda-container nanda-grid-2col">
+        <div class="nanda-highlight-box" style="background: rgba(212, 149, 47, 0.06); border-color: rgba(212, 149, 47, 0.22);">
+          <h3>⚔️ The Nanda War Machine</h3>
+          <ul>
+            <li><strong>Infantry</strong>: Greek accounts credit the Nandas with around 200,000 foot soldiers.</li>
+            <li><strong>Cavalry</strong>: An estimated 20,000 to 80,000 horsemen, depending on the source.</li>
+            <li><strong>War elephants</strong>: Between 3,000 and 6,000 elephants, the single most feared element of the army.</li>
+            <li><strong>Chariots</strong>: Roughly 2,000 to 8,000 four-horse war chariots.</li>
+          </ul>
+        </div>
+        <div class="nanda-text-block">
+          <span class="nanda-eyebrow">The Army That Turned Back Alexander</span>
+          <h2>A Deterrent Even to the Greeks</h2>
+          <p>When Alexander the Great's army reached the Hyphasis (the modern Beas River) in 326 BCE after defeating King Porus, his exhausted soldiers mutinied and refused to march further east. Greek historians such as Diodorus, Curtius and Plutarch record that fear of the Nanda and Gangaridai armies — described as fielding tens of thousands of cavalry, hundreds of thousands of infantry, and thousands of war elephants — was a decisive factor in the retreat.</p>
+          <p>Whatever the precise numbers, the episode reflects how formidable the Nanda military reputation had become by the late 4th century BCE, marking the easternmost point Alexander's campaign ever reached in the Indian subcontinent.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="nanda-section" id="legacy">
+      <div class="nanda-container">
+        <div class="nanda-section-header">
+          <span class="nanda-eyebrow">An Administrative Blueprint</span>
+          <h2>Legacy: Governing a Vast Empire</h2>
+          <p>Beyond their army, the Nandas are remembered for building the administrative machinery that later Mauryan rulers inherited and refined.</p>
+        </div>
+
+        <div class="nanda-card-grid">
+          <div class="nanda-card">
+            <span class="nanda-card-icon">🏛️</span>
+            <h3>Centralised Administration</h3>
+            <p>The Nandas built on the administrative foundations of their Haryanka and Shishunaga predecessors, creating a more centralised bureaucracy capable of governing a much larger territory from Pataliputra.</p>
+          </div>
+          <div class="nanda-card">
+            <span class="nanda-card-icon">📊</span>
+            <h3>Systematic Taxation</h3>
+            <p>Ancient sources describe a well-organised system for assessing and collecting taxes, which filled the Nanda treasury with legendary wealth — though it also made the dynasty unpopular with its subjects.</p>
+          </div>
+          <div class="nanda-card">
+            <span class="nanda-card-icon">🪙</span>
+            <h3>A Model for the Mauryas</h3>
+            <p>Many of the Nandas' fiscal and administrative methods were carried forward largely unchanged by the Mauryan Empire, which inherited both the Nanda capital of Pataliputra and much of its governing apparatus.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="nanda-section" id="timeline">
+      <div class="nanda-container">
+        <div class="nanda-section-header">
+          <span class="nanda-eyebrow">Milestones</span>
+          <h2>Chronology of the Nanda Dynasty</h2>
+          <p>Tracing the Nandas from Mahapadma's seizure of Magadha to Dhana Nanda's fall before Chandragupta Maurya.</p>
+        </div>
+
+        <div class="nanda-timeline-flow">
+          <div class="nanda-timeline-step">
+            <div class="nanda-timeline-marker"></div>
+            <div class="nanda-timeline-card">
+              <span class="nanda-timeline-year">c. mid-4th century BCE</span>
+              <h3>Mahapadma Overthrows the Shishunagas</h3>
+              <p>Mahapadma Nanda deposes the last Shishunaga ruler of Magadha and founds the Nanda dynasty at Pataliputra.</p>
+            </div>
+          </div>
+          <div class="nanda-timeline-step">
+            <div class="nanda-timeline-marker"></div>
+            <div class="nanda-timeline-card">
+              <span class="nanda-timeline-year">c. 345–338 BCE</span>
+              <h3>Expansion Across Northern India</h3>
+              <p>Mahapadma's campaigns extend Nanda territory from the Kuru region in the northwest to the Godavari valley in the south, and east to Kalinga.</p>
+            </div>
+          </div>
+          <div class="nanda-timeline-step">
+            <div class="nanda-timeline-marker"></div>
+            <div class="nanda-timeline-card">
+              <span class="nanda-timeline-year">326 BCE</span>
+              <h3>Alexander's Army Halts at the Hyphasis</h3>
+              <p>Fear of the Nanda and Gangaridai armies contributes to the mutiny of Alexander's soldiers at the Beas River, ending his advance into the Gangetic plains.</p>
+            </div>
+          </div>
+          <div class="nanda-timeline-step">
+            <div class="nanda-timeline-marker"></div>
+            <div class="nanda-timeline-card">
+              <span class="nanda-timeline-year">c. 329–321 BCE</span>
+              <h3>Reign of Dhana Nanda</h3>
+              <p>The last Nanda king rules Magadha from Pataliputra, commanding immense wealth and, by Greek accounts, the largest standing army in the region.</p>
+            </div>
+          </div>
+          <div class="nanda-timeline-step">
+            <div class="nanda-timeline-marker"></div>
+            <div class="nanda-timeline-card">
+              <span class="nanda-timeline-year">c. 321 BCE</span>
+              <h3>Fall to Chandragupta Maurya</h3>
+              <p>Chandragupta Maurya, guided by his advisor Chanakya, raises an army that defeats Dhana Nanda and captures Pataliputra, ending Nanda rule and founding the Mauryan Empire.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="nanda-section" id="gallery">
+      <div class="nanda-container">
+        <div class="nanda-section-header">
+          <span class="nanda-eyebrow">Visual Tour</span>
+          <h2>The Capital, Army &amp; Treasury of the Nandas</h2>
+          <p>Illustrated impressions of Pataliputra's fortifications, the Nanda throne, the war-elephant corps, and the empire's legendary wealth.</p>
+        </div>
+
+        <div class="nanda-gallery-grid">
+          <div class="nanda-gallery-item" data-title="Pataliputra's Ramparts" data-desc="A stylised view of the fortified walls and watchtowers of Pataliputra, the Nanda capital on the banks of the Ganges.">
+            <img src="../assets/nanda_pataliputra_banner.svg" alt="Illustrated fortified walls of Pataliputra" loading="lazy">
+            <div class="nanda-gallery-overlay">
+              <h4>Pataliputra's Ramparts</h4>
+              <p>Capital on the Ganges</p>
+            </div>
+          </div>
+          <div class="nanda-gallery-item" data-title="Mahapadma's Conquest" data-desc="A stylised depiction of Mahapadma Nanda's throne and the sweeping conquests that unified much of northern India under Nanda rule.">
+            <img src="../assets/nanda_mahapadma_conquest.svg" alt="Illustrated Nanda throne with conquest arrows" loading="lazy">
+            <div class="nanda-gallery-overlay">
+              <h4>Mahapadma's Conquest</h4>
+              <p>Unifying northern India</p>
+            </div>
+          </div>
+          <div class="nanda-gallery-item" data-title="The War-Elephant Corps" data-desc="An illustrated impression of the thousands of war elephants that made the Nanda army one of the most feared forces of its era.">
+            <img src="../assets/nanda_army_alexander.svg" alt="Illustrated war elephants beside a river" loading="lazy">
+            <div class="nanda-gallery-overlay">
+              <h4>War-Elephant Corps</h4>
+              <p>The army that halted Alexander</p>
+            </div>
+          </div>
+          <div class="nanda-gallery-item" data-title="The Royal Treasury" data-desc="A stylised impression of the Nanda treasury, filled through systematic taxation and later inherited in large part by the Mauryan Empire.">
+            <img src="../assets/nanda_treasury_administration.svg" alt="Illustrated stacks of coins and a tax ledger" loading="lazy">
+            <div class="nanda-gallery-overlay">
+              <h4>The Royal Treasury</h4>
+              <p>Systematic taxation and wealth</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="nanda-section" id="references">
+      <div class="nanda-container">
+        <div class="nanda-references">
+          <h3>📚 References &amp; Further Reading</h3>
+          <ul>
+            <li><strong>Raychaudhuri, H. C. (1988)</strong>. <em>Political History of Ancient India</em>. University of Calcutta.</li>
+            <li><strong>Habib, Irfan &amp; Jha, Vivekanand (2004)</strong>. <em>Mauryan India</em>. Tulika Books / Aligarh Historians Society.</li>
+            <li><strong>Singh, Upinder (2016)</strong>. <em>A History of Ancient and Early Medieval India</em>. Pearson.</li>
+            <li><strong>Arrian (trans. de Sélincourt, Aubrey)</strong>. <em>The Campaigns of Alexander, Book V</em>. Penguin Classics.</li>
+            <li><strong>Diodorus Siculus</strong>. <em>Bibliotheca Historica, Book XVII</em>, on the armies of the Gangaridai and Prasii.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <div class="nanda-modal" id="nanda-modal" role="dialog" aria-modal="true" aria-labelledby="nanda-modal-title" aria-hidden="true">
+    <div class="nanda-modal-card">
+      <button class="nanda-modal-close" id="nanda-modal-close" type="button" aria-label="Close details">✕</button>
+      <span class="nanda-modal-category" id="nanda-modal-category">Gallery Highlight</span>
+      <img class="nanda-modal-image" id="nanda-modal-image" alt="">
+      <h2 id="nanda-modal-title"></h2>
+      <p class="nanda-modal-location" id="nanda-modal-heading"></p>
+      <div class="nanda-modal-divider">
+        <p class="nanda-modal-description" id="nanda-modal-description"></p>
+      </div>
+    </div>
+  </div>
+
+  <footer class="nanda-footer">
+    <div class="nanda-container">
+      <p>Part of <a href="../../index.html">Incredible India Explorer</a> · Explore Magadha's Nanda heritage and the empire that preceded the Mauryas.</p>
+    </div>
+  </footer>
+
+  <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+
+  <script src="../app.js" defer></script>
+  <script src="../../frontend/journey/journey.js" defer></script>
+  <script src="script.js" defer></script>
+  <script type="module" src="../firebase-config.js"></script>
+  <script type="module" src="../auth.js"></script>
+  <script src="../router.js" defer></script>
+  <script src="../js-modules/page-progress/page-progress.js"></script>
+</body>
+</html>

--- a/frontend/nanda-dynasty-explorer/script.js
+++ b/frontend/nanda-dynasty-explorer/script.js
@@ -1,0 +1,118 @@
+// ===== Nanda Dynasty Explorer — Page Script =====
+
+document.addEventListener('DOMContentLoaded', function () {
+
+  // ---------- Gallery Modal ----------
+  const modal = document.getElementById('nanda-modal');
+  const modalClose = document.getElementById('nanda-modal-close');
+  const modalImage = document.getElementById('nanda-modal-image');
+  const modalTitle = document.getElementById('nanda-modal-title');
+  const modalCategory = document.getElementById('nanda-modal-category');
+  const modalHeading = document.getElementById('nanda-modal-heading');
+  const modalDescription = document.getElementById('nanda-modal-description');
+  const galleryItems = document.querySelectorAll('.nanda-gallery-item');
+
+  function openModal(item) {
+    const image = item.querySelector('img');
+    const title = item.getAttribute('data-title') || '';
+    const desc = item.getAttribute('data-desc') || '';
+
+    if (image && modalImage) {
+      modalImage.src = image.currentSrc || image.src;
+      modalImage.alt = image.alt;
+    }
+
+    modalTitle.textContent = title;
+    modalCategory.textContent = 'Gallery Highlight';
+    modalHeading.textContent = 'Nanda Dynasty';
+    modalDescription.textContent = desc;
+
+    modal.classList.add('active');
+    modal.setAttribute('aria-hidden', 'false');
+    document.body.style.overflow = 'hidden';
+  }
+
+  function closeModal() {
+    modal.classList.remove('active');
+    modal.setAttribute('aria-hidden', 'true');
+    document.body.style.overflow = '';
+  }
+
+  galleryItems.forEach(function (item) {
+    item.addEventListener('click', function () {
+      openModal(item);
+    });
+    item.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openModal(item);
+      }
+    });
+    item.setAttribute('tabindex', '0');
+    item.setAttribute('role', 'button');
+  });
+
+  if (modalClose) {
+    modalClose.addEventListener('click', closeModal);
+  }
+
+  if (modal) {
+    modal.addEventListener('click', function (e) {
+      if (e.target === modal) closeModal();
+    });
+  }
+
+  document.addEventListener('keydown', function (e) {
+    if (modal && e.key === 'Escape' && modal.classList.contains('active')) {
+      closeModal();
+    }
+  });
+
+  // ---------- Bookmark Button (Journey integration) ----------
+  // NOTE: same assumption as the Motupalli/Kozhikode/Chandela pages — Journey.toggle(id, title, thumbnail)
+  // and Journey.isSaved(id) are assumed based on CodeRabbit's review of an earlier PR.
+  // Please share frontend/journey/journey.js so this can be verified/corrected.
+  const bookmarkBtn = document.querySelector('.journey-bookmark-btn[data-bookmark-id="nanda-dynasty-main"]');
+
+  if (bookmarkBtn) {
+    const bookmarkId = bookmarkBtn.getAttribute('data-bookmark-id');
+    const bookmarkTitle = 'Nanda Dynasty';
+    const bookmarkThumbnail = '../assets/nanda_pataliputra_banner.svg';
+
+    function refreshButtonState() {
+      let isSaved = false;
+      if (typeof Journey !== 'undefined' && typeof Journey.isSaved === 'function') {
+        isSaved = Journey.isSaved(bookmarkId);
+      }
+      bookmarkBtn.setAttribute('aria-pressed', isSaved ? 'true' : 'false');
+      bookmarkBtn.textContent = isSaved ? '♥ Saved to Journey' : '♡ Save to Journey';
+    }
+
+    bookmarkBtn.addEventListener('click', function () {
+      if (typeof Journey === 'undefined' || typeof Journey.toggle !== 'function') {
+        console.warn('Journey.toggle() not found — journey.js may not be loaded before script.js, or the shared API differs from what was assumed.');
+        return;
+      }
+      Journey.toggle(bookmarkId, bookmarkTitle, bookmarkThumbnail);
+      refreshButtonState();
+    });
+
+    refreshButtonState();
+  }
+
+  // ---------- Scroll to top button ----------
+  const scrollTopBtn = document.getElementById('btn-scroll-top');
+  if (scrollTopBtn) {
+    function syncScrollTopVisibility() {
+      scrollTopBtn.classList.toggle('visible', window.scrollY > 400);
+    }
+
+    window.addEventListener('scroll', syncScrollTopVisibility);
+    syncScrollTopVisibility();
+
+    scrollTopBtn.addEventListener('click', function () {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  }
+
+});

--- a/frontend/nanda-dynasty-explorer/style.css
+++ b/frontend/nanda-dynasty-explorer/style.css
@@ -1,0 +1,480 @@
+/* ===== Nanda Dynasty Explorer — Page Styles ===== */
+
+:root {
+  --nanda-navy: #0a1930;
+  --nanda-gold: #d4952f;
+  --nanda-gold-light: #f0c674;
+  --nanda-teal: #0e5c5c;
+}
+
+.nanda-main {
+  background: #050d1c;
+  color: #f5f0e6;
+}
+.nanda-section {
+  background: #050d1c;
+}
+
+/* ---------- Hero ---------- */
+.nanda-hero {
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 140px 24px 80px;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(212, 149, 47, 0.15), transparent 60%),
+    radial-gradient(circle at 80% 80%, rgba(14, 92, 92, 0.25), transparent 60%),
+    #050d1c;
+}
+
+.nanda-hero-content {
+  max-width: 760px;
+}
+
+.nanda-kicker {
+  display: inline-block;
+  font-size: 0.85rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--nanda-gold-light);
+  background: rgba(212, 149, 47, 0.1);
+  border: 1px solid rgba(212, 149, 47, 0.3);
+  padding: 6px 16px;
+  border-radius: 999px;
+  margin-bottom: 20px;
+}
+
+.nanda-hero h1 {
+  font-family: "Playfair Display", serif;
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  line-height: 1.15;
+  margin: 0 0 18px;
+  color: #f5f0e6;
+}
+
+.nanda-hero h1 span {
+  color: var(--nanda-gold);
+  font-style: italic;
+}
+
+.nanda-hero p {
+  font-size: 1.05rem;
+  line-height: 1.7;
+  opacity: 0.85;
+  margin: 0 auto 28px;
+}
+
+.nanda-bookmark-btn {
+  font-family: inherit;
+  font-size: 0.95rem;
+  padding: 10px 22px;
+  border-radius: 999px;
+  border: 1px solid var(--nanda-gold);
+  background: transparent;
+  color: var(--nanda-gold-light);
+  cursor: pointer;
+  transition: all 0.25s ease;
+}
+
+.nanda-bookmark-btn:hover {
+  background: var(--nanda-gold);
+  color: #1a0f00;
+}
+
+.nanda-bookmark-btn[aria-pressed="true"] {
+  background: var(--nanda-gold);
+  color: #1a0f00;
+}
+
+/* ---------- Sections ---------- */
+.nanda-section {
+  padding: 70px 24px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.nanda-container {
+  max-width: 1080px;
+  margin: 0 auto;
+}
+
+.nanda-section-header {
+  text-align: center;
+  max-width: 620px;
+  margin: 0 auto 44px;
+}
+
+.nanda-eyebrow {
+  display: block;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #4fd1c5;
+  margin-bottom: 10px;
+}
+
+.nanda-section-header h2,
+.nanda-text-block h2 {
+  font-family: "Playfair Display", serif;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  margin: 0 0 14px;
+  color: #f5f0e6;
+}
+
+.nanda-section-header p,
+.nanda-text-block p {
+  line-height: 1.75;
+  opacity: 0.85;
+  margin: 0 0 14px;
+}
+
+/* ---------- Two-column grid ---------- */
+.nanda-grid-2col {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 48px;
+  align-items: start;
+}
+
+@media (max-width: 800px) {
+  .nanda-grid-2col {
+    grid-template-columns: 1fr;
+  }
+}
+
+.nanda-highlight-box {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 28px;
+}
+
+.nanda-highlight-box h3 {
+  margin: 0 0 16px;
+  font-size: 1.15rem;
+  color: #f5f0e6;
+}
+
+.nanda-highlight-box ul {
+  margin: 0;
+  padding-left: 20px;
+  line-height: 1.9;
+}
+
+/* ---------- Card grid ---------- */
+.nanda-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+
+@media (max-width: 800px) {
+  .nanda-card-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.nanda-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 26px;
+  text-align: left;
+  transition: transform 0.25s ease, border-color 0.25s ease;
+}
+
+.nanda-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(212, 149, 47, 0.4);
+}
+
+.nanda-card-icon {
+  font-size: 1.8rem;
+  display: block;
+  margin-bottom: 12px;
+}
+
+.nanda-card h3 {
+  margin: 0 0 8px;
+  font-size: 1.05rem;
+  color: #f5f0e6;
+}
+
+.nanda-card p {
+  margin: 0;
+  line-height: 1.6;
+  opacity: 0.8;
+  font-size: 0.95rem;
+}
+
+/* ---------- Timeline ---------- */
+.nanda-timeline-flow {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  padding-left: 30px;
+  border-left: 2px solid rgba(212, 149, 47, 0.3);
+}
+
+.nanda-timeline-step {
+  position: relative;
+}
+
+.nanda-timeline-marker {
+  position: absolute;
+  left: -37px;
+  top: 4px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--nanda-gold);
+  box-shadow: 0 0 0 4px rgba(212, 149, 47, 0.15);
+}
+
+.nanda-timeline-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 14px;
+  padding: 18px 22px;
+}
+
+.nanda-timeline-year {
+  display: inline-block;
+  font-size: 0.8rem;
+  color: var(--nanda-gold-light);
+  margin-bottom: 6px;
+  font-weight: 600;
+}
+
+.nanda-timeline-card h3 {
+  margin: 0 0 6px;
+  font-size: 1.05rem;
+  color: #f5f0e6;
+}
+
+.nanda-timeline-card p {
+  margin: 0;
+  line-height: 1.6;
+  opacity: 0.8;
+  font-size: 0.95rem;
+}
+
+/* ---------- Gallery ---------- */
+.nanda-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 18px;
+}
+
+@media (max-width: 900px) {
+  .nanda-gallery-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.nanda-gallery-item {
+  position: relative;
+  border-radius: 14px;
+  overflow: hidden;
+  cursor: pointer;
+  aspect-ratio: 1 / 1;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: #0a1930;
+}
+
+.nanda-gallery-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.4s ease;
+}
+
+.nanda-gallery-item:hover img {
+  transform: scale(1.06);
+}
+
+.nanda-gallery-overlay {
+  position: absolute;
+  inset: auto 0 0 0;
+  background: linear-gradient(0deg, rgba(0,0,0,0.85) 40%, transparent);
+  padding: 14px;
+  pointer-events: none;
+}
+
+.nanda-gallery-overlay h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #ffffff;
+}
+
+.nanda-gallery-overlay p {
+  margin: 2px 0 0;
+  font-size: 0.8rem;
+  opacity: 0.85;
+  color: #f5f0e6;
+}
+
+/* ---------- References ---------- */
+.nanda-references {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 28px;
+}
+
+.nanda-references h3 {
+  margin: 0 0 14px;
+  color: #f5f0e6;
+}
+
+.nanda-references ul {
+  margin: 0;
+  padding-left: 20px;
+  line-height: 1.9;
+  font-size: 0.92rem;
+  opacity: 0.85;
+}
+
+/* ---------- Footer ---------- */
+.nanda-footer {
+  padding: 30px 24px;
+  text-align: center;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  font-size: 0.9rem;
+  opacity: 0.7;
+  background: #050d1c;
+}
+
+.nanda-footer a {
+  color: var(--nanda-gold-light);
+}
+
+/* ---------- Nanda Modal (self-contained, unique names) ---------- */
+.nanda-modal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  z-index: 999;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.nanda-modal.active {
+  display: flex;
+}
+
+.nanda-modal-card {
+  position: relative;
+  background: #0a1930;
+  border: 1px solid rgba(212, 149, 47, 0.3);
+  border-radius: 16px;
+  padding: 32px;
+  max-width: 480px;
+  width: 100%;
+  color: #f5f0e6;
+}
+
+.nanda-modal-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  background: transparent;
+  border: none;
+  color: #f5f0e6;
+  font-size: 1.2rem;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.nanda-modal-category {
+  display: inline-block;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--nanda-gold-light);
+  margin-bottom: 10px;
+}
+
+.nanda-modal-image {
+  display: block;
+  width: 100%;
+  max-height: min(55vh, 360px);
+  margin: 0 0 18px;
+  border-radius: 10px;
+  object-fit: contain;
+}
+
+.nanda-modal-card h2 {
+  margin: 0 0 6px;
+  font-family: "Playfair Display", serif;
+  font-size: 1.4rem;
+}
+
+.nanda-modal-location {
+  color: var(--nanda-gold-light);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.nanda-modal-divider {
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  margin-top: 15px;
+  padding-top: 15px;
+}
+
+.nanda-modal-description {
+  margin: 0;
+  line-height: 1.7;
+  opacity: 0.9;
+}
+
+/* ---------- Scroll to top button ---------- */
+.btn-scroll-top {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid rgba(212, 149, 47, 0.4);
+  background: #0a1930;
+  color: var(--nanda-gold-light);
+  font-size: 1.2rem;
+  cursor: pointer;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.25s ease, visibility 0.25s ease;
+  z-index: 90;
+}
+
+.btn-scroll-top.visible {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* ---------- Light theme overrides: force this page to stay dark ---------- */
+body.light-theme .nanda-main,
+body.light-theme .nanda-hero,
+body.light-theme .nanda-section,
+body.light-theme .nanda-footer {
+  background: #050d1c !important;
+  color: #f5f0e6 !important;
+}
+
+body.light-theme .nanda-card,
+body.light-theme .nanda-highlight-box,
+body.light-theme .nanda-timeline-card,
+body.light-theme .nanda-references {
+  background: rgba(255, 255, 255, 0.04) !important;
+  border-color: rgba(255, 255, 255, 0.1) !important;
+  color: #f5f0e6 !important;
+}
+
+body.light-theme .nanda-gallery-item {
+  background: #0a1930 !important;
+}


### PR DESCRIPTION
## Description
Adds a dedicated explorer page for the Nanda Dynasty of Magadha — the empire that preceded the Mauryas, remembered for its vast army, systematic taxation, and administrative innovations that Chandragupta Maurya's empire later inherited.

## Changes
- Created `frontend/nanda-dynasty-explorer/index.html` with:
  - Historical overview (Mahapadma Nanda's rise, overthrow of the Shishunaga dynasty)
  - Major rulers section (Mahapadma Nanda, the Nava Nandas, Dhana Nanda)
  - Dedicated section on the Nanda army and its role in halting Alexander's advance at the Hyphasis (Beas River)
  - Legacy section covering administrative and taxation innovations inherited by the Mauryas
  - Chronology timeline (mid-4th century BCE to the fall to Chandragupta Maurya, c. 321 BCE)
  - Image gallery with modal viewer
  - References and further reading
- Added `style.css` and `script.js` for page-specific styling and interactivity
- Added 4 custom SVG illustrations in `frontend/assets/`
- Added Nanda Dynasty link to the navigation dropdown

## Requirements fulfilled
- [x] Historical overview
- [x] Timeline
- [x] Major rulers
- [x] Legacy
- [x] Gallery & references
- [x] Proper navigation
- [x] Responsive UI
- [ ] Landing page card — pending, needs the landing page file to add consistently with other cards

## Screenshots
<img width="1440" height="852" alt="Screenshot 2026-08-05 110509" src="https://github.com/user-attachments/assets/564c83b3-ca39-46a2-82fa-edf1b76a4310" />
<img width="1440" height="852" alt="Screenshot 2026-08-05 110520" src="https://github.com/user-attachments/assets/c57bc238-cdf4-4d68-9e29-780283bd6bef" />

<img width="1440" height="852" alt="Screenshot 2026-08-05 110513" src="https://github.com/user-attachments/assets/2fd73c0a-b774-4a41-91eb-a76a82c10367" />

Closes #1509