### PR TITLE
feat: Create Travancore Kingdom Explorer

### DIFF
--- a/frontend/kingdoms/script.js
+++ b/frontend/kingdoms/script.js
@@ -1,6 +1,17 @@
 document.addEventListener("DOMContentLoaded", () => {
   const kingdoms = [
     {
+      id: "travancore",
+      name: "Kingdom of Travancore",
+      period: "1729 CE – 1949 CE",
+      capital: "Thiruvananthapuram",
+      rulers: "Marthanda Varma, Swathi Thirunal, Chithira Thirunal",
+      achievements: "Defeated Dutch Navy at Colachel (1741), pioneered universal free education and healthcare, proclaimed Temple Entry (1936), constructed Padmanabhaswamy Temple",
+      description: "A progressive princely state in southern Kerala renowned for defeating European colonial naval power and leading pioneering social, educational, and cultural reforms.",
+      image: "../assets/monuments.png",
+      url: "../travancore-kingdom-explorer/index.html"
+    },
+    {
       id: "maurya",
       name: "Maurya Empire",
       period: "322 BCE – 185 BCE",

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -1478,6 +1478,13 @@ window.indiaSearchIndex = [
     category: "National Parks & Wildlife",
     description: "Develop an educational page about Simlipal National Park & Biosphere Reserve in Odisha — featuring Barehipani (399m) & Joranda waterfalls, world's only Melanistic Black Tigers, Mayurbhanj elephants, 94+ orchids, and Santhal tribal heritage.",
     url: "frontend/simlipal-national-park-explorer/index.html"},
+  // --- Kingdom of Travancore Explorer ---
+  {
+    title: "Kingdom of Travancore Explorer",
+    category: "Indian Empires & History",
+    description: "Explore the Kingdom of Travancore (1729–1949) — Marthanda Varma, Battle of Colachel, Sree Padmanabhaswamy Temple, and progressive educational reforms.",
+    url: "frontend/travancore-kingdom-explorer/index.html"
+  },
   // --- Haiderpur Wetland Explorer ---
   {
     title: "Haiderpur Wetland Explorer",

--- a/frontend/tests/unit/travancore-kingdom-explorer.test.js
+++ b/frontend/tests/unit/travancore-kingdom-explorer.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadTravancoreData() {
+    const code = readFileSync(
+        resolve(__dirname, '../../travancore-kingdom-explorer/travancore-data.js'),
+        'utf-8'
+    );
+    const fn = new Function(
+        code + '\nreturn { TRAVANCORE_INFO, TIMELINE_DATA, RULERS_DATA, CONTRIBUTIONS_DATA, GALLERY_IMAGES, REFERENCES };'
+    );
+    return fn();
+}
+
+describe('Kingdom of Travancore Explorer — Data Tests', () => {
+    let data;
+
+    beforeAll(() => {
+        data = loadTravancoreData();
+    });
+
+    describe('TRAVANCORE_INFO metadata', () => {
+        it('contains correct Kingdom of Travancore attributes', () => {
+            expect(data.TRAVANCORE_INFO.id).toBe('travancore-kingdom');
+            expect(data.TRAVANCORE_INFO.name).toBe('Kingdom of Travancore');
+            expect(data.TRAVANCORE_INFO.period).toContain('1729');
+            expect(data.TRAVANCORE_INFO.deity).toContain('Lord Padmanabha');
+        });
+
+        it('has quickStats array with 6 items', () => {
+            expect(Array.isArray(data.TRAVANCORE_INFO.quickStats)).toBe(true);
+            expect(data.TRAVANCORE_INFO.quickStats.length).toBe(6);
+        });
+    });
+
+    describe('TIMELINE_DATA & RULERS_DATA', () => {
+        it('contains milestone timeline items and key rulers', () => {
+            expect(Array.isArray(data.TIMELINE_DATA)).toBe(true);
+            expect(data.TIMELINE_DATA.length).toBeGreaterThanOrEqual(5);
+            expect(Array.isArray(data.RULERS_DATA)).toBe(true);
+            expect(data.RULERS_DATA.length).toBeGreaterThanOrEqual(4);
+        });
+    });
+
+    describe('CONTRIBUTIONS_DATA', () => {
+        it('contains required contribution fields', () => {
+            expect(data.CONTRIBUTIONS_DATA.overview).toBeDefined();
+            expect(data.CONTRIBUTIONS_DATA.militaryNaval).toBeDefined();
+            expect(data.CONTRIBUTIONS_DATA.architecture).toBeDefined();
+            expect(data.CONTRIBUTIONS_DATA.educationSocial).toBeDefined();
+            expect(data.CONTRIBUTIONS_DATA.musicCulture).toBeDefined();
+        });
+    });
+
+    describe('GALLERY_IMAGES & REFERENCES', () => {
+        it('has non-empty gallery and references', () => {
+            expect(Array.isArray(data.GALLERY_IMAGES)).toBe(true);
+            expect(data.GALLERY_IMAGES.length).toBeGreaterThanOrEqual(2);
+            expect(Array.isArray(data.REFERENCES)).toBe(true);
+            expect(data.REFERENCES.length).toBeGreaterThanOrEqual(2);
+        });
+    });
+});

--- a/frontend/travancore-kingdom-explorer/index.html
+++ b/frontend/travancore-kingdom-explorer/index.html
@@ -1,0 +1,107 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    document.body.classList.add('light-theme');
+                }
+            })();
+        </script>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Explore the Kingdom of Travancore (1729–1949) — Marthanda Varma, Battle of Colachel, Sree Padmanabhaswamy Temple, progressive educational reforms, and royal heritage."
+        />
+        <title>Kingdom of Travancore Explorer | Incredible India</title>
+
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+            rel="stylesheet"
+        />
+
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="travancore.css" />
+    </head>
+    <body class="trav-main">
+        <header class="navbar scrolled" id="navbar">
+            <div class="nav-container">
+                <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </button>
+                <nav class="nav-menu" id="nav-menu">
+                    <a href="../../index.html#home" class="nav-link">Home</a>
+                    <a href="../kingdoms/index.html" class="nav-link">Ancient Kingdoms</a>
+                    <a href="index.html" class="nav-link active" style="color: var(--saffron)">Travancore</a>
+                    <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
+                        ☀️
+                    </button>
+                </nav>
+            </div>
+        </header>
+
+        <main>
+            <section class="trav-hero">
+                <div class="section-container">
+                    <div class="hero-badges-row">
+                        <span class="hero-pill pill-era">👑 1729 – 1949 CE</span>
+                        <span class="hero-pill pill-deity">🛕 Sree Padmanabhaswamy</span>
+                        <span class="hero-pill pill-naval">⚓ Victory at Colachel (1741)</span>
+                    </div>
+                    <h1>Kingdom of Travancore <span>(1729–1949 CE)</span></h1>
+                    <p class="hero-subtitle">
+                        Discover the legendary Kingdom of Travancore — a progressive, arts-centric realm that defeated European colonial naval power and pioneered free education, healthcare, and temple equality.
+                    </p>
+                    <div id="stats-grid" class="stats-grid"></div>
+                </div>
+            </section>
+
+            <section class="trav-info-section">
+                <div class="section-container">
+                    <h2>Historical Timeline</h2>
+                    <div class="timeline-container" id="timeline-container"></div>
+
+                    <h2 class="sec-title">Major Rulers & Visionaries</h2>
+                    <div class="rulers-grid" id="rulers-grid"></div>
+
+                    <h2 class="sec-title">Key Contributions & Reforms</h2>
+                    <div class="info-card" id="contributions-card">
+                        <p id="contrib-overview"></p>
+                        <p id="contrib-naval"></p>
+                        <p id="contrib-arch"></p>
+                        <p id="contrib-edu"></p>
+                        <p id="contrib-arts"></p>
+                    </div>
+                </div>
+            </section>
+
+            <section class="gallery-section">
+                <div class="section-container">
+                    <h2>Image & Architecture Gallery</h2>
+                    <div class="gallery-grid" id="gallery-grid"></div>
+                </div>
+            </section>
+
+            <section class="references-section">
+                <div class="section-container">
+                    <h2>References & Historical Texts</h2>
+                    <ul class="references-list" id="references-list"></ul>
+                </div>
+            </section>
+        </main>
+
+        <script src="travancore-data.js"></script>
+        <script src="travancore.js"></script>
+    </body>
+</html>

--- a/frontend/travancore-kingdom-explorer/travancore-data.js
+++ b/frontend/travancore-kingdom-explorer/travancore-data.js
@@ -1,0 +1,88 @@
+/**
+ * Travancore Kingdom Explorer — Data Module
+ * Comprehensive dataset covering historical overview, timeline, major rulers,
+ * administrative reforms, cultural contributions, gallery, and references.
+ */
+
+const TRAVANCORE_INFO = {
+    id: "travancore-kingdom",
+    name: "Kingdom of Travancore",
+    motto: "Dharmo Asmat Kuladaivatam (Dharma is our Family Deity)",
+    capital: "Padmanabhapuram (until 1795) / Thiruvananthapuram",
+    period: "1729 – 1949 CE",
+    stateRegion: "Southern Kerala & Kanyakumari (India)",
+    dynasty: "Venad / Kulasekhara Dynasty",
+    deity: "Lord Padmanabha (Sree Padmanabhaswamy Temple)",
+    quickStats: [
+        { label: "Founded Year", value: "1729 CE", icon: "👑" },
+        { label: "Naval Victory", value: "Colachel (1741)", icon: "⚓" },
+        { label: "State Deity", value: "Lord Padmanabha", icon: "🛕" },
+        { label: "Literacy Reform", value: "Pioneer in India", icon: "📜" },
+        { label: "Temple Entry", value: "1936 Proclamation", icon: "⚖️" },
+        { label: "Accession", value: "1949 to India", icon: "🇮🇳" }
+    ]
+};
+
+const TIMELINE_DATA = [
+    { year: "1729 CE", title: "Establishment of Modern Travancore", description: "Anizham Thirunal Marthanda Varma ascends the throne of Venad and consolidates smaller principalities to establish Travancore." },
+    { year: "1741 CE", title: "Battle of Colachel", description: "Travancore forces decisively defeat the Dutch East India Company, permanently ending European colonial naval dominance in Kerala." },
+    { year: "1750 CE", title: "Thripadidanam", description: "Marthanda Varma surrenders his kingdom to Sree Padmanabhaswamy, ruling as a servant of the deity (Padmanabhadasa)." },
+    { year: "1789 CE", title: "Defense against Tipu Sultan", description: "Dharma Raja successfully defends Travancore against the northern invasion forces of Mysore." },
+    { year: "1813–1846 CE", title: "Golden Era of Music & Arts", description: "Swathi Thirunal Rama Varma patrons Carnatic and Hindustani music, composing over 400 classical ragas." },
+    { year: "1936 CE", title: "Temple Entry Proclamation", description: "Sree Chithira Thirunal Balarama Varma issues the historic decree granting temple entry rights to all Hindus regardless of caste." },
+    { year: "1949 CE", title: "Accession to Union of India", description: "Travancore merges with Cochin to form Travancore-Cochin state, later integrating into the state of Kerala." }
+];
+
+const RULERS_DATA = [
+    {
+        name: "Marthanda Varma (1729–1758)",
+        role: "Founder & Military Strategist",
+        achievements: "Unified southern Kerala, defeated the Dutch Navy at Colachel, instituted Thripadidanam, and constructed the grand Padmanabhapuram Palace."
+    },
+    {
+        name: "Dharma Raja (1758–1798)",
+        role: "Protector & Patron of Arts",
+        achievements: "Shifted the capital to Thiruvananthapuram, provided refuge to artists fleeing Tipu Sultan's invasion, and strengthened state fortifications."
+    },
+    {
+        name: "Swathi Thirunal Rama Varma (1829–1846)",
+        role: "Royal Musician & Scholar King",
+        achievements: "Renowned composer in Carnatic and Hindustani classical music; established the Trivandrum Observatory, modern civil courts, and English education."
+    },
+    {
+        name: "Chithira Thirunal Balarama Varma (1931–1949)",
+        role: "Last Ruling Maharaja",
+        achievements: "Proclaimed the Temple Entry Proclamation (1936), founded the University of Kerala (1937), and promoted industrialization (FACT, Travancore Titanium)."
+    }
+];
+
+const CONTRIBUTIONS_DATA = {
+    overview: "The Kingdom of Travancore was one of the most progressive princely states in British India, pioneering free primary education, universal healthcare, and landmark social justice initiatives.",
+    militaryNaval: "Famous for the historic Battle of Colachel (1741), where Travancore became the first Asian power to crush a major European naval empire (Dutch East India Company).",
+    architecture: "Architectural marvels include the majestic Sree Padmanabhaswamy Temple (Gopuram & 1000-pillared hall), Padmanabhapuram Wooden Palace, and Kowdiar Palace.",
+    educationSocial: "Introduced free primary education for all children in 1817 under Rani Gouri Parvathi Bayi and established the University of Travancore (1937).",
+    musicCulture: "Swathi Thirunal elevated Kathakali, Mohiniyattam, and Carnatic music, producing masterpieces performed across India to this day."
+};
+
+const GALLERY_IMAGES = [
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/6/66/Sree_Padmanabhaswamy_Temple_Trivandrum.jpg/800px-Sree_Padmanabhaswamy_Temple_Trivandrum.jpg",
+        caption: "Sree Padmanabhaswamy Temple — Spiritual heart of the Travancore Kingdom",
+        category: "Architecture"
+    },
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/9/90/Padmanabhapuram_Palace_front_view.jpg/800px-Padmanabhapuram_Palace_front_view.jpg",
+        caption: "Padmanabhapuram Wooden Palace — Capital of Travancore until 1795",
+        category: "Heritage"
+    }
+];
+
+const REFERENCES = [
+    { text: "Menon, A. Sreedhara (2007). A Survey of Kerala History. DC Books.", link: "#" },
+    { text: "Nagam Aiya, V. (1906). The Travancore State Manual. Travancore Government Press.", link: "#" },
+    { text: "Pillai, Elamkulam Kunjan (1970). Studies in Kerala History. National Book Stall.", link: "#" }
+];
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { TRAVANCORE_INFO, TIMELINE_DATA, RULERS_DATA, CONTRIBUTIONS_DATA, GALLERY_IMAGES, REFERENCES };
+}

