### PR TITLE
feat: Integrate the Battle of Takkolam into the Historic Battles Explorer

### DIFF
--- a/frontend/battle-of-takkolam-explorer/index.html
+++ b/frontend/battle-of-takkolam-explorer/index.html
@@ -1,0 +1,427 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore the Battle of Takkolam (c. 949 CE): the Chola–Rashtrakuta clash where crown prince Rajaditya fell and Emperor Krishna III broke the Chola hold on Thondaimandalam.">
+  <title>Battle of Takkolam Explorer | Incredible India</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css?v=1.0">
+  <link rel="stylesheet" href="../js-modules/page-progress/page-progress.css">
+
+  <!-- Open Graph / Social Media Tags -->
+  <meta property="og:title" content="Battle of Takkolam Explorer | Incredible India Explorer">
+  <meta property="og:description" content="Relive the Battle of Takkolam, the decisive Chola–Rashtrakuta conflict where crown prince Rajaditya fell from his war elephant and Krishna III captured Kanchi and Tanjore.">
+  <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/frontend/assets/sri_battle_banner.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/battle-of-takkolam-explorer/index.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Incredible India Explorer">
+  <meta property="og:locale" content="en_IN">
+
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/battle-of-takkolam-explorer/index.html">
+</head>
+<body>
+  <script>
+    (function() {
+      const theme = localStorage.getItem('theme') || 'dark';
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+
+  <!-- Sticky Navigation Bar -->
+  <header class="navbar" id="navbar">
+    <div class="nav-container">
+        <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+            <span class="saffron">Incredible</span>
+            <span class="gold">India</span>
+            <span class="green">Explorer</span>
+        </a>
+        <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+            <span class="bar"></span>
+            <span class="bar"></span>
+            <span class="bar"></span>
+        </button>
+        <nav class="nav-menu" id="nav-menu">
+            <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
+                    <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                    <a href="../../frontend/ancient-ports-explorer/index.html" class="dropdown-item">Ancient Ports of India</a>
+                    <a href="../../frontend/islands/islands.html" class="dropdown-item">Islands of India</a>
+                    <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    <a href="../../frontend/route-planner/route-planner.html" class="dropdown-item">Route Planner</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+                    <a href="../../frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
+                    <a href="../../frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
+                    <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
+                    <a href="../../frontend/national-symbols-gallery/national-symbols-gallery.html" class="dropdown-item">National Symbols</a>
+                    <a href="../../frontend/cuisine-discovery-hub/index.html" class="dropdown-item">UP Cuisine</a>
+                    <a href="../../frontend/handicrafts-showcase/index.html" class="dropdown-item">UP Handicrafts</a>
+                    <a href="../../frontend/national-days-calendar/index.html" class="dropdown-item">National Days</a>
+                    <a href="../../frontend/ganga-ghats-experience/index.html" class="dropdown-item">Ganga Ghats</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Nature ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/national-parks-explorer/index.html" class="dropdown-item">National Parks</a>
+                    <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                    <a href="../../frontend/wildlife-rescue/wildlife-rescue.html" class="dropdown-item">Wildlife Rescue</a>
+                    <a href="../../frontend/endemic-flora-fauna-explorer/index.html" class="dropdown-item">Endemic Flora & Fauna</a>
+                    <a href="../../frontend/harike-wetland/harike-wetland.html" class="dropdown-item">Harike Wetland</a>
+                    <a href="../../frontend/wular-lake/wular-lake.html" class="dropdown-item">Wular Lake</a>
+                    <a href="../../frontend/crowd-density/index.html" class="dropdown-item">Crowd Density Predictor</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Games ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/passport-quest/passport-quest.html" class="dropdown-item">Passport Quest</a>
+                    <a href="../../frontend/culinary-game/culinary-game.html" class="dropdown-item">Culinary Challenge</a>
+                    <a href="../../frontend/monsoon-game/monsoon-game.html" class="dropdown-item">Monsoon Game</a>
+                    <a href="../../frontend/river-game/river-game.html" class="dropdown-item">River Explorer</a>
+                    <a href="../../frontend/geo-guesser-india/index.html" class="dropdown-item">GeoGuesser</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Community ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/contributors/contributors.html" class="dropdown-item">Contributors</a>
+                    <a href="../../frontend/world-records-india/index.html" class="dropdown-item">World Records</a>
+                </div>
+            </div>
+
+            <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+        </nav>
+    </div>
+</header>
+
+  <!-- SPA Router Target Container -->
+  <main id="app-root" class="tak-main">
+
+    <!-- Hero Banner -->
+    <section class="tak-hero">
+      <div class="tak-hero-content">
+        <span class="tak-kicker">⚔️ Thondaimandalam · c. 949 CE</span>
+        <h1>Battle of Takkolam <span>Explorer</span></h1>
+        <p>Step onto the sun-scorched plains of the northern Tamil country. Uncover the epic Chola–Rashtrakuta clash where crown prince Rajaditya fell from his war elephant and Emperor Krishna III broke the Chola hold on Thondaimandalam — a defeat whose consequences echoed for a generation.</p>
+        <div class="tak-bookmark-container">
+          <button class="tak-bookmark-btn journey-bookmark-btn" type="button" data-bookmark-id="takkolam-battle-main" aria-pressed="false" aria-label="Bookmark Battle of Takkolam">
+            ♡ Save to Journey
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Battle Overview -->
+    <section class="tak-section" id="overview">
+      <div class="tak-container tak-grid-2col">
+        <div class="tak-text-block">
+          <span class="tak-eyebrow">The Southern Crusade</span>
+          <h2>The Rashtrakuta Invasion of the Chola Kingdom</h2>
+          <p>By the mid-10th century, Chola king Parantaka I had carried his dynasty to the summit of its early power — conquering the Pandya and Chera countries and sweeping down the Kaveri. Across the Deccan, however, the Rashtrakuta emperor Krishna III was bent on restoring the imperial glory that had slipped from his predecessors. Sensing his ageing rival's overreach, he launched a devastating invasion of the Chola kingdom.</p>
+          <p>Parantaka I dispatched his eldest son and crown prince, Rajaditya, at the head of the Chola army. The two great forces collided at Takkolam in Thondaimandalam, near the Pallava heartland of Kanchi — a single, ferocious encounter that would decide the fate of South India for a generation.</p>
+        </div>
+        <div class="tak-highlight-box">
+          <h3>🏛️ At a Glance</h3>
+          <ul>
+            <li><strong>Combatants</strong>: Chola Dynasty vs. Rashtrakuta Empire.</li>
+            <li><strong>Location</strong>: Takkolam, Thondaimandalam (Tamil Nadu).</li>
+            <li><strong>Outcome</strong>: Decisive Rashtrakuta victory.</li>
+            <li><strong>Significance</strong>: Rajaditya slain; Kanchi &amp; Tanjore fell to Krishna III.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Commanders -->
+    <section class="tak-section" id="commanders">
+      <div class="tak-container">
+        <div class="tak-section-header">
+          <span class="tak-eyebrow">Commanders &amp; Empires</span>
+          <h2>Sovereigns of the Battle</h2>
+          <p>The commanders at Takkolam were titans of the 10th-century Deccan, whose rivalry would redraw the map of South India.</p>
+        </div>
+
+        <div class="tak-card-grid">
+          <div class="tak-card">
+            <span class="tak-card-icon">👑</span>
+            <h3>Krishna III</h3>
+            <p>The Rashtrakuta Emperor of Manyakheta, architect of the southern crusade. His generalship at Takkolam re-established Rashtrakuta supremacy across the Deccan and Tamil country.</p>
+          </div>
+          <div class="tak-card">
+            <span class="tak-card-icon">🐘</span>
+            <h3>Rajaditya</h3>
+            <p>The Chola crown prince and commander of the expedition. He fought in the vanguard from atop a war elephant, and fell in the thick of battle — a martyrdom immortalised in contemporary inscriptions.</p>
+          </div>
+          <div class="tak-card">
+            <span class="tak-card-icon">🛡️</span>
+            <h3>Butuga II</h3>
+            <p>The Western Ganga feudatory of the Rashtrakutas, whose veteran troops and elephant corps turned the tide. The Atakur inscription credits him with striking down the Chola prince.</p>
+          </div>
+          <div class="tak-card">
+            <span class="tak-card-icon">⚖️</span>
+            <h3>Parantaka I</h3>
+            <p>The ageing Chola sovereign who sent his heir to war. The loss of his beloved son and his northern provinces clouded the closing years of his long and glorious reign.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Belligerents -->
+    <section class="tak-section" id="belligerents">
+      <div class="tak-container">
+        <div class="tak-section-header">
+          <span class="tak-eyebrow">The Two Camps</span>
+          <h2>Belligerents &amp; Alliances</h2>
+          <p>Two great imperial systems, each reinforced by loyal feudatories, met in a single decisive field.</p>
+        </div>
+
+        <div class="tak-card-grid">
+          <div class="tak-card" style="border-color: rgba(234, 88, 12, 0.25);">
+            <span class="tak-card-icon">🐅</span>
+            <h3>The Chola Kingdom</h3>
+            <p>Led by crown prince Rajaditya on behalf of Parantaka I. Supported by the Bana and Vaidumba chieftains of the northern Tamil frontier, fighting to defend Thondaimandalam.</p>
+          </div>
+          <div class="tak-card" style="border-color: rgba(217, 119, 6, 0.25);">
+            <span class="tak-card-icon">🐂</span>
+            <h3>The Rashtrakuta Empire</h3>
+            <p>Led by Krishna III from his capital at Manyakheta. Commanded the might of the Deccan and its formidable war-elephant corps, freshly hardened in campaigns across the plateau.</p>
+          </div>
+          <div class="tak-card" style="border-color: rgba(217, 119, 6, 0.25);">
+            <span class="tak-card-icon">🐘</span>
+            <h3>The Western Gangas</h3>
+            <p>Feudatories of the Rashtrakutas under Butuga II. Their disciplined Ganga levy and elite elephants formed the spearhead that broke the Chola centre.</p>
+          </div>
+          <div class="tak-card" style="border-color: rgba(234, 88, 12, 0.25);">
+            <span class="tak-card-icon">🏹</span>
+            <h3>Bana &amp; Vaidumba Allies</h3>
+            <p>Loyal Chola feudatories of the northern Tamil country who fought alongside Rajaditya, their hill forts and levies anchoring the Chola line at Takkolam.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Outcome & Consequences -->
+    <section class="tak-section" id="outcome">
+      <div class="tak-container tak-grid-2col">
+        <div class="tak-highlight-box" style="background: rgba(180, 83, 9, 0.05); border-color: rgba(180, 83, 9, 0.2);">
+          <h3>📈 Outcome &amp; Strategic Impact</h3>
+          <ul>
+            <li><strong>Battle Winner</strong>: Krishna III routs the Chola army at Takkolam.</li>
+            <li><strong>Martyrdom</strong>: Crown prince Rajaditya is slain atop his war elephant.</li>
+            <li><strong>Kanchi &amp; Tanjore Fall</strong>: The Rashtrakutas seize both great capitals in the following years.</li>
+            <li><strong>Chola Eclipse</strong>: Thondaimandalam is lost and Chola power recedes for two decades.</li>
+          </ul>
+        </div>
+        <div class="tak-text-block">
+          <span class="tak-eyebrow">A Fallen Prince, A Broken Front</span>
+          <h2>The Price of Takkolam</h2>
+          <p>The battle opened with a ferocious exchange of arrows and elephants. Rajaditya, crowned with royal honours and fighting from a towering war elephant, pressed deep into the Rashtrakuta ranks. Wounded early in the day, he refused to leave the field and fought on — until a final volley struck him down. The death of the crown prince threw the Chola army into confusion and sealed a total Rashtrakuta victory.</p>
+          <p>Krishna III exploited the triumph without mercy. His armies swept through Thondaimandalam, seized Kanchipuram, raised a pillar of victory, and marched south to the Kaveri, briefly occupying Tanjore itself. The heartbroken Parantaka I withdrew to the deep south and died a few years later, leaving the Chola state battered and on the defensive.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Timeline -->
+    <section class="tak-section" id="timeline">
+      <div class="tak-container">
+        <div class="tak-section-header">
+          <span class="tak-eyebrow">Milestones</span>
+          <h2>Chronology of the Chola–Rashtrakuta Struggle</h2>
+          <p>Follow the events before and after Takkolam that reshaped South Indian history.</p>
+        </div>
+
+        <div class="timeline-flow">
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">c. 940s CE</span>
+              <h3>Krishna III's Rise</h3>
+              <p>The new Rashtrakuta emperor consolidates the Deccan and begins probing the northern frontiers of the Chola kingdom.</p>
+            </div>
+          </div>
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">c. 949 CE</span>
+              <h3>The Battle of Takkolam</h3>
+              <p>The Chola army under Rajaditya is crushed. The crown prince falls in battle, and Thondaimandalam passes into Rashtrakuta hands.</p>
+            </div>
+          </div>
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">c. 950–952 CE</span>
+              <h3>Kanchi and Tanjore Fall</h3>
+              <p>Krishna III captures Kanchipuram, plants a pillar of victory, and pushes south of the Kaveri to occupy Tanjore — the height of Rashtrakuta power.</p>
+            </div>
+          </div>
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">c. 955 CE</span>
+              <h3>Death of Parantaka I</h3>
+              <p>The ageing Chola king, broken by the loss of his heir and his kingdom, passes away while the Cholas struggle to recover.</p>
+            </div>
+          </div>
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">965 CE</span>
+              <h3>End of Krishna III</h3>
+              <p>The death of the Rashtrakuta emperor loosens his empire's grip, and Chola fortunes begin to revive under Uttama Chola.</p>
+            </div>
+          </div>
+          <div class="timeline-step">
+            <div class="timeline-step-marker"></div>
+            <div class="timeline-step-card">
+              <span class="timeline-step-year">985–1014 CE</span>
+              <h3>The Chola Resurgence</h3>
+              <p>Rajaraja Chola I rebuilds the dynasty into the mightiest empire of South India — a recovery forged in the shadow of Takkolam.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Long-term Consequences -->
+    <section class="tak-section" id="legacy">
+      <div class="tak-container">
+        <div class="tak-section-header">
+          <span class="tak-eyebrow">Aftermath</span>
+          <h2>Long-Term Consequences</h2>
+          <p>How one afternoon on a field in Thondaimandalam redefined two imperial dynasties.</p>
+        </div>
+
+        <div class="tak-card-grid">
+          <div class="tak-card">
+            <span class="tak-card-icon">📉</span>
+            <h3>The Chola Eclipse</h3>
+            <p>The defeat cost the Cholas Thondaimandalam and both capitals. For nearly two decades the dynasty fought to hold the Kaveri heartland against Rashtrakuta raids.</p>
+          </div>
+          <div class="tak-card">
+            <span class="tak-card-icon">📈</span>
+            <h3>Rashtrakuta High-Water Mark</h3>
+            <p>Takkolam carried Krishna III to the apogee of Rashtrakuta power, from the Narmada to the Kaveri — a supremacy that lasted until his death in 965 CE.</p>
+          </div>
+          <div class="tak-card">
+            <span class="tak-card-icon">🔁</span>
+            <h3>A Reformed Chola State</h3>
+            <p>The trauma of Takkolam forced the Cholas to reorganise their army, administration, and succession — reforms that made the imperial expansion of Rajaraja I possible.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Gallery -->
+    <section class="tak-section" id="gallery">
+      <div class="tak-container">
+        <div class="tak-section-header">
+          <span class="tak-eyebrow">Visual Tour</span>
+          <h2>Relics of the Chola–Rashtrakuta Age</h2>
+          <p>Explore the temples, copper-plate charters, and stone carvings that preserve the memory of this age of titans.</p>
+        </div>
+
+        <div class="tak-gallery-grid">
+          <div class="tak-gallery-item" data-title="Brihadeeswarar Temple, Thanjavur" data-desc="The great Chola temple of Thanjavur, built by Rajaraja I, stands as the enduring monument of the dynasty that rose again after its humiliation at Takkolam.">
+            <div class="tak-gallery-image-wrapper">
+              <img src="../assets/Brihadeeswara_Temple.png" alt="Brihadeeswarar Temple at Thanjavur" loading="lazy">
+            </div>
+            <div class="tak-gallery-caption">
+              <h4>Brihadeeswarar Temple</h4>
+              <p>The Chola legacy that outlived the defeat at Takkolam.</p>
+            </div>
+          </div>
+          <div class="tak-gallery-item" data-title="Kanchipuram War Reliefs" data-desc="Sandstone carvings of royal guards, war horses, and elephant corps in the temples of Kanchipuram — the city Krishna III seized in the wake of his victory.">
+            <div class="tak-gallery-image-wrapper">
+              <img src="../assets/kanchipuram_relic.png" alt="Kanchipuram temple war carving" loading="lazy">
+            </div>
+            <div class="tak-gallery-caption">
+              <h4>Kanchipuram Reliefs</h4>
+              <p>Stone armies of the city that changed hands at Takkolam.</p>
+            </div>
+          </div>
+          <div class="tak-gallery-item" data-title="Udayendiram Copper Plates" data-desc="The copper-plate charters of the Western Gangas and Banas that record the alliances, the campaigns, and the heroic fall of crown prince Rajaditya.">
+            <div class="tak-gallery-image-wrapper">
+              <img src="../assets/udayendiram_plates.png" alt="Udayendiram copper plates" loading="lazy">
+            </div>
+            <div class="tak-gallery-caption">
+              <h4>Udayendiram Plates</h4>
+              <p>Charter records of the battles that shaped the Tamil country.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: References -->
+    <section class="tak-section" id="references">
+      <div class="tak-container">
+        <div class="tak-references">
+          <h3>📚 References &amp; Further Reading</h3>
+          <ul>
+            <li><strong>The Atakur Inscription of Butuga II (c. 949 CE)</strong>. <em>Ganga-Rashtrakuta record of the campaign and the slaying of Rajaditya</em>.</li>
+            <li><strong>Nilakanta Sastri, K. A. (1935)</strong>. <em>The Colas</em>. University of Madras.</li>
+            <li><strong>Nilakanta Sastri, K. A. (1955)</strong>. <em>A History of South India</em>. Oxford University Press.</li>
+            <li><strong>Champakalakshmi, R. (1996)</strong>. <em>Trade, Ideology and Urbanization: South India 300 BC to AD 1300</em>. Oxford University Press.</li>
+            <li><strong>Thapar, Romila (2002)</strong>. <em>Early India: From the Origins to AD 1300</em>. University of California Press.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- Interactive Detail Modal -->
+  <div class="museum-modal" id="port-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-hidden="true">
+    <div class="museum-modal-card">
+      <button class="museum-modal-close" id="port-modal-close" type="button" aria-label="Close details">✕</button>
+      <span class="modal-category" id="modal-category">Historical Highlight</span>
+      <h2 id="modal-title"></h2>
+      <p class="modal-location" style="color: var(--tak-gold-light);" id="modal-heading"></p>
+      <div style="border-top: 1px solid rgba(255,255,255,0.1); margin-top: 15px; padding-top: 15px;">
+        <p class="modal-description" id="modal-description"></p>
+      </div>
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <footer class="tak-footer">
+    <div class="tak-container">
+      <p>Part of <a href="../../index.html">Incredible India Explorer</a> · Discover the battles and dynasties of medieval South India.</p>
+    </div>
+  </footer>
+
+  <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+
+  <!-- JS Dependencies -->
+  <script src="../app.js" defer></script>
+  <script src="../../frontend/journey/journey.js" defer></script>
+  <script src="script.js" defer></script>
+  <script type="module" src="../firebase-config.js"></script>
+  <script type="module" src="../auth.js"></script>
+  <script src="../router.js" defer></script>
+  <script src="../js-modules/page-progress/page-progress.js"></script>
+</body>
+</html>

--- a/frontend/battle-of-takkolam-explorer/script.js
+++ b/frontend/battle-of-takkolam-explorer/script.js
@@ -1,0 +1,126 @@
+document.addEventListener("app:route-changed", () => {
+  const bookmarkButtons = [...document.querySelectorAll(".journey-bookmark-btn")];
+  const galleryItems = [...document.querySelectorAll(".tak-gallery-item")];
+  
+  const modal = document.getElementById("port-modal");
+  const modalClose = document.getElementById("port-modal-close");
+  const modalTitle = document.getElementById("modal-title");
+  const modalHeading = document.getElementById("modal-heading");
+  const modalDescription = document.getElementById("modal-description");
+
+  // --- Journey Integration (Bookmarks & Global Search) -------------
+  function initJourney() {
+    if (!window.Journey) return;
+
+    // 1. Bookmark functionality
+    bookmarkButtons.forEach((btn) => {
+      const id = btn.dataset.bookmarkId;
+      const title = "Battle of Takkolam Explorer";
+      const thumbnail = "frontend/assets/sri_battle_banner.png";
+      const category = "history";
+
+      const updateBookmarkUI = () => {
+        const isSaved = window.Journey.isSaved(id);
+        btn.classList.toggle("is-saved", isSaved);
+        btn.setAttribute("aria-pressed", String(isSaved));
+        btn.innerHTML = isSaved ? "♥ Saved to Journey" : "♡ Save to Journey";
+      };
+
+      updateBookmarkUI();
+
+      btn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        window.Journey.toggle({
+          id,
+          explorerPage: "frontend/battle-of-takkolam-explorer/index.html",
+          title,
+          thumbnail,
+          category
+        });
+        updateBookmarkUI();
+      });
+    });
+
+    // 2. Global search index registration
+    window.Journey.registerSearchItems("frontend/battle-of-takkolam-explorer/index.html", [
+      {
+        id: "takkolam-battle-main",
+        title: "Battle of Takkolam Explorer",
+        description: "Explore the Battle of Takkolam (c. 949 CE), the decisive Chola–Rashtrakuta clash where crown prince Rajaditya fell and Krishna III captured Kanchi and Tanjore.",
+        link: "frontend/battle-of-takkolam-explorer/index.html"
+      },
+      {
+        id: "takkolam-battle-commanders",
+        title: "Takkolam Commanders",
+        description: "Learn about the commanders at Takkolam: Krishna III of the Rashtrakutas, crown prince Rajaditya of the Cholas, and the Ganga feudatory Butuga II.",
+        link: "frontend/battle-of-takkolam-explorer/index.html#commanders"
+      },
+      {
+        id: "takkolam-battle-timeline",
+        title: "Takkolam Conflict Timeline",
+        description: "Discover the chronology of the Chola–Rashtrakuta struggle, from the fall of Takkolam to the Chola resurgence under Rajaraja I.",
+        link: "frontend/battle-of-takkolam-explorer/index.html#timeline"
+      }
+    ]);
+  }
+
+  // --- Gallery Modal Logic -----------------------------------------
+  let lastFocusedElement = null;
+
+  function openModal(item) {
+    lastFocusedElement = item;
+
+    modalTitle.textContent = item.dataset.title;
+    modalHeading.textContent = item.querySelector("p")?.textContent || "Historical Highlight";
+    modalDescription.textContent = item.dataset.desc;
+
+    modal.classList.add("open");
+    modal.setAttribute("aria-hidden", "false");
+    document.body.classList.add("modal-open");
+
+    if (modalClose) modalClose.focus();
+  }
+
+  function closeModal() {
+    modal.classList.remove("open");
+    modal.setAttribute("aria-hidden", "true");
+    document.body.classList.remove("modal-open");
+
+    if (lastFocusedElement) {
+      lastFocusedElement.focus();
+    }
+  }
+
+  // Bind gallery click events
+  galleryItems.forEach((item) => {
+    item.setAttribute("tabindex", "0");
+    item.addEventListener("click", () => openModal(item));
+    item.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        openModal(item);
+      }
+    });
+  });
+
+  if (modalClose) {
+    modalClose.addEventListener("click", closeModal);
+  }
+
+  if (modal) {
+    modal.addEventListener("click", (e) => {
+      if (e.target === modal) {
+        closeModal();
+      }
+    });
+  }
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && modal && modal.classList.contains("open")) {
+      closeModal();
+    }
+  });
+
+  // Run initialization
+  initJourney();
+});

