### PR TITLE
feat: create Sopara Ancient Port Explorer

### DIFF
--- a/frontend/ancient-ports-explorer/index.html
+++ b/frontend/ancient-ports-explorer/index.html
@@ -376,6 +376,25 @@
                             <a href="../cuddalore-port-explorer/index.html" class="award-btn">Explore Cuddalore Port &rarr;</a>
                         </div>
                     </div>
+
+                    <!-- Sopara Ancient Port Explorer Card -->
+                    <div class="award-card glass-card" data-category="West Coast">
+                        <div class="card-header">
+                            <span class="award-icon">⚓</span>
+                            <span class="award-category">West Coast</span>
+                        </div>
+                        <h3 class="award-name">Sopara Ancient Port</h3>
+                        <div class="award-meta">
+                            <span class="award-year">Ashokan Edict (250 BCE)</span>
+                            <span class="award-tier">Buddhist Stupa City</span>
+                        </div>
+                        <p class="award-description">
+                            Explore Sopara (Shurparaka), the ancient Buddhist emporium of Maharashtra's west coast, its Ashokan rock edict, maritime silk-route trade, stupas, and layered archaeological relics.
+                        </p>
+                        <div class="card-footer">
+                            <a href="../sopara-port-explorer/index.html" class="award-btn">Explore Sopara Port &rarr;</a>
+                        </div>
+                    </div>
                 </div>
             </div>
         </section>

