### PR TITLE
feat: add Siege of Chittor explorer page

### DIFF
--- a/frontend/history/battles/index.html
+++ b/frontend/history/battles/index.html
@@ -123,6 +123,25 @@
                 </div>
             </div>
         </section>
+
+        <!-- Featured Explorer: Siege of Chittor -->
+        <section class="featured-explorer-section" aria-label="Featured battle explorer">
+            <div class="featured-explorer-card">
+                <div class="featured-explorer-content">
+                    <span class="featured-explorer-badge">Featured Explorer</span>
+                    <h2>Siege of Chittor (1567–1568)</h2>
+                    <p>Relive Akbar's four-month siege of the great Sisodia fortress of Chittorgarh — the defiant defence of Jaimal and Patta, and the third jauhar of Chittor.</p>
+                    <a href="../../siege-of-chittor-explorer/index.html" class="featured-explorer-btn">
+                        Explore the Siege of Chittor →
+                    </a>
+                </div>
+                <div class="featured-explorer-meta">
+                    <span class="featured-explorer-date">23 Oct 1567 – 23 Feb 1568</span>
+                    <span class="featured-explorer-outcome">Mughal Victory</span>
+                    <span class="featured-explorer-treaty">Third Jauhar of Chittor</span>
+                </div>
+            </div>
+        </section>
     </main>
 
     <footer class="site-footer">

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -1931,5 +1931,12 @@ window.indiaSearchIndex = [
     category: "Featured Explorers",
     description: "Explore the Battle of Buxar (22 October 1764) - the East India Company's decisive victory over Mir Qasim, Shuja-ud-Daulah, and Shah Alam II, and the Treaty of Allahabad that granted the Diwani.",
     url: "frontend/battle-of-buxar-explorer/index.html"
+  },
+  // --- Siege of Chittor Explorer ---
+  {
+    title: "Siege of Chittor Explorer",
+    category: "Featured Explorers",
+    description: "Explore the Siege of Chittorgarh (1567-1568) - Akbar's four-month siege of the Sisodia capital of Mewar, the defiant defence of Jaimal and Patta, and the third jauhar of Chittor.",
+    url: "frontend/siege-of-chittor-explorer/index.html"
   }
 ];

