### PR TITLE
feat: Build a Bastar iron craft explorer highlighting tribal metal artistry

### DIFF
--- a/frontend/bastar-iron-craft-explorer/bastar-data.js
+++ b/frontend/bastar-iron-craft-explorer/bastar-data.js
@@ -1,0 +1,66 @@
+/**
+ * Bastar Iron Craft Explorer — Data Module
+ * Comprehensive dataset covering history, GI tag, manufacturing process,
+ * traditional motifs, artisan spotlight, craft gallery, and references.
+ */
+
+const BASTAR_INFO = {
+    id: "bastar-iron-craft",
+    title: "Bastar Iron Craft (Loha Shilp)",
+    originRegion: "Bastar & Kondagaon, Chhattisgarh",
+    community: "Lohar Tribal Artisan Guilds",
+    giTagStatus: "Geographical Indication (GI) Certified",
+    material: "Wrought Iron & Recycled Scrap Iron",
+    toolsUsed: "Charcoal Furnace, Anvil, Tongs, Chisels, Heavy Hammers",
+    quickStats: [
+        { label: "GI Tag Certified", value: "Chhattisgarh", icon: "🏷️" },
+        { label: "Technique", value: "Hand Forging", icon: "🔨" },
+        { label: "Artisan Hub", value: "Kondagaon", icon: "📍" },
+        { label: "Raw Material", value: "Recycled Iron", icon: "⚒️" },
+        { label: "Welding", value: "Zero Welding", icon: "⚙️" },
+        { label: "Motifs", value: "Tribal Deities & Flora", icon: "🦌" }
+    ]
+};
+
+const PROCESS_STEPS = [
+    { step: 1, title: "Iron Sourcing & Scrap Heating", description: "Artisans source scrap iron bars and heat them in traditional charcoal furnaces (bhatti) until malleable." },
+    { step: 2, title: "Manual Hammering & Beating", description: "Master blacksmiths manually beat red-hot iron on heavy anvils to flatten, draw out, and shape individual components." },
+    { step: 3, title: "Intricate Bending & Joinery", description: "Components are intricately twisted and joined using rivets, bends, and interlocking joints without modern welding." },
+    { step: 4, title: "Detail Chisel Carving", description: "Fine surface textures, eyes, clothing folds, and traditional tribal markings are carved into warm iron using hand chisels." },
+    { step: 5, title: "Cooling & Natural Black Finish", description: "Completed items are coated with protective oil or beeswax and cooled to develop a rich rust-resistant matte black patina." }
+];
+
+const TRADITIONAL_DESIGNS = [
+    { name: "Tribal Musicians & Dancers", description: "Slender human figurines holding traditional drums (mandar), flutes, and cymbals in ceremonial dance poses." },
+    { name: "Forest Animals (Deer & Elephant)", description: "Elongated deer, peacocks, and elephants symbolizing the deep spiritual connection between Bastar tribes and nature." },
+    { name: "Diyas & Tree Lamps (Dipa Stambha)", description: "Branching iron oil lamps featuring perching birds and multiple flame trays used in village shrines." },
+    { name: "Tribal Deities (Budha Deo & Danteshwari)", description: "Reverent representations of tribal guardian deities protecting villages and agricultural harvests." }
+];
+
+const ARTISAN_SPOTLIGHT = {
+    title: "Kondagaon Craft Guilds",
+    description: "Kondagaon in Bastar district is known as the 'Craft Village' of Chhattisgarh, home to generations of Lohar master craftsmen who preserve ancestral iron forging secrets passed down orally across centuries."
+};
+
+const GALLERY_IMAGES = [
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e0/Bastar_iron_craft.jpg/800px-Bastar_iron_craft.jpg",
+        caption: "Traditional Bastar Iron Craft figurine depicting a tribal musician",
+        category: "Artifact"
+    },
+    {
+        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/d/d4/Bastar_tribal_metal_art.jpg/800px-Bastar_tribal_metal_art.jpg",
+        caption: "Hand-forged iron oil lamp (Dipa Stambha) with bird motifs",
+        category: "Traditional Design"
+    }
+];
+
+const REFERENCES = [
+    { text: "Handicrafts Development Corporation of Chhattisgarh — Bastar Loha Shilp GI Documentation.", link: "#" },
+    { text: "Development Commissioner (Handicrafts), Ministry of Textiles, Government of India.", link: "https://handicrafts.nic.in" },
+    { text: "Bastar Tribal Art & Culture Research Centre, Jagdalpur.", link: "#" }
+];
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { BASTAR_INFO, PROCESS_STEPS, TRADITIONAL_DESIGNS, ARTISAN_SPOTLIGHT, GALLERY_IMAGES, REFERENCES };
+}

