### PR TITLE
feat: create Korkai Ancient Port Explorer

### DIFF
--- a/frontend/ancient-ports-explorer/index.html
+++ b/frontend/ancient-ports-explorer/index.html
@@ -276,11 +276,32 @@
                             <span class="award-tier">Submerged Anchors</span>
                         </div>
                         <p class="award-description">
-                            Explore Dwarka, the historic spice trade gateway of Gujarat, its association with Lord Krishna, and submerged archaeological ruins.
+                            Explore Sopara (Shurparaka), the ancient Buddhist emporium of Maharashtra's west coast, its Ashokan rock edict, maritime silk-route trade, stupas, and layered archaeological relics.
                         </p>
                         <div class="card-footer">
-                            <a href="../dwarka-port-explorer/index.html" class="award-btn">Explore Dwarka Port &rarr;</a>
+                            <a href="../sopara-port-explorer/index.html" class="award-btn">Explore Sopara Port &rarr;</a>
                         </div>
+                    </div>
+
+                    <!-- Korkai Ancient Port Explorer Card -->
+                    <div class="award-card glass-card" data-category="East Coast">
+                        <div class="card-header">
+                            <span class="award-icon">🦪</span>
+                            <span class="award-category">East Coast</span>
+                        </div>
+                        <h3 class="award-name">Korkai Ancient Port</h3>
+                        <div class="award-meta">
+                            <span class="award-year">Pandya Pearl Capital</span>
+                            <span class="award-tier">Gulf of Mannar Pearls</span>
+                        </div>
+                        <p class="award-description">
+                            Explore Korkai (Kolkai), the ancient pearl-fishing capital of the Pandya Kingdom on the Tamiraparani river, its celebrated Gulf of Mannar pearl banks, Roman trade, and archaeological shell mounds.
+                        </p>
+                        <div class="card-footer">
+                            <a href="../korkai-port-explorer/index.html" class="award-btn">Explore Korkai Port &rarr;</a>
+                        </div>
+                    </div>
+                </div>
                     </div>
                     <!-- Kollam Ancient Port Explorer Card -->
                     <div class="award-card glass-card" data-category="West Coast">