--- a/frontend/siege-of-chittor-explorer/index.html
+++ b/frontend/siege-of-chittor-explorer/index.html
@@ -1,0 +1,457 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore the Siege of Chittorgarh (23 October 1567 – 23 February 1568): Akbar's four-month siege of the Sisodia capital, the defiance of Jaimal and Patta, and the third jauhar of Chittor.">
+  <title>Siege of Chittor Explorer | Incredible India</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="../js-modules/page-progress/page-progress.css">
+
+  <!-- Open Graph / Social Media Tags -->
+  <meta property="og:title" content="Siege of Chittor Explorer | Incredible India Explorer">
+  <meta property="og:description" content="Relive the Siege of Chittorgarh (1567–68), when Akbar's Mughal army took the great Sisodia fortress after months of mining, sapping, and siege — and the defiant jauhar of its Rajput defenders.">
+  <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/frontend/assets/travel_deserts.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/siege-of-chittor-explorer/index.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Incredible India Explorer">
+  <meta property="og:locale" content="en_IN">
+
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/siege-of-chittor-explorer/index.html">
+</head>
+<body>
+  <script>
+    (function() {
+      const theme = localStorage.getItem('theme') || 'dark';
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+
+  <!-- Sticky Navigation Bar -->
+  <header class="navbar" id="navbar">
+    <div class="nav-container">
+        <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+            <span class="saffron">Incredible</span>
+            <span class="gold">India</span>
+            <span class="green">Explorer</span>
+        </a>
+        <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+            <span class="bar"></span>
+            <span class="bar"></span>
+            <span class="bar"></span>
+        </button>
+        <nav class="nav-menu" id="nav-menu">
+            <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
+                    <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                    <a href="../../frontend/islands/islands.html" class="dropdown-item">Islands of India</a>
+                    <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    <a href="../../frontend/route-planner/route-planner.html" class="dropdown-item">Route Planner</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+                    <a href="../../frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
+                    <a href="../../frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
+                    <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
+                    <a href="../../frontend/national-symbols-gallery/national-symbols-gallery.html" class="dropdown-item">National Symbols</a>
+                    <a href="../../frontend/cuisine-discovery-hub/index.html" class="dropdown-item">UP Cuisine</a>
+                    <a href="../../frontend/handicrafts-showcase/index.html" class="dropdown-item">UP Handicrafts</a>
+                    <a href="../../frontend/national-days-calendar/index.html" class="dropdown-item">National Days</a>
+                    <a href="../../frontend/ganga-ghats-experience/index.html" class="dropdown-item">Ganga Ghats</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Nature ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/national-parks-explorer/index.html" class="dropdown-item">National Parks</a>
+                    <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                    <a href="../../frontend/wildlife-rescue/wildlife-rescue.html" class="dropdown-item">Wildlife Rescue</a>
+                    <a href="../../frontend/endemic-flora-fauna-explorer/index.html" class="dropdown-item">Endemic Flora & Fauna</a>
+                    <a href="../../frontend/harike-wetland/harike-wetland.html" class="dropdown-item">Harike Wetland</a>
+                    <a href="../../frontend/wular-lake/wular-lake.html" class="dropdown-item">Wular Lake</a>
+                    <a href="../../frontend/crowd-density/index.html" class="dropdown-item">Crowd Density Predictor</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Games ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/passport-quest/passport-quest.html" class="dropdown-item">Passport Quest</a>
+                    <a href="../../frontend/culinary-game/culinary-game.html" class="dropdown-item">Culinary Challenge</a>
+                    <a href="../../frontend/monsoon-game/monsoon-game.html" class="dropdown-item">Monsoon Game</a>
+                    <a href="../../frontend/river-game/river-game.html" class="dropdown-item">River Explorer</a>
+                    <a href="../../frontend/geo-guesser-india/index.html" class="dropdown-item">GeoGuesser</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Community ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/contributors/contributors.html" class="dropdown-item">Contributors</a>
+                    <a href="../../frontend/world-records-india/index.html" class="dropdown-item">World Records</a>
+                </div>
+            </div>
+            
+            <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+        </nav>
+    </div>
+</header>
+
+  <!-- SPA Router Target Container -->
+  <main id="app-root" class="chittor-main">
+
+    <!-- Hero Banner -->
+    <section class="chittor-hero">
+      <div class="chittor-hero-content">
+        <span class="chittor-kicker">⚔️ Rajasthan · 1567–1568</span>
+        <h1>Siege of Chittor <span>Explorer</span></h1>
+        <p>For four months, Akbar's great army ringed the fortress of Chittorgarh — the proud capital of the Sisodia house of Mewar. Its eight thousand defenders, led by Jaimal and Patta, turned siegecraft into legend, until the third jauhar of Chittor ended one of the most famous sieges in Indian history.</p>
+        <div class="chittor-bookmark-container">
+          <button class="chittor-bookmark-btn journey-bookmark-btn" type="button" data-bookmark-id="siege-of-chittor-main" aria-pressed="false" aria-label="Bookmark Siege of Chittor">
+            ♡ Save to Journey
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Historical Background -->
+    <section class="chittor-section" id="background">
+      <div class="chittor-container chittor-grid-2col">
+        <div class="chittor-text-block">
+          <span class="chittor-eyebrow">The Proud House of Mewar</span>
+          <h2>Why Akbar Marched on Chittor</h2>
+          <p>Chittorgarh was the greatest fortress of the Sisodia Rajputs — the one Rajput house that had never submitted to Mughal authority. Its capture mattered strategically: it guarded the road between Delhi, Malwa, and Gujarat, and opened the way to the Deccan.</p>
+          <p>By 1567 Akbar had crushed the Uzbek revolts and was free to turn on Rajputana. Rana Udai Singh II — the son of Rana Sanga, who had defied even Babur — refused to bend the knee and gave refuge to the fugitive Afghan rebel Baz Bahadur of Malwa. Enraged, Akbar declared the campaign against Mewar a <em>jihad</em>, and marched from Agra with his army and artillery.</p>
+        </div>
+        <div class="chittor-highlight-box">
+          <h3>🏛️ At a Glance</h3>
+          <ul>
+            <li><strong>23 October 1567 – 23 February 1568</strong> — A siege of over four months.</li>
+            <li><strong>Akbar in Person</strong> — The Mughal emperor commanded the siege himself.</li>
+            <li><strong>~8,000 Defenders</strong> — Jaimal and Patta held the fort against a vast imperial host.</li>
+            <li><strong>Third Jauhar of Chittor</strong> — The women of the fort chose fire over capture.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Major Commanders -->
+    <section class="chittor-section" id="commanders">
+      <div class="chittor-container">
+        <div class="chittor-section-header">
+          <span class="chittor-eyebrow">Men Who Decided the Day</span>
+          <h2>The Major Commanders</h2>
+          <p>An emperor who led from the front against a band of Rajput chiefs who chose death over surrender.</p>
+        </div>
+
+        <div class="chittor-commanders-grid">
+          <div class="chittor-commander-card chittor-commander-mughal">
+            <span class="chittor-commander-rank">Mughal · Emperor</span>
+            <h3>Emperor Akbar</h3>
+            <p>Third Mughal emperor, in command throughout the siege. He directed the sabat, the mines, and the great siege gun — and on 22 February 1568 personally shot Jaimal with his matchlock, breaking the defence's morale.</p>
+          </div>
+          <div class="chittor-commander-card">
+            <span class="chittor-commander-rank">Mewar · Commander-in-Chief</span>
+            <h3>Jaimal Rathore of Badnore</h3>
+            <p>A famed warrior of the Rathore clan, given the command of Chittor's defence. He led the garrison for four months and was killed by Akbar's shot while repairing the breached wall at night — his death shattered the defenders' will.</p>
+          </div>
+          <div class="chittor-commander-card">
+            <span class="chittor-commander-rank">Mewar · Command of the Fortress</span>
+            <h3>Patta Sisodia of Kelwa</h3>
+            <p>The young Sisodia chief who took command after Jaimal fell. He led the final saka — the last saffron-clad charge of the garrison — and died fighting, trampled by a Mughal war elephant.</p>
+          </div>
+          <div class="chittor-commander-card">
+            <span class="chittor-commander-rank">Mewar · Rana (absent from the fort)</span>
+            <h3>Rana Udai Singh II</h3>
+            <p>The Rana of Mewar who withdrew to the hills of the Girwa valley with his family, leaving the fortress to Jaimal and Patta. He founded Udaipur and kept resisting the Mughals until his death in 1572.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Battle Strategy -->
+    <section class="chittor-section" id="strategy">
+      <div class="chittor-container">
+        <div class="chittor-section-header">
+          <span class="chittor-eyebrow">The Art of the Siege</span>
+          <h2>The Battle Strategy</h2>
+          <p>Chittor's walls could not be stormed. The siege was won by engineers, miners, and gunners — and by one accurate shot.</p>
+        </div>
+
+        <div class="chittor-strategy-grid">
+          <div class="chittor-strategy-card">
+            <span class="chittor-strategy-step">1</span>
+            <h3>The Investment</h3>
+            <p>Akbar encamped on the plains before the fort and, over a month of careful reconnaissance, ringed Chittor with siege lines and batteries. The garrison's sallies cost the Mughals dearly before a direct assault was abandoned.</p>
+          </div>
+          <div class="chittor-strategy-card">
+            <span class="chittor-strategy-step">2</span>
+            <h3>The Sabat and the Mines</h3>
+            <p>Some 5,000 builders, stonemasons, and carpenters constructed a great covered approach trench — the <strong>sabat</strong>, wide enough for ten men abreast — while sappers dug two mines beneath the walls. On 17 December 1567 the mines exploded and breached the rampart, but the defenders sealed the gap.</p>
+          </div>
+          <div class="chittor-strategy-card">
+            <span class="chittor-strategy-step">3</span>
+            <h3>The Great Gun</h3>
+            <p>A massive siege cannon was cast on site and brought forward under the shelter of the sabat, joining three artillery batteries that bombarded the fortress. Under the cover of the trench, Akbar himself took position and fired his matchlock against the defenders.</p>
+          </div>
+          <div class="chittor-strategy-card">
+            <span class="chittor-strategy-step">4</span>
+            <h3>The Breach and the Shot</h3>
+            <p>On 22 February 1568 the guns opened several breaches at once. As Jaimal supervised repairs by torchlight, Akbar's musket shot struck him down — the single stroke that decided the siege and doomed the garrison.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Outcome -->
+    <section class="chittor-section" id="outcome">
+      <div class="chittor-container chittor-grid-2col">
+        <div class="chittor-outcome-box">
+          <h3>⚔️ The Fall of Chittor</h3>
+          <ul>
+            <li><strong>23 February 1568</strong> — The fort fell on the day of Holi, after over four months of siege.</li>
+            <li><strong>Jauhar and Saka</strong> — On the night of 22 February the women immolated themselves; the saffron-clad garrison, led by Patta, charged to their deaths in the final saka.</li>
+            <li><strong>Massacre</strong> — Akbar ordered a general slaughter; around 30,000 inhabitants were killed.</li>
+            <li><strong>Mughal Victory</strong> — The last great independent Rajput fortress had fallen to the empire.</li>
+          </ul>
+        </div>
+        <div class="chittor-text-block">
+          <span class="chittor-eyebrow">The Third Sack</span>
+          <h2>Why Chittor Was the Turning Point</h2>
+          <p>Chittorgarh had been sacked twice before — by Alauddin Khalji in 1303 and by Bahadur Shah of Gujarat in 1535. The siege of 1567–68 was the third and final time the fortress fell, and its capture broke the back of independent Rajput resistance.</p>
+          <p>Akbar acknowledged the valour of his fallen foes in an extraordinary way: he had stone statues of Jaimal and Patta carved and set at the gates of his own palace at Agra — honouring the two commanders whose resistance had made the siege famous across India.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Historical Impact -->
+    <section class="chittor-section" id="impact">
+      <div class="chittor-container">
+        <div class="chittor-section-header">
+          <span class="chittor-eyebrow">The Aftermath</span>
+          <h2>Historical Impact</h2>
+          <p>The fall of Chittor was one of the defining moments of Akbar's reign — and of Mughal empire-building in North India.</p>
+        </div>
+
+        <div class="chittor-impact-grid">
+          <div class="chittor-impact-card">
+            <span class="chittor-impact-icon">🏰</span>
+            <h3>The Chain of Conquest</h3>
+            <p>The great fortresses fell one by one: Ranthambhor (1569) and Kalinjar (1569) followed Chittor. Akbar's sieges of 1567–69 became the template of Mughal expansion.</p>
+          </div>
+          <div class="chittor-impact-card">
+            <span class="chittor-impact-icon">🤝</span>
+            <h3>The Rajput Alliance</h3>
+            <p>With Chittor gone, almost every major Rajput state — Jodhpur, Bikaner, Jaisalmer, Bundi, Sirohi, Dungarpur — accepted Mughal overlordship, ushering in the era of Rajput generals, marriages, and mansabdars in Akbar's service.</p>
+          </div>
+          <div class="chittor-impact-card">
+            <span class="chittor-impact-icon">🗺️</span>
+            <h3>A Road to the Deccan</h3>
+            <p>The route to Malwa and Gujarat now lay open, and Mughal armies could march southward at will — preparing the way for the empire's expansion into the Deccan.</p>
+          </div>
+          <div class="chittor-impact-card">
+            <span class="chittor-impact-icon">🕯️</span>
+            <h3>The Unconquered Spirit</h3>
+            <p>Mewar's defiance became a legend. The Rana's house, though it lost its capital, kept its independence and reclaimed Chittor from the Mughals in 1616, when Jahangir returned it — a symbol that never faded.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Timeline -->
+    <section class="chittor-section" id="timeline">
+      <div class="chittor-container">
+        <div class="chittor-section-header">
+          <span class="chittor-eyebrow">Milestones</span>
+          <h2>Chronology of the Siege</h2>
+          <p>From the march on Mewar to the fall of the fortress on the day of Holi.</p>
+        </div>
+
+        <div class="chittor-timeline">
+          <div class="chittor-timeline-step">
+            <div class="chittor-timeline-marker"></div>
+            <div class="chittor-timeline-card">
+              <span class="chittor-timeline-year">1562–1567</span>
+              <h3>Defiance of Mewar</h3>
+              <p>While most Rajput houses submit, Rana Udai Singh II holds out, sheltering the fugitive Baz Bahadur. Amber's ruler Bharmal, by contrast, seals an alliance by sending his daughter to the Mughal harem.</p>
+            </div>
+          </div>
+          <div class="chittor-timeline-step">
+            <div class="chittor-timeline-marker"></div>
+            <div class="chittor-timeline-card">
+              <span class="chittor-timeline-year">September–October 1567</span>
+              <h3>The March and the Investment</h3>
+              <p>Akbar leaves Agra, and by 23 October encamps before Chittor. Udai Singh withdraws to the hills, leaving Jaimal and Patta with about 8,000 men to hold the fortress.</p>
+            </div>
+          </div>
+          <div class="chittor-timeline-step">
+            <div class="chittor-timeline-marker"></div>
+            <div class="chittor-timeline-card">
+              <span class="chittor-timeline-year">17 December 1567</span>
+              <h3>Two Mines Exploded</h3>
+              <p>Fifty-eight days into the siege, the imperial sappers reach the walls. The mines breach the rampart, but the defenders repair the gap; the assault stalls.</p>
+            </div>
+          </div>
+          <div class="chittor-timeline-step">
+            <div class="chittor-timeline-marker"></div>
+            <div class="chittor-timeline-card">
+              <span class="chittor-timeline-year">22 February 1568</span>
+              <h3>The Fatal Shot</h3>
+              <p>A coordinated artillery barrage opens several breaches. As Jaimal supervises the night repairs, Akbar's matchlock shot kills him — the morale of the garrison breaks.</p>
+            </div>
+          </div>
+          <div class="chittor-timeline-step">
+            <div class="chittor-timeline-marker"></div>
+            <div class="chittor-timeline-card">
+              <span class="chittor-timeline-year">23 February 1568</span>
+              <h3>Jauhar, Saka, and Fall</h3>
+              <p>On Holi, the women perform jauhar while the saffron-clad Rajputs, led by Patta, make their last charge. Patta falls and the fort is taken by night.</p>
+            </div>
+          </div>
+          <div class="chittor-timeline-step">
+            <div class="chittor-timeline-marker"></div>
+            <div class="chittor-timeline-card">
+              <span class="chittor-timeline-year">After 1568</span>
+              <h3>The Empire Consolidated</h3>
+              <p>Ranthambhor and Kalinjar fall in 1569. Akbar raises statues to Jaimal and Patta at Agra, and the Rajput states of Rajasthan enter the Mughal fold.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Gallery -->
+    <section class="chittor-section" id="gallery">
+      <div class="chittor-container">
+        <div class="chittor-section-header">
+          <span class="chittor-eyebrow">Visual Tour</span>
+          <h2>The Fortress Remembered</h2>
+          <p>A glimpse of the legendary hill fortress, the empire that besieged it, and the hills where Mewar's flame burned on.</p>
+        </div>
+
+        <div class="chittor-gallery-grid">
+          <div class="chittor-gallery-item" data-title="The Fortress of Chittor" data-desc="The mighty Chittorgarh rises from a sheer plateau of the Aravalli hills — the greatest fort of the Sisodia Rajputs and the last great independent stronghold of Rajputana.">
+            <img src="../assets/travel_deserts.png" alt="Rajasthani landscape evoking the hill fortress of Chittorgarh" loading="lazy">
+            <div class="chittor-gallery-overlay">
+              <h4>The Fortress of Chittor</h4>
+              <p>Pride of the Sisodias</p>
+            </div>
+          </div>
+          <div class="chittor-gallery-item" data-title="The Might of the Mughals" data-desc="Akbar's empire fielded engineers, miners, and a great siege gun against Chittor. His victory made the Mughal artillery and siegecraft the terror of North India.">
+            <img src="../assets/red_fort.png" alt="Mughal-era fort architecture evoking Akbar's imperial power" loading="lazy">
+            <div class="chittor-gallery-overlay">
+              <h4>The Might of the Mughals</h4>
+              <p>Akbar's Imperial Army</p>
+            </div>
+          </div>
+          <div class="chittor-gallery-item" data-title="The Hills of Mewar" data-desc="From the Girwa valley of the Aravallis, Rana Udai Singh kept the flame of resistance alive, founding Udaipur — the city that would outlast the empire that had taken Chittor.">
+            <img src="../assets/travel_mountains.png" alt="Mountain landscape evoking the Girwa valley hills of Mewar" loading="lazy">
+            <div class="chittor-gallery-overlay">
+              <h4>The Hills of Mewar</h4>
+              <p>Resistance Beyond the Fort</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: References -->
+    <section class="chittor-section" id="references">
+      <div class="chittor-container">
+        <div class="chittor-references">
+          <h3>📚 References &amp; Further Reading</h3>
+          <ul>
+            <li><strong>Abu'l Fazl (c. 1590)</strong>. <em>Akbarnama</em>. The official chronicle of Akbar's reign and the siege of Chittor.</li>
+            <li><strong>Nizamuddin Ahmad (c. 1594)</strong>. <em>Tabaqat-i Akbari</em>.</li>
+            <li><strong>Muhammad Arif Qandahari (c. 1579)</strong>. <em>Tarikh-i Akbari</em>.</li>
+            <li><strong>Tod, James (1829)</strong>. <em>Annals and Antiquities of Rajasthan</em>.</li>
+            <li><strong>Wink, Andre (2012)</strong>. <em>Akbar</em>. Oneworld Publications.</li>
+            <li><strong>Streusand, Douglas E. (2011)</strong>. <em>The Formation of the Mughal Empire</em>. Oxford University Press.</li>
+            <li><strong>Encyclopaedia Britannica</strong>. <em>Chittorgarh</em>.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- Interactive Detail Modal -->
+  <div class="museum-modal" id="chittor-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-hidden="true">
+    <div class="museum-modal-card">
+      <button class="museum-modal-close" id="chittor-modal-close" type="button" aria-label="Close details">✕</button>
+      <span class="modal-category" id="modal-category">Gallery Highlight</span>
+      <h2 id="modal-title"></h2>
+      <p class="modal-location" style="color: var(--chittor-gold-light);" id="modal-heading"></p>
+      <div style="border-top: 1px solid rgba(255,255,255,0.1); margin-top: 15px; padding-top: 15px;">
+        <p class="modal-description" id="modal-description"></p>
+      </div>
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <footer class="footer">
+    <div class="footer-container">
+      <div class="footer-brand">
+        <h3>Incredible India Explorer</h3>
+        <p>An interactive digital guide to the geography, food, festivals, and cultural heritage of India. Built with passion and pure vanilla web technologies.</p>
+      </div>
+      <div class="footer-links">
+        <h3>Quick Navigation</h3>
+        <ul>
+          <li><a href="../../index.html#home">Home</a></li>
+          <li><a href="../../index.html#map">Interactive Map</a></li>
+          <li><a href="../../frontend/cuisine/cuisine.html">Cuisine</a></li>
+          <li><a href="../../frontend/festivals/festivals.html">Festivals</a></li>
+          <li><a href="../../frontend/culture/culture.html">Culture</a></li>
+          <li><a href="../history/battles/index.html">Historic Battles</a></li>
+          <li><a href="../../index.html#quiz">Quiz</a></li>
+          <li><a href="../../frontend/about/about.html">About</a></li>
+        </ul>
+      </div>
+
+      <div class="footer-links">
+        <h3>Legal &amp; Support</h3>
+        <ul>
+          <li><a href="../../frontend/support/support.html">Help &amp; Support</a></li>
+          <li><a href="../../frontend/changelog/changelog.html">What's New</a></li>
+          <li><a href="../../frontend/newsletter/newsletter.html">Newsletter</a></li>
+          <li><a href="../../frontend/terms/terms.html">Terms of Service</a></li>
+          <li><a href="../../frontend/privacy/privacy.html">Privacy Policy</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-credits footer-credits-center">
+      <p>&copy; 2026 Incredible India Explorer · Part of <a href="../../index.html">Incredible India Explorer</a> · Relive the battles that shaped modern India — from Plassey to Kargil.</p>
+    </div>
+  </footer>
+
+  <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+
+  <!-- JS Dependencies -->
+  <script src="../app.js" defer></script>
+  <script src="../../frontend/journey/journey.js" defer></script>
+  <script src="script.js" defer></script>
+  <script type="module" src="../firebase-config.js"></script>
+  <script type="module" src="../auth.js"></script>
+  <script src="../router.js" defer></script>
+  <script src="../js-modules/page-progress/page-progress.js"></script>
+</body>
+</html>

--- a/frontend/siege-of-chittor-explorer/script.js
+++ b/frontend/siege-of-chittor-explorer/script.js
@@ -1,0 +1,167 @@
+document.addEventListener("app:route-changed", () => {
+  const bookmarkButtons = [...document.querySelectorAll(".journey-bookmark-btn")];
+  const galleryItems = [...document.querySelectorAll(".chittor-gallery-item")];
+
+  const modal = document.getElementById("chittor-modal");
+  const modalClose = document.getElementById("chittor-modal-close");
+  const modalTitle = document.getElementById("modal-title");
+  const modalHeading = document.getElementById("modal-heading");
+  const modalDescription = document.getElementById("modal-description");
+
+  // --- Welcome Toast (auto-dismisses) -------------------------------
+  function showWelcomeToast() {
+    if (document.getElementById("chittor-welcome-toast")) return;
+
+    const toast = document.createElement("div");
+    toast.id = "chittor-welcome-toast";
+    toast.className = "chittor-welcome-toast";
+    toast.setAttribute("role", "status");
+    toast.setAttribute("aria-live", "polite");
+    toast.innerHTML = "<strong>⚔️ Siege of Chittor</strong> — 23 October 1567 to 23 February 1568. The siege that made Jaimal and Patta immortal.";
+    document.body.appendChild(toast);
+
+    requestAnimationFrame(() => toast.classList.add("is-visible"));
+
+    setTimeout(() => {
+      toast.classList.remove("is-visible");
+      toast.addEventListener("transitionend", () => toast.remove(), { once: true });
+      setTimeout(() => toast.remove(), 500);
+    }, 3200);
+  }
+
+  showWelcomeToast();
+
+  // --- Journey Integration (Bookmarks & Global Search) -------------
+  function initJourney() {
+    if (!window.Journey) return;
+
+    // 1. Bookmark functionality
+    bookmarkButtons.forEach((btn) => {
+      const id = btn.dataset.bookmarkId;
+      const title = "Siege of Chittor Explorer";
+      const thumbnail = "frontend/assets/travel_deserts.png";
+      const category = "history";
+
+      const updateBookmarkUI = () => {
+        const isSaved = window.Journey.isSaved(id);
+        btn.classList.toggle("is-saved", isSaved);
+        btn.setAttribute("aria-pressed", String(isSaved));
+        btn.innerHTML = isSaved ? "♥ Saved to Journey" : "♡ Save to Journey";
+      };
+
+      updateBookmarkUI();
+
+      btn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        window.Journey.toggle({
+          id,
+          explorerPage: "frontend/siege-of-chittor-explorer/index.html",
+          title,
+          thumbnail,
+          category
+        });
+        updateBookmarkUI();
+      });
+    });
+
+    // 2. Global search index registration
+    window.Journey.registerSearchItems("frontend/siege-of-chittor-explorer/index.html", [
+      {
+        id: "siege-of-chittor-main",
+        title: "Siege of Chittor Explorer",
+        description: "Explore the Siege of Chittorgarh (1567–1568): Akbar's four-month campaign against the Sisodia capital of Mewar, and the defiant jauhar of its defenders under Jaimal and Patta.",
+        link: "frontend/siege-of-chittor-explorer/index.html"
+      },
+      {
+        id: "siege-of-chittor-commanders",
+        title: "Major Commanders of the Siege of Chittor",
+        description: "Meet the commanders who decided the siege: Emperor Akbar, Jaimal Rathore, Patta Sisodia, and Rana Udai Singh II of Mewar.",
+        link: "frontend/siege-of-chittor-explorer/index.html#commanders"
+      },
+      {
+        id: "siege-of-chittor-strategy",
+        title: "Battle Strategy of the Siege of Chittor",
+        description: "How the Mughals took an impregnable fortress: the siege lines, the sabat covered trench, the mines of 17 December 1567, and the great siege gun.",
+        link: "frontend/siege-of-chittor-explorer/index.html#strategy"
+      },
+      {
+        id: "siege-of-chittor-outcome",
+        title: "Outcome of the Siege of Chittor",
+        description: "The fall of Chittorgarh on 23 February 1568 after jauhar and saka — and the massacre that followed the third sack of the fortress.",
+        link: "frontend/siege-of-chittor-explorer/index.html#outcome"
+      },
+      {
+        id: "siege-of-chittor-impact",
+        title: "Historical Impact of the Siege of Chittor",
+        description: "How the fall of Chittor broke independent Rajput resistance and opened the Rajput alliance, Ranthambhor, Kalinjar, and the road to the Deccan.",
+        link: "frontend/siege-of-chittor-explorer/index.html#impact"
+      },
+      {
+        id: "siege-of-chittor-timeline",
+        title: "Siege of Chittor Timeline",
+        description: "A chronology from the defiance of Mewar and the investment of October 1567 to the mines, the fatal shot of 22 February 1568, and the fall on the day of Holi.",
+        link: "frontend/siege-of-chittor-explorer/index.html#timeline"
+      }
+    ]);
+  }
+
+  // --- Gallery Modal Logic -----------------------------------------
+  let lastFocusedElement = null;
+
+  function openModal(item) {
+    lastFocusedElement = item;
+
+    modalTitle.textContent = item.dataset.title;
+    modalHeading.textContent = item.querySelector("p")?.textContent || "Gallery Highlight";
+    modalDescription.textContent = item.dataset.desc;
+
+    modal.classList.add("open");
+    modal.setAttribute("aria-hidden", "false");
+    document.body.classList.add("modal-open");
+
+    if (modalClose) modalClose.focus();
+  }
+
+  function closeModal() {
+    modal.classList.remove("open");
+    modal.setAttribute("aria-hidden", "true");
+    document.body.classList.remove("modal-open");
+
+    if (lastFocusedElement) {
+      lastFocusedElement.focus();
+    }
+  }
+
+  // Bind gallery click events
+  galleryItems.forEach((item) => {
+    item.setAttribute("tabindex", "0");
+    item.addEventListener("click", () => openModal(item));
+    item.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        openModal(item);
+      }
+    });
+  });
+
+  if (modalClose) {
+    modalClose.addEventListener("click", closeModal);
+  }
+
+  if (modal) {
+    modal.addEventListener("click", (e) => {
+      if (e.target === modal) {
+        closeModal();
+      }
+    });
+  }
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && modal && modal.classList.contains("open")) {
+      closeModal();
+    }
+  });
+
+  // Run initialization
+  initJourney();
+});

