### PR TITLE
feat: Explore Manjusha painting with mythology-inspired artwork collections

### DIFF
--- a/frontend/handicrafts-showcase/script.js
+++ b/frontend/handicrafts-showcase/script.js
@@ -1,6 +1,17 @@
 // ---------- Handicrafts Data (16 crafts across UP districts) ----------
 const allCrafts = [
   {
+    name: "Manjusha Painting",
+    icon: "🐍",
+    district: "Bhagalpur, Bihar",
+    category: "folk-art",
+    tags: ["GI Tagged", "Snake Painting", "Bihula–Bishari"],
+    description: "Mythology-inspired temple-box folk art of the Anga region, painted for the Bishari Puja with swirling serpent motifs.",
+    history: "A 7th-century folk-art tradition from Bhagalpur (Anga Mahajanapada), Manjusha paintings retell the Bihula–Bishari legend on temple-shaped bamboo, jute and paper caskets.",
+    artisan: "Kumbhakar and Malakar community artists who paint bold outlines with bamboo kalams on gum-pasted cloth, keeping the Shravan Bishari Puja alive.",
+    detailsUrl: "../manjusha-painting-explorer/index.html"
+  },
+  {
     name: "Chhau Dance Masks",
     icon: "🎭",
     district: "Purulia & Charida",
@@ -10,7 +21,8 @@ const allCrafts = [
     history: "Centuries-old folk performance mask art created by Sutradhar artisans depicting Ramayana, Mahabharata, and Puranic deities.",
     artisan: "Charida village artisans in Purulia crafting lightweight paper-mache shells embellished with peacock feathers and zari crowns.",
     detailsUrl: "../chhau-masks-explorer/index.html"
-},
+  },
+  {
     name: "Bidriware Metal Inlay",
     icon: "✨",
     district: "Bidar, Karnataka",
@@ -20,7 +32,8 @@ const allCrafts = [
     history: "14th-century Bahmani Sultanate metalcraft developed in Bidar using unique nitrate-rich Bidar Fort soil for oxidation.",
     artisan: "Master Bidri engravers hammering pure silver wire into zinc-copper castings.",
     detailsUrl: "../bidriware-craftsmanship-explorer/index.html"
-},
+  },
+  {
     name: "Bastar Iron Craft (Loha Shilp)",
     icon: "🔨",
     district: "Bastar & Kondagaon",

--- a/frontend/manjusha-painting-explorer/index.html
+++ b/frontend/manjusha-painting-explorer/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Manjusha Painting Explorer — Bhagalpur's Bihula–Bishari Folk Art</title>
+    <meta name="description" content="Explore Manjusha painting, the mythology-inspired temple-box folk art of Anga region (Bhagalpur, Bihar), its Bihula–Bishari legend, motifs, materials and GI-tagged heritage.">
+    <link rel="stylesheet" href="manjusha.css">
+</head>
+<body>
+    <nav class="manjusha-nav">
+        <h1>🏺 Manjusha Painting Explorer</h1>
+        <button class="theme-toggle-btn" id="theme-toggle" aria-label="Toggle dark mode">🌙 Toggle Theme</button>
+    </nav>
+
+    <main class="manjusha-main">
+        <section class="manjusha-hero">
+            <h2>Manjusha Painting<br>& the Bihula–Bishari Legend</h2>
+            <p class="tagline">A mythology-inspired folk art of the Anga region — temple-shaped caskets and swirling serpents telling the night-long tale of Bihula's devotion.</p>
+            <div class="hero-tags">
+                <span class="hero-tag">🏷️ GI Certified</span>
+                <span class="hero-tag">📍 Bhagalpur, Bihar</span>
+                <span class="hero-tag">🐍 Snake Paintings</span>
+            </div>
+        </section>
+
+        <section>
+            <h2 class="section-title">At a Glance</h2>
+            <p class="section-intro">Manjusha is one of India's oldest living folk-art traditions, painted for the annual Bishari Puja during Shravan — a cycle of devotion as much as an art form.</p>
+            <div id="quick-stats" class="stats-grid"></div>
+        </section>
+
+        <section>
+            <h2 class="section-title">Materials & Method</h2>
+            <p class="section-intro">From bamboo kalam to tamarind-seed paste — how a Manjusha casket comes alive in red, green and yellow.</p>
+            <div id="process-steps" class="process-steps"></div>
+        </section>
+
+        <section>
+            <h2 class="section-title">Traditional Motifs</h2>
+            <p class="section-intro">The visual vocabulary of the Anga region — goddesses, serpents and riverine symbols that frame every narrative.</p>
+            <div id="motif-grid" class="motif-grid"></div>
+        </section>
+
+        <section>
+            <h2 class="section-title">The Mythology Behind the Art</h2>
+            <p class="section-intro">Every brushstroke retells the Bihula–Bishari legend — a story of devotion, snakes and salvation.</p>
+            <div id="stories-grid" class="stories-grid"></div>
+        </section>
+
+        <section class="artisan-section">
+            <div id="artisan-community"></div>
+        </section>
+
+        <section>
+            <h2 class="section-title">Gallery</h2>
+            <p class="section-intro">The casket, the raft and the canvas — glimpses of Manjusha art in its ritual and contemporary forms.</p>
+            <div id="gallery-grid" class="gallery-grid"></div>
+        </section>
+
+        <section>
+            <h2 class="section-title">References & Further Reading</h2>
+            <ul id="references" class="references-list"></ul>
+        </section>
+
+        <footer class="manjusha-footer">
+            <p>Part of Incredible India Explorer — handcrafted heritage collection.</p>
+            <a class="back-link" href="../handicrafts-showcase/index.html">← Back to Indian Handicrafts Showcase</a>
+        </footer>
+    </main>
+
+    <script src="manjusha-data.js"></script>
+    <script src="manjusha.js"></script>
+</body>
+</html>

--- a/frontend/manjusha-painting-explorer/manjusha-data.js
+++ b/frontend/manjusha-painting-explorer/manjusha-data.js
@@ -1,0 +1,98 @@
+/**
+ * Manjusha Painting Explorer — Data Module
+ * Comprehensive dataset covering the Anga-region folk art of Bhagalpur (Bihar),
+ * its Bihula–Bishari mythological tradition, motifs, materials, gallery, and references.
+ */
+
+const MANJUSHA_INFO = {
+    id: "manjusha-painting",
+    title: "Manjusha Painting & Bihula–Bishari Folk Art",
+    originRegion: "Bhagalpur, Bihar (Anga Region)",
+    eraOrigin: "Ancient Anga Mahajanapada (c. 7th Century CE)",
+    giTagStatus: "Geographical Indication (GI) Certified",
+    ritualTradition: "Bihula–Bishari Puja (Manasa Puja)",
+    signatureColors: "Red, Green & Yellow",
+    specialElement: "Temple-shaped ritual caskets known as Manjusha boxes",
+    quickStats: [
+        { label: "GI Tag Certified", value: "Bhagalpur, Bihar", icon: "🏷️" },
+        { label: "Origin Region", value: "Anga Mahajanapada", icon: "🏛️" },
+        { label: "Ritual Tradition", value: "Bihula–Bishari Puja", icon: "🐍" },
+        { label: "Signature Colors", value: "Red, Green & Yellow", icon: "🎨" },
+        { label: "Backdrop Styles", value: "Kala, Peela & Lal", icon: "🖌️" },
+        { label: "Traditional Medium", value: "Cloth & Natural Pigments", icon: "🧵" }
+    ]
+};
+
+const MATERIALS_AND_METHOD = [
+    { step: 1, title: "Canvas & Casket Preparation", description: "Artisans coat hand-woven cotton cloth or temple-shaped bamboo, jute and paper caskets with tamarind-seed gum paste to create a smooth painting surface." },
+    { step: 2, title: "Natural Color Extraction", description: "Pigments are drawn from turmeric, indigo, lampblack and vermilion, and mixed with gum arabic to create the vivid red, green and yellow folk palette." },
+    { step: 3, title: "The Bamboo Kalam", description: "Fine-pointed bamboo pens trace bold black outlines, with every figure drawn in a single unbroken stroke — a hallmark discipline of Manjusha art." },
+    { step: 4, title: "Ritual Backdrops", description: "The background is painted in one of the three auspicious shades — black (Kala Manjusha), yellow (Peela Manjusha) or red (Lal Manjusha)." },
+    { step: 5, title: "Narrative Panels", description: "Episodes of the Bihula–Bishari story are painted in sequence around the casket and scrolls, each panel moving the tale from darkness to light." }
+];
+
+const TRADITIONAL_MOTIFS = [
+    { name: "Bishari Devi (Snake Goddess)", description: "The central serpent-goddess figure whose blessings shield the household from snakebite — the heart of the entire Bihula–Bishari legend." },
+    { name: "Bihula & Lakshindra", description: "The devoted couple at the centre of the myth, shown on their wedding couch and upon the night-long raft journey down the Ganga." },
+    { name: "Serpent Coils & Hoods", description: "Swirling snakes and cobra hoods dominate the compositions, earning Manjusha the name 'snake paintings' among early western viewers." },
+    { name: "The Manjusha Casket", description: "The temple-shaped box with eight pillars — the ritual object that gives the art its name and around which the painted narrative unfolds." },
+    { name: "Lotus, Fish & Tortoise", description: "Riverine auspicious symbols of the Anga countryside that frame the scenes of Bihula's journey." },
+    { name: "Sun, Mango & Flower", description: "Marks of fertility, prosperity and renewal that complete the folk vocabulary of the paintings." }
+];
+
+const MYTH_STORIES = [
+    {
+        title: "The Devotion of Bihula",
+        icon: "🌙",
+        story: "On the night of her wedding, the serpents of the snake-goddess Bishari struck Bihula's husband Lakshindra. Refusing to accept her fate, the merchant's daughter carried his body on a raft down the Ganga through the long night, singing and offering worship, until the goddess relented and restored him to life. Her unshakeable devotion is the soul of every Manjusha painting."
+    },
+    {
+        title: "The Bishari Puja",
+        icon: "🐍",
+        story: "During the month of Shravan, families of the Anga region create Manjusha paintings and display them on ritual caskets to honour Bishari — locally known as Manasa Devi — seeking her protection from snakes and her blessings for the home. The paintings are created anew each season, keeping the tradition alive year after year."
+    },
+    {
+        title: "The Manjusha Box",
+        icon: "🎁",
+        story: "The temple-shaped manjusha, built of bamboo, jute and paper with eight pillars, is the ritual centre of the puja. Covered with white paper and painted with the Bihula–Bishari narrative, it transforms a simple casket into a moving shrine that carries the mythology of the Anga region into every home."
+    }
+];
+
+const ARTISAN_COMMUNITY = {
+    title: "Artisans of the Anga Region",
+    description: "Historically practised by the Kumbhakar (potter) and Malakar (gardener) communities around the Bishari puja, Manjusha art once faced near extinction. Today a new generation of painters — including state-awardee artists such as Ulupi Kumari of Bhagalpur — has revived the tradition, carrying the Bihula–Bishari story onto canvas, cloth and paper."
+};
+
+const GALLERY_IMAGES = [
+    {
+        url: "https://upload.wikimedia.org/wikipedia/en/4/44/Manjusha.jpg",
+        caption: "Manjusha box used in the Snake Festival — the temple-shaped ritual casket that gives the art its name.",
+        category: "Ritual"
+    },
+    {
+        url: "https://commons.wikimedia.org/wiki/Special:FilePath/Manjusha_boat_art.jpg",
+        caption: "Manjusha boat art depicting Bihula's night-long raft journey down the Ganga with the fallen Lakshindra.",
+        category: "Mythology"
+    },
+    {
+        url: "https://commons.wikimedia.org/wiki/Special:FilePath/Manjusha_drawing.jpg",
+        caption: "Traditional Manjusha drawing with bold black outlines and the characteristic single-stroke figures.",
+        category: "Artwork"
+    },
+    {
+        url: "https://commons.wikimedia.org/wiki/Special:FilePath/Manjusha_Painting_of_Map_of_Bihar.png",
+        caption: "Contemporary Manjusha painting of the map of Bihar, showing how the folk idiom travels beyond ritual.",
+        category: "Contemporary"
+    }
+];
+
+const REFERENCES = [
+    { text: "Geographical Indications Registry — Manjusha Art (GI certified, Bhagalpur, Bihar).", link: "https://ipindia.gov.in" },
+    { text: "Sahapedia (2021). Manjusha Art of Eastern Bihar.", link: "https://www.sahapedia.org/manjusha-art-eastern-bihar" },
+    { text: "Bihar Museum — Bihula–Bishari Folklore (Manjusha) by Ulupi Kumari.", link: "https://www.biharmuseum.org/bihulla-vishari-folklore-manjusha-ulupi-kumari/" },
+    { text: "Handicrafts India (Office of the Development Commissioner for Handicrafts) — Manjusha Art.", link: "https://handicrafts.nic.in" }
+];
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { MANJUSHA_INFO, MATERIALS_AND_METHOD, TRADITIONAL_MOTIFS, MYTH_STORIES, ARTISAN_COMMUNITY, GALLERY_IMAGES, REFERENCES };
+}

--- a/frontend/manjusha-painting-explorer/manjusha.css
+++ b/frontend/manjusha-painting-explorer/manjusha.css
@@ -1,0 +1,379 @@
+/* Manjusha Painting Explorer Styles */
+
+:root {
+    --manjusha-red: #a3222b;
+    --manjusha-deep-red: #7d151d;
+    --manjusha-yellow: #e5b23c;
+    --manjusha-green: #2c6e49;
+    --manjusha-cream: #faf3e3;
+    --manjusha-dark: #1e1a17;
+    --manjusha-text: #2b241f;
+    --manjusha-muted: #6b6157;
+    --manjusha-white: #ffffff;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Georgia', 'Times New Roman', serif;
+    background-color: var(--manjusha-cream);
+    color: var(--manjusha-text);
+    line-height: 1.7;
+}
+
+.manjusha-main {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 1.5rem 4rem;
+}
+
+.manjusha-nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 1.5rem;
+    background: linear-gradient(90deg, var(--manjusha-deep-red), var(--manjusha-red));
+    color: var(--manjusha-cream);
+}
+
+.manjusha-nav h1 {
+    font-size: 1.15rem;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+}
+
+.theme-toggle-btn {
+    background: rgba(255, 255, 255, 0.15);
+    color: var(--manjusha-cream);
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    border-radius: 999px;
+    padding: 0.4rem 0.9rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.theme-toggle-btn:hover {
+    background: rgba(255, 255, 255, 0.3);
+}
+
+.manjusha-hero {
+    background:
+        radial-gradient(circle at 15% 20%, rgba(229, 178, 60, 0.18) 0%, transparent 40%),
+        radial-gradient(circle at 85% 30%, rgba(255, 255, 255, 0.12) 0%, transparent 45%),
+        linear-gradient(120deg, var(--manjusha-deep-red), var(--manjusha-red) 55%, #b03a2e);
+    color: var(--manjusha-cream);
+    text-align: center;
+    padding: 4rem 1.5rem;
+    margin-bottom: 3rem;
+    border-bottom: 5px solid var(--manjusha-yellow);
+}
+
+.manjusha-hero h2 {
+    font-size: 2.6rem;
+    line-height: 1.2;
+    margin-bottom: 0.8rem;
+}
+
+.manjusha-hero .tagline {
+    font-size: 1.15rem;
+    opacity: 0.92;
+    max-width: 720px;
+    margin: 0 auto 1.2rem;
+    font-style: italic;
+}
+
+.hero-tags {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.6rem;
+}
+
+.hero-tag {
+    background: rgba(255, 255, 255, 0.16);
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    border-radius: 999px;
+    padding: 0.3rem 0.9rem;
+    font-size: 0.85rem;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+    gap: 1rem;
+    margin: 2.5rem 0;
+}
+
+.stat-card {
+    background: var(--manjusha-white);
+    border-left: 4px solid var(--manjusha-red);
+    border-radius: 10px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+    padding: 1rem 1.2rem;
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+}
+
+.stat-icon {
+    font-size: 1.6rem;
+}
+
+.stat-card h4 {
+    font-size: 0.85rem;
+    color: var(--manjusha-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 0.15rem;
+}
+
+.stat-card p {
+    font-weight: 700;
+    font-size: 0.95rem;
+    color: var(--manjusha-text);
+}
+
+.section-title {
+    font-size: 1.8rem;
+    color: var(--manjusha-deep-red);
+    text-align: center;
+    margin: 3rem 0 1.5rem;
+    position: relative;
+}
+
+.section-title::after {
+    content: '';
+    display: block;
+    width: 80px;
+    height: 4px;
+    background: var(--manjusha-yellow);
+    margin: 0.5rem auto 0;
+    border-radius: 2px;
+}
+
+.section-intro {
+    text-align: center;
+    max-width: 760px;
+    margin: 0 auto 2rem;
+    color: var(--manjusha-muted);
+}
+
+.process-steps {
+    display: grid;
+    gap: 1.2rem;
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.process-step {
+    display: flex;
+    align-items: flex-start;
+    gap: 1.2rem;
+    background: var(--manjusha-white);
+    border-radius: 10px;
+    padding: 1.2rem 1.4rem;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+}
+
+.step-number {
+    flex-shrink: 0;
+    width: 46px;
+    height: 46px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--manjusha-red);
+    color: var(--manjusha-cream);
+    font-weight: 700;
+    font-size: 1rem;
+    border-radius: 50%;
+}
+
+.step-content h4 {
+    color: var(--manjusha-deep-red);
+    margin-bottom: 0.3rem;
+}
+
+.motif-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.2rem;
+}
+
+.motif-card {
+    background: var(--manjusha-white);
+    border-radius: 10px;
+    padding: 1.3rem 1.4rem;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+    border-top: 4px solid var(--manjusha-green);
+}
+
+.motif-card h4 {
+    color: var(--manjusha-deep-red);
+    margin-bottom: 0.4rem;
+}
+
+.stories-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.2rem;
+}
+
+.story-card {
+    background: linear-gradient(160deg, var(--manjusha-white), #fdf6e7);
+    border-radius: 12px;
+    padding: 1.5rem;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.07);
+    border-bottom: 4px solid var(--manjusha-yellow);
+}
+
+.story-icon {
+    font-size: 1.9rem;
+    margin-bottom: 0.6rem;
+}
+
+.story-card h3 {
+    color: var(--manjusha-deep-red);
+    margin-bottom: 0.5rem;
+}
+
+.artisan-section {
+    background: linear-gradient(120deg, var(--manjusha-deep-red), var(--manjusha-red));
+    color: var(--manjusha-cream);
+    border-radius: 12px;
+    padding: 2.5rem 2rem;
+    margin: 2rem auto;
+    max-width: 900px;
+    text-align: center;
+}
+
+.artisan-section h2 {
+    margin-bottom: 0.8rem;
+    font-size: 1.6rem;
+}
+
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.2rem;
+}
+
+.gallery-item {
+    background: var(--manjusha-white);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.gallery-item img {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+    display: block;
+}
+
+.gallery-item figcaption {
+    padding: 0.8rem 1rem;
+    font-size: 0.85rem;
+    color: var(--manjusha-muted);
+}
+
+.references-list {
+    list-style: none;
+    max-width: 820px;
+    margin: 0 auto;
+}
+
+.references-list li {
+    background: var(--manjusha-white);
+    border-radius: 8px;
+    margin-bottom: 0.7rem;
+    padding: 0.9rem 1.2rem;
+    border-left: 4px solid var(--manjusha-yellow);
+}
+
+.references-list a {
+    color: var(--manjusha-red);
+    text-decoration: none;
+}
+
+.references-list a:hover {
+    text-decoration: underline;
+}
+
+.manjusha-footer {
+    text-align: center;
+    padding: 2rem 1.5rem 3rem;
+    color: var(--manjusha-muted);
+    font-size: 0.9rem;
+}
+
+.back-link {
+    display: inline-block;
+    margin-top: 0.8rem;
+    color: var(--manjusha-red);
+    text-decoration: none;
+    font-weight: 700;
+}
+
+.back-link:hover {
+    text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+    .manjusha-hero h2 {
+        font-size: 1.9rem;
+    }
+    .manjusha-nav h1 {
+        font-size: 0.95rem;
+    }
+    .process-step {
+        flex-direction: column;
+    }
+}
+
+/* Dark Mode */
+body.dark-mode {
+    background-color: var(--manjusha-dark);
+    color: var(--manjusha-cream);
+}
+
+body.dark-mode .stat-card,
+body.dark-mode .process-step,
+body.dark-mode .motif-card,
+body.dark-mode .gallery-item,
+body.dark-mode .references-list li {
+    background: #2a241f;
+    color: var(--manjusha-cream);
+}
+
+body.dark-mode .stat-card p,
+body.dark-mode .motif-card p,
+body.dark-mode .step-content p {
+    color: var(--manjusha-cream);
+}
+
+body.dark-mode .stat-card h4,
+body.dark-mode .section-intro,
+body.dark-mode .gallery-item figcaption,
+body.dark-mode .manjusha-footer {
+    color: #c9b8a4;
+}
+
+body.dark-mode .story-card {
+    background: #2a241f;
+    color: var(--manjusha-cream);
+}
+
+body.dark-mode .references-list a {
+    color: var(--manjusha-yellow);
+}
+
+body.dark-mode .section-title {
+    color: var(--manjusha-yellow);
+}

--- a/frontend/manjusha-painting-explorer/manjusha.js
+++ b/frontend/manjusha-painting-explorer/manjusha.js
@@ -1,0 +1,108 @@
+/**
+ * Manjusha Painting Explorer — Controller Module
+ * Renders the data module into the explorer page.
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    initThemeToggle();
+    renderStats(MANJUSHA_INFO.quickStats, 'quick-stats');
+    renderProcess(MATERIALS_AND_METHOD, 'process-steps');
+    renderMotifs(TRADITIONAL_MOTIFS, 'motif-grid');
+    renderStories(MYTH_STORIES, 'stories-grid');
+    renderArtisan(ARTISAN_COMMUNITY, 'artisan-community');
+    renderGallery(GALLERY_IMAGES, 'gallery-grid');
+    renderReferences(REFERENCES, 'references');
+});
+
+function initThemeToggle() {
+    const toggle = document.querySelector('#theme-toggle');
+    if (!toggle) return;
+    toggle.addEventListener('click', () => {
+        document.body.classList.toggle('dark-mode');
+        localStorage.setItem('manjusha-theme', document.body.classList.contains('dark-mode') ? 'dark' : 'light');
+    });
+    if (localStorage.getItem('manjusha-theme') === 'dark') {
+        document.body.classList.add('dark-mode');
+    }
+}
+
+function renderStats(stats, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = stats.map(stat => `
+        <div class="stat-card">
+            <span class="stat-icon" aria-hidden="true">${stat.icon}</span>
+            <div>
+                <h4>${stat.label}</h4>
+                <p>${stat.value}</p>
+            </div>
+        </div>
+    `).join('');
+}
+
+function renderProcess(steps, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = steps.map(step => `
+        <div class="process-step">
+            <div class="step-number">${String(step.step).padStart(2, '0')}</div>
+            <div class="step-content">
+                <h4>${step.title}</h4>
+                <p>${step.description}</p>
+            </div>
+        </div>
+    `).join('');
+}
+
+function renderMotifs(motifs, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = motifs.map(motif => `
+        <div class="motif-card">
+            <h4>${motif.name}</h4>
+            <p>${motif.description}</p>
+        </div>
+    `).join('');
+}
+
+function renderStories(stories, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = stories.map(story => `
+        <div class="story-card">
+            <div class="story-icon" aria-hidden="true">${story.icon}</div>
+            <h3>${story.title}</h3>
+            <p>${story.story}</p>
+        </div>
+    `).join('');
+}
+
+function renderArtisan(community, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = `
+        <h2>${community.title}</h2>
+        <p>${community.description}</p>
+    `;
+}
+
+function renderGallery(images, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = images.map(image => `
+        <figure class="gallery-item">
+            <img src="${image.url}" alt="${image.caption}" loading="lazy" onerror="this.closest('.gallery-item').style.display='none';">
+            <figcaption>${image.caption}</figcaption>
+        </figure>
+    `).join('');
+}
+
+function renderReferences(references, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = references.map(ref => `
+        <li>
+            <a href="${ref.link}" target="_blank" rel="noopener noreferrer">${ref.text}</a>
+        </li>
+    `).join('');
+}

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -1505,6 +1505,13 @@ window.indiaSearchIndex = [
     description: "Explore Chhau Masks Heritage — UNESCO Intangible Cultural Heritage of Purulia and Seraikela, paper-mache mask making, divine/asura mask types, and folk dance performance gallery.",
     url: "frontend/chhau-masks-explorer/index.html"
   },
+  // --- Manjusha Painting Explorer ---
+  {
+    title: "Manjusha Painting Explorer",
+    category: "Arts & Culture",
+    description: "Explore Manjusha Painting — GI-tagged mythology-inspired temple-box folk art of the Anga region (Bhagalpur, Bihar), the Bihula–Bishari legend, serpent motifs, materials and gallery.",
+    url: "frontend/manjusha-painting-explorer/index.html"
+  },
   // --- Bidriware Craftsmanship Explorer ---
   {
     title: "Bidriware Craftsmanship Explorer",

--- a/frontend/tests/unit/manjusha-painting-explorer.test.js
+++ b/frontend/tests/unit/manjusha-painting-explorer.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadManjushaData() {
+    const code = readFileSync(
+        resolve(__dirname, '../../manjusha-painting-explorer/manjusha-data.js'),
+        'utf-8'
+    );
+    const fn = new Function(
+        code + '\nreturn { MANJUSHA_INFO, MATERIALS_AND_METHOD, TRADITIONAL_MOTIFS, MYTH_STORIES, ARTISAN_COMMUNITY, GALLERY_IMAGES, REFERENCES };'
+    );
+    return fn();
+}
+
+describe('Manjusha Painting Explorer — Data Tests', () => {
+    let data;
+
+    beforeAll(() => {
+        data = loadManjushaData();
+    });
+
+    describe('MANJUSHA_INFO metadata', () => {
+        it('contains correct Manjusha metadata and GI tag', () => {
+            expect(data.MANJUSHA_INFO.id).toBe('manjusha-painting');
+            expect(data.MANJUSHA_INFO.title).toContain('Manjusha');
+            expect(data.MANJUSHA_INFO.originRegion).toContain('Bihar');
+            expect(data.MANJUSHA_INFO.giTagStatus).toContain('GI');
+        });
+
+        it('has quickStats array with 6 items', () => {
+            expect(Array.isArray(data.MANJUSHA_INFO.quickStats)).toBe(true);
+            expect(data.MANJUSHA_INFO.quickStats.length).toBe(6);
+        });
+    });
+
+    describe('MATERIALS_AND_METHOD & TRADITIONAL_MOTIFS', () => {
+        it('contains process steps and traditional motifs', () => {
+            expect(Array.isArray(data.MATERIALS_AND_METHOD)).toBe(true);
+            expect(data.MATERIALS_AND_METHOD.length).toBeGreaterThanOrEqual(5);
+            expect(Array.isArray(data.TRADITIONAL_MOTIFS)).toBe(true);
+            expect(data.TRADITIONAL_MOTIFS.length).toBeGreaterThanOrEqual(4);
+        });
+    });
+
+    describe('MYTH_STORIES', () => {
+        it('contains Bihula–Bishari mythology stories', () => {
+            expect(Array.isArray(data.MYTH_STORIES)).toBe(true);
+            expect(data.MYTH_STORIES.length).toBeGreaterThanOrEqual(3);
+            expect(data.MYTH_STORIES.some(s => s.title.includes('Bihula'))).toBe(true);
+        });
+    });
+
+    describe('ARTISAN_COMMUNITY', () => {
+        it('contains artisan community details', () => {
+            expect(data.ARTISAN_COMMUNITY.title).toBeDefined();
+            expect(data.ARTISAN_COMMUNITY.description).toContain('Bhagalpur');
+        });
+    });
+
+    describe('GALLERY_IMAGES & REFERENCES', () => {
+        it('has non-empty gallery and references', () => {
+            expect(Array.isArray(data.GALLERY_IMAGES)).toBe(true);
+            expect(data.GALLERY_IMAGES.length).toBeGreaterThanOrEqual(2);
+            expect(Array.isArray(data.REFERENCES)).toBe(true);
+            expect(data.REFERENCES.length).toBeGreaterThanOrEqual(2);
+        });
+    });
+});


### PR DESCRIPTION
## feat: Explore Manjusha painting with mythology-inspired artwork collections

Closes #1704

### Overview
Adds a fully self-contained **Manjusha Painting Explorer** page — a mythology-inspired folk-art explorer covering the Bihula–Bishari tradition of Bhagalpur (Anga region), Bihar.

### What's included
- **New explorer page** `frontend/manjusha-painting-explorer/` with 4 files:
  - `index.html` — page structure
  - `manjusha-data.js` — data module (info, quick stats, materials & method, motifs, mythology stories, artisan community, gallery, references)
  - `manjusha.js` — controller (renders all sections + theme toggle)
  - `manjusha.css` — themed styling with dark-mode support
- **Landing page integration** — new craft card in `frontend/handicrafts-showcase/script.js` linking to the explorer.
- **Search index integration** — new entry in `frontend/search-index.js` (Arts & Culture).
- **Unit tests** — `frontend/tests/unit/manjusha-painting-explorer.test.js` (6 tests, all passing).

### Highlights of the page
- At-a-glance stats (GI certification, origin, ritual, colors, backdrop styles, medium)
- Materials & Method (canvas/casket prep, natural colors, bamboo kalam, ritual backdrops, narrative panels)
- Traditional motifs (Bishari Devi, Bihula & Lakshindra, serpent coils, manjusha casket, riverine symbols)
- Mythology section (Devotion of Bihula, Bishari Puja, the Manjusha Box)
- Artisan community spotlight and image gallery with references

### Verification
- `node --check` passes on all modified/new JS files.
- `vitest` unit test passes (6/6).
- `search.test.js` and `smoke.test.js` pass.

### Note
Also fixes a pre-existing syntax error in `frontend/handicrafts-showcase/script.js` where the Bidriware and Bastar entries were missing opening braces (introduced by earlier PRs), which made the file fail to parse.