--- a/frontend/bastar-iron-craft-explorer/bastar.css
+++ b/frontend/bastar-iron-craft-explorer/bastar.css
@@ -1,0 +1,182 @@
+.bastar-main {
+    background-color: var(--bg-primary, #1c1917);
+    color: var(--text-primary, #e7e5e4);
+    font-family: 'Outfit', sans-serif;
+}
+
+.bastar-hero {
+    padding: 6rem 1.5rem 3rem;
+    background: linear-gradient(135deg, rgba(28, 25, 23, 0.95), rgba(87, 83, 78, 0.85));
+    text-align: center;
+}
+
+.hero-badges-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+}
+
+.hero-pill {
+    padding: 0.4rem 1rem;
+    border-radius: 9999px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(8px);
+}
+
+.bastar-hero h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2.75rem;
+    font-weight: 800;
+    margin-bottom: 1rem;
+}
+
+.bastar-hero h1 span {
+    color: #f59e0b;
+}
+
+.hero-subtitle {
+    max-width: 800px;
+    margin: 0 auto 2.5rem;
+    font-size: 1.1rem;
+    color: #d6d3d1;
+    line-height: 1.6;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1.25rem;
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.stat-card {
+    background: rgba(68, 64, 60, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 1.25rem;
+    border-radius: 12px;
+    text-align: center;
+}
+
+.stat-icon {
+    font-size: 1.75rem;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.stat-val {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #f59e0b;
+}
+
+.stat-lbl {
+    font-size: 0.85rem;
+    color: #d6d3d1;
+}
+
+.section-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem;
+}
+
+.section-container h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2rem;
+    margin-bottom: 1.5rem;
+    color: #e7e5e4;
+}
+
+.sec-title {
+    margin-top: 2.5rem;
+}
+
+.process-steps {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-bottom: 2rem;
+}
+
+.step-card {
+    display: flex;
+    gap: 1.5rem;
+    background: rgba(68, 64, 60, 0.4);
+    padding: 1.25rem;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.step-num {
+    font-weight: 800;
+    color: #f59e0b;
+    min-width: 90px;
+    font-size: 1.1rem;
+}
+
+.step-content h3 {
+    margin-bottom: 0.25rem;
+    color: #e7e5e4;
+}
+
+.designs-grid, .gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.design-card, .gallery-card {
+    background: rgba(68, 64, 60, 0.5);
+    border-radius: 12px;
+    overflow: hidden;
+    padding: 1.25rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    transition: transform 0.2s ease;
+}
+
+.design-card:hover, .gallery-card:hover {
+    transform: translateY(-4px);
+}
+
+.info-card {
+    background: rgba(68, 64, 60, 0.5);
+    border-radius: 12px;
+    padding: 2rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    line-height: 1.7;
+}
+
+.info-card h3 {
+    color: #f59e0b;
+    margin-bottom: 0.5rem;
+}
+
+.gallery-card img {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+    border-radius: 8px;
+}
+
+.references-list {
+    list-style: none;
+    padding: 0;
+}
+
+.references-list li {
+    margin-bottom: 0.75rem;
+}
+
+.references-list a {
+    color: #f59e0b;
+    text-decoration: none;
+}
+
+.references-list a:hover {
+    text-decoration: underline;
+}

--- a/frontend/bastar-iron-craft-explorer/bastar.js
+++ b/frontend/bastar-iron-craft-explorer/bastar.js
@@ -1,0 +1,104 @@
+document.addEventListener('DOMContentLoaded', () => {
+    renderStats();
+    renderProcess();
+    renderDesigns();
+    renderArtisan();
+    renderGallery();
+    renderReferences();
+    initThemeToggle();
+});
+
+function renderStats() {
+    const grid = document.getElementById('stats-grid');
+    if (!grid || typeof BASTAR_INFO === 'undefined') return;
+
+    grid.innerHTML = BASTAR_INFO.quickStats
+        .map(
+            stat => `
+        <div class="stat-card">
+            <span class="stat-icon">${stat.icon}</span>
+            <div class="stat-val">${stat.value}</div>
+            <div class="stat-lbl">${stat.label}</div>
+        </div>
+    `
+        )
+        .join('');
+}
+
+function renderProcess() {
+    const container = document.getElementById('process-steps');
+    if (!container || typeof PROCESS_STEPS === 'undefined') return;
+
+    container.innerHTML = PROCESS_STEPS.map(
+        s => `
+        <div class="step-card">
+            <div class="step-num">Step ${s.step}</div>
+            <div class="step-content">
+                <h3>${s.title}</h3>
+                <p>${s.description}</p>
+            </div>
+        </div>
+    `
+    ).join('');
+}
+
+function renderDesigns() {
+    const grid = document.getElementById('designs-grid');
+    if (!grid || typeof TRADITIONAL_DESIGNS === 'undefined') return;
+
+    grid.innerHTML = TRADITIONAL_DESIGNS.map(
+        d => `
+        <div class="design-card">
+            <h3>✨ ${d.name}</h3>
+            <p>${d.description}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function renderArtisan() {
+    if (typeof ARTISAN_SPOTLIGHT === 'undefined') return;
+    const titleEl = document.getElementById('artisan-title');
+    const descEl = document.getElementById('artisan-desc');
+
+    if (titleEl) titleEl.textContent = ARTISAN_SPOTLIGHT.title;
+    if (descEl) descEl.textContent = ARTISAN_SPOTLIGHT.description;
+}
+
+function renderGallery() {
+    const grid = document.getElementById('gallery-grid');
+    if (!grid || typeof GALLERY_IMAGES === 'undefined') return;
+
+    grid.innerHTML = GALLERY_IMAGES.map(
+        img => `
+        <div class="gallery-card">
+            <img src="${img.url}" alt="${img.caption}" loading="lazy" />
+            <p>${img.caption}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function renderReferences() {
+    const list = document.getElementById('references-list');
+    if (!list || typeof REFERENCES === 'undefined') return;
+
+    list.innerHTML = REFERENCES.map(
+        r => `
+        <li>
+            <a href="${r.link}" target="_blank" rel="noopener noreferrer">📚 ${r.text}</a>
+        </li>
+    `
+    ).join('');
+}
+
+function initThemeToggle() {
+    const toggleBtn = document.getElementById('theme-toggle');
+    if (!toggleBtn) return;
+
+    toggleBtn.addEventListener('click', () => {
+        const isLight = document.body.classList.toggle('light-theme');
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        toggleBtn.textContent = isLight ? '🌙' : '☀️';
+    });
+}

--- a/frontend/bastar-iron-craft-explorer/index.html
+++ b/frontend/bastar-iron-craft-explorer/index.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    document.body.classList.add('light-theme');
+                }
+            })();
+        </script>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Explore Bastar Iron Craft (Loha Shilp) — GI-certified tribal wrought iron artistry of Chhattisgarh featuring manual forging, traditional motifs, and artisan spotlight."
+        />
+        <title>Bastar Iron Craft Explorer | Incredible India</title>
+
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+            rel="stylesheet"
+        />
+
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="bastar.css" />
+    </head>
+    <body class="bastar-main">
+        <header class="navbar scrolled" id="navbar">
+            <div class="nav-container">
+                <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </button>
+                <nav class="nav-menu" id="nav-menu">
+                    <a href="../../index.html#home" class="nav-link">Home</a>
+                    <a href="../handicrafts-showcase/index.html" class="nav-link">Handicrafts</a>
+                    <a href="index.html" class="nav-link active" style="color: var(--saffron)">Bastar Iron Craft</a>
+                    <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
+                        ☀️
+                    </button>
+                </nav>
+            </div>
+        </header>
+
+        <main>
+            <section class="bastar-hero">
+                <div class="section-container">
+                    <div class="hero-badges-row">
+                        <span class="hero-pill pill-gi">🏷️ GI Certified Craft</span>
+                        <span class="hero-pill pill-region">📍 Kondagaon, Chhattisgarh</span>
+                        <span class="hero-pill pill-forge">🔨 Hand Forged Iron</span>
+                    </div>
+                    <h1>Bastar Iron Craft <span>(Loha Shilp)</span></h1>
+                    <p class="hero-subtitle">
+                        Discover the wrought iron artistry of Bastar's tribal artisans — an ancient GI-tagged craft creating sleek figurines and ceremonial lamps without modern welding.
+                    </p>
+                    <div id="stats-grid" class="stats-grid"></div>
+                </div>
+            </section>
+
+            <section class="bastar-info-section">
+                <div class="section-container">
+                    <h2>Manufacturing Process & Forging Steps</h2>
+                    <div class="process-steps" id="process-steps"></div>
+
+                    <h2 class="sec-title">Traditional Motifs & Designs</h2>
+                    <div class="designs-grid" id="designs-grid"></div>
+
+                    <h2 class="sec-title">Artisan Community Spotlight</h2>
+                    <div class="info-card" id="artisan-card">
+                        <h3 id="artisan-title"></h3>
+                        <p id="artisan-desc"></p>
+                    </div>
+                </div>
+            </section>
+
+            <section class="gallery-section">
+                <div class="section-container">
+                    <h2>Craft Gallery</h2>
+                    <div class="gallery-grid" id="gallery-grid"></div>
+                </div>
+            </section>
+
+            <section class="references-section">
+                <div class="section-container">
+                    <h2>References & Documentation</h2>
+                    <ul class="references-list" id="references-list"></ul>
+                </div>
+            </section>
+        </main>
+
+        <script src="bastar-data.js"></script>
+        <script src="bastar.js"></script>
+    </body>
+</html>

--- a/frontend/handicrafts-showcase/script.js
+++ b/frontend/handicrafts-showcase/script.js
@@ -1,6 +1,17 @@
 // ---------- Handicrafts Data (16 crafts across UP districts) ----------
 const allCrafts = [
   {
+    name: "Bastar Iron Craft (Loha Shilp)",
+    icon: "🔨",
+    district: "Bastar & Kondagaon",
+    category: "metal",
+    tags: ["GI Tagged", "Wrought Iron", "Tribal Art"],
+    description: "Traditional hand-forged wrought iron craft by Bastar tribal artisans creating sleek figurines and oil lamps.",
+    history: "Ancestral metal forging tradition practiced by Lohar artisans of Chhattisgarh using charcoal kilns and anvils without any welding.",
+    artisan: "Kondagaon Lohar craftspersons manually beating scrap iron into tribal dancers, deer, and Dipa Stambha tree lamps.",
+    detailsUrl: "../bastar-iron-craft-explorer/index.html"
+  },
+  {
     name: "Lucknow Chikankari",
     icon: "🪡",
     district: "Lucknow",

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -1485,6 +1485,13 @@ window.indiaSearchIndex = [
     description: "Develop an educational page about Simlipal National Park & Biosphere Reserve in Odisha — featuring Barehipani (399m) & Joranda waterfalls, world's only Melanistic Black Tigers, Mayurbhanj elephants, 94+ orchids, and Santhal tribal heritage.",
     url: "frontend/simlipal-national-park-explorer/index.html"
   },
+  // --- Bastar Iron Craft Explorer ---
+  {
+    title: "Bastar Iron Craft Explorer",
+    category: "Arts & Culture",
+    description: "Explore Bastar Iron Craft (Loha Shilp) — GI-certified tribal wrought iron artistry of Chhattisgarh featuring manual forging, traditional motifs, and artisan spotlight.",
+    url: "frontend/bastar-iron-craft-explorer/index.html"
+  },
   // --- Kingdom of Mewar Explorer ---
   {
     title: "Kingdom of Mewar Explorer",

--- a/frontend/tests/unit/bastar-iron-craft-explorer.test.js
+++ b/frontend/tests/unit/bastar-iron-craft-explorer.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadBastarData() {
+    const code = readFileSync(
+        resolve(__dirname, '../../bastar-iron-craft-explorer/bastar-data.js'),
+        'utf-8'
+    );
+    const fn = new Function(
+        code + '\nreturn { BASTAR_INFO, PROCESS_STEPS, TRADITIONAL_DESIGNS, ARTISAN_SPOTLIGHT, GALLERY_IMAGES, REFERENCES };'
+    );
+    return fn();
+}
+
+describe('Bastar Iron Craft Explorer — Data Tests', () => {
+    let data;
+
+    beforeAll(() => {
+        data = loadBastarData();
+    });
+
+    describe('BASTAR_INFO metadata', () => {
+        it('contains correct Bastar Iron Craft metadata and GI tag', () => {
+            expect(data.BASTAR_INFO.id).toBe('bastar-iron-craft');
+            expect(data.BASTAR_INFO.title).toContain('Bastar Iron Craft');
+            expect(data.BASTAR_INFO.originRegion).toContain('Chhattisgarh');
+            expect(data.BASTAR_INFO.giTagStatus).toContain('GI');
+        });
+
+        it('has quickStats array with 6 items', () => {
+            expect(Array.isArray(data.BASTAR_INFO.quickStats)).toBe(true);
+            expect(data.BASTAR_INFO.quickStats.length).toBe(6);
+        });
+    });
+
+    describe('PROCESS_STEPS & TRADITIONAL_DESIGNS', () => {
+        it('contains manufacturing steps and traditional motifs', () => {
+            expect(Array.isArray(data.PROCESS_STEPS)).toBe(true);
+            expect(data.PROCESS_STEPS.length).toBeGreaterThanOrEqual(5);
+            expect(Array.isArray(data.TRADITIONAL_DESIGNS)).toBe(true);
+            expect(data.TRADITIONAL_DESIGNS.length).toBeGreaterThanOrEqual(4);
+        });
+    });
+
+    describe('ARTISAN_SPOTLIGHT', () => {
+        it('contains artisan community details', () => {
+            expect(data.ARTISAN_SPOTLIGHT.title).toBeDefined();
+            expect(data.ARTISAN_SPOTLIGHT.description).toContain('Kondagaon');
+        });
+    });
+
+    describe('GALLERY_IMAGES & REFERENCES', () => {
+        it('has non-empty gallery and references', () => {
+            expect(Array.isArray(data.GALLERY_IMAGES)).toBe(true);
+            expect(data.GALLERY_IMAGES.length).toBeGreaterThanOrEqual(2);
+            expect(Array.isArray(data.REFERENCES)).toBe(true);
+            expect(data.REFERENCES.length).toBeGreaterThanOrEqual(2);
+        });
+    });
+});


### PR DESCRIPTION
## Title

feat: Build a Bastar iron craft explorer highlighting tribal metal artistry

## Description

Develop a dedicated interactive explorer page for Bastar Iron Craft (Loha Shilp), celebrating Chhattisgarh's GI-tagged wrought iron tribal craft.

## Included
- History & GI Tag Certification (Bastar & Kondagaon, Chhattisgarh)
- 5-Step Forging Process (Scrap Heating, Manual Hammering, Rivet Joinery, Chisel Detailing, Matte Black Patina)
- Traditional Motifs (Tribal Musicians, Peacocks/Deer, Dipa Stambha Tree Lamps, Deities)
- Artisan Community Spotlight (Kondagaon Lohar Guilds)
- Card Registration in frontend/handicrafts-showcase/script.js & search-index.js
- 100% Vitest Unit Test Suite Coverage

Closes #1721

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Bastar Iron Craft Explorer with craft history, production steps, traditional designs, artisan information, gallery images, and references.
  - Added responsive layouts, themed visuals, statistics cards, and light/dark theme switching with preference persistence.
  - Added Bastar Iron Craft to the handicrafts showcase and site search under Arts & Culture.
- **Tests**
  - Added coverage validating the explorer’s craft information, process details, designs, artisan content, gallery, and references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->