--- a/frontend/siege-of-chittor-explorer/style.css
+++ b/frontend/siege-of-chittor-explorer/style.css
@@ -1,0 +1,750 @@
+/* ==========================================================================
+   Siege of Chittor Explorer - Stylesheet
+   Rajput-Mughal palette (fort crimson, saffron, imperial gold, night umber).
+   ========================================================================== */
+
+:root {
+  --chittor-night: #140e0a;       /* Deep burnt umber night */
+  --chittor-night-light: #221711;
+  --chittor-red: #b3472f;         /* Fort crimson */
+  --chittor-red-light: #d9684c;
+  --chittor-gold: #e6b566;        /* Imperial gold */
+  --chittor-gold-light: #f0cd8f;
+  --chittor-gold-dark: #a07a3a;
+  --chittor-saffron: #f2a541;     /* Rajput saffron */
+  --chittor-parchment: #ece2d0;
+  --chittor-glass: rgba(34, 23, 17, 0.5);
+  --chittor-border: rgba(230, 181, 102, 0.18);
+}
+
+/* Page Main Container */
+.chittor-main {
+  background-color: var(--chittor-night);
+  color: #f1f5f9;
+  font-family: 'Outfit', sans-serif;
+  overflow-x: hidden;
+}
+
+/* Hero Section */
+.chittor-hero {
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+  padding: 120px 0 60px;
+  background: linear-gradient(180deg, rgba(20, 14, 10, 0.35), rgba(20, 14, 10, 0.95)),
+              url('../assets/travel_deserts.png') center/cover no-repeat;
+  text-align: center;
+}
+
+.chittor-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 50%, rgba(179, 71, 47, 0.18), transparent 60%);
+  z-index: 1;
+}
+
+.chittor-hero-content {
+  position: relative;
+  z-index: 2;
+  width: min(880px, 90%);
+}
+
+.chittor-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 20px;
+  padding: 6px 16px;
+  background: rgba(179, 71, 47, 0.14);
+  border: 1px solid rgba(230, 181, 102, 0.3);
+  border-radius: 100px;
+  color: var(--chittor-gold-light);
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  backdrop-filter: blur(8px);
+}
+
+.chittor-hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2.5rem, 6vw, 4.5rem);
+  line-height: 1.1;
+  margin: 0 0 20px;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.chittor-hero h1 span {
+  color: var(--chittor-gold-light);
+  background: linear-gradient(135deg, var(--chittor-gold-light), var(--chittor-gold));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.chittor-hero p {
+  font-size: clamp(1rem, 2vw, 1.2rem);
+  line-height: 1.6;
+  color: #d6c7b8;
+  margin: 0 auto;
+  max-width: 720px;
+}
+
+/* Sections General */
+.chittor-section {
+  padding: 80px 0;
+}
+
+.chittor-section:nth-of-type(even) {
+  background-color: rgba(255, 255, 255, 0.01);
+}
+
+.chittor-container {
+  width: min(1200px, 90%);
+  margin: 0 auto;
+}
+
+.chittor-section-header {
+  margin-bottom: 50px;
+  text-align: center;
+}
+
+.chittor-eyebrow {
+  color: var(--chittor-gold-light);
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.chittor-section-header h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin: 0 0 16px;
+  color: #ffffff;
+}
+
+.chittor-section-header p {
+  color: #a89c8a;
+  max-width: 650px;
+  margin: 0 auto;
+  line-height: 1.6;
+  font-size: 1.05rem;
+}
+
+/* Content Grid / Two Columns */
+.chittor-grid-2col {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 50px;
+  align-items: center;
+}
+
+@media (max-width: 900px) {
+  .chittor-grid-2col {
+    grid-template-columns: 1fr;
+    gap: 30px;
+  }
+}
+
+.chittor-text-block p {
+  line-height: 1.75;
+  color: #cbbdab;
+  margin-bottom: 20px;
+  font-size: 1.05rem;
+}
+
+.chittor-text-block p:last-child {
+  margin-bottom: 0;
+}
+
+.chittor-highlight-box {
+  background: var(--chittor-glass);
+  border: 1px solid var(--chittor-border);
+  border-radius: 16px;
+  padding: 30px;
+  backdrop-filter: blur(12px);
+}
+
+.chittor-highlight-box h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.4rem;
+  margin: 0 0 16px;
+  color: var(--chittor-gold-light);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.chittor-highlight-box ul {
+  padding-left: 20px;
+  margin: 0;
+}
+
+.chittor-highlight-box li {
+  color: #cbbdab;
+  margin-bottom: 12px;
+  line-height: 1.6;
+}
+
+.chittor-highlight-box li:last-child {
+  margin-bottom: 0;
+}
+
+/* Commanders Section */
+.chittor-commanders-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.chittor-commander-card {
+  background: var(--chittor-glass);
+  border: 1px solid var(--chittor-border);
+  border-radius: 16px;
+  padding: 28px;
+  transition: transform 0.3s, border-color 0.3s;
+  backdrop-filter: blur(10px);
+}
+
+.chittor-commander-card:hover {
+  transform: translateY(-4px);
+  border-color: var(--chittor-gold-light);
+}
+
+.chittor-commander-mughal {
+  border-color: rgba(226, 106, 79, 0.3);
+}
+
+.chittor-commander-rank {
+  display: inline-block;
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--chittor-saffron);
+  background: rgba(242, 165, 65, 0.1);
+  border: 1px solid rgba(242, 165, 65, 0.28);
+  border-radius: 100px;
+  padding: 4px 12px;
+  margin-bottom: 14px;
+}
+
+.chittor-commander-card h3 {
+  margin: 0 0 10px;
+  font-family: 'Playfair Display', serif;
+  font-size: 1.25rem;
+  color: #ffffff;
+}
+
+.chittor-commander-card p {
+  margin: 0;
+  color: #cbbdab;
+  line-height: 1.65;
+  font-size: 0.95rem;
+}
+
+/* Strategy Grid */
+.chittor-strategy-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.chittor-strategy-card {
+  background: var(--chittor-glass);
+  border: 1px solid var(--chittor-border);
+  border-radius: 16px;
+  padding: 28px;
+  transition: transform 0.3s, border-color 0.3s;
+  backdrop-filter: blur(10px);
+}
+
+.chittor-strategy-card:hover {
+  transform: translateY(-4px);
+  border-color: var(--chittor-gold-light);
+}
+
+.chittor-strategy-step {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: rgba(179, 71, 47, 0.18);
+  border: 1px solid rgba(179, 71, 47, 0.4);
+  color: var(--chittor-red-light);
+  font-weight: 800;
+  font-size: 1rem;
+  margin-bottom: 14px;
+}
+
+.chittor-strategy-card h3 {
+  margin: 0 0 10px;
+  font-size: 1.15rem;
+  color: #ffffff;
+}
+
+.chittor-strategy-card p {
+  margin: 0;
+  color: #cbbdab;
+  line-height: 1.65;
+  font-size: 0.95rem;
+}
+
+.chittor-strategy-card p strong {
+  color: var(--chittor-gold-light);
+}
+
+/* Outcome Section */
+.chittor-outcome-box {
+  background: var(--chittor-glass);
+  border: 1px solid var(--chittor-border);
+  border-radius: 16px;
+  padding: 30px;
+  backdrop-filter: blur(12px);
+}
+
+.chittor-outcome-box h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.4rem;
+  margin: 0 0 16px;
+  color: var(--chittor-red-light);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.chittor-outcome-box ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.chittor-outcome-box li {
+  color: #cbbdab;
+  margin-bottom: 14px;
+  line-height: 1.6;
+  padding-left: 22px;
+  position: relative;
+}
+
+.chittor-outcome-box li::before {
+  content: '✓';
+  position: absolute;
+  left: 0;
+  top: 0;
+  color: var(--chittor-red-light);
+  font-weight: 800;
+}
+
+.chittor-outcome-box li:last-child {
+  margin-bottom: 0;
+}
+
+.chittor-outcome-box li strong {
+  color: var(--chittor-gold-light);
+}
+
+/* Impact Grid */
+.chittor-impact-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+}
+
+.chittor-impact-card {
+  background: var(--chittor-glass);
+  border: 1px solid var(--chittor-border);
+  border-radius: 16px;
+  padding: 28px;
+  transition: transform 0.3s, border-color 0.3s;
+  backdrop-filter: blur(10px);
+}
+
+.chittor-impact-card:hover {
+  transform: translateY(-4px);
+  border-color: var(--chittor-gold-light);
+}
+
+.chittor-impact-icon {
+  font-size: 2rem;
+  margin-bottom: 14px;
+  display: block;
+}
+
+.chittor-impact-card h3 {
+  margin: 0 0 10px;
+  font-size: 1.15rem;
+  color: #ffffff;
+}
+
+.chittor-impact-card p {
+  margin: 0;
+  color: #cbbdab;
+  line-height: 1.65;
+  font-size: 0.95rem;
+}
+
+/* Interactive Timeline */
+.chittor-timeline {
+  position: relative;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 20px 0;
+}
+
+.chittor-timeline::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(180deg, transparent, var(--chittor-border) 10%, var(--chittor-border) 90%, transparent);
+  transform: translateX(-50%);
+}
+
+.chittor-timeline-step {
+  display: flex;
+  justify-content: flex-end;
+  padding-right: 50%;
+  position: relative;
+  margin-bottom: 40px;
+}
+
+.chittor-timeline-step:nth-child(even) {
+  justify-content: flex-start;
+  padding-right: 0;
+  padding-left: 50%;
+}
+
+.chittor-timeline-marker {
+  position: absolute;
+  left: 50%;
+  top: 15px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--chittor-night);
+  border: 3px solid var(--chittor-gold-light);
+  transform: translateX(-50%);
+  z-index: 2;
+  transition: background 0.3s;
+}
+
+.chittor-timeline-step:hover .chittor-timeline-marker {
+  background: var(--chittor-red);
+  box-shadow: 0 0 10px var(--chittor-red);
+}
+
+.chittor-timeline-card {
+  background: var(--chittor-glass);
+  border: 1px solid var(--chittor-border);
+  border-radius: 12px;
+  padding: 24px;
+  width: 85%;
+  margin-right: 40px;
+  position: relative;
+  transition: transform 0.3s, border-color 0.3s;
+}
+
+.chittor-timeline-step:nth-child(even) .chittor-timeline-card {
+  margin-right: 0;
+  margin-left: 40px;
+}
+
+.chittor-timeline-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--chittor-gold-light);
+}
+
+.chittor-timeline-year {
+  color: var(--chittor-gold);
+  font-weight: 800;
+  font-size: 1.25rem;
+  margin-bottom: 8px;
+  display: block;
+}
+
+.chittor-timeline-card h3 {
+  margin: 0 0 8px;
+  font-size: 1.15rem;
+}
+
+.chittor-timeline-card p {
+  margin: 0;
+  color: #a89c8a;
+  line-height: 1.6;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 768px) {
+  .chittor-timeline::before {
+    left: 20px;
+  }
+  .chittor-timeline-step {
+    justify-content: flex-start;
+    padding-left: 45px;
+    padding-right: 0;
+  }
+  .chittor-timeline-step:nth-child(even) {
+    padding-left: 45px;
+  }
+  .chittor-timeline-marker {
+    left: 20px;
+  }
+  .chittor-timeline-card {
+    width: 100%;
+    margin-right: 0;
+  }
+  .chittor-timeline-step:nth-child(even) .chittor-timeline-card {
+    margin-left: 0;
+  }
+}
+
+/* Visual Gallery Grid */
+.chittor-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 20px;
+}
+
+.chittor-gallery-item {
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  aspect-ratio: 4 / 3;
+  border: 1px solid var(--chittor-border);
+  cursor: pointer;
+}
+
+.chittor-gallery-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.5s ease;
+}
+
+.chittor-gallery-item:hover img {
+  transform: scale(1.08);
+}
+
+.chittor-gallery-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(0deg, rgba(20, 14, 10, 0.95) 0%, rgba(20, 14, 10, 0.4) 60%, transparent 100%);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 20px;
+  opacity: 0.9;
+  transition: opacity 0.3s;
+}
+
+.chittor-gallery-overlay h4 {
+  margin: 0 0 4px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.chittor-gallery-overlay p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--chittor-gold-light);
+}
+
+/* References Section */
+.chittor-references {
+  background: var(--chittor-glass);
+  border: 1px solid var(--chittor-border);
+  border-radius: 16px;
+  padding: 40px;
+}
+
+.chittor-references h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.4rem;
+  margin: 0 0 20px;
+  color: #ffffff;
+}
+
+.chittor-references ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.chittor-references li {
+  position: relative;
+  padding-left: 24px;
+  margin-bottom: 16px;
+  line-height: 1.6;
+  color: #cbbdab;
+  font-size: 0.98rem;
+}
+
+.chittor-references li:last-child {
+  margin-bottom: 0;
+}
+
+.chittor-references li::before {
+  content: '📖';
+  position: absolute;
+  left: 0;
+  top: 2px;
+  font-size: 0.9rem;
+}
+
+/* Welcome Toast (auto-dismiss) */
+.chittor-welcome-toast {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  max-width: 340px;
+  z-index: 1000;
+  padding: 14px 18px;
+  border-radius: 12px;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: var(--chittor-gold-light);
+  background: rgba(20, 14, 10, 0.95);
+  border: 1px solid var(--chittor-border);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+  opacity: 0;
+  transform: translateY(16px);
+  transition: opacity 0.4s ease, transform 0.4s ease;
+}
+
+.chittor-welcome-toast.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.chittor-welcome-toast strong {
+  color: var(--chittor-gold);
+}
+
+/* Bookmark UI Integration */
+.chittor-bookmark-container {
+  display: flex;
+  justify-content: center;
+  margin-top: 30px;
+}
+
+.chittor-bookmark-btn {
+  background: var(--chittor-glass);
+  border: 1px solid var(--chittor-border);
+  color: var(--chittor-gold-light);
+  padding: 10px 24px;
+  border-radius: 30px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: all 0.2s ease;
+}
+
+.chittor-bookmark-btn:hover {
+  border-color: var(--chittor-gold-light);
+  background: rgba(230, 181, 102, 0.1);
+  transform: translateY(-1px);
+}
+
+.chittor-bookmark-btn.is-saved {
+  background: var(--chittor-gold-light);
+  color: var(--chittor-night);
+  border-color: var(--chittor-gold-light);
+}
+
+/* Interactive Detail Modal */
+.museum-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1600;
+  display: none;
+  place-items: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.78);
+  backdrop-filter: blur(10px);
+}
+
+.museum-modal.open {
+  display: grid;
+}
+
+.museum-modal-card {
+  position: relative;
+  width: min(680px, 96vw);
+  max-height: 90vh;
+  overflow: auto;
+  padding: 30px;
+  border: 1px solid var(--chittor-border);
+  border-radius: 22px;
+  background: var(--chittor-night-light);
+  color: #f1f5f9;
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.45);
+}
+
+.museum-modal-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  width: 38px;
+  height: 38px;
+  border: 1px solid var(--chittor-border);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.05);
+  color: #cbbdab;
+  font-size: 1.45rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.museum-modal-close:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.modal-category {
+  display: inline-block;
+  margin-bottom: 10px;
+  color: var(--chittor-gold-light);
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+}
+
+.museum-modal-card h2 {
+  margin: 0 42px 7px 0;
+  font-family: "Playfair Display", serif;
+  font-size: clamp(1.9rem, 4vw, 2.7rem);
+}
+
+.modal-location {
+  margin: 0 0 20px;
+  color: #cbbdab;
+  font-weight: 600;
+}
+
+.modal-description {
+  margin: 0;
+  color: #cbbdab;
+  line-height: 1.75;
+}
+
+body.modal-open {
+  overflow: hidden;
+}

