### PR TITLE
feat: Create a Kalighat painting showcase featuring Bengal's iconic brushwork

### DIFF
--- a/frontend/handicrafts-showcase/script.js
+++ b/frontend/handicrafts-showcase/script.js
@@ -1,6 +1,17 @@
 // ---------- Handicrafts Data (16 crafts across UP districts) ----------
 const allCrafts = [
   {
+    name: "Kalighat Painting",
+    icon: "🎨",
+    district: "Kalighat, Kolkata",
+    category: "folk-art",
+    tags: ["Bold Brushwork", "Social Satire", "19th Century Bengal"],
+    description: "Bengal's iconic temple-ghat painting school — bold single-stroke brushwork on mill paper, fusing divine icons with biting social commentary.",
+    history: "Emerged in 19th-century Calcutta near the Kalighat temple, where patua painters turned pilgrim souvenirs into India's first popular urban art school, lampooning baboos, priests and zamindars.",
+    artisan: "Patua painters of the Kali ghat who drew each figure in one unbroken tapering stroke, now carried forward by revivalists like Santanu Chakraverty.",
+    detailsUrl: "../kalighat-painting-showcase/index.html"
+  },
+  {
     name: "Chhau Dance Masks",
     icon: "🎭",
     district: "Purulia & Charida",
@@ -10,7 +21,8 @@ const allCrafts = [
     history: "Centuries-old folk performance mask art created by Sutradhar artisans depicting Ramayana, Mahabharata, and Puranic deities.",
     artisan: "Charida village artisans in Purulia crafting lightweight paper-mache shells embellished with peacock feathers and zari crowns.",
     detailsUrl: "../chhau-masks-explorer/index.html"
-},
+  },
+  {
     name: "Bidriware Metal Inlay",
     icon: "✨",
     district: "Bidar, Karnataka",
@@ -20,7 +32,8 @@ const allCrafts = [
     history: "14th-century Bahmani Sultanate metalcraft developed in Bidar using unique nitrate-rich Bidar Fort soil for oxidation.",
     artisan: "Master Bidri engravers hammering pure silver wire into zinc-copper castings.",
     detailsUrl: "../bidriware-craftsmanship-explorer/index.html"
-},
+  },
+  {
     name: "Bastar Iron Craft (Loha Shilp)",
     icon: "🔨",
     district: "Bastar & Kondagaon",

--- a/frontend/kalighat-painting-showcase/index.html
+++ b/frontend/kalighat-painting-showcase/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kalighat Painting Showcase — Bengal's Iconic Brushwork</title>
+    <meta name="description" content="Explore Kalighat painting, 19th-century Bengal's iconic brushwork from the temple ghats of Calcutta — bold single-stroke lines, divine themes and biting social satire.">
+    <link rel="stylesheet" href="kalighat.css">
+</head>
+<body>
+    <nav class="kalighat-nav">
+        <h1>🎨 Kalighat Painting Showcase</h1>
+        <button class="theme-toggle-btn" id="theme-toggle" aria-label="Toggle dark mode">🌙 Toggle Theme</button>
+    </nav>
+
+    <main class="kalighat-main">
+        <section class="kalighat-hero">
+            <h2>Kalighat Painting<br>& the Bold Brushwork of Bengal</h2>
+            <p class="tagline">Born at the Kali temple ghats of Calcutta, a fearless school of single-stroke line — divine devotion in one hand, sharp social satire in the other.</p>
+            <div class="hero-tags">
+                <span class="hero-tag">🛕 Kalighat, Kolkata</span>
+                <span class="hero-tag">✒️ Single-Stroke Line</span>
+                <span class="hero-tag">🎭 Divine & Satire</span>
+            </div>
+        </section>
+
+        <section>
+            <h2 class="section-title">At a Glance</h2>
+            <p class="section-intro">Kalighat is the first modern school of Indian popular art — cheap souvenir paintings for pilgrims that grew into a sharp-eyed chronicle of colonial Calcutta.</p>
+            <div id="quick-stats" class="stats-grid"></div>
+        </section>
+
+        <section>
+            <h2 class="section-title">History</h2>
+            <p class="section-intro">From a riverside pilgrim trade to a school of satire — the journey of Kalighat across a century of change.</p>
+            <div id="history-timeline" class="history-timeline"></div>
+        </section>
+
+        <section>
+            <h2 class="section-title">Brushwork Visualization</h2>
+            <p class="section-intro">Deconstructing the technique that made Kalighat instantly recognisable — the discipline of a line never lifted.</p>
+            <div id="brushwork-steps" class="brush-steps"></div>
+        </section>
+
+        <section>
+            <h2 class="section-title">Themes</h2>
+            <p class="section-intro">Two souls in one art — the divine icons of the temple and the satirical mirror held up to society.</p>
+            <div id="themes-grid" class="themes-grid"></div>
+        </section>
+
+        <section class="artist-section">
+            <div id="artist-community"></div>
+        </section>
+
+        <section>
+            <h2 class="section-title">Gallery</h2>
+            <p class="section-intro">Deities, epics and everyday satire — the faces of Kalighat in colour and line.</p>
+            <div id="gallery-grid" class="gallery-grid"></div>
+        </section>
+
+        <section>
+            <h2 class="section-title">References & Further Reading</h2>
+            <ul id="references" class="references-list"></ul>
+        </section>
+
+        <footer class="kalighat-footer">
+            <p>Part of Incredible India Explorer — handcrafted heritage collection.</p>
+            <a class="back-link" href="../handicrafts-showcase/index.html">← Back to Indian Handicrafts Showcase</a>
+        </footer>
+    </main>
+
+    <script src="kalighat-data.js"></script>
+    <script src="kalighat.js"></script>
+</body>
+</html>

--- a/frontend/kalighat-painting-showcase/kalighat-data.js
+++ b/frontend/kalighat-painting-showcase/kalighat-data.js
@@ -1,0 +1,112 @@
+/**
+ * Kalighat Painting Showcase — Data Module
+ * Comprehensive dataset covering the 19th-century Bengali folk-art school of Kalighat,
+ * Kolkata: its bold single-stroke brushwork, history, themes of divinity and social satire, gallery, and references.
+ */
+
+const KALIGHAT_INFO = {
+    id: "kalighat-painting",
+    title: "Kalighat Painting — Bengal's Iconic Brushwork",
+    originRegion: "Kalighat, Kolkata (Calcutta), West Bengal",
+    eraOrigin: "19th Century Bengal (c. 1800–1930)",
+    heritageStatus: "Celebrated folk-painting school of colonial Calcutta",
+    signatureStyle: "Bold single-stroke line, flat unshaded washes",
+    quickStats: [
+        { label: "Birthplace", value: "Kalighat Temple, Kolkata", icon: "🛕" },
+        { label: "Golden Era", value: "19th Century (c. 1800–1930)", icon: "⏳" },
+        { label: "Medium", value: "Watercolour on Mill Paper", icon: "🎨" },
+        { label: "Hallmark Stroke", value: "Single Unbroken Tapering Line", icon: "✒️" },
+        { label: "Signature Palette", value: "Black, Red, Green & Yellow", icon: "🌈" },
+        { label: "Twin Themes", value: "Divine & Social Satire", icon: "🎭" }
+    ]
+};
+
+const HISTORY_CHAPTERS = [
+    {
+        title: "Roots at the Kali Ghat",
+        period: "Late 18th – Early 19th Century",
+        description: "Patua scroll painters migrating from rural Bengal settled along the Hooghly riverbank near the Kalighat temple, beside the sacred ghat that gave the school its name."
+    },
+    {
+        title: "The Pilgrim Trade",
+        period: "Mid 19th Century",
+        description: "Pilgrims visiting the goddess Kali bought these cheap, quickly-made watercolours as souvenirs. Religious subjects — Kali, Durga, Shiva and the epics — dominated this early phase."
+    },
+    {
+        title: "The Bold Brushwork",
+        period: "Late 19th Century",
+        description: "Kalighat painters refined a strikingly modern idiom: sweeping single-stroke outlines, tapering brush lines, flat unshaded washes and empty backgrounds — a sharp break from ornate court miniatures."
+    },
+    {
+        title: "Social Satire",
+        period: "1870s – 1930s",
+        description: "Artists turned their brush on Calcutta's colonial society — the English-educated baboo, the liberated bibi, cunning priests and grasping zamindars — creating India's first school of satirical popular art."
+    },
+    {
+        title: "Decline & Rediscovery",
+        period: "1930s – Present",
+        description: "Oleographs and photography undercut the hand-painted trade, and the school faded by the 1930s. Today museums worldwide preserve it, and contemporary artists such as Santanu Chakraverty keep the brushwork alive."
+    }
+];
+
+const BRUSHWORK_STEPS = [
+    { step: 1, title: "One Unbroken Stroke", description: "The painter draws each figure with a single sweep of the brush, never lifting it mid-line — a feat of control that gives the art its electric, immediate energy." },
+    { step: 2, title: "Tapering Outlines", description: "Lines swell thick at the shoulder of a figure and die away to a hair-thin point, shaping arms, necks and saris with effortless grace." },
+    { step: 3, title: "Flat, Unshaded Washes", description: "Colour is laid in even, unmodulated washes. There is no shading, no perspective — form is built entirely by the outline." },
+    { step: 4, title: "Restrained Palette", description: "Black, grey, crimson red, green, yellow and blue dominate, applied against the bare white of cheap mill-made paper." },
+    { step: 5, title: "Expressive Faces", description: "Large, heavily-lidded almond eyes, sharply arched brows and finely drawn hands carry the drama of each scene." },
+    { step: 6, title: "Empty Backgrounds", description: "Figures float on untouched paper, the emptiness focusing the eye on gesture and expression alone." }
+];
+
+const THEMES = [
+    { name: "Hindu Deities", category: "Divine", icon: "🕉️", description: "Kali, Durga, Ganesha, Shiva and Lakshmi were the earliest and most beloved subjects, painted as pilgrims' souvenirs at the temple ghat." },
+    { name: "Radha–Krishna & Vaishnava Love", category: "Divine", icon: "🪈", description: "Tender scenes of Radha and Krishna, and episodes from the Vaishnava tradition, rendered with the school's signature lyric line." },
+    { name: "The Epics", category: "Divine", icon: "📜", description: "Ramayana and Mahabharata episodes — Ravana battling Hanuman, Kichak's slaying — brought the great stories to the common man." },
+    { name: "The Baboo & the Bibi", category: "Social Satire", icon: "🤵", description: "The English-educated Bengali gentleman with his anglicised manners was caricatured mercilessly, lampooning colonial mimicry." },
+    { name: "Women & Domestic Life", category: "Social Satire", icon: "🏠", description: "Bibi ladies smoking hookahs, applying kohl and scolding husbands painted a lively picture of Calcutta's changing domestic world." },
+    { name: "Greed, Priests & Zamindars", category: "Social Satire", icon: "🐱", description: "Cats stealing prawns, cunning priests and grasping landlords exposed hypocrisy — sly fables told in a single image." }
+];
+
+const ARTIST_COMMUNITY = {
+    title: "The Patuas of Kalighat & the Living Legacy",
+    description: "The painters were village patuas (scroll artists) who turned a temple pilgrimage trade into India's first popular urban art school. Though the original shops closed by the 1930s, Kalighat's bold line now lives on in contemporary studios — carried forward by revivalists such as Santanu Chakraverty, and treasured in collections from the Victoria Memorial to the British Museum and the Cleveland Museum of Art."
+};
+
+const GALLERY_IMAGES = [
+    {
+        url: "https://commons.wikimedia.org/wiki/Special:FilePath/Radha-_Krishna,_Kalighat_Painting.jpg",
+        caption: "Radha–Krishna, Kalighat painting — the divine-love theme in the school's lyrical single-stroke style.",
+        category: "Divine"
+    },
+    {
+        url: "https://commons.wikimedia.org/wiki/Special:FilePath/The_demon_ravana_fighting_with_the_ape_hanuman,_1880,_kalighat_school.jpg",
+        caption: "Ravana battling Hanuman (c. 1880) — an epic Ramayana scene from the Kalighat school.",
+        category: "Divine"
+    },
+    {
+        url: "https://commons.wikimedia.org/wiki/Special:FilePath/Yashoda_coaxing_baby_Krishna,_Kalighat_Painting.jpg",
+        caption: "Yashoda coaxing baby Krishna — domestic devotion rendered in flat, unshaded washes.",
+        category: "Divine"
+    },
+    {
+        url: "https://commons.wikimedia.org/wiki/Special:FilePath/Kalighat_Painting_Calcutta_19th_Century_-_Woman_Striking_Man_With_Broom.jpg",
+        caption: "Woman striking a man with a broom — a famous Kalighat social-commentary panel turning the tables on the baboo.",
+        category: "Social Satire"
+    },
+    {
+        url: "https://commons.wikimedia.org/wiki/Special:FilePath/Untitled_(Cat_Stealing_Prawn).jpg",
+        caption: "Cat stealing a prawn — the sly Kalighat fable on greed, hypocrisy and the Bengali kitchen.",
+        category: "Social Satire"
+    }
+];
+
+const REFERENCES = [
+    { text: "Britannica — Kalighat painting: origin, style and social commentary.", link: "https://www.britannica.com/art/Kalighat-painting" },
+    { text: "Victoria and Albert Museum — Kalighat paintings of 19th-century Calcutta.", link: "https://www.vam.ac.uk/articles/kalighat-paintings" },
+    { text: "Cleveland Museum of Art — Kalighat paintings in the collection (e.g. Trivikramapada, acc. 2003.165).", link: "https://www.clevelandart.org/art/2003.165" },
+    { text: "Sahapedia — Kalighat paintings: faith, craft and satire.", link: "https://www.sahapedia.org/kalighat-paintings" }
+];
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { KALIGHAT_INFO, HISTORY_CHAPTERS, BRUSHWORK_STEPS, THEMES, ARTIST_COMMUNITY, GALLERY_IMAGES, REFERENCES };
+}

--- a/frontend/kalighat-painting-showcase/kalighat.css
+++ b/frontend/kalighat-painting-showcase/kalighat.css
@@ -1,0 +1,435 @@
+/* Kalighat Painting Showcase Styles */
+
+:root {
+    --kalighat-crimson: #b52b2b;
+    --kalighat-deep-red: #7d1c1c;
+    --kalighat-gold: #d9a441;
+    --kalighat-green: #2c6e49;
+    --kalighat-ink: #221c19;
+    --kalighat-cream: #f6efe0;
+    --kalighat-paper: #fdfaf3;
+    --kalighat-text: #2b241f;
+    --kalighat-muted: #6b6157;
+    --kalighat-white: #ffffff;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Georgia', 'Times New Roman', serif;
+    background-color: var(--kalighat-cream);
+    color: var(--kalighat-text);
+    line-height: 1.7;
+}
+
+.kalighat-main {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 1.5rem 4rem;
+}
+
+.kalighat-nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 1.5rem;
+    background: linear-gradient(90deg, var(--kalighat-deep-red), var(--kalighat-crimson));
+    color: var(--kalighat-cream);
+}
+
+.kalighat-nav h1 {
+    font-size: 1.15rem;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+}
+
+.theme-toggle-btn {
+    background: rgba(255, 255, 255, 0.15);
+    color: var(--kalighat-cream);
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    border-radius: 999px;
+    padding: 0.4rem 0.9rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.theme-toggle-btn:hover {
+    background: rgba(255, 255, 255, 0.3);
+}
+
+.kalighat-hero {
+    background:
+        radial-gradient(circle at 85% 25%, rgba(217, 164, 65, 0.2) 0%, transparent 40%),
+        radial-gradient(circle at 12% 30%, rgba(255, 255, 255, 0.12) 0%, transparent 45%),
+        linear-gradient(120deg, var(--kalighat-deep-red), var(--kalighat-crimson) 58%, #9a2c22);
+    color: var(--kalighat-cream);
+    text-align: center;
+    padding: 4rem 1.5rem;
+    margin-bottom: 3rem;
+    border-bottom: 5px solid var(--kalighat-gold);
+}
+
+.kalighat-hero h2 {
+    font-size: 2.6rem;
+    line-height: 1.2;
+    margin-bottom: 0.8rem;
+}
+
+.kalighat-hero .tagline {
+    font-size: 1.15rem;
+    opacity: 0.92;
+    max-width: 740px;
+    margin: 0 auto 1.2rem;
+    font-style: italic;
+}
+
+.hero-tags {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.6rem;
+}
+
+.hero-tag {
+    background: rgba(255, 255, 255, 0.16);
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    border-radius: 999px;
+    padding: 0.3rem 0.9rem;
+    font-size: 0.85rem;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+    gap: 1rem;
+    margin: 2.5rem 0;
+}
+
+.stat-card {
+    background: var(--kalighat-paper);
+    border-left: 4px solid var(--kalighat-crimson);
+    border-radius: 10px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+    padding: 1rem 1.2rem;
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+}
+
+.stat-icon {
+    font-size: 1.6rem;
+}
+
+.stat-card h4 {
+    font-size: 0.85rem;
+    color: var(--kalighat-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 0.15rem;
+}
+
+.stat-card p {
+    font-weight: 700;
+    font-size: 0.95rem;
+    color: var(--kalighat-text);
+}
+
+.section-title {
+    font-size: 1.8rem;
+    color: var(--kalighat-deep-red);
+    text-align: center;
+    margin: 3rem 0 1.5rem;
+    position: relative;
+}
+
+.section-title::after {
+    content: '';
+    display: block;
+    width: 80px;
+    height: 4px;
+    background: var(--kalighat-gold);
+    margin: 0.5rem auto 0;
+    border-radius: 2px;
+}
+
+.section-intro {
+    text-align: center;
+    max-width: 760px;
+    margin: 0 auto 2rem;
+    color: var(--kalighat-muted);
+}
+
+/* History Timeline */
+.history-timeline {
+    position: relative;
+    max-width: 860px;
+    margin: 0 auto;
+    padding-left: 1.6rem;
+    border-left: 3px solid var(--kalighat-crimson);
+}
+
+.history-entry {
+    position: relative;
+    background: var(--kalighat-paper);
+    border-radius: 10px;
+    padding: 1.2rem 1.4rem;
+    margin-bottom: 1.2rem;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+}
+
+.history-entry::before {
+    content: '';
+    position: absolute;
+    left: -1.9rem;
+    top: 1.5rem;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--kalighat-gold);
+    border: 3px solid var(--kalighat-crimson);
+}
+
+.history-period {
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--kalighat-crimson);
+    margin-bottom: 0.3rem;
+}
+
+.history-entry h4 {
+    color: var(--kalighat-deep-red);
+    margin-bottom: 0.3rem;
+}
+
+/* Brushwork */
+.brush-steps {
+    display: grid;
+    gap: 1.2rem;
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.brush-step {
+    display: flex;
+    align-items: flex-start;
+    gap: 1.2rem;
+    background: var(--kalighat-paper);
+    border-radius: 10px;
+    padding: 1.2rem 1.4rem;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+}
+
+.step-number {
+    flex-shrink: 0;
+    width: 46px;
+    height: 46px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--kalighat-crimson);
+    color: var(--kalighat-cream);
+    font-weight: 700;
+    font-size: 1rem;
+    border-radius: 50%;
+}
+
+.step-content h4 {
+    color: var(--kalighat-deep-red);
+    margin-bottom: 0.3rem;
+}
+
+/* Themes */
+.themes-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.2rem;
+}
+
+.theme-card {
+    background: var(--kalighat-paper);
+    border-radius: 10px;
+    padding: 1.3rem 1.4rem;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+    border-top: 4px solid var(--kalighat-green);
+}
+
+.theme-card.theme-social-satire {
+    border-top-color: var(--kalighat-crimson);
+}
+
+.theme-icon {
+    font-size: 1.7rem;
+    margin-bottom: 0.5rem;
+}
+
+.theme-category {
+    display: inline-block;
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    color: var(--kalighat-cream);
+    background: var(--kalighat-green);
+    border-radius: 999px;
+    padding: 0.15rem 0.7rem;
+    margin-bottom: 0.5rem;
+}
+
+.theme-social-satire .theme-category {
+    background: var(--kalighat-crimson);
+}
+
+.theme-card h4 {
+    color: var(--kalighat-deep-red);
+    margin-bottom: 0.4rem;
+}
+
+/* Artist Community */
+.artist-section {
+    background: linear-gradient(120deg, var(--kalighat-deep-red), var(--kalighat-crimson));
+    color: var(--kalighat-cream);
+    border-radius: 12px;
+    padding: 2.5rem 2rem;
+    margin: 2rem auto;
+    max-width: 900px;
+    text-align: center;
+}
+
+.artist-section h2 {
+    margin-bottom: 0.8rem;
+    font-size: 1.6rem;
+}
+
+/* Gallery */
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.2rem;
+}
+
+.gallery-item {
+    background: var(--kalighat-paper);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.gallery-item img {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+    display: block;
+}
+
+.gallery-item figcaption {
+    padding: 0.8rem 1rem;
+    font-size: 0.85rem;
+    color: var(--kalighat-muted);
+}
+
+/* References */
+.references-list {
+    list-style: none;
+    max-width: 820px;
+    margin: 0 auto;
+}
+
+.references-list li {
+    background: var(--kalighat-paper);
+    border-radius: 8px;
+    margin-bottom: 0.7rem;
+    padding: 0.9rem 1.2rem;
+    border-left: 4px solid var(--kalighat-gold);
+}
+
+.references-list a {
+    color: var(--kalighat-crimson);
+    text-decoration: none;
+}
+
+.references-list a:hover {
+    text-decoration: underline;
+}
+
+.kalighat-footer {
+    text-align: center;
+    padding: 2rem 1.5rem 3rem;
+    color: var(--kalighat-muted);
+    font-size: 0.9rem;
+}
+
+.back-link {
+    display: inline-block;
+    margin-top: 0.8rem;
+    color: var(--kalighat-crimson);
+    text-decoration: none;
+    font-weight: 700;
+}
+
+.back-link:hover {
+    text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+    .kalighat-hero h2 {
+        font-size: 1.9rem;
+    }
+    .kalighat-nav h1 {
+        font-size: 0.95rem;
+    }
+    .brush-step {
+        flex-direction: column;
+    }
+}
+
+/* Dark Mode */
+body.dark-mode {
+    background-color: var(--kalighat-ink);
+    color: var(--kalighat-cream);
+}
+
+body.dark-mode .stat-card,
+body.dark-mode .history-entry,
+body.dark-mode .brush-step,
+body.dark-mode .theme-card,
+body.dark-mode .gallery-item,
+body.dark-mode .references-list li {
+    background: #2b241f;
+    color: var(--kalighat-cream);
+}
+
+body.dark-mode .stat-card p,
+body.dark-mode .theme-card p,
+body.dark-mode .brush-step p,
+body.dark-mode .history-entry p {
+    color: var(--kalighat-cream);
+}
+
+body.dark-mode .stat-card h4,
+body.dark-mode .section-intro,
+body.dark-mode .gallery-item figcaption,
+body.dark-mode .kalighat-footer,
+body.dark-mode .history-period {
+    color: #cbb99f;
+}
+
+body.dark-mode .references-list a {
+    color: var(--kalighat-gold);
+}
+
+body.dark-mode .section-title {
+    color: var(--kalighat-gold);
+}
+
+body.dark-mode .history-entry h4,
+body.dark-mode .brush-step h4,
+body.dark-mode .theme-card h4 {
+    color: #e8c87a;
+}

--- a/frontend/kalighat-painting-showcase/kalighat.js
+++ b/frontend/kalighat-painting-showcase/kalighat.js
@@ -1,0 +1,110 @@
+/**
+ * Kalighat Painting Showcase — Controller Module
+ * Renders the data module into the showcase page.
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    initThemeToggle();
+    renderStats(KALIGHAT_INFO.quickStats, 'quick-stats');
+    renderHistory(HISTORY_CHAPTERS, 'history-timeline');
+    renderBrushwork(BRUSHWORK_STEPS, 'brushwork-steps');
+    renderThemes(THEMES, 'themes-grid');
+    renderArtisan(ARTIST_COMMUNITY, 'artist-community');
+    renderGallery(GALLERY_IMAGES, 'gallery-grid');
+    renderReferences(REFERENCES, 'references');
+});
+
+function initThemeToggle() {
+    const toggle = document.querySelector('#theme-toggle');
+    if (!toggle) return;
+    toggle.addEventListener('click', () => {
+        document.body.classList.toggle('dark-mode');
+        localStorage.setItem('kalighat-theme', document.body.classList.contains('dark-mode') ? 'dark' : 'light');
+    });
+    if (localStorage.getItem('kalighat-theme') === 'dark') {
+        document.body.classList.add('dark-mode');
+    }
+}
+
+function renderStats(stats, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = stats.map(stat => `
+        <div class="stat-card">
+            <span class="stat-icon" aria-hidden="true">${stat.icon}</span>
+            <div>
+                <h4>${stat.label}</h4>
+                <p>${stat.value}</p>
+            </div>
+        </div>
+    `).join('');
+}
+
+function renderHistory(chapters, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = chapters.map(chapter => `
+        <div class="history-entry">
+            <div class="history-period">${chapter.period}</div>
+            <h4>${chapter.title}</h4>
+            <p>${chapter.description}</p>
+        </div>
+    `).join('');
+}
+
+function renderBrushwork(steps, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = steps.map(step => `
+        <div class="brush-step">
+            <div class="step-number">${String(step.step).padStart(2, '0')}</div>
+            <div class="step-content">
+                <h4>${step.title}</h4>
+                <p>${step.description}</p>
+            </div>
+        </div>
+    `).join('');
+}
+
+function renderThemes(themes, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = themes.map(theme => `
+        <div class="theme-card theme-${theme.category.toLowerCase().replace(/[^a-z]+/g, '-')}">
+            <div class="theme-icon" aria-hidden="true">${theme.icon}</div>
+            <span class="theme-category">${theme.category}</span>
+            <h4>${theme.name}</h4>
+            <p>${theme.description}</p>
+        </div>
+    `).join('');
+}
+
+function renderArtisan(community, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = `
+        <h2>${community.title}</h2>
+        <p>${community.description}</p>
+    `;
+}
+
+function renderGallery(images, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = images.map(image => `
+        <figure class="gallery-item">
+            <img src="${image.url}" alt="${image.caption}" loading="lazy" onerror="this.closest('.gallery-item').style.display='none';">
+            <figcaption>${image.caption}</figcaption>
+        </figure>
+    `).join('');
+}
+
+function renderReferences(references, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = references.map(ref => `
+        <li>
+            <a href="${ref.link}" target="_blank" rel="noopener noreferrer">${ref.text}</a>
+        </li>
+    `).join('');
+}

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -1505,6 +1505,13 @@ window.indiaSearchIndex = [
     description: "Explore Chhau Masks Heritage — UNESCO Intangible Cultural Heritage of Purulia and Seraikela, paper-mache mask making, divine/asura mask types, and folk dance performance gallery.",
     url: "frontend/chhau-masks-explorer/index.html"
   },
+  // --- Kalighat Painting Showcase ---
+  {
+    title: "Kalighat Painting Showcase",
+    category: "Arts & Culture",
+    description: "Explore Kalighat Painting — 19th-century Bengal's iconic temple-ghat brushwork with bold single-stroke lines, divine themes, social satire, brushwork visualization and gallery.",
+    url: "frontend/kalighat-painting-showcase/index.html"
+  },
   // --- Bidriware Craftsmanship Explorer ---
   {
     title: "Bidriware Craftsmanship Explorer",

--- a/frontend/tests/unit/kalighat-painting-showcase.test.js
+++ b/frontend/tests/unit/kalighat-painting-showcase.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadKalighatData() {
+    const code = readFileSync(
+        resolve(__dirname, '../../kalighat-painting-showcase/kalighat-data.js'),
+        'utf-8'
+    );
+    const fn = new Function(
+        code + '\nreturn { KALIGHAT_INFO, HISTORY_CHAPTERS, BRUSHWORK_STEPS, THEMES, ARTIST_COMMUNITY, GALLERY_IMAGES, REFERENCES };'
+    );
+    return fn();
+}
+
+describe('Kalighat Painting Showcase — Data Tests', () => {
+    let data;
+
+    beforeAll(() => {
+        data = loadKalighatData();
+    });
+
+    describe('KALIGHAT_INFO metadata', () => {
+        it('contains correct Kalighat metadata', () => {
+            expect(data.KALIGHAT_INFO.id).toBe('kalighat-painting');
+            expect(data.KALIGHAT_INFO.title).toContain('Kalighat');
+            expect(data.KALIGHAT_INFO.originRegion).toContain('Kolkata');
+            expect(data.KALIGHAT_INFO.signatureStyle).toContain('stroke');
+        });
+
+        it('has quickStats array with 6 items', () => {
+            expect(Array.isArray(data.KALIGHAT_INFO.quickStats)).toBe(true);
+            expect(data.KALIGHAT_INFO.quickStats.length).toBe(6);
+        });
+    });
+
+    describe('HISTORY_CHAPTERS & BRUSHWORK_STEPS', () => {
+        it('contains history chapters and brushwork steps', () => {
+            expect(Array.isArray(data.HISTORY_CHAPTERS)).toBe(true);
+            expect(data.HISTORY_CHAPTERS.length).toBeGreaterThanOrEqual(4);
+            expect(Array.isArray(data.BRUSHWORK_STEPS)).toBe(true);
+            expect(data.BRUSHWORK_STEPS.length).toBeGreaterThanOrEqual(4);
+        });
+    });
+
+    describe('THEMES', () => {
+        it('contains divine and social-satire themes', () => {
+            expect(Array.isArray(data.THEMES)).toBe(true);
+            expect(data.THEMES.length).toBeGreaterThanOrEqual(4);
+            expect(data.THEMES.some(t => t.category === 'Divine')).toBe(true);
+            expect(data.THEMES.some(t => t.category === 'Social Satire')).toBe(true);
+        });
+    });
+
+    describe('ARTIST_COMMUNITY', () => {
+        it('contains artist community details', () => {
+            expect(data.ARTIST_COMMUNITY.title).toBeDefined();
+            expect(data.ARTIST_COMMUNITY.description).toContain('Kalighat');
+        });
+    });
+
+    describe('GALLERY_IMAGES & REFERENCES', () => {
+        it('has non-empty gallery and references', () => {
+            expect(Array.isArray(data.GALLERY_IMAGES)).toBe(true);
+            expect(data.GALLERY_IMAGES.length).toBeGreaterThanOrEqual(2);
+            expect(Array.isArray(data.REFERENCES)).toBe(true);
+            expect(data.REFERENCES.length).toBeGreaterThanOrEqual(2);
+        });
+    });
+});


### PR DESCRIPTION
## feat: Create a Kalighat painting showcase featuring Bengal's iconic brushwork

Closes #1705

### Overview
Adds a fully self-contained **Kalighat Painting Showcase** page — a celebration of 19th-century Bengal's iconic brushwork from the temple ghats of Calcutta, covering its bold single-stroke style and its twin themes of divinity and social satire.

### What's included
- **New showcase page** `frontend/kalighat-painting-showcase/` with 4 files:
  - `index.html` — page structure
  - `kalighat-data.js` — data module (info, quick stats, history, brushwork, themes, artist community, gallery, references)
  - `kalighat.js` — controller (renders all sections + theme toggle)
  - `kalighat.css` — themed styling with dark-mode support
- **Landing page integration** — new Kalighat Painting card in `frontend/handicrafts-showcase/script.js` linking to the showcase.
- **Search index integration** — new entry in `frontend/search-index.js` (Arts & Culture).
- **Unit tests** — `frontend/tests/unit/kalighat-painting-showcase.test.js` (6 tests, all passing).

### Features per the issue
- **History** — a 5-chapter timeline from the Kali ghat pilgrim trade to decline and rediscovery
- **Gallery** — 5 real Kalighat artworks from Wikimedia Commons (divine icons + social satire)
- **Brushwork visualization** — 6-step deconstruction of the single-stroke tapering-line technique
- **Themes** — divine icons vs. social satire (baboo & bibi, cat-and-prawn fables, etc.)
- **References** — Britannica, V&A, Cleveland Museum of Art, Sahapedia

### Verification
- `node --check` passes on all modified/new JS files.
- `vitest` unit test passes (6/6); `search.test.js` and `smoke.test.js` also pass.

### Note
Also fixes a pre-existing syntax error in `frontend/handicrafts-showcase/script.js` where the Bidriware and Bastar entries were missing opening braces (introduced by earlier PRs), which made the file fail to parse.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Kalighat Painting showcase exploring its Bengal heritage, history, techniques, themes, artists, gallery, and references.
  * Added responsive navigation, themed visuals, statistics, timelines, and brushwork demonstrations.
  * Added dark-mode support with saved display preferences.
  * Added Kalighat Painting to the crafts directory and search experience.
* **Tests**
  * Added coverage validating showcase content, artwork collections, artist information, and references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->