### PR TITLE
feat: Add Battle of Pratapgad explorer to Historic Battles (#1619)

### DIFF
--- a/frontend/history/battles/data.js
+++ b/frontend/history/battles/data.js
@@ -104,6 +104,32 @@ export const battles = [
         color: "#DAA520"
     },
     {
+        name: "Battle of Pratapgad",
+        date: "17 July 1659",
+        year: 1659,
+        era: "medieval",
+        location: "Pratapgad Fort, Maharashtra",
+        coordinates: { top: "55%", left: "34%" },
+        combatants: {
+            side1: { name: "Maratha Empire", leader: "Chhatrapati Shivaji Maharaj", forces: "~2,000-3,000" },
+            side2: { name: "Adil Shahi Forces", leader: "Afzal Khan", forces: "~30,000-40,000" }
+        },
+        outcome: "Decisive Maratha victory — Afzal Khan killed",
+        significance: "Established Maratha military strength and secured Shivaji's position in the Deccan",
+        summary: "The Battle of Pratapgad in 1659 was a decisive victory for Chhatrapati Shivaji Maharaj against the forces of the Adil Shah of Bijapur, commanded by Afzal Khan. Shivaji used superior knowledge of the terrain, a deceptive truce meeting, and a surprise ambush to annihilate the enemy army, personally killing Afzal Khan in close combat.",
+        keyEvents: [
+            "Shivaji invited Afzal Khan to a meeting under flag of truce at Pratapgad",
+            "Afzal Khan was ambushed and killed in close combat by Shivaji",
+            "Maratha forces launched a coordinated surprise attack using the mountain terrain",
+            "Afzal Khan's elite cavalry was encircled and destroyed by concealed forces",
+            "The remaining Adil Shahi forces retreated in disarray through the valleys"
+        ],
+        casualties: { side1: "Minimal (~50-100)", side2: "Heavy (~2,000-4,000 killed)" },
+        tactics: "Deceptive truce meeting to draw the enemy into a prepared ambush, concealed forces in mountain valleys, use of arquebuses and terrain advantage. The 'wolf's mouth' tactic funnelled the enemy into kill zones.",
+        impact: "Established Shivaji as a major regional power in the Deccan. Demoralized the Adil Shahi forces and demonstrated the effectiveness of guerrilla tactics against larger conventional armies. Marked the beginning of the Maratha rise to power.",
+        color: "#1A7040"
+    },
+    {
         name: "Battle of Plassey",
         date: "23 June 1757",
         year: 1757,
@@ -219,7 +245,9 @@ export const commanders = [
     { name: "Major K.S. Chandpuri", era: "Modern", title: "Hero of Longewala", battles: ["Battle of Longewala"], description: "Commanded 120 soldiers who held off 2,000+ Pakistani troops and 40+ tanks for an entire night. Awarded the Maha Vir Chakra for his extraordinary courage.", color: "#FF6600" },
     { name: "Captain Vikram Batra", era: "Modern", title: "Param Vir Chakra Awardee", battles: ["Battle of Kargil"], description: "Led the capture of Point 5140 and then Point 4875 in Kargil. His famous line 'Yeh Dil Maange More' became iconic. Killed in action while rescuing a wounded officer. Posthumously awarded India's highest wartime honour.", color: "#DC143C" },
     { name: "Hemu (Hemchandra Vikramaditya)", era: "Medieval", title: "Last Hindu Emperor of Delhi", battles: ["Battle of Panipat (Second)"], description: "A Hindu general who briefly restored Hindu rule in Delhi and Agra. Killed by an arrow in the eye during the Second Battle of Panipat, ending his short reign.", color: "#8B0000" },
-    { name: "Siraj ud-Daulah", era: "Colonial", title: "Last Independent Nawab of Bengal", battles: ["Battle of Plassey"], description: "The young Nawab of Bengal who opposed British interference in trade and politics. Betrayed by his own commander Mir Jafar during the Battle of Plassey.", color: "#4B0082" }
+    { name: "Siraj ud-Daulah", era: "Colonial", title: "Last Independent Nawab of Bengal", battles: ["Battle of Plassey"], description: "The young Nawab of Bengal who opposed British interference in trade and politics. Betrayed by his own commander Mir Jafar during the Battle of Plassey.", color: "#4B0082" },
+    { name: "Chhatrapati Shivaji Maharaj", era: "Medieval", title: "Founder of the Maratha Empire", battles: ["Battle of Pratapgad"], description: "The legendary Maratha warrior-king who carved out a sovereign kingdom from the declining Adil Shahi and Mughal empires. At Pratapgad, he used guerrilla tactics, terrain advantage, and a deceptive truce to destroy Afzal Khan's larger army, establishing Maratha military prowess.", color: "#1A7040" },
+    { name: "Afzal Khan", era: "Medieval", title: "Adil Shahi General", battles: ["Battle of Pratapgad"], description: "The trusted general of the Adil Shah of Bijapur, known for his military experience and elite cavalry. He was killed by Shivaji in single combat during a deceptive truce meeting at Pratapgad, leading to the catastrophic defeat of his forces.", color: "#8B0000" }
 ];
 
 export const eraInfo = {

--- a/tests/unit/pratapgad-battle.test.js
+++ b/tests/unit/pratapgad-battle.test.js
@@ -1,0 +1,109 @@
+/**
+ * pratapgad-battle.test.js
+ * Unit tests for the Battle of Pratapgad entry in the Historic Battles data.
+ * Validates data structure, required fields, historical accuracy,
+ * timeline sorting, and commander integration.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { battles, commanders, eraInfo } from '../../frontend/history/battles/data.js';
+
+describe('Battle of Pratapgad — Data Entry', () => {
+    const pratapgad = battles.find(b => b.name === 'Battle of Pratapgad');
+
+    it('exists in the battles array', () => {
+        expect(pratapgad).toBeDefined();
+    });
+
+    it('has all required fields populated', () => {
+        const fields = ['name', 'date', 'year', 'era', 'location', 'coordinates', 'combatants', 'outcome', 'significance', 'summary', 'keyEvents', 'casualties', 'tactics', 'impact', 'color'];
+        fields.forEach(field => {
+            expect(pratapgad[field], `Field "${field}" should be defined`).toBeDefined();
+        });
+    });
+
+    it('is set to the medieval era', () => {
+        expect(pratapgad.era).toBe('medieval');
+        expect(eraInfo[pratapgad.era]).toBeDefined();
+    });
+
+    it('has the correct historical date and year', () => {
+        expect(pratapgad.date).toContain('1659');
+        expect(pratapgad.year).toBe(1659);
+    });
+
+    it('has Maratha forces led by Shivaji on side 1', () => {
+        expect(pratapgad.combatants.side1.name).toContain('Maratha');
+        expect(pratapgad.combatants.side1.leader).toContain('Shivaji');
+    });
+
+    it('has Adil Shahi forces led by Afzal Khan on side 2', () => {
+        expect(pratapgad.combatants.side2.name).toContain('Adil Shahi');
+        expect(pratapgad.combatants.side2.leader).toContain('Afzal Khan');
+    });
+
+    it('records the Maratha victory and death of Afzal Khan', () => {
+        expect(pratapgad.outcome.toLowerCase()).toContain('maratha victory');
+        expect(pratapgad.outcome.toLowerCase()).toContain('afzal khan');
+    });
+
+    it('has at least 5 key events', () => {
+        expect(pratapgad.keyEvents.length).toBeGreaterThanOrEqual(5);
+    });
+
+    it('has casualties for both sides', () => {
+        expect(pratapgad.casualties.side1).toBeTruthy();
+        expect(pratapgad.casualties.side2).toBeTruthy();
+    });
+
+    it('has map coordinates', () => {
+        expect(pratapgad.coordinates.top).toMatch(/%$/);
+        expect(pratapgad.coordinates.left).toMatch(/%$/);
+    });
+
+    it('mentions the deceptive truce tactic in key events or tactics', () => {
+        const content = (pratapgad.keyEvents.join(' ') + ' ' + pratapgad.tactics).toLowerCase();
+        expect(content).toContain('truce');
+    });
+});
+
+describe('Battle of Pratapgad — Timeline Integration', () => {
+    let sorted;
+
+    beforeAll(() => {
+        sorted = [...battles].sort((a, b) => a.year - b.year);
+    });
+
+    it('appears in the chronologically sorted timeline', () => {
+        const idx = sorted.findIndex(b => b.name === 'Battle of Pratapgad');
+        expect(idx).toBeGreaterThan(-1);
+        if (idx > 0) {
+            expect(sorted[idx - 1].year).toBeLessThanOrEqual(sorted[idx].year);
+        }
+    });
+
+    it('is listed between Haldighati and Plassey chronologically', () => {
+        const pratapgadIdx = sorted.findIndex(b => b.name === 'Battle of Pratapgad');
+        const haldighatiIdx = sorted.findIndex(b => b.name === 'Battle of Haldighati');
+        const plasseyIdx = sorted.findIndex(b => b.name === 'Battle of Plassey');
+        expect(pratapgadIdx).toBeGreaterThan(haldighatiIdx);
+        expect(pratapgadIdx).toBeLessThan(plasseyIdx);
+    });
+});
+
+describe('Battle of Pratapgad — Commander Integration', () => {
+    const shivaji = commanders.find(c => c.name === 'Chhatrapati Shivaji Maharaj');
+    const afzal = commanders.find(c => c.name === 'Afzal Khan');
+
+    it('has Chhatrapati Shivaji Maharaj as a commander', () => {
+        expect(shivaji).toBeDefined();
+        expect(shivaji.era).toBe('Medieval');
+        expect(shivaji.battles).toContain('Battle of Pratapgad');
+    });
+
+    it('has Afzal Khan as a commander', () => {
+        expect(afzal).toBeDefined();
+        expect(afzal.era).toBe('Medieval');
+        expect(afzal.battles).toContain('Battle of Pratapgad');
+    });
+});


### PR DESCRIPTION
Adds the Battle of Pratapgad (1659 CE) explorer entry to the Historic Battles collection.

- New battle entry with historical overview, timeline, belligerents, commanders, battle strategy, outcome, and impact
- Map coordinates placed in the Western Ghats region of Maharashtra
- Adds Chhatrapati Shivaji Maharaj and Afzal Khan to the commanders gallery
- Includes 15 unit tests covering data structure, timeline sorting, and commander integration
- Closes #1619

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Battle of Pratapgad to the historical battle timeline.
  * Included details on participants, commanders, outcome, events, casualties, tactics, impact, location, and era.

* **Tests**
  * Added coverage validating the battle’s historical data and chronological placement in the timeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->