--- a/frontend/battle-of-takkolam-explorer/style.css
+++ b/frontend/battle-of-takkolam-explorer/style.css
@@ -1,0 +1,594 @@
+/* ==========================================================================
+   Battle of Takkolam Explorer - Stylesheet
+   Pure Vanilla CSS matching the application's premium aesthetic.
+   ========================================================================== */
+
+:root {
+  --tak-dark: #0a0b0f; /* Deep Deccan basalt slate */
+  --tak-dark-light: #161822;
+  --tak-bronze: #b45309; /* Rashtrakuta Regal Copper */
+  --tak-bronze-light: #f59e0b;
+  --tak-saffron: #ea580c; /* Chola Sacred Saffron */
+  --tak-gold: #d97706; /* Imperial Gold */
+  --tak-gold-light: #fbbf24;
+  --tak-glass: rgba(10, 11, 15, 0.7);
+  --tak-border: rgba(180, 83, 9, 0.18);
+}
+
+/* Page Main Container */
+.tak-main {
+  background-color: var(--tak-dark);
+  color: #f1f5f9;
+  font-family: 'Outfit', sans-serif;
+  overflow-x: hidden;
+}
+
+/* Hero Section */
+.tak-hero {
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+  padding: 120px 0 60px;
+  background: linear-gradient(180deg, rgba(10, 11, 15, 0.35), rgba(10, 11, 15, 0.95)), 
+              url('../assets/sri_battle_banner.png') center/cover no-repeat;
+  text-align: center;
+}
+
+.tak-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 50%, rgba(180, 83, 9, 0.18), transparent 60%);
+  z-index: 1;
+}
+
+.tak-hero-content {
+  position: relative;
+  z-index: 2;
+  width: min(880px, 90%);
+}
+
+.tak-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 20px;
+  padding: 6px 16px;
+  background: rgba(180, 83, 9, 0.15);
+  border: 1px solid rgba(217, 119, 6, 0.3);
+  border-radius: 100px;
+  color: var(--tak-gold-light);
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  backdrop-filter: blur(8px);
+}
+
+.tak-hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2.5rem, 6vw, 4.5rem);
+  line-height: 1.1;
+  margin: 0 0 20px;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.tak-hero h1 span {
+  color: var(--tak-saffron);
+  background: linear-gradient(135deg, var(--tak-saffron), var(--tak-bronze));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.tak-hero p {
+  font-size: clamp(1rem, 2vw, 1.2rem);
+  line-height: 1.6;
+  color: #cbd5e1;
+  margin: 0 auto;
+  max-width: 760px;
+}
+
+/* Sections General */
+.tak-section {
+  padding: 80px 0;
+}
+
+.tak-section:nth-of-type(even) {
+  background-color: rgba(255, 255, 255, 0.01);
+}
+
+.tak-container {
+  width: min(1200px, 90%);
+  margin: 0 auto;
+}
+
+.tak-section-header {
+  margin-bottom: 50px;
+  text-align: center;
+}
+
+.tak-eyebrow {
+  color: var(--tak-gold-light);
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.tak-section-header h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin: 0 0 16px;
+  color: #ffffff;
+}
+
+.tak-section-header p {
+  color: #94a3b8;
+  max-width: 700px;
+  margin: 0 auto;
+  line-height: 1.6;
+  font-size: 1.05rem;
+}
+
+/* Content Grid / Two Columns */
+.tak-grid-2col {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 50px;
+  align-items: center;
+}
+
+@media (max-width: 900px) {
+  .tak-grid-2col {
+    grid-template-columns: 1fr;
+    gap: 30px;
+  }
+}
+
+.tak-text-block p {
+  line-height: 1.75;
+  color: #cbd5e1;
+  margin-bottom: 20px;
+  font-size: 1.05rem;
+}
+
+.tak-text-block p:last-child {
+  margin-bottom: 0;
+}
+
+.tak-highlight-box {
+  background: var(--tak-glass);
+  border: 1px solid var(--tak-border);
+  border-radius: 16px;
+  padding: 30px;
+  backdrop-filter: blur(12px);
+}
+
+.tak-highlight-box h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.4rem;
+  margin: 0 0 16px;
+  color: var(--tak-gold-light);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.tak-highlight-box ul {
+  padding-left: 20px;
+  margin: 0;
+}
+
+.tak-highlight-box li {
+  color: #cbd5e1;
+  margin-bottom: 12px;
+  line-height: 1.6;
+}
+
+.tak-highlight-box li:last-child {
+  margin-bottom: 0;
+}
+
+/* Interactive Timeline */
+.timeline-flow {
+  position: relative;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 20px 0;
+}
+
+.timeline-flow::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(180deg, transparent, var(--tak-border) 10%, var(--tak-border) 90%, transparent);
+  transform: translateX(-50%);
+}
+
+.timeline-step {
+  display: flex;
+  justify-content: flex-end;
+  padding-right: 50%;
+  position: relative;
+  margin-bottom: 40px;
+}
+
+.timeline-step:nth-child(even) {
+  justify-content: flex-start;
+  padding-right: 0;
+  padding-left: 50%;
+}
+
+.timeline-step-marker {
+  position: absolute;
+  left: 50%;
+  top: 15px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--tak-dark);
+  border: 3px solid var(--tak-gold-light);
+  transform: translateX(-50%);
+  z-index: 2;
+  transition: background 0.3s;
+}
+
+.timeline-step:hover .timeline-step-marker {
+  background: var(--tak-saffron);
+  box-shadow: 0 0 10px var(--tak-saffron);
+}
+
+.timeline-step-card {
+  background: var(--tak-glass);
+  border: 1px solid var(--tak-border);
+  border-radius: 12px;
+  padding: 24px;
+  width: 85%;
+  margin-right: 40px;
+  position: relative;
+  transition: transform 0.3s, border-color 0.3s;
+}
+
+.timeline-step:nth-child(even) .timeline-step-card {
+  margin-right: 0;
+  margin-left: 40px;
+}
+
+.timeline-step-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--tak-gold-light);
+}
+
+.timeline-step-year {
+  color: var(--tak-saffron);
+  font-weight: 800;
+  font-size: 1.25rem;
+  margin-bottom: 8px;
+  display: block;
+}
+
+.timeline-step-card h3 {
+  margin: 0 0 8px;
+  font-size: 1.15rem;
+}
+
+.timeline-step-card p {
+  margin: 0;
+  color: #94a3b8;
+  line-height: 1.6;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 768px) {
+  .timeline-flow::before {
+    left: 20px;
+  }
+  .timeline-step {
+    justify-content: flex-start;
+    padding-left: 45px;
+    padding-right: 0;
+  }
+  .timeline-step:nth-child(even) {
+    padding-left: 45px;
+  }
+  .timeline-step-marker {
+    left: 20px;
+  }
+  .timeline-step-card {
+    width: 100%;
+    margin-right: 0;
+  }
+  .timeline-step:nth-child(even) .timeline-step-card {
+    margin-left: 0;
+  }
+}
+
+/* Card Grid Styles for Commanders and Legacy */
+.tak-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.tak-card {
+  background: var(--tak-glass);
+  border: 1px solid var(--tak-border);
+  border-radius: 16px;
+  padding: 30px;
+  transition: transform 0.3s, border-color 0.3s, box-shadow 0.3s;
+  backdrop-filter: blur(10px);
+}
+
+.tak-card:hover {
+  transform: translateY(-5px);
+  border-color: var(--tak-gold-light);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
+}
+
+.tak-card-icon {
+  font-size: 2.2rem;
+  margin-bottom: 20px;
+  display: block;
+}
+
+.tak-card h3 {
+  margin: 0 0 12px;
+  font-family: 'Playfair Display', serif;
+  font-size: 1.3rem;
+  color: #ffffff;
+}
+
+.tak-card p {
+  margin: 0;
+  line-height: 1.6;
+  color: #cbd5e1;
+  font-size: 0.95rem;
+}
+
+/* Visual Gallery Grid */
+.tak-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 20px;
+}
+
+.tak-gallery-item {
+  display: flex;
+  flex-direction: column;
+  background: var(--tak-glass);
+  border: 1px solid var(--tak-border);
+  border-radius: 16px;
+  overflow: hidden;
+  cursor: pointer;
+  transition: transform 0.3s, border-color 0.3s, box-shadow 0.3s;
+  backdrop-filter: blur(10px);
+}
+
+.tak-gallery-item:hover {
+  transform: translateY(-4px);
+  border-color: var(--tak-gold-light);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.4);
+}
+
+.tak-gallery-image-wrapper {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+  position: relative;
+  border-bottom: 1px solid var(--tak-border);
+}
+
+.tak-gallery-image-wrapper img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.5s ease;
+}
+
+.tak-gallery-item:hover .tak-gallery-image-wrapper img {
+  transform: scale(1.06);
+}
+
+.tak-gallery-caption {
+  padding: 20px;
+}
+
+.tak-gallery-caption h4 {
+  margin: 0 0 6px;
+  font-family: 'Playfair Display', serif;
+  font-size: 1.15rem;
+  color: #ffffff;
+}
+
+.tak-gallery-caption p {
+  margin: 0;
+  font-size: 0.88rem;
+  color: #94a3b8;
+  line-height: 1.5;
+}
+
+/* References Section */
+.tak-references {
+  background: var(--tak-glass);
+  border: 1px solid var(--tak-border);
+  border-radius: 16px;
+  padding: 40px;
+}
+
+.tak-references h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.4rem;
+  margin: 0 0 20px;
+  color: #ffffff;
+}
+
+.tak-references ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.tak-references li {
+  position: relative;
+  padding-left: 24px;
+  margin-bottom: 16px;
+  line-height: 1.6;
+  color: #cbd5e1;
+  font-size: 0.98rem;
+}
+
+.tak-references li:last-child {
+  margin-bottom: 0;
+}
+
+.tak-references li::before {
+  content: '📜';
+  position: absolute;
+  left: 0;
+  top: 2px;
+  font-size: 0.9rem;
+}
+
+/* Page Footer */
+.tak-footer {
+  padding: 40px 0;
+  text-align: center;
+  color: #94a3b8;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.tak-footer a {
+  color: var(--tak-gold-light);
+  text-decoration: none;
+  font-weight: 600;
+  transition: color 0.2s;
+}
+
+.tak-footer a:hover {
+  color: var(--tak-gold);
+}
+
+/* Bookmark UI Integration */
+.tak-bookmark-container {
+  display: flex;
+  justify-content: center;
+  margin-top: 30px;
+}
+
+.tak-bookmark-btn {
+  background: var(--tak-glass);
+  border: 1px solid var(--tak-border);
+  color: var(--tak-gold-light);
+  padding: 10px 24px;
+  border-radius: 30px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: all 0.2s ease;
+}
+
+.tak-bookmark-btn:hover {
+  border-color: var(--tak-gold-light);
+  background: rgba(180, 83, 9, 0.1);
+  transform: translateY(-1px);
+}
+
+.tak-bookmark-btn.is-saved {
+  background: var(--tak-gold-light);
+  color: var(--tak-dark);
+  border-color: var(--tak-gold-light);
+}
+
+/* Interactive Detail Modal */
+.museum-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1600;
+  display: none;
+  place-items: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.78);
+  backdrop-filter: blur(10px);
+}
+
+.museum-modal.open {
+  display: grid;
+}
+
+.museum-modal-card {
+  position: relative;
+  width: min(680px, 96vw);
+  max-height: 90vh;
+  overflow: auto;
+  padding: 30px;
+  border: 1px solid var(--tak-border);
+  border-radius: 22px;
+  background: var(--tak-dark-light);
+  color: #f1f5f9;
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.45);
+}
+
+.museum-modal-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  width: 38px;
+  height: 38px;
+  border: 1px solid var(--tak-border);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.05);
+  color: #cbd5e1;
+  font-size: 1.45rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.museum-modal-close:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.modal-category {
+  display: inline-block;
+  margin-bottom: 10px;
+  color: var(--tak-gold-light);
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+}
+
+.museum-modal-card h2 {
+  margin: 0 42px 7px 0;
+  font-family: "Playfair Display", serif;
+  font-size: clamp(1.9rem, 4vw, 2.7rem);
+}
+
+.modal-location {
+  margin: 0 0 20px;
+  color: #cbd5e1;
+  font-weight: 600;
+}
+
+.modal-description {
+  margin: 0;
+  color: #cbd5e1;
+  line-height: 1.75;
+}
+
+body.modal-open {
+  overflow: hidden;
+}