--- a/tests/unit/siege-of-chittor-explorer.test.js
+++ b/tests/unit/siege-of-chittor-explorer.test.js
@@ -1,0 +1,123 @@
+/**
+ * siege-of-chittor-explorer.test.js
+ * Unit tests for the Siege of Chittor Explorer page.
+ * Validates required sections, key historical content, accessibility,
+ * and landing page card integration on the Historic Battles of India page.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function readExplorerFile(file) {
+    return readFileSync(
+        resolve(__dirname, '../../frontend/siege-of-chittor-explorer', file),
+        'utf-8'
+    );
+}
+
+function readLandingPage() {
+    return readFileSync(
+        resolve(__dirname, '../../frontend/history/battles/index.html'),
+        'utf-8'
+    );
+}
+
+describe('Siege of Chittor Explorer — Page Structure', () => {
+    let html;
+
+    beforeAll(() => {
+        html = readExplorerFile('index.html');
+    });
+
+    it('contains a hero section with page title and kicker', () => {
+        expect(html).toContain('class="chittor-hero"');
+        expect(html).toContain('<h1>');
+        expect(html).toContain('Siege of Chittor');
+        expect(html).toContain('1567');
+    });
+
+    it('contains all required content sections from the issue', () => {
+        const sections = ['background', 'commanders', 'strategy', 'outcome', 'impact', 'timeline', 'references'];
+        sections.forEach(id => {
+            expect(html).toContain(`id="${id}"`);
+        });
+    });
+
+    it('contains all required section topics', () => {
+        ['Historical', 'Timeline', 'Commanders', 'Strategy', 'Outcome', 'Impact', 'References'].forEach(topic => {
+            expect(html).toContain(topic);
+        });
+    });
+
+    it('contains the key historical and structural details', () => {
+        expect(html).toContain('Akbar');
+        expect(html).toContain('Jaimal');
+        expect(html).toContain('Patta');
+        expect(html).toContain('Udai Singh');
+        expect(html).toContain('Chittor');
+        expect(html).toContain('jauhar');
+        expect(html).toContain('23 February 1568');
+    });
+
+    it('has a semantic heading hierarchy (single h1, multiple section h2s)', () => {
+        const h1Count = (html.match(/<h1[\s>]/g) || []).length;
+        const h2Count = (html.match(/<h2[\s>]/g) || []).length;
+        expect(h1Count).toBe(1);
+        expect(h2Count).toBeGreaterThanOrEqual(5);
+    });
+
+    it('uses HTTPS OG image URLs', () => {
+        const ogImages = html.match(/property="og:image" content="([^"]*)"/g) || [];
+        expect(ogImages.length).toBeGreaterThanOrEqual(1);
+        ogImages.forEach(tag => {
+            expect(tag).toMatch(/https:\/\//);
+        });
+    });
+
+    it('links the shared stylesheet, page stylesheet, and script', () => {
+        expect(html).toContain('href="../../styles.css"');
+        expect(html).toContain('href="style.css"');
+        expect(html).toContain('src="script.js"');
+    });
+});
+
+describe('Siege of Chittor Explorer — Assets', () => {
+    it('includes a non-empty stylesheet', () => {
+        const css = readExplorerFile('style.css');
+        expect(css.length).toBeGreaterThan(1000);
+        expect(css).toContain('.chittor-hero');
+        expect(css).toContain('.chittor-timeline');
+        expect(css).toContain('.chittor-references');
+    });
+
+    it('includes a valid interactive script with required features', () => {
+        const js = readExplorerFile('script.js');
+        expect(js).toContain('registerSearchItems');
+        expect(js).toContain('Journey');
+        expect(js).toContain('chittor-modal');
+        expect(js).toContain('app:route-changed');
+    });
+});
+
+describe('Siege of Chittor — Landing Page Integration', () => {
+    it('is listed as a featured explorer card on the Historic Battles of India landing page', () => {
+        const index = readLandingPage();
+        expect(index).toContain('Siege of Chittor');
+        expect(index).toContain('../../siege-of-chittor-explorer/index.html');
+        expect(index).toContain('featured-explorer-card');
+    });
+
+    it('matches the existing featured card pattern (badge, heading, button)', () => {
+        const index = readLandingPage();
+        const cardStart = index.indexOf('Siege of Chittor');
+        expect(cardStart).toBeGreaterThan(-1);
+        const card = index.slice(cardStart, cardStart + 1200);
+        expect(card).toContain('featured-explorer-badge');
+        expect(card).toContain('featured-explorer-btn');
+        expect(card).toContain('Jaimal');
+    });
+});


### PR DESCRIPTION
# Pull Request

## Description

Adds a dedicated explorer page for the Siege of Chittorgarh (23 October 1567 – 23 February 1568), Akbar's four-month campaign against the Sisodia capital of Mewar, covering the defiant defence of Jaimal and Patta and the third jauhar of Chittor. Follows the same structure as the Battle of Buxar explorer.

- New `frontend/siege-of-chittor-explorer/` page (index.html, style.css, script.js) with hero, historical background, major commanders, battle strategy, outcome, historical impact, timeline, gallery modal, and references
- Featured explorer card added to the Battles hub (`frontend/history/battles/index.html`)
- Search-index entry in `frontend/search-index.js`
- Unit tests in `tests/unit/siege-of-chittor-explorer.test.js`

Fixes #1599

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Ran unit tests: `tests/unit/siege-of-chittor-explorer.test.js` (11/11 pass; Buxar explorer tests also pass)
- [ ] Tested locally in browser
- [ ] Tested in both dark and light themes
- [ ] Tested at mobile viewport widths
- [ ] Verified no console errors

## Checklist

- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)