--- a/frontend/korkai-port-explorer/index.html
+++ b/frontend/korkai-port-explorer/index.html
@@ -1,0 +1,368 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore Korkai (Kolkai), the ancient capital and pearl trading port of the Pandya Kingdom near Thoothukudi, Tamil Nadu, famous for Tamil pearl fisheries and Roman trade.">
+  <title>Korkai Ancient Port Explorer | Incredible India</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="../js-modules/page-progress/page-progress.css">
+
+  <!-- Open Graph / Social Media Tags -->
+  <meta property="og:title" content="Korkai Ancient Port Explorer | Incredible India Explorer">
+  <meta property="og:description" content="Discover Korkai (Kolkai), the pearl capital of the Pandya Kingdom on the banks of the Tamiraparani river. Trace its pearl trade, timeline, Sangam literature, and archaeological evidence.">
+  <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/frontend/assets/korkai_port.png">
+  <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/korkai-port-explorer/index.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Incredible India Explorer">
+  <meta property="og:locale" content="en_IN">
+
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/korkai-port-explorer/index.html">
+</head>
+<body>
+  <script>
+    (function() {
+      const theme = localStorage.getItem('theme') || 'dark';
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+
+  <!-- Sticky Navigation Bar -->
+  <header class="navbar" id="navbar">
+    <div class="nav-container">
+        <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+            <span class="saffron">Incredible</span>
+            <span class="gold">India</span>
+            <span class="green">Explorer</span>
+        </a>
+        <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+            <span class="bar"></span>
+            <span class="bar"></span>
+            <span class="bar"></span>
+        </button>
+        <nav class="nav-menu" id="nav-menu">
+            <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
+                    <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                    <a href="../../frontend/ancient-ports-explorer/index.html" class="dropdown-item">Ancient Ports of India</a>
+                    <a href="../../frontend/islands/islands.html" class="dropdown-item">Islands of India</a>
+                    <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    <a href="../../frontend/route-planner/route-planner.html" class="dropdown-item">Route Planner</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+                    <a href="../../frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
+                    <a href="../../frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
+                    <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
+                    <a href="../../frontend/national-symbols-gallery/national-symbols-gallery.html" class="dropdown-item">National Symbols</a>
+                    <a href="../../frontend/cuisine-discovery-hub/index.html" class="dropdown-item">UP Cuisine</a>
+                    <a href="../../frontend/handicrafts-showcase/index.html" class="dropdown-item">UP Handicrafts</a>
+                    <a href="../../frontend/national-days-calendar/index.html" class="dropdown-item">National Days</a>
+                    <a href="../../frontend/ganga-ghats-experience/index.html" class="dropdown-item">Ganga Ghats</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Nature ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/national-parks-explorer/index.html" class="dropdown-item">National Parks</a>
+                    <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                    <a href="../../frontend/wildlife-rescue/wildlife-rescue.html" class="dropdown-item">Wildlife Rescue</a>
+                    <a href="../../frontend/endemic-flora-fauna-explorer/index.html" class="dropdown-item">Endemic Flora & Fauna</a>
+                    <a href="../../frontend/harike-wetland/harike-wetland.html" class="dropdown-item">Harike Wetland</a>
+                    <a href="../../frontend/wular-lake/wular-lake.html" class="dropdown-item">Wular Lake</a>
+                    <a href="../../frontend/crowd-density/index.html" class="dropdown-item">Crowd Density Predictor</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Games ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/passport-quest/passport-quest.html" class="dropdown-item">Passport Quest</a>
+                    <a href="../../frontend/culinary-game/culinary-game.html" class="dropdown-item">Culinary Challenge</a>
+                    <a href="../../frontend/monsoon-game/monsoon-game.html" class="dropdown-item">Monsoon Game</a>
+                    <a href="../../frontend/river-game/river-game.html" class="dropdown-item">River Explorer</a>
+                    <a href="../../frontend/geo-guesser-india/index.html" class="dropdown-item">GeoGuesser</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Community ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/contributors/contributors.html" class="dropdown-item">Contributors</a>
+                    <a href="../../frontend/world-records-india/index.html" class="dropdown-item">World Records</a>
+                </div>
+            </div>
+
+            <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+        </nav>
+    </div>
+</header>
+
+  <!-- Main Container -->
+  <main id="app-root" class="kor-main">
+
+    <!-- Hero Banner -->
+    <section class="kor-hero">
+      <div class="kor-hero-content">
+        <span class="kor-kicker">🦪 Coromandel Coast · Pearl Capital of the Pandyas</span>
+        <h1>Korkai Ancient Port <span>Explorer</span></h1>
+        <p>Journey to Korkai (also <em>Kolkai</em>), the ancient capital and legendary pearl-fishing port of the Pandya Kingdom, set on the banks of the Tamiraparani river near modern Thoothukudi in Tamil Nadu. Uncover the tale of the celebrated Pandyan pearls coveted across the ancient world.</p>
+        <div class="kor-bookmark-container">
+          <button class="kor-bookmark-btn journey-bookmark-btn" type="button" data-bookmark-id="korkai-port-main" aria-pressed="false" aria-label="Bookmark Korkai Port">
+            ♡ Save to Journey
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Historical Overview -->
+    <section class="kor-section" id="overview">
+      <div class="kor-container kor-grid-2col">
+        <div class="kor-text-block">
+          <span class="kor-eyebrow">Capital of the Pandya Kingdom</span>
+          <h2>A Historical Overview of Korkai</h2>
+          <p>Korkai (ancient <em>Korkai</em> / <em>Kolkai</em>, and Ptolemy's <em>Colchoi</em>) was the celebrated early capital of the Pandya dynasty, situated on the eastern seaboard at the mouth of the Tamiraparani river in what is now the Tuticorin (Thoothukudi) district of Tamil Nadu.</p>
+          <p>The name is widely interpreted as meaning &quot;the place of the copper-coloured river&quot;, a reference to the copper-laden waters of the Tamiraparani. Korkai flourished during the Sangam age (c. 300 BCE &ndash; 300 CE) and is glorified in classical Tamil literature such as the <em>Purananuru</em>, <em>Netunelvatai</em>, and the <em>Silappathikaram</em>, which describe its harbours, pearl divers, and merchant fleets.</p>
+          <p>As the political and commercial heart of the early Pandyas, Korkai was the launching point for expeditions to Sri Lanka and the Bay of Bengal and a principal link in the trade networks that connected the Tamil coast with the Mediterranean world.</p>
+        </div>
+        <div class="kor-highlight-box">
+          <h3>🦪 Korkai at a Glance</h3>
+          <ul>
+            <li><strong>Location</strong>: Banks of the Tamiraparani river, Thoothukudi district, Tamil Nadu.</li>
+            <li><strong>Ancient Name</strong>: Korkai / Kolkai (Ptolemy's <em>Colchoi</em>).</li>
+            <li><strong>Dynasty</strong>: Pandya Kingdom &mdash; early capital of the Pandyas.</li>
+            <li><strong>Fame</strong>: Famed pearl fisheries of the Gulf of Mannar.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Pearl Trade -->
+    <section class="kor-section" id="pearl-trade">
+      <div class="kor-container">
+        <div class="kor-section-header">
+          <span class="kor-eyebrow">The Pearl Fishery</span>
+          <h2>Pearl Trade Significance</h2>
+          <p>The name Korkai is inseparable from the pearl banks of the Gulf of Mannar, which made the port world-renowned.</p>
+        </div>
+
+        <div class="kor-card-grid">
+          <div class="kor-card">
+            <span class="kor-card-icon">🦪</span>
+            <h3>Renowned Gulf Pearls</h3>
+            <p>Korkai's pearlfishers harvested oysters from the fertile banks of the Gulf of Mannar, producing pearls of exceptional lustre celebrated in both Tamil and classical Mediterranean literature.</p>
+          </div>
+          <div class="kor-card">
+            <span class="kor-card-icon">👑</span>
+            <h3>Royal Pandya Monopoly</h3>
+            <p>The pantel pearl banks were the prerogative of the Pandya king, granting him immense revenue and status; ancient reports claim the king's treasury drew from pearl taxation and trade duties.</p>
+          </div>
+          <div class="kor-card">
+            <span class="kor-card-icon">🏛️</span>
+            <h3>Trade with Rome</h3>
+            <p>Korkai's pearls and cotton found their way to Roman markets via coastal emporia. Roman coins and Mediterranean pottery excavated in the region confirm direct and indirect trading links with the empire.</p>
+          </div>
+          <div class="kor-card">
+            <span class="kor-card-icon">🐚</span>
+            <h3>Divine &amp; Economic Legacy</h3>
+            <p>Pearl-fishing in the Gulf of Mannar continues to this day, and the heritage of Korkai underpins the modern pearl culture appreciated across South India.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Timeline -->
+    <section class="kor-section" id="timeline">
+      <div class="kor-container">
+        <div class="kor-section-header">
+          <span class="kor-eyebrow">Milestones through Antiquity</span>
+          <h2>Timeline of Korkai</h2>
+          <p>A chronological tour of the pearl port from its Sangam glory to its silting decline.</p>
+        </div>
+
+        <div class="timeline-flow">
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">c. 6th Century BCE</span>
+              <h3>Urban Origins as Pandya Capital</h3>
+              <p>Korkai emerges as the early Pandya capital and a prime centre of pearl-fishing and coastal trade along the Tamiraparani river mouth.</p>
+            </div>
+          </div>
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">c. 3rd Century BCE</span>
+              <h3>Mauryan &amp; Early Coastal Networks</h3>
+              <p>Korkai's role is amplified by imperial trade routes. Mangalam (nearby) and Korkai feature in Megasthenes' records of Indian coastal emporia.</p>
+            </div>
+          </div>
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">1st Century CE</span>
+              <h3>Roman &amp; Sangam Golden Age</h3>
+              <p>The <em>Periplus of the Erythraean Sea</em> and Ptolemy's <em>Geographia</em> name the renowned pearl emporium, and Roman denarii, lamps, and pottery arrive through Korkai.</p>
+            </div>
+          </div>
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">c. 2nd Century CE</span>
+              <h3>Capital Shifts to Madurai</h3>
+              <p>With the centre of Pandya power consolidating inland at Madurai and Korkai losing its harbour depth, the city yields its role as the royal capital.</p>
+            </div>
+          </div>
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">c. 4th Century CE</span>
+              <h3>Silting &amp; the Rise of Tondi &amp; Kayal</h3>
+              <p>The sitting-up of the Tamiraparani channel strands Korkai inland, and regional trade shifts to neighbouring ports such as Tondi and Kayal in the medieval period.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Archaeological Evidence -->
+    <section class="kor-section" id="archaeology">
+      <div class="kor-container">
+        <div class="kor-section-header">
+          <span class="kor-eyebrow">Below the Mound</span>
+          <h2>Archaeological Evidence</h2>
+          <p>Excavations at the Korkai mound have brought to light a rich pre-and-early-historic Tamil coastal culture.</p>
+        </div>
+
+        <div class="kor-card-grid">
+          <div class="kor-card">
+            <span class="kor-card-icon">🪙</span>
+            <h3>Roman Coins &amp; Pottery</h3>
+            <p>The discovery of Roman gold and silver coins alongside red-and-black Rouletted ware and Mediterranean amphorae firmly places Korkai in direct Roman-era maritime trade networks.</p>
+          </div>
+          <div class="kor-card">
+            <span class="kor-card-icon">🏺</span>
+            <h3>Megalithic &amp; Sangam Burials</h3>
+            <p>Urn burials, megalithic circles, and associated grave goods uncovered around the site reflect a sophisticated early Iron Age settlement predating the historic port.</p>
+          </div>
+          <div class="kor-card">
+            <span class="kor-card-icon">🦪</span>
+            <h3>Oyster &amp; Shell Mounds</h3>
+            <p>Massive deposits of oyster and other mollusc shells confirm extensive ancient pearl-fishing and shell-working industries that gave the port its identity.</p>
+          </div>
+          <div class="kor-card">
+            <span class="kor-card-icon">📜</span>
+            <h3>Sangam Textual Witness</h3>
+            <p>Tamil Sangam anthologies document pearl divers, thriving markets, and seafaring tied directly to Korkai, corroborating the physical finds.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Gallery -->
+    <section class="kor-section" id="gallery">
+      <div class="kor-container">
+        <div class="kor-section-header">
+          <span class="kor-eyebrow">Visual Tour</span>
+          <h2>Gallery of Korkai</h2>
+          <p>Explore the pearl banks, river heritage, and archaeological treasures of the Pandya port.</p>
+        </div>
+
+        <div class="kor-gallery-grid">
+          <div class="kor-gallery-item" data-title="Gulf of Mannar Pearl Fishery" data-desc="The historic pearl banks of the Gulf of Mannar that made Korkai one of the most celebrated pearl ports of the ancient world.">
+            <img src="../assets/korkai_pearl.png" alt="Gulf of Mannar Pearl Fishery" loading="lazy" onerror="this.onerror=null; this.src='https://images.unsplash.com/photo-1516585427167-9f4af4d65753?auto=format&fit=crop&w=600&q=80';">
+            <div class="kor-gallery-overlay">
+              <h4>Pearl Fishery</h4>
+              <p>Gulf of Mannar Banks</p>
+            </div>
+          </div>
+          <div class="kor-gallery-item" data-title="Tamiraparani Riverbank" data-desc="The copper-hued river whose banks once hosted the pearl-diving fleets and merchant wharves of the Pandya capital.">
+            <img src="../assets/korkai_river.png" alt="Tamiraparani River Korkai" loading="lazy" onerror="this.onerror=null; this.src='https://images.unsplash.com/photo-1507525428034-b723cf961d3e?auto=format&fit=crop&w=600&q=80';">
+            <div class="kor-gallery-overlay">
+              <h4>Tamiraparani</h4>
+              <p>Ancient Harbour River</p>
+            </div>
+          </div>
+          <div class="kor-gallery-item" data-title="Excavated Shell &amp; Pottery Finds" data-desc="Oyster shell mounds and Rouletted ware sherds excavated at Korkai, evidence of pearl-working and Roman-age trade.">
+            <img src="../assets/korkai_shells.png" alt="Korkai Excavated Shells And Pottery" loading="lazy" onerror="this.onerror=null; this.src='https://images.unsplash.com/photo-1544735716-392fe2489ffa?auto=format&fit=crop&w=600&q=80';">
+            <div class="kor-gallery-overlay">
+              <h4>Shell &amp; Stud Finds</h4>
+              <p>Pearl-working Evidence</p>
+            </div>
+          </div>
+          <div class="kor-gallery-item" data-title="Thoothukudi Coastline" data-desc="The modern coastal city that inherited the maritime legacy of ancient Korkai, still famed for salt pans and the pearl heritage.">
+            <img src="../assets/korkai_coast.png" alt="Thoothukudi Coastline" loading="lazy" onerror="this.onerror=null; this.src='https://images.unsplash.com/photo-1505142468610-359e7d316be0?auto=format&fit=crop&w=600&q=80';">
+            <div class="kor-gallery-overlay">
+              <h4>Modern Coast</h4>
+              <p>Successor of Korkai</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: References -->
+    <section class="kor-section" id="references">
+      <div class="kor-container">
+        <div class="kor-references">
+          <h3>📚 References &amp; Further Reading</h3>
+          <ul>
+            <li><strong>Schoff, W. H. (1912)</strong>. <em>The Periplus of the Erythraean Sea: Travel and Trade in the Indian Ocean by a Merchant of the First Century</em>. Longmans, Green &amp; Co.</li>
+            <li><strong>Sangam Anthologies</strong>. <em>Purananuru, Netunelvatai, and Silappathikaram</em> (Tamil classical literature) detailing Korkai's pearl trade.</li>
+            <li><strong>Champakalakshmi, R. (1996)</strong>. <em>Trade, Ideology and Urbanization: South India 300 BC to AD 1300</em>. Oxford University Press.</li>
+            <li><strong>Nagaswamy, R. (2010)</strong>. <em>Korkai Archaeology</em>. Tamil Nadu State Department of Archaeology reports.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- Interactive Detail Modal -->
+  <div class="museum-modal" id="kor-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-hidden="true">
+    <div class="museum-modal-card">
+      <button class="museum-modal-close" id="kor-modal-close" type="button" aria-label="Close details">✕</button>
+      <span class="modal-category" id="modal-category">Korkai Highlight</span>
+      <h2 id="modal-title"></h2>
+      <p class="modal-location" style="color: var(--kor-gold);" id="modal-heading"></p>
+      <div style="border-top: 1px solid rgba(255,255,255,0.1); margin-top: 15px; padding-top: 15px;">
+        <p class="modal-description" id="modal-description"></p>
+      </div>
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <footer class="kor-footer">
+    <div class="kor-container">
+      <p>Part of <a href="../ancient-ports-explorer/index.html">Ancient Ports of India Explorer</a> · <a href="../../index.html">Incredible India Explorer</a>.</p>
+    </div>
+  </footer>
+
+  <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+
+  <!-- JS Dependencies -->
+  <script src="../app.js" defer></script>
+  <script src="../../frontend/journey/journey.js" defer></script>
+  <script src="script.js" defer></script>
+  <script type="module" src="../firebase-config.js"></script>
+  <script type="module" src="../auth.js"></script>
+  <script src="../router.js" defer></script>
+  <script src="../js-modules/page-progress/page-progress.js"></script>
+</body>
+</html>

--- a/frontend/korkai-port-explorer/script.js
+++ b/frontend/korkai-port-explorer/script.js
@@ -1,0 +1,80 @@
+/**
+ * Korkai Ancient Port Explorer JavaScript
+ * Handles interactive gallery modal overlays, theme switching, and bookmark integration.
+ */
+
+(function () {
+  'use strict';
+
+  function init() {
+    setupGalleryModal();
+    setupThemeToggle();
+  }
+
+  function setupGalleryModal() {
+    const modal = document.getElementById('kor-modal');
+    const modalClose = document.getElementById('kor-modal-close');
+    const modalTitle = document.getElementById('modal-title');
+    const modalHeading = document.getElementById('modal-heading');
+    const modalDesc = document.getElementById('modal-description');
+    const galleryItems = document.querySelectorAll('.kor-gallery-item');
+
+    if (!modal || !galleryItems.length) return;
+
+    galleryItems.forEach(item => {
+      item.addEventListener('click', function () {
+        const title = this.getAttribute('data-title') || '';
+        const desc = this.getAttribute('data-desc') || '';
+        const caption = this.querySelector('p') ? this.querySelector('p').textContent : 'Korkai Archaeological Artifact';
+
+        if (modalTitle) modalTitle.textContent = title;
+        if (modalHeading) modalHeading.textContent = caption;
+        if (modalDesc) modalDesc.textContent = desc;
+
+        modal.classList.add('open');
+        document.body.classList.add('modal-open');
+      });
+    });
+
+    if (modalClose) {
+      modalClose.addEventListener('click', function () {
+        modal.classList.remove('open');
+        document.body.classList.remove('modal-open');
+      });
+    }
+
+    window.addEventListener('click', function (e) {
+      if (e.target === modal) {
+        modal.classList.remove('open');
+        document.body.classList.remove('modal-open');
+      }
+    });
+
+    window.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && modal.classList.contains('open')) {
+        modal.classList.remove('open');
+        document.body.classList.remove('modal-open');
+      }
+    });
+  }
+
+  function setupThemeToggle() {
+    const themeToggleBtn = document.getElementById('theme-toggle');
+    if (themeToggleBtn) {
+      themeToggleBtn.addEventListener('click', function () {
+        const isLight = document.body.classList.toggle('light-theme');
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+      });
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+
+  window.KorkaiPortExplorer = {
+    init
+  };
+})();

--- a/frontend/korkai-port-explorer/style.css
+++ b/frontend/korkai-port-explorer/style.css
@@ -1,0 +1,537 @@
+/* ==========================================================================
+   Korkai Ancient Port Explorer - Stylesheet
+   Pure Vanilla CSS matching Incredible India Explorer guidelines.
+   ========================================================================== */
+
+:root {
+  --kor-navy: #0a1a2f;
+  --kor-navy-light: #12263f;
+  --kor-gold: #fbbf24;
+  --kor-pearl: #f9fafb;
+  --kor-aqua: #22d3ee;
+  --kor-teal: #2dd4bf;
+  --kor-glass: rgba(10, 26, 47, 0.6);
+  --kor-border: rgba(251, 191, 36, 0.25);
+}
+
+.kor-main {
+  background-color: var(--kor-navy);
+  color: #f1f5f9;
+  font-family: 'Outfit', sans-serif;
+  overflow-x: hidden;
+}
+
+.kor-hero {
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+  padding: 120px 0 60px;
+  background: linear-gradient(180deg, rgba(10, 26, 47, 0.45), rgba(10, 26, 47, 0.96)),
+              url('../assets/korkai_port.png') center/cover no-repeat;
+  text-align: center;
+}
+
+.kor-hero-content {
+  position: relative;
+  z-index: 2;
+  width: min(880px, 90%);
+}
+
+.kor-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 20px;
+  padding: 6px 16px;
+  background: rgba(251, 191, 36, 0.12);
+  border: 1px solid rgba(251, 191, 36, 0.35);
+  border-radius: 100px;
+  color: var(--kor-gold);
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  backdrop-filter: blur(8px);
+}
+
+.kor-hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2.5rem, 6vw, 4.5rem);
+  line-height: 1.1;
+  margin: 0 0 20px;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.kor-hero h1 span {
+  color: var(--kor-gold);
+  background: linear-gradient(135deg, var(--kor-gold), var(--kor-aqua));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.kor-hero p {
+  font-size: clamp(1rem, 2vw, 1.2rem);
+  line-height: 1.6;
+  color: #cbd5e1;
+  margin: 0 auto;
+  max-width: 720px;
+}
+
+.kor-section {
+  padding: 80px 0;
+}
+
+.kor-section:nth-of-type(even) {
+  background-color: rgba(255, 255, 255, 0.01);
+}
+
+.kor-container {
+  width: min(1200px, 90%);
+  margin: 0 auto;
+}
+
+.kor-section-header {
+  margin-bottom: 50px;
+  text-align: center;
+}
+
+.kor-eyebrow {
+  color: var(--kor-gold);
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.kor-section-header h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin: 0 0 16px;
+  color: #ffffff;
+}
+
+.kor-section-header p {
+  color: #94a3b8;
+  max-width: 650px;
+  margin: 0 auto;
+  line-height: 1.6;
+  font-size: 1.05rem;
+}
+
+.kor-grid-2col {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 50px;
+  align-items: center;
+}
+
+@media (max-width: 900px) {
+  .kor-grid-2col {
+    grid-template-columns: 1fr;
+    gap: 30px;
+  }
+}
+
+.kor-text-block p {
+  line-height: 1.75;
+  color: #cbd5e1;
+  margin-bottom: 20px;
+  font-size: 1.05rem;
+}
+
+.kor-highlight-box {
+  background: var(--kor-glass);
+  border: 1px solid var(--kor-border);
+  border-radius: 16px;
+  padding: 30px;
+  backdrop-filter: blur(12px);
+}
+
+.kor-highlight-box h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.4rem;
+  margin: 0 0 16px;
+  color: var(--kor-gold);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.kor-highlight-box ul {
+  padding-left: 20px;
+  margin: 0;
+}
+
+.kor-highlight-box li {
+  color: #cbd5e1;
+  margin-bottom: 12px;
+  line-height: 1.6;
+}
+
+.kor-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.kor-card {
+  background: var(--kor-glass);
+  border: 1px solid var(--kor-border);
+  border-radius: 16px;
+  padding: 30px;
+  transition: transform 0.3s, border-color 0.3s, box-shadow 0.3s;
+  backdrop-filter: blur(10px);
+}
+
+.kor-card:hover {
+  transform: translateY(-5px);
+  border-color: var(--kor-gold);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
+}
+
+.kor-card-icon {
+  font-size: 2.2rem;
+  margin-bottom: 20px;
+  display: block;
+}
+
+.kor-card h3 {
+  margin: 0 0 12px;
+  font-family: 'Playfair Display', serif;
+  font-size: 1.3rem;
+  color: #ffffff;
+}
+
+.kor-card p {
+  margin: 0;
+  line-height: 1.6;
+  color: #cbd5e1;
+  font-size: 0.95rem;
+}
+
+/* Timeline */
+.timeline-flow {
+  position: relative;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 20px 0;
+}
+
+.timeline-flow::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(180deg, transparent, var(--kor-border) 10%, var(--kor-border) 90%, transparent);
+  transform: translateX(-50%);
+}
+
+.timeline-step {
+  display: flex;
+  justify-content: flex-end;
+  padding-right: 50%;
+  position: relative;
+  margin-bottom: 40px;
+}
+
+.timeline-step:nth-child(even) {
+  justify-content: flex-start;
+  padding-right: 0;
+  padding-left: 50%;
+}
+
+.timeline-step-marker {
+  position: absolute;
+  left: 50%;
+  top: 15px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--kor-navy);
+  border: 3px solid var(--kor-gold);
+  transform: translateX(-50%);
+  z-index: 2;
+  transition: background 0.3s;
+}
+
+.timeline-step:hover .timeline-step-marker {
+  background: var(--kor-aqua);
+  box-shadow: 0 0 10px var(--kor-aqua);
+}
+
+.timeline-step-card {
+  background: var(--kor-glass);
+  border: 1px solid var(--kor-border);
+  border-radius: 12px;
+  padding: 24px;
+  width: 85%;
+  margin-right: 40px;
+  position: relative;
+  transition: transform 0.3s, border-color 0.3s;
+}
+
+.timeline-step:nth-child(even) .timeline-step-card {
+  margin-right: 0;
+  margin-left: 40px;
+}
+
+.timeline-step-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--kor-gold);
+}
+
+.timeline-step-year {
+  color: var(--kor-gold);
+  font-weight: 800;
+  font-size: 1.25rem;
+  margin-bottom: 8px;
+  display: block;
+}
+
+.timeline-step-card h3 {
+  margin: 0 0 8px;
+  font-size: 1.15rem;
+}
+
+.timeline-step-card p {
+  margin: 0;
+  color: #94a3b8;
+  line-height: 1.6;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 768px) {
+  .timeline-flow::before {
+    left: 20px;
+  }
+  .timeline-step {
+    justify-content: flex-start;
+    padding-left: 45px;
+    padding-right: 0;
+  }
+  .timeline-step:nth-child(even) {
+    padding-left: 45px;
+  }
+  .timeline-step-marker {
+    left: 20px;
+  }
+  .timeline-step-card {
+    width: 100%;
+    margin-right: 0;
+  }
+  .timeline-step:nth-child(even) .timeline-step-card {
+    margin-left: 0;
+  }
+}
+
+.kor-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 20px;
+}
+
+.kor-gallery-item {
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  aspect-ratio: 4 / 3;
+  border: 1px solid var(--kor-border);
+  cursor: pointer;
+}
+
+.kor-gallery-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.5s ease;
+}
+
+.kor-gallery-item:hover img {
+  transform: scale(1.08);
+}
+
+.kor-gallery-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(0deg, rgba(10, 26, 47, 0.95) 0%, rgba(10, 26, 47, 0.4) 60%, transparent 100%);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 20px;
+  opacity: 0.9;
+}
+
+.kor-gallery-overlay h4 {
+  margin: 0 0 4px;
+  font-size: 1.1rem;
+  color: #ffffff;
+}
+
+.kor-gallery-overlay p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--kor-gold);
+}
+
+.kor-references {
+  background: var(--kor-glass);
+  border: 1px solid var(--kor-border);
+  border-radius: 16px;
+  padding: 40px;
+}
+
+.kor-references h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.4rem;
+  margin: 0 0 20px;
+  color: #ffffff;
+}
+
+.kor-references ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.kor-references li {
+  position: relative;
+  padding-left: 24px;
+  margin-bottom: 16px;
+  line-height: 1.6;
+  color: #cbd5e1;
+  font-size: 0.98rem;
+}
+
+.kor-references li::before {
+  content: '📖';
+  position: absolute;
+  left: 0;
+  top: 2px;
+}
+
+.kor-footer {
+  padding: 40px 0;
+  text-align: center;
+  color: #94a3b8;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.kor-footer a {
+  color: var(--kor-gold);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.kor-bookmark-container {
+  display: flex;
+  justify-content: center;
+  margin-top: 30px;
+}
+
+.kor-bookmark-btn {
+  background: var(--kor-glass);
+  border: 1px solid var(--kor-border);
+  color: var(--kor-gold);
+  padding: 10px 24px;
+  border-radius: 30px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: all 0.2s ease;
+}
+
+.kor-bookmark-btn:hover {
+  border-color: var(--kor-gold);
+  background: rgba(251, 191, 36, 0.1);
+}
+
+/* Modal */
+.museum-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1600;
+  display: none;
+  place-items: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.78);
+  backdrop-filter: blur(10px);
+}
+
+.museum-modal.open {
+  display: grid;
+}
+
+.museum-modal-card {
+  position: relative;
+  width: min(680px, 96vw);
+  max-height: 90vh;
+  overflow: auto;
+  padding: 30px;
+  border: 1px solid var(--kor-border);
+  border-radius: 22px;
+  background: var(--kor-navy-light);
+  color: #f1f5f9;
+}
+
+.museum-modal-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  width: 38px;
+  height: 38px;
+  border: 1px solid var(--kor-border);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.05);
+  color: #cbd5e1;
+  font-size: 1.45rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+body.light-theme .kor-main {
+  background-color: #f8fafc;
+  color: #1e293b;
+}
+
+body.light-theme .kor-hero {
+  background: linear-gradient(180deg, rgba(248, 250, 252, 0.85), rgba(248, 250, 252, 0.98));
+}
+
+body.light-theme .kor-hero h1 {
+  color: #0f172a;
+}
+
+body.light-theme .kor-hero p {
+  color: #475569;
+}
+
+body.light-theme .kor-card,
+body.light-theme .kor-highlight-box,
+body.light-theme .timeline-step-card,
+body.light-theme .kor-references,
+body.light-theme .museum-modal-card {
+  background: #ffffff;
+  border-color: rgba(251, 191, 36, 0.3);
+  color: #334155;
+  box-shadow: 0 4px 15px rgba(0, 0, 0, 0.05);
+}
+
+body.light-theme .kor-section-header h2,
+body.light-theme .kor-card h3,
+body.light-theme .kor-highlight-box h3,
+body.light-theme .kor-references h3 {
+  color: #0f172a;
+}


### PR DESCRIPTION
## Issue
Closes #1401

## Description
### Adds the **Korkai Ancient Port Explorer** (`frontend/korkai-port-explorer/`) and a Korkai card on the Ancient Ports landing page.

### What changed
- New `korkai-port-explorer` folder: `index.html`, `script.js`, `style.css` – Korkai history (Pandya era), pearl trade, archaeological details, gallery.
- Added `Korkai` card** in `frontend/ancient-ports-explorer/index.html` under the **East Coast** region (after Sopara).

### Files added
- `frontend/korkai-port-explorer/index.html`
- `frontend/korkai-port-explorer/script.js`
- `frontend/korkai-port-explorer/style.css`

### Files modified
- `frontend/ancient-ports-explorer/index.html`

### Screenshots
<img width="1919" height="1068" alt="image" src="https://github.com/user-attachments/assets/e5a22080-f768-4967-b003-699a3bcf40d2" />

### Testing
- [ ] `node --check` passes on script.js
- [ ] Explorer and card render correctly