--- a/frontend/history/battles/index.html
+++ b/frontend/history/battles/index.html
@@ -436,6 +436,25 @@
                 </div>
             </div>
         </section>
+
+        <!-- Featured Explorer: Battle of Takkolam (c. 949 CE) -->
+        <section class="featured-explorer-section" aria-label="Featured battle explorer">
+            <div class="featured-explorer-card">
+                <div class="featured-explorer-content">
+                    <span class="featured-explorer-badge">Featured Explorer</span>
+                    <h2>Battle of Takkolam (c. 949 CE)</h2>
+                    <p>Relive the Chola–Rashtrakuta clash where crown prince Rajaditya fell from his war elephant and Emperor Krishna III broke the Chola hold on Thondaimandalam — a defeat that cost the Cholas Kanchi and Tanjore, and reshaped South India for a generation.</p>
+                    <a href="../../battle-of-takkolam-explorer/index.html" class="featured-explorer-btn">
+                        Explore the Battle of Takkolam →
+                    </a>
+                </div>
+                <div class="featured-explorer-meta">
+                    <span class="featured-explorer-date">c. 949 CE</span>
+                    <span class="featured-explorer-outcome">Rashtrakuta Victory</span>
+                    <span class="featured-explorer-treaty">Rajaditya Fallen · Kanchi &amp; Tanjore Captured</span>
+                </div>
+            </div>
+        </section>
     </main>
 
     <!-- Footer -->

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -2049,5 +2049,12 @@ window.indiaSearchIndex = [
     category: "Featured Explorers",
     description: "Explore the Battle of Pullalur (c. 618–619 CE) - the epic clash between Western Chalukya Emperor Pulakeshin II and Pallava King Mahendravarman I, initiating a century-long struggle for Deccan supremacy.",
     url: "frontend/battle-of-pullalur-explorer/index.html"
+  },
+  // --- Battle of Takkolam Explorer ---
+  {
+    title: "Battle of Takkolam Explorer",
+    category: "Featured Explorers",
+    description: "Explore the Battle of Takkolam (c. 949 CE) - the decisive Chola–Rashtrakuta clash where crown prince Rajaditya fell and Emperor Krishna III captured Kanchi and Tanjore.",
+    url: "frontend/battle-of-takkolam-explorer/index.html"
   }
 ];