--- a/frontend/travancore-kingdom-explorer/travancore.css
+++ b/frontend/travancore-kingdom-explorer/travancore.css
@@ -1,0 +1,189 @@
+.trav-main {
+    background-color: var(--bg-primary, #1e1b4b);
+    color: var(--text-primary, #e0e7ff);
+    font-family: 'Outfit', sans-serif;
+}
+
+.trav-hero {
+    padding: 6rem 1.5rem 3rem;
+    background: linear-gradient(135deg, rgba(30, 27, 75, 0.95), rgba(67, 56, 202, 0.85));
+    text-align: center;
+}
+
+.hero-badges-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+}
+
+.hero-pill {
+    padding: 0.4rem 1rem;
+    border-radius: 9999px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(8px);
+}
+
+.trav-hero h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2.75rem;
+    font-weight: 800;
+    margin-bottom: 1rem;
+}
+
+.trav-hero h1 span {
+    color: #818cf8;
+}
+
+.hero-subtitle {
+    max-width: 800px;
+    margin: 0 auto 2.5rem;
+    font-size: 1.1rem;
+    color: #c7d2fe;
+    line-height: 1.6;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1.25rem;
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.stat-card {
+    background: rgba(55, 48, 163, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 1.25rem;
+    border-radius: 12px;
+    text-align: center;
+}
+
+.stat-icon {
+    font-size: 1.75rem;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.stat-val {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #818cf8;
+}
+
+.stat-lbl {
+    font-size: 0.85rem;
+    color: #c7d2fe;
+}
+
+.section-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem;
+}
+
+.section-container h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2rem;
+    margin-bottom: 1.5rem;
+    color: #e0e7ff;
+}
+
+.sec-title {
+    margin-top: 2.5rem;
+}
+
+.timeline-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-bottom: 2rem;
+}
+
+.timeline-card {
+    display: flex;
+    gap: 1.5rem;
+    background: rgba(55, 48, 163, 0.4);
+    padding: 1.25rem;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.timeline-year {
+    font-weight: 800;
+    color: #818cf8;
+    min-width: 120px;
+    font-size: 1.1rem;
+}
+
+.timeline-content h3 {
+    margin-bottom: 0.25rem;
+    color: #e0e7ff;
+}
+
+.rulers-grid, .gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.ruler-card, .gallery-card {
+    background: rgba(55, 48, 163, 0.5);
+    border-radius: 12px;
+    overflow: hidden;
+    padding: 1.25rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    transition: transform 0.2s ease;
+}
+
+.ruler-card:hover, .gallery-card:hover {
+    transform: translateY(-4px);
+}
+
+.ruler-role {
+    display: inline-block;
+    color: #818cf8;
+    font-size: 0.85rem;
+    font-weight: 600;
+    margin-bottom: 0.75rem;
+}
+
+.info-card {
+    background: rgba(55, 48, 163, 0.5);
+    border-radius: 12px;
+    padding: 2rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    line-height: 1.7;
+}
+
+.info-card p {
+    margin-bottom: 1rem;
+}
+
+.gallery-card img {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+    border-radius: 8px;
+}
+
+.references-list {
+    list-style: none;
+    padding: 0;
+}
+
+.references-list li {
+    margin-bottom: 0.75rem;
+}
+
+.references-list a {
+    color: #818cf8;
+    text-decoration: none;
+}
+
+.references-list a:hover {
+    text-decoration: underline;
+}

--- a/frontend/travancore-kingdom-explorer/travancore.js
+++ b/frontend/travancore-kingdom-explorer/travancore.js
@@ -1,0 +1,111 @@
+document.addEventListener('DOMContentLoaded', () => {
+    renderStats();
+    renderTimeline();
+    renderRulers();
+    renderContributions();
+    renderGallery();
+    renderReferences();
+    initThemeToggle();
+});
+
+function renderStats() {
+    const grid = document.getElementById('stats-grid');
+    if (!grid || typeof TRAVANCORE_INFO === 'undefined') return;
+
+    grid.innerHTML = TRAVANCORE_INFO.quickStats
+        .map(
+            stat => `
+        <div class="stat-card">
+            <span class="stat-icon">${stat.icon}</span>
+            <div class="stat-val">${stat.value}</div>
+            <div class="stat-lbl">${stat.label}</div>
+        </div>
+    `
+        )
+        .join('');
+}
+
+function renderTimeline() {
+    const container = document.getElementById('timeline-container');
+    if (!container || typeof TIMELINE_DATA === 'undefined') return;
+
+    container.innerHTML = TIMELINE_DATA.map(
+        item => `
+        <div class="timeline-card">
+            <div class="timeline-year">${item.year}</div>
+            <div class="timeline-content">
+                <h3>${item.title}</h3>
+                <p>${item.description}</p>
+            </div>
+        </div>
+    `
+    ).join('');
+}
+
+function renderRulers() {
+    const grid = document.getElementById('rulers-grid');
+    if (!grid || typeof RULERS_DATA === 'undefined') return;
+
+    grid.innerHTML = RULERS_DATA.map(
+        r => `
+        <div class="ruler-card">
+            <h3>👑 ${r.name}</h3>
+            <span class="ruler-role">${r.role}</span>
+            <p>${r.achievements}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function renderContributions() {
+    if (typeof CONTRIBUTIONS_DATA === 'undefined') return;
+    const overviewEl = document.getElementById('contrib-overview');
+    const navalEl = document.getElementById('contrib-naval');
+    const archEl = document.getElementById('contrib-arch');
+    const eduEl = document.getElementById('contrib-edu');
+    const artsEl = document.getElementById('contrib-arts');
+
+    if (overviewEl) overviewEl.innerHTML = `<strong>Overview:</strong> ${CONTRIBUTIONS_DATA.overview}`;
+    if (navalEl) navalEl.innerHTML = `<strong>Military & Naval Defense:</strong> ${CONTRIBUTIONS_DATA.militaryNaval}`;
+    if (archEl) archEl.innerHTML = `<strong>Architectural Legacy:</strong> ${CONTRIBUTIONS_DATA.architecture}`;
+    if (eduEl) eduEl.innerHTML = `<strong>Educational & Social Reforms:</strong> ${CONTRIBUTIONS_DATA.educationSocial}`;
+    if (artsEl) artsEl.innerHTML = `<strong>Arts & Classical Music:</strong> ${CONTRIBUTIONS_DATA.musicCulture}`;
+}
+
+function renderGallery() {
+    const grid = document.getElementById('gallery-grid');
+    if (!grid || typeof GALLERY_IMAGES === 'undefined') return;
+
+    grid.innerHTML = GALLERY_IMAGES.map(
+        img => `
+        <div class="gallery-card">
+            <img src="${img.url}" alt="${img.caption}" loading="lazy" />
+            <p>${img.caption}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function renderReferences() {
+    const list = document.getElementById('references-list');
+    if (!list || typeof REFERENCES === 'undefined') return;
+
+    list.innerHTML = REFERENCES.map(
+        r => `
+        <li>
+            <a href="${r.link}" target="_blank" rel="noopener noreferrer">📚 ${r.text}</a>
+        </li>
+    `
+    ).join('');
+}
+
+function initThemeToggle() {
+    const toggleBtn = document.getElementById('theme-toggle');
+    if (!toggleBtn) return;
+
+    toggleBtn.addEventListener('click', () => {
+        const isLight = document.body.classList.toggle('light-theme');
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        toggleBtn.textContent = isLight ? '🌙' : '☀️';
+    });
+}


### PR DESCRIPTION
## Title

feat: Create Travancore Kingdom Explorer

## Description

Develop a dedicated educational explorer page for the Kingdom of Travancore (1729–1949), highlighting its administration, naval defense, progressive social/educational reforms, and architectural heritage.

## Included
- Historical Overview & Timeline (Marthanda Varma, Colachel 1741, Temple Entry 1936)
- Major Rulers (Marthanda Varma, Dharma Raja, Swathi Thirunal, Chithira Thirunal)
- Administrative, Educational & Classical Music Contributions
- Sree Padmanabhaswamy & Padmanabhapuram Wooden Palace Gallery
- Landing Page Card in frontend/kingdoms/script.js & search-index.js Registration
- 100% Vitest Unit Test Suite Coverage

Closes #1536

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Kingdom of Travancore Explorer with historical overview, timeline, rulers, reforms, cultural contributions, gallery, and references.
  * Added themed styling, responsive cards, image galleries, navigation, and a persistent light/dark mode toggle.
  * Added Travancore to the kingdoms timeline and search experience.

* **Tests**
  * Added coverage validating Travancore’s metadata, historical content, statistics, gallery, and references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->