--- a/frontend/sopara-port-explorer/index.html
+++ b/frontend/sopara-port-explorer/index.html
@@ -1,0 +1,336 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore Sopara (Shurparaka / Supparaka), an ancient west-coast Indian port with significant Buddhist and maritime trade history, located near Palghar in Maharashtra.">
+  <title>Sopara Ancient Port Explorer | Incredible India</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="../js-modules/page-progress/page-progress.css">
+
+  <!-- Open Graph / Social Media Tags -->
+  <meta property="og:title" content="Sopara Ancient Port Explorer | Incredible India Explorer">
+  <meta property="og:description" content="Discover Sopara (Shurparaka), the ancient Buddhist port of Maharashtra's west coast. Explore its Ashokan rock edict, maritime silk-route trade, stupas, and archaeological discoveries.">
+  <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/frontend/assets/sopara_port.png">
+  <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/sopara-port-explorer/index.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Incredible India Explorer">
+  <meta property="og:locale" content="en_IN">
+
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/sopara-port-explorer/index.html">
+</head>
+<body>
+  <script>
+    (function() {
+      const theme = localStorage.getItem('theme') || 'dark';
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+
+  <!-- Sticky Navigation Bar -->
+  <header class="navbar" id="navbar">
+    <div class="nav-container">
+        <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+            <span class="saffron">Incredible</span>
+            <span class="gold">India</span>
+            <span class="green">Explorer</span>
+        </a>
+        <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+            <span class="bar"></span>
+            <span class="bar"></span>
+            <span class="bar"></span>
+        </button>
+        <nav class="nav-menu" id="nav-menu">
+            <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
+                    <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                    <a href="../../frontend/ancient-ports-explorer/index.html" class="dropdown-item">Ancient Ports of India</a>
+                    <a href="../../frontend/islands/islands.html" class="dropdown-item">Islands of India</a>
+                    <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    <a href="../../frontend/route-planner/route-planner.html" class="dropdown-item">Route Planner</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+                    <a href="../../frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
+                    <a href="../../frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
+                    <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
+                    <a href="../../frontend/national-symbols-gallery/national-symbols-gallery.html" class="dropdown-item">National Symbols</a>
+                    <a href="../../frontend/cuisine-discovery-hub/index.html" class="dropdown-item">UP Cuisine</a>
+                    <a href="../../frontend/handicrafts-showcase/index.html" class="dropdown-item">UP Handicrafts</a>
+                    <a href="../../frontend/national-days-calendar/index.html" class="dropdown-item">National Days</a>
+                    <a href="../../frontend/ganga-ghats-experience/index.html" class="dropdown-item">Ganga Ghats</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Nature ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/national-parks-explorer/index.html" class="dropdown-item">National Parks</a>
+                    <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                    <a href="../../frontend/wildlife-rescue/wildlife-rescue.html" class="dropdown-item">Wildlife Rescue</a>
+                    <a href="../../frontend/endemic-flora-fauna-explorer/index.html" class="dropdown-item">Endemic Flora & Fauna</a>
+                    <a href="../../frontend/harike-wetland/harike-wetland.html" class="dropdown-item">Harike Wetland</a>
+                    <a href="../../frontend/wular-lake/wular-lake.html" class="dropdown-item">Wular Lake</a>
+                    <a href="../../frontend/crowd-density/index.html" class="dropdown-item">Crowd Density Predictor</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Games ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/passport-quest/passport-quest.html" class="dropdown-item">Passport Quest</a>
+                    <a href="../../frontend/culinary-game/culinary-game.html" class="dropdown-item">Culinary Challenge</a>
+                    <a href="../../frontend/monsoon-game/monsoon-game.html" class="dropdown-item">Monsoon Game</a>
+                    <a href="../../frontend/river-game/river-game.html" class="dropdown-item">River Explorer</a>
+                    <a href="../../frontend/geo-guesser-india/index.html" class="dropdown-item">GeoGuesser</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Community ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/contributors/contributors.html" class="dropdown-item">Contributors</a>
+                    <a href="../../frontend/world-records-india/index.html" class="dropdown-item">World Records</a>
+                </div>
+            </div>
+
+            <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+        </nav>
+    </div>
+</header>
+
+  <!-- Main Container -->
+  <main id="app-root" class="sop-main">
+
+    <!-- Hero Banner -->
+    <section class="sop-hero">
+      <div class="sop-hero-content">
+        <span class="sop-kicker">🌊 West Coast of India · Buddhist &amp; Maritime Trade Hub</span>
+        <h1>Sopara Ancient Port <span>Explorer</span></h1>
+        <p>Discover Sopara (ancient <em>Shurparaka</em> / <em>Supparaka</em>), one of India's oldest west-coast trading emporiums, nestled along the Vasai creek near modern Nala Sopara in Maharashtra. Trace its story as a great Buddhist centre, a Roman-era trading hub, and a vital gateway of the ancient maritime silk roads.</p>
+        <div class="sop-bookmark-container">
+          <button class="sop-bookmark-btn journey-bookmark-btn" type="button" data-bookmark-id="sopara-port-main" aria-pressed="false" aria-label="Bookmark Sopara Port">
+            ♡ Save to Journey
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Historical Overview -->
+    <section class="sop-section" id="overview">
+      <div class="sop-container sop-grid-2col">
+        <div class="sop-text-block">
+          <span class="sop-eyebrow">The Ancient Buddhist City</span>
+          <h2>A Historical Overview of Sopara</h2>
+          <p>Sopara (also written <em>Shurparaka</em>, <em>Soparaka</em>, <em>Supparaka</em>, and <em>Sopara</em> in Ptolemy's <em>Geographia</em>) was an ancient port-city on the western coast of India, located along the creeks and salt-brackish wetlands near the present-day Nala Sopara region of the Palghar district, Maharashtra.</p>
+          <p>It finds mention in the <em>Mahabharata</em>, the <em>Shaivagama</em> literature, and the Buddhist Jataka tales &mdash; notably the <em>Supparaka Jataka</em>, which celebrates the fearless sea-captain Supparaka. Alongside Bharukachchha (Broach) and Kalyana (Kalyan), Sopara ranked among the most celebrated seaports of ancient western India.</p>
+          <p>Its standing as a premier Buddhist seat is underscored by the <strong>Ashokan Rock Edict of Sopara</strong> &mdash; one of only two major rock edicts of Emperor Ashoka found on the west coast &mdash; discovered in 1882 by Dr. Bhagwanlal Indraji. The edict confirms that Ashoka's Dhamma reached as far west as the Konkan coast, and that Sopara hosted an important Buddhist monastic community.</p>
+        </div>
+        <div class="sop-highlight-box">
+          <h3>⚓ Sopara at a Glance</h3>
+          <ul>
+            <li><strong>Location</strong>: Near Nala Sopara, Palghar district, Maharashtra (Vasai creek area).</li>
+            <li><strong>Ancient Names</strong>: Shurparaka, Supparaka, Soparaka, Sopara (Ptolemy).</li>
+            <li><strong>Dynasties</strong>: Maurya, Satavahana, Western Kshatrapa, Traikutaka.</li>
+            <li><strong>Significance</strong>: Major Buddhist monastery city and western terminus of early maritime trade.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Maritime Trade -->
+    <section class="sop-section" id="trade">
+      <div class="sop-container">
+        <div class="sop-section-header">
+          <span class="sop-eyebrow">Emporium of the Western Sea</span>
+          <h2>Maritime Trade &amp; the Periplus</h2>
+          <p>Sopara's sheltered harbour on the Vasai creek linked inland India with Arabia, Persia, Egypt, and the wider Mediterranean world.</p>
+        </div>
+
+        <div class="sop-card-grid">
+          <div class="sop-card">
+            <span class="sop-card-icon">🕌</span>
+            <h3>Greco-Roman Connections</h3>
+            <p>Sopara is named in the <em>Periplus of the Erythraean Sea</em> (1st century CE) as a thriving emporium, exporting Indian cotton textiles, ivory, and ceramics to the Greco-Roman world in exchange for glass, wine, and gold.</p>
+          </div>
+          <div class="sop-card">
+            <span class="sop-card-icon">🐚</span>
+            <h3>Arabian Sea Networks</h3>
+            <p>Sailing dhows and masted vessels linked Sopara with the Arabian and Persian Gulf ports, bringing frankincense, myrrh, and pearls while carrying away Indian muslins and beads.</p>
+          </div>
+          <div class="sop-card">
+            <span class="sop-card-icon">💰</span>
+            <h3>Roman Denarii &amp; Local Coinage</h3>
+            <p>Excavations at Sopara yielded Roman aurei and denarii alongside punch-marked and Satavahana coins, pointing to a monetised, cosmopolitan trading economy.</p>
+          </div>
+          <div class="sop-card">
+            <span class="sop-card-icon">🗺️</span>
+            <h3>Northern Emporium Route</h3>
+            <p>Caravans from Ujjain and the Ganges plains funnelled cotton, indigo, and metal goods to Sopara's wharves, making it a crucial land-sea transit hub of the Konkan.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Archaeological Discoveries -->
+    <section class="sop-section" id="archaeology">
+      <div class="sop-container">
+        <div class="sop-section-header">
+          <span class="sop-eyebrow">Unearthing the Past</span>
+          <h2>Archaeological Discoveries</h2>
+          <p>From Ashokan edicts to Buddhist reliquary caskets, Sopara's soil has revealed the layered history of two millennia.</p>
+        </div>
+
+        <div class="sop-card-grid">
+          <div class="sop-card">
+            <span class="sop-card-icon">🪨</span>
+            <h3>The Sopara Rock Edict (1882)</h3>
+            <p>Discovered by Bhagwanlal Indraji, the two fragments of Ashoka's 4th and 9th rock edicts were engraved on black basalt, confirming Mauryan provincial administration and Buddhist patronage in the Konkan.</p>
+          </div>
+          <div class="sop-card">
+            <span class="sop-card-icon">🕉️</span>
+            <h3>Buddhist Stupa &amp; Relics</h3>
+            <p>Excavations at the Burud Rajacha Thaka mound revealed a large brick stupa complex (c. 2nd century BCE &ndash; 3rd century CE) with relic caskets, stone umbrellas, and sculpted railings, some now housed in museums.</p>
+          </div>
+          <div class="sop-card">
+            <span class="sop-card-icon">🏺</span>
+            <h3>Trade Goods &amp; Pottery</h3>
+            <p>Rouletted ware, Northern Black Polished Ware, terracotta figurines, beads of carnelian and glass, and Roman amphorae sherds all testify to long-distance exchange networks.</p>
+          </div>
+          <div class="sop-card">
+            <span class="sop-card-icon">🗿</span>
+            <h3>Sculptures &amp; Terracottas</h3>
+            <p>Beautifully modelled terracotta human and animal figurines, yaksha images, and architectural fragments in the Chakreshwar temple area reflect the artistic vibrancy of the Shunga-Satavahana age.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Important Monuments -->
+    <section class="sop-section" id="monuments">
+      <div class="sop-container sop-grid-2col">
+        <div class="sop-highlight-box" style="background: rgba(245, 158, 11, 0.05); border-color: rgba(245, 158, 11, 0.3);">
+          <h3>🏛️ Monuments &amp; Heritage</h3>
+          <ul>
+            <li><strong>Ashokan Rock Edict Site</strong>: Commemorative pillar site near Nala Sopara marking where the edict was discovered.</li>
+            <li><strong>Burud Rajacha Thaka</strong>: The ancient Buddhist stupa mound, now a protected ASI site.</li>
+            <li><strong>Chakreshwar Temple</strong>: A historic Shiva temple whose precincts yielded many sculptural finds.</li>
+            <li><strong>Vasai (Bassein) Fort</strong>: The later Portuguese citadel built over the medieval successor port of Sopara.</li>
+            <li><strong>Shirgaon &amp; Arnala Heritage</strong>: Nearby creek-island sites preserving medieval maritime defences.</li>
+          </ul>
+        </div>
+        <div class="sop-text-block">
+          <span class="sop-eyebrow">From Sopara to Vasai</span>
+          <h2>Monuments Along the Creek</h2>
+          <p>As the silt of the creek crept in, Sopara's prominence gradually passed to its successor, Vasai (Bassein), which the Portuguese fortified in the 16th century. Yet the landscape around Nala Sopara still preserves the ghosts of the ancient emporium: the edict mound, stupa remains, and temple precincts.</p>
+          <p>Today the Archaeological Survey of India protects the stupa mound and the edict commemorative site, making Sopara an evocative stop for students of Buddhist and maritime history.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Image Gallery -->
+    <section class="sop-section" id="gallery">
+      <div class="sop-container">
+        <div class="sop-section-header">
+          <span class="sop-eyebrow">Visual Tour</span>
+          <h2>Gallery of Sopara</h2>
+          <p>Explore the archaeological relics, edict fragments, and coastal heritage of this ancient port.</p>
+        </div>
+
+        <div class="sop-gallery-grid">
+          <div class="sop-gallery-item" data-title="Ashokan Rock Edict Fragments" data-desc="Two black-basalt fragments of Emperor Ashoka's 4th and 9th rock edicts discovered at Sopara in 1882.">
+            <img src="../assets/sopara_edict.png" alt="Sopara Ashokan Rock Edict" loading="lazy" onerror="this.onerror=null; this.src='https://images.unsplash.com/photo-1564419320461-6870880221ad?auto=format&fit=crop&w=600&q=80';">
+            <div class="sop-gallery-overlay">
+              <h4>Ashokan Edict</h4>
+              <p>Mauryan Inscription (c. 250 BCE)</p>
+            </div>
+          </div>
+          <div class="sop-gallery-item" data-title="Sopara Buddhist Stupa" data-desc="Brick stupa complex and relic caskets excavated at the Burud Rajacha Thaka mound, dating c. 2nd century BCE.">
+            <img src="../assets/sopara_stupa.png" alt="Sopara Buddhist Stupa Remains" loading="lazy" onerror="this.onerror=null; this.src='https://images.unsplash.com/photo-1544735716-392fe2489ffa?auto=format&fit=crop&w=600&q=80';">
+            <div class="sop-gallery-overlay">
+              <h4>Buddhist Stupa</h4>
+              <p>Relic Casket Site</p>
+            </div>
+          </div>
+          <div class="sop-gallery-item" data-title="Vasai Creek &amp; Harbour" data-desc="The sheltered creek that served as Sopara's ancient harbour, linking the town with the Arabian Sea.">
+            <img src="../assets/sopara_creek.png" alt="Vasai Creek Sopara Harbour" loading="lazy" onerror="this.onerror=null; this.src='https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=600&q=80';">
+            <div class="sop-gallery-overlay">
+              <h4>Vasai Creek</h4>
+              <p>Ancient Harbour Approach</p>
+            </div>
+          </div>
+          <div class="sop-gallery-item" data-title="Chakreshwar Temple Artifacts" data-desc="Sculptural fragments and terracottas recovered from the Chakreshwar temple precincts around Sopara.">
+            <img src="../assets/sopara_artifacts.png" alt="Sopara Terracotta Artifacts" loading="lazy" onerror="this.onerror=null; this.src='https://images.unsplash.com/photo-1580406611427-b238b4e3c4b4?auto=format&fit=crop&w=600&q=80';">
+            <div class="sop-gallery-overlay">
+              <h4>Terracotta Art</h4>
+              <p>Shunga-Satavahana Finds</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: References -->
+    <section class="sop-section" id="references">
+      <div class="sop-container">
+        <div class="sop-references">
+          <h3>📚 References &amp; Further Reading</h3>
+          <ul>
+            <li><strong>Indraji, B. (1882)</strong>. <em>Notes on the Buddhist Remains at Sopara</em>. Journal of the Bombay Branch of the Royal Asiatic Society.</li>
+            <li><strong>Schoff, W. H. (1912)</strong>. <em>The Periplus of the Erythraean Sea: Travel and Trade in the Indian Ocean by a Merchant of the First Century</em>. Longmans, Green &amp; Co.</li>
+            <li><strong>Thapar, R. (1997)</strong>. <em>Ashoka and the Decline of the Mauryas</em>. Oxford University Press.</li>
+            <li><strong>Dikshit, M. G. (1966)</strong>. <em>Some Religious Relics Excavated at Sopara</em>. Journal of Indian History.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- Interactive Detail Modal -->
+  <div class="museum-modal" id="sop-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-hidden="true">
+    <div class="museum-modal-card">
+      <button class="museum-modal-close" id="sop-modal-close" type="button" aria-label="Close details">✕</button>
+      <span class="modal-category" id="modal-category">Sopara Highlight</span>
+      <h2 id="modal-title"></h2>
+      <p class="modal-location" style="color: var(--sop-gold);" id="modal-heading"></p>
+      <div style="border-top: 1px solid rgba(255,255,255,0.1); margin-top: 15px; padding-top: 15px;">
+        <p class="modal-description" id="modal-description"></p>
+      </div>
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <footer class="sop-footer">
+    <div class="sop-container">
+      <p>Part of <a href="../ancient-ports-explorer/index.html">Ancient Ports of India Explorer</a> · <a href="../../index.html">Incredible India Explorer</a>.</p>
+    </div>
+  </footer>
+
+  <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+
+  <!-- JS Dependencies -->
+  <script src="../app.js" defer></script>
+  <script src="../../frontend/journey/journey.js" defer></script>
+  <script src="script.js" defer></script>
+  <script type="module" src="../firebase-config.js"></script>
+  <script type="module" src="../auth.js"></script>
+  <script src="../router.js" defer></script>
+  <script src="../js-modules/page-progress/page-progress.js"></script>
+</body>
+</html>

--- a/frontend/sopara-port-explorer/script.js
+++ b/frontend/sopara-port-explorer/script.js
@@ -1,0 +1,80 @@
+/**
+ * Sopara Ancient Port Explorer JavaScript
+ * Handles interactive gallery modal overlays, theme switching, and bookmark integration.
+ */
+
+(function () {
+  'use strict';
+
+  function init() {
+    setupGalleryModal();
+    setupThemeToggle();
+  }
+
+  function setupGalleryModal() {
+    const modal = document.getElementById('sop-modal');
+    const modalClose = document.getElementById('sop-modal-close');
+    const modalTitle = document.getElementById('modal-title');
+    const modalHeading = document.getElementById('modal-heading');
+    const modalDesc = document.getElementById('modal-description');
+    const galleryItems = document.querySelectorAll('.sop-gallery-item');
+
+    if (!modal || !galleryItems.length) return;
+
+    galleryItems.forEach(item => {
+      item.addEventListener('click', function () {
+        const title = this.getAttribute('data-title') || '';
+        const desc = this.getAttribute('data-desc') || '';
+        const caption = this.querySelector('p') ? this.querySelector('p').textContent : 'Sopara Archaeological Artifact';
+
+        if (modalTitle) modalTitle.textContent = title;
+        if (modalHeading) modalHeading.textContent = caption;
+        if (modalDesc) modalDesc.textContent = desc;
+
+        modal.classList.add('open');
+        document.body.classList.add('modal-open');
+      });
+    });
+
+    if (modalClose) {
+      modalClose.addEventListener('click', function () {
+        modal.classList.remove('open');
+        document.body.classList.remove('modal-open');
+      });
+    }
+
+    window.addEventListener('click', function (e) {
+      if (e.target === modal) {
+        modal.classList.remove('open');
+        document.body.classList.remove('modal-open');
+      }
+    });
+
+    window.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && modal.classList.contains('open')) {
+        modal.classList.remove('open');
+        document.body.classList.remove('modal-open');
+      }
+    });
+  }
+
+  function setupThemeToggle() {
+    const themeToggleBtn = document.getElementById('theme-toggle');
+    if (themeToggleBtn) {
+      themeToggleBtn.addEventListener('click', function () {
+        const isLight = document.body.classList.toggle('light-theme');
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+      });
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+  window.SoparaPortExplorer = {
+    init
+  };
+})();

--- a/frontend/sopara-port-explorer/style.css
+++ b/frontend/sopara-port-explorer/style.css
@@ -1,0 +1,419 @@
+/* ==========================================================================
+   Sopara Ancient Port Explorer - Stylesheet
+   Pure Vanilla CSS matching Incredible India Explorer guidelines.
+   ========================================================================== */
+
+:root {
+  --sop-ocean: #0b1220;
+  --sop-ocean-light: #151d31;
+  --sop-gold: #f5b50a;
+  --sop-laterite: #b45309;
+  --sop-emerald: #34d399;
+  --sop-blue: #38bdf8;
+  --sop-glass: rgba(11, 18, 32, 0.6);
+  --sop-border: rgba(245, 181, 10, 0.25);
+}
+
+.sop-main {
+  background-color: var(--sop-ocean);
+  color: #f1f5f9;
+  font-family: 'Outfit', sans-serif;
+  overflow-x: hidden;
+}
+
+.sop-hero {
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+  padding: 120px 0 60px;
+  background: linear-gradient(180deg, rgba(11, 18, 32, 0.4), rgba(11, 18, 32, 0.95)),
+              url('../assets/sopara_port.png') center/cover no-repeat;
+  text-align: center;
+}
+
+.sop-hero-content {
+  position: relative;
+  z-index: 2;
+  width: min(880px, 90%);
+}
+
+.sop-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 20px;
+  padding: 6px 16px;
+  background: rgba(245, 181, 10, 0.12);
+  border: 1px solid rgba(245, 181, 10, 0.35);
+  border-radius: 100px;
+  color: var(--sop-gold);
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  backdrop-filter: blur(8px);
+}
+
+.sop-hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2.5rem, 6vw, 4.5rem);
+  line-height: 1.1;
+  margin: 0 0 20px;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.sop-hero h1 span {
+  color: var(--sop-gold);
+  background: linear-gradient(135deg, var(--sop-gold), var(--sop-emerald));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.sop-hero p {
+  font-size: clamp(1rem, 2vw, 1.2rem);
+  line-height: 1.6;
+  color: #cbd5e1;
+  margin: 0 auto;
+  max-width: 720px;
+}
+
+.sop-section {
+  padding: 80px 0;
+}
+
+.sop-section:nth-of-type(even) {
+  background-color: rgba(255, 255, 255, 0.01);
+}
+
+.sop-container {
+  width: min(1200px, 90%);
+  margin: 0 auto;
+}
+
+.sop-section-header {
+  margin-bottom: 50px;
+  text-align: center;
+}
+
+.sop-eyebrow {
+  color: var(--sop-gold);
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.sop-section-header h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin: 0 0 16px;
+  color: #ffffff;
+}
+
+.sop-section-header p {
+  color: #94a3b8;
+  max-width: 650px;
+  margin: 0 auto;
+  line-height: 1.6;
+  font-size: 1.05rem;
+}
+
+.sop-grid-2col {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 50px;
+  align-items: center;
+}
+
+@media (max-width: 900px) {
+  .sop-grid-2col {
+    grid-template-columns: 1fr;
+    gap: 30px;
+  }
+}
+
+.sop-text-block p {
+  line-height: 1.75;
+  color: #cbd5e1;
+  margin-bottom: 20px;
+  font-size: 1.05rem;
+}
+
+.sop-highlight-box {
+  background: var(--sop-glass);
+  border: 1px solid var(--sop-border);
+  border-radius: 16px;
+  padding: 30px;
+  backdrop-filter: blur(12px);
+}
+
+.sop-highlight-box h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.4rem;
+  margin: 0 0 16px;
+  color: var(--sop-gold);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.sop-highlight-box ul {
+  padding-left: 20px;
+  margin: 0;
+}
+
+.sop-highlight-box li {
+  color: #cbd5e1;
+  margin-bottom: 12px;
+  line-height: 1.6;
+}
+
+.sop-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.sop-card {
+  background: var(--sop-glass);
+  border: 1px solid var(--sop-border);
+  border-radius: 16px;
+  padding: 30px;
+  transition: transform 0.3s, border-color 0.3s, box-shadow 0.3s;
+  backdrop-filter: blur(10px);
+}
+
+.sop-card:hover {
+  transform: translateY(-5px);
+  border-color: var(--sop-gold);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
+}
+
+.sop-card-icon {
+  font-size: 2.2rem;
+  margin-bottom: 20px;
+  display: block;
+}
+
+.sop-card h3 {
+  margin: 0 0 12px;
+  font-family: 'Playfair Display', serif;
+  font-size: 1.3rem;
+  color: #ffffff;
+}
+
+.sop-card p {
+  margin: 0;
+  line-height: 1.6;
+  color: #cbd5e1;
+  font-size: 0.95rem;
+}
+
+.sop-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 20px;
+}
+
+.sop-gallery-item {
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  aspect-ratio: 4 / 3;
+  border: 1px solid var(--sop-border);
+  cursor: pointer;
+}
+
+.sop-gallery-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.5s ease;
+}
+
+.sop-gallery-item:hover img {
+  transform: scale(1.08);
+}
+
+.sop-gallery-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(0deg, rgba(11, 18, 32, 0.95) 0%, rgba(11, 18, 32, 0.4) 60%, transparent 100%);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 20px;
+  opacity: 0.9;
+}
+
+.sop-gallery-overlay h4 {
+  margin: 0 0 4px;
+  font-size: 1.1rem;
+  color: #ffffff;
+}
+
+.sop-gallery-overlay p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--sop-gold);
+}
+
+.sop-references {
+  background: var(--sop-glass);
+  border: 1px solid var(--sop-border);
+  border-radius: 16px;
+  padding: 40px;
+}
+
+.sop-references h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.4rem;
+  margin: 0 0 20px;
+  color: #ffffff;
+}
+
+.sop-references ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sop-references li {
+  position: relative;
+  padding-left: 24px;
+  margin-bottom: 16px;
+  line-height: 1.6;
+  color: #cbd5e1;
+  font-size: 0.98rem;
+}
+
+.sop-references li::before {
+  content: '📖';
+  position: absolute;
+  left: 0;
+  top: 2px;
+}
+
+.sop-footer {
+  padding: 40px 0;
+  text-align: center;
+  color: #94a3b8;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.sop-footer a {
+  color: var(--sop-gold);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.sop-bookmark-container {
+  display: flex;
+  justify-content: center;
+  margin-top: 30px;
+}
+
+.sop-bookmark-btn {
+  background: var(--sop-glass);
+  border: 1px solid var(--sop-border);
+  color: var(--sop-gold);
+  padding: 10px 24px;
+  border-radius: 30px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: all 0.2s ease;
+}
+
+.sop-bookmark-btn:hover {
+  border-color: var(--sop-gold);
+  background: rgba(245, 181, 10, 0.1);
+}
+
+/* Modal */
+.museum-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1600;
+  display: none;
+  place-items: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.78);
+  backdrop-filter: blur(10px);
+}
+
+.museum-modal.open {
+  display: grid;
+}
+
+.museum-modal-card {
+  position: relative;
+  width: min(680px, 96vw);
+  max-height: 90vh;
+  overflow: auto;
+  padding: 30px;
+  border: 1px solid var(--sop-border);
+  border-radius: 22px;
+  background: var(--sop-ocean-light);
+  color: #f1f5f9;
+}
+
+.museum-modal-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  width: 38px;
+  height: 38px;
+  border: 1px solid var(--sop-border);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.05);
+  color: #cbd5e1;
+  font-size: 1.45rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+body.light-theme .sop-main {
+  background-color: #f8fafc;
+  color: #1e293b;
+}
+
+body.light-theme .sop-hero {
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.85), rgba(248, 250, 252, 0.98));
+}
+
+body.light-theme .sop-hero h1 {
+  color: #0f172a;
+}
+
+body.light-theme .sop-hero p {
+  color: #475569;
+}
+
+body.light-theme .sop-card,
+body.light-theme .sop-highlight-box,
+body.light-theme .sop-references,
+body.light-theme .museum-modal-card {
+  background: #ffffff;
+  border-color: rgba(245, 181, 10, 0.3);
+  color: #334155;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.05);
+}
+
+body.light-theme .sop-section-header h2,
+body.light-theme .sop-card h3,
+body.light-theme .sop-highlight-box h3,
+body.light-theme .sop-references h3 {
+  color: #0f172a;
+}


### PR DESCRIPTION
## Related Issue

Closes #1400 

## Description
- Builds the **Sopara Ancient Port Explorer** (`frontend/sopara-port-explorer/`) and adds a Sopara card to the Ancient Ports landing page.

### What changed
- New `sopara-port-explorer` with `index.html`, `script.js`, `style.css` – historical narrative, archaeological finds, and image gallery (lightbox).
- Added a Sopara card to `frontend/ancient-ports-explorer/index.html` under the **West Coast** region.

### Files added
- `frontend/sopara-port-explorer/index.html`
- `frontend/sopara-port-explorer/script.js`
- `frontend/sopara-port-explorer/style.css`

### Files modified
- `frontend/ancient-ports-explorer/index.html`

### Screenshots
<img width="1919" height="1072" alt="image" src="https://github.com/user-attachments/assets/41964603-2b45-4739-a6da-ef75f52dceb5" />

### Testing
- [ ] `node --check` passes on script.js
- [ ] Explorer opens with valid content
- [ ] Card links work