### PR DESCRIPTION
## Description
Closes #1591

Develops a dedicated explorer page for the **Battle of Takkolam (c. 949 CE)**, covering the Chola–Rashtrakuta conflict and its long-term consequences.

## Requirements covered
- **Battle overview** — hero banner and overview of the Rashtrakuta invasion
- **Timeline** — chronology from Krishna III's rise to the Chola resurgence under Rajaraja I
- **Commanders** — Krishna III, Rajaditya, Butuga II, and Parantaka I
- **Belligerents** — Chola Kingdom (with Bana & Vaidumba allies) vs Rashtrakuta Empire (with Western Ganga feudatories)
- **Outcome** — decisive Rashtrakuta victory; Kanchi and Tanjore captured
- **Gallery** — relic and monument images of the Chola–Rashtrakuta age
- **References** — Atakur inscription, Nilakanta Sastri, Champakalakshmi, Thapar

## Landing Page Integration
- Added a **Battle of Takkolam card** to the Historic Battles landing page (frontend/history/battles/index.html)
- Registered the page in the global search index (frontend/search-index.js)

## Files
- frontend/battle-of-takkolam-explorer/index.html
- frontend/battle-of-takkolam-explorer/style.css
- frontend/battle-of-takkolam-explorer/script.js
- frontend/history/battles/index.html
- frontend/search-index.js


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Battle of Takkolam Explorer with historical overview, commanders, timeline, consequences, gallery, and references.
  * Added responsive navigation, theme support, bookmarking, and searchable discovery.
  * Added an interactive image gallery with accessible modal viewing and keyboard controls.
  * Added a featured Battle of Takkolam entry to the battles collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->