### PR TITLE
feat: Highlight Dokra metal art through an interactive craftsmanship explorer

### DIFF
--- a/frontend/dokra-art-explorer/dokra-data.js
+++ b/frontend/dokra-art-explorer/dokra-data.js
@@ -1,0 +1,118 @@
+/**
+ * Dokra Art Explorer — Data Module
+ * Comprehensive dataset on Dokra (Dhokra), India's ancient lost-wax metal casting craft
+ * practised by tribal artisans: history, the cire-perdue process, artisan communities, gallery, and references.
+ */
+
+const DOKRA_INFO = {
+    id: "dokra-art",
+    title: "Dokra Art — The Lost-Wax Metal Craft",
+    originRegion: "Bastar (Chhattisgarh), Dhenkanal (Odisha), Bankura (West Bengal)",
+    eraOrigin: "Ancestral — traced to the Indus Valley (c. 2500 BCE)",
+    heritageStatus: "Ancient tribal metal-casting heritage of India",
+    technique: "Cire Perdue (Lost-Wax) Casting",
+    quickStats: [
+        { label: "Technique", value: "Lost-Wax (Cire Perdue) Casting", icon: "🪔" },
+        { label: "Heritage", value: "Indus Valley Roots (c. 2500 BCE)", icon: "🏺" },
+        { label: "Artisans", value: "Dokra Damar & Kamar Tribes", icon: "🧑‍🎨" },
+        { label: "Materials", value: "Brass, Bronze, Beeswax & Clay", icon: "⚙️" },
+        { label: "Key Centres", value: "Bastar, Dhenkanal, Bankura", icon: "🗺️" },
+        { label: "Craft Name", value: "From the 'Dokra Damar' Smelters", icon: "📛" }
+    ]
+};
+
+const HISTORY_CHAPTERS = [
+    {
+        title: "The Indus Valley Legacy",
+        period: "c. 2500 BCE",
+        description: "The bronze 'Dancing Girl' of Mohenjo-daro — cast by the lost-wax method some 4,500 years ago — is among the world's oldest metal sculptures. Dokra is regarded as its living descendant, carrying an unbroken chain of tribal metal casting through the millennia."
+    },
+    {
+        title: "The Dokra Damar Smelters",
+        period: "Ancient – Modern",
+        description: "The craft takes its name from the Dokra Damar tribes, nomadic metal smiths of central and eastern India, who wandered the tribal belt casting ritual objects — gods, beasts and ornaments — at village doorsteps."
+    },
+    {
+        title: "Regional Schools of Dokra",
+        period: "19th – 20th Century",
+        description: "Distinct clusters flowered in Bastar (Chhattisgarh), Dhenkanal and Mayurbhanj (Odisha), and Bankura and Midnapore (West Bengal), each developing its own gods, beasts and decorative motifs."
+    },
+    {
+        title: "Ritual & Folk Iconography",
+        period: "Continuous",
+        description: "Mother goddesses, horses with riders, elephants, owls, musicians and lamp-holders serve tribal rituals, harvest festivals and household devotion — each figure an object of worship as much as an ornament."
+    },
+    {
+        title: "Revival & Recognition",
+        period: "20th Century – Present",
+        description: "Handicraft boards, museums and export markets revived the craft after its mid-century decline. Today Dokra is celebrated worldwide as one of India's proudest tribal metal heritages."
+    }
+];
+
+const LOST_WAX_PROCESS = [
+    { step: 1, title: "Wax Model", description: "The artisan shapes the figure from fine beeswax with bare hands and simple tools, modelling every detail before any metal is touched." },
+    { step: 2, title: "Clay Core & Gates", description: "A clay core is formed, and the wax figure is fitted with sprue channels — 'gates' that will later carry the molten metal and release air." },
+    { step: 3, title: "The Mould", description: "Successive coats of clay mixed with paddy husk and dung encase the model, baking into a robust fire-proof mould." },
+    { step: 4, title: "Dewaxing", description: "The mould is heated over the furnace; the wax melts and runs out through the gates, leaving an exact hollow cavity — the 'lost wax'." },
+    { step: 5, title: "Pouring the Bronze", description: "Scrap brass or bronze is melted in a crucible and poured into the cavity once occupied by the wax." },
+    { step: 6, title: "Breaking & Finishing", description: "The cooled mould is broken away and the cast is cleaned, filed and polished — each piece made in one piece, with no seams, and no two ever alike." }
+];
+
+const ARTISAN_COMMUNITIES = [
+    {
+        name: "The Dokra Damar Tribes",
+        description: "The nomadic metal smiths of Jharkhand, Odisha, Chhattisgarh and West Bengal who gave the craft its name and carried its lost-wax lore across generations of travel."
+    },
+    {
+        name: "The Kamar of Bastar",
+        description: "The Kamar community of Chhattisgarh's Bastar district, celebrated for mother-goddess figures and tribal dancers cast in brass and bronze with deep folk symbolism."
+    },
+    {
+        name: "The Dhenkanal & Bankura Schools",
+        description: "Odisha's Dhenkanal cluster and West Bengal's Bankura Dhokra villages keep distinct regional iconographies alive — from horses and elephants to gods astride owls."
+    }
+];
+
+const GALLERY_IMAGES = [
+    {
+        url: "https://commons.wikimedia.org/wiki/Special:FilePath/Dancing_girl_of_Mohenjo-daro.jpg",
+        caption: "The 'Dancing Girl' of Mohenjo-daro (2300–1750 BCE, National Museum, New Delhi) — the Indus Valley bronze cast by the same lost-wax method Dokra still uses.",
+        category: "Heritage"
+    },
+    {
+        url: "https://commons.wikimedia.org/wiki/Special:FilePath/Dokra_from_tribes_of_Bastar_DSCN1172_01.jpg",
+        caption: "Dokra figures from the tribes of Bastar, Chhattisgarh — mother goddesses and tribal icons in brass and bronze.",
+        category: "Bastar"
+    },
+    {
+        url: "https://commons.wikimedia.org/wiki/Special:FilePath/God_astride_an_owl,_Dhokra_(Dokra)_craftsmen,_Bankura,_West_Bengal,_19th_century,_lost-wax_cast_brass,_HAA.JPG",
+        caption: "God astride an owl — 19th-century lost-wax cast brass by Dhokra craftsmen of Bankura, West Bengal.",
+        category: "Bankura"
+    },
+    {
+        url: "https://commons.wikimedia.org/wiki/Special:FilePath/Dokra_Art.jpg",
+        caption: "A Durga idol cast in Dokra craft — the festival goddess re-imagined in the tribal lost-wax idiom.",
+        category: "Iconography"
+    },
+    {
+        url: "https://commons.wikimedia.org/wiki/Special:FilePath/Dokra_art.png",
+        caption: "Dokra metal casting in progress — the hollow, seamless forms that define the technique.",
+        category: "Process"
+    },
+    {
+        url: "https://commons.wikimedia.org/wiki/Special:FilePath/Tribal_Anklets_called_Andu_made_of_Bell_Metal_using_Dhokra_Craft_Technique,_Orissa.jpg",
+        caption: "'Andu' tribal anklets of bell metal cast by the Dhokra technique, Odisha — Dokra extends beyond idols to ornament.",
+        category: "Ornaments"
+    }
+];
+
+const REFERENCES = [
+    { text: "Britannica — Lost-wax process (cire perdue) and Indian metalwork.", link: "https://www.britannica.com/art/lost-wax-process" },
+    { text: "Sahapedia — Dhokra metal craft of India.", link: "https://www.sahapedia.org/dhokra-metal-craft" },
+    { text: "Office of the Development Commissioner (Handicrafts) — Dhokra / Dokra craft.", link: "https://handicrafts.nic.in" },
+    { text: "National Museum, New Delhi — The Dancing Girl of Mohenjo-daro.", link: "https://nationalmuseumindia.gov.in" }
+];
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { DOKRA_INFO, HISTORY_CHAPTERS, LOST_WAX_PROCESS, ARTISAN_COMMUNITIES, GALLERY_IMAGES, REFERENCES };
+}

--- a/frontend/dokra-art-explorer/dokra.css
+++ b/frontend/dokra-art-explorer/dokra.css
@@ -1,0 +1,394 @@
+/* Dokra Art Explorer Styles */
+
+:root {
+    --dokra-bronze: #b07a2a;
+    --dokra-dark-bronze: #7c4f15;
+    --dokra-amber: #e0a33c;
+    --dokra-forge: #8c3b1f;
+    --dokra-ink: #201a15;
+    --dokra-cream: #f5eddc;
+    --dokra-paper: #fdf8ec;
+    --dokra-text: #2b241f;
+    --dokra-muted: #6b6157;
+    --dokra-white: #ffffff;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Georgia', 'Times New Roman', serif;
+    background-color: var(--dokra-cream);
+    color: var(--dokra-text);
+    line-height: 1.7;
+}
+
+.dokra-main {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 1.5rem 4rem;
+}
+
+.dokra-nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 1.5rem;
+    background: linear-gradient(90deg, var(--dokra-dark-bronze), var(--dokra-bronze));
+    color: var(--dokra-cream);
+}
+
+.dokra-nav h1 {
+    font-size: 1.15rem;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+}
+
+.theme-toggle-btn {
+    background: rgba(255, 255, 255, 0.15);
+    color: var(--dokra-cream);
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    border-radius: 999px;
+    padding: 0.4rem 0.9rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.theme-toggle-btn:hover {
+    background: rgba(255, 255, 255, 0.3);
+}
+
+.dokra-hero {
+    background:
+        radial-gradient(circle at 82% 20%, rgba(224, 163, 60, 0.22) 0%, transparent 42%),
+        radial-gradient(circle at 15% 35%, rgba(255, 255, 255, 0.12) 0%, transparent 45%),
+        linear-gradient(120deg, var(--dokra-dark-bronze), var(--dokra-bronze) 55%, #c0793a);
+    color: var(--dokra-cream);
+    text-align: center;
+    padding: 4rem 1.5rem;
+    margin-bottom: 3rem;
+    border-bottom: 5px solid var(--dokra-amber);
+}
+
+.dokra-hero h2 {
+    font-size: 2.6rem;
+    line-height: 1.2;
+    margin-bottom: 0.8rem;
+}
+
+.dokra-hero .tagline {
+    font-size: 1.15rem;
+    opacity: 0.92;
+    max-width: 740px;
+    margin: 0 auto 1.2rem;
+    font-style: italic;
+}
+
+.hero-tags {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.6rem;
+}
+
+.hero-tag {
+    background: rgba(255, 255, 255, 0.16);
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    border-radius: 999px;
+    padding: 0.3rem 0.9rem;
+    font-size: 0.85rem;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+    gap: 1rem;
+    margin: 2.5rem 0;
+}
+
+.stat-card {
+    background: var(--dokra-paper);
+    border-left: 4px solid var(--dokra-bronze);
+    border-radius: 10px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+    padding: 1rem 1.2rem;
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+}
+
+.stat-icon {
+    font-size: 1.6rem;
+}
+
+.stat-card h4 {
+    font-size: 0.85rem;
+    color: var(--dokra-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 0.15rem;
+}
+
+.stat-card p {
+    font-weight: 700;
+    font-size: 0.95rem;
+    color: var(--dokra-text);
+}
+
+.section-title {
+    font-size: 1.8rem;
+    color: var(--dokra-dark-bronze);
+    text-align: center;
+    margin: 3rem 0 1.5rem;
+    position: relative;
+}
+
+.section-title::after {
+    content: '';
+    display: block;
+    width: 80px;
+    height: 4px;
+    background: var(--dokra-amber);
+    margin: 0.5rem auto 0;
+    border-radius: 2px;
+}
+
+.section-intro {
+    text-align: center;
+    max-width: 760px;
+    margin: 0 auto 2rem;
+    color: var(--dokra-muted);
+}
+
+/* History Timeline */
+.history-timeline {
+    position: relative;
+    max-width: 860px;
+    margin: 0 auto;
+    padding-left: 1.6rem;
+    border-left: 3px solid var(--dokra-bronze);
+}
+
+.history-entry {
+    position: relative;
+    background: var(--dokra-paper);
+    border-radius: 10px;
+    padding: 1.2rem 1.4rem;
+    margin-bottom: 1.2rem;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+}
+
+.history-entry::before {
+    content: '';
+    position: absolute;
+    left: -1.9rem;
+    top: 1.5rem;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--dokra-amber);
+    border: 3px solid var(--dokra-bronze);
+}
+
+.history-period {
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--dokra-bronze);
+    margin-bottom: 0.3rem;
+}
+
+.history-entry h4 {
+    color: var(--dokra-dark-bronze);
+    margin-bottom: 0.3rem;
+}
+
+/* Lost-Wax Process */
+.process-steps {
+    display: grid;
+    gap: 1.2rem;
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.process-step {
+    display: flex;
+    align-items: flex-start;
+    gap: 1.2rem;
+    background: var(--dokra-paper);
+    border-radius: 10px;
+    padding: 1.2rem 1.4rem;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+}
+
+.step-number {
+    flex-shrink: 0;
+    width: 46px;
+    height: 46px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--dokra-forge);
+    color: var(--dokra-cream);
+    font-weight: 700;
+    font-size: 1rem;
+    border-radius: 50%;
+}
+
+.step-content h4 {
+    color: var(--dokra-dark-bronze);
+    margin-bottom: 0.3rem;
+}
+
+/* Artisan Communities */
+.communities-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.2rem;
+}
+
+.community-card {
+    background: var(--dokra-paper);
+    border-radius: 10px;
+    padding: 1.3rem 1.4rem;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+    border-top: 4px solid var(--dokra-amber);
+}
+
+.community-card h4 {
+    color: var(--dokra-dark-bronze);
+    margin-bottom: 0.4rem;
+}
+
+/* Gallery */
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.2rem;
+}
+
+.gallery-item {
+    background: var(--dokra-paper);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.gallery-item img {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+    display: block;
+}
+
+.gallery-item figcaption {
+    padding: 0.8rem 1rem;
+    font-size: 0.85rem;
+    color: var(--dokra-muted);
+}
+
+/* References */
+.references-list {
+    list-style: none;
+    max-width: 820px;
+    margin: 0 auto;
+}
+
+.references-list li {
+    background: var(--dokra-paper);
+    border-radius: 8px;
+    margin-bottom: 0.7rem;
+    padding: 0.9rem 1.2rem;
+    border-left: 4px solid var(--dokra-amber);
+}
+
+.references-list a {
+    color: var(--dokra-dark-bronze);
+    text-decoration: none;
+    font-weight: 700;
+}
+
+.references-list a:hover {
+    text-decoration: underline;
+}
+
+.dokra-footer {
+    text-align: center;
+    padding: 2rem 1.5rem 3rem;
+    color: var(--dokra-muted);
+    font-size: 0.9rem;
+}
+
+.back-link {
+    display: inline-block;
+    margin-top: 0.8rem;
+    color: var(--dokra-dark-bronze);
+    text-decoration: none;
+    font-weight: 700;
+}
+
+.back-link:hover {
+    text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+    .dokra-hero h2 {
+        font-size: 1.9rem;
+    }
+    .dokra-nav h1 {
+        font-size: 0.95rem;
+    }
+    .process-step {
+        flex-direction: column;
+    }
+}
+
+/* Dark Mode */
+body.dark-mode {
+    background-color: var(--dokra-ink);
+    color: var(--dokra-cream);
+}
+
+body.dark-mode .stat-card,
+body.dark-mode .history-entry,
+body.dark-mode .process-step,
+body.dark-mode .community-card,
+body.dark-mode .gallery-item,
+body.dark-mode .references-list li {
+    background: #2b241f;
+    color: var(--dokra-cream);
+}
+
+body.dark-mode .stat-card p,
+body.dark-mode .community-card p,
+body.dark-mode .process-step p,
+body.dark-mode .history-entry p {
+    color: var(--dokra-cream);
+}
+
+body.dark-mode .stat-card h4,
+body.dark-mode .section-intro,
+body.dark-mode .gallery-item figcaption,
+body.dark-mode .dokra-footer,
+body.dark-mode .history-period {
+    color: #cdb78f;
+}
+
+body.dark-mode .references-list a {
+    color: var(--dokra-amber);
+}
+
+body.dark-mode .section-title {
+    color: var(--dokra-amber);
+}
+
+body.dark-mode .history-entry h4,
+body.dark-mode .process-step h4,
+body.dark-mode .community-card h4 {
+    color: #ecc87a;
+}

--- a/frontend/dokra-art-explorer/dokra.js
+++ b/frontend/dokra-art-explorer/dokra.js
@@ -1,0 +1,98 @@
+/**
+ * Dokra Art Explorer — Controller Module
+ * Renders the data module into the explorer page.
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    initThemeToggle();
+    renderStats(DOKRA_INFO.quickStats, 'quick-stats');
+    renderHistory(HISTORY_CHAPTERS, 'history-timeline');
+    renderProcess(LOST_WAX_PROCESS, 'process-steps');
+    renderCommunities(ARTISAN_COMMUNITIES, 'communities-grid');
+    renderGallery(GALLERY_IMAGES, 'gallery-grid');
+    renderReferences(REFERENCES, 'references');
+});
+
+function initThemeToggle() {
+    const toggle = document.querySelector('#theme-toggle');
+    if (!toggle) return;
+    toggle.addEventListener('click', () => {
+        document.body.classList.toggle('dark-mode');
+        localStorage.setItem('dokra-theme', document.body.classList.contains('dark-mode') ? 'dark' : 'light');
+    });
+    if (localStorage.getItem('dokra-theme') === 'dark') {
+        document.body.classList.add('dark-mode');
+    }
+}
+
+function renderStats(stats, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = stats.map(stat => `
+        <div class="stat-card">
+            <span class="stat-icon" aria-hidden="true">${stat.icon}</span>
+            <div>
+                <h4>${stat.label}</h4>
+                <p>${stat.value}</p>
+            </div>
+        </div>
+    `).join('');
+}
+
+function renderHistory(chapters, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = chapters.map(chapter => `
+        <div class="history-entry">
+            <div class="history-period">${chapter.period}</div>
+            <h4>${chapter.title}</h4>
+            <p>${chapter.description}</p>
+        </div>
+    `).join('');
+}
+
+function renderProcess(steps, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = steps.map(step => `
+        <div class="process-step">
+            <div class="step-number">${String(step.step).padStart(2, '0')}</div>
+            <div class="step-content">
+                <h4>${step.title}</h4>
+                <p>${step.description}</p>
+            </div>
+        </div>
+    `).join('');
+}
+
+function renderCommunities(communities, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = communities.map(community => `
+        <div class="community-card">
+            <h4>${community.name}</h4>
+            <p>${community.description}</p>
+        </div>
+    `).join('');
+}
+
+function renderGallery(images, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = images.map(image => `
+        <figure class="gallery-item">
+            <img src="${image.url}" alt="${image.caption}" loading="lazy" onerror="this.closest('.gallery-item').style.display='none';">
+            <figcaption>${image.caption}</figcaption>
+        </figure>
+    `).join('');
+}
+
+function renderReferences(references, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = references.map(ref => `
+        <li>
+            <a href="${ref.link}" target="_blank" rel="noopener noreferrer">${ref.text}</a>
+        </li>
+    `).join('');
+}

--- a/frontend/dokra-art-explorer/index.html
+++ b/frontend/dokra-art-explorer/index.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dokra Art Explorer — The Lost-Wax Metal Craft</title>
+    <meta name="description" content="Explore Dokra (Dhokra) art — India's ancient lost-wax metal casting technique practised by tribal artisans, from the Dancing Girl of Mohenjo-daro to Bastar, Dhenkanal and Bankura.">
+    <link rel="stylesheet" href="dokra.css">
+</head>
+<body>
+    <nav class="dokra-nav">
+        <h1>🪔 Dokra Art Explorer</h1>
+        <button class="theme-toggle-btn" id="theme-toggle" aria-label="Toggle dark mode">🌙 Toggle Theme</button>
+    </nav>
+
+    <main class="dokra-main">
+        <section class="dokra-hero">
+            <h2>Dokra Art<br>& the Lost-Wax Craft of Tribal India</h2>
+            <p class="tagline">A casting technique as old as the Indus Valley — beeswax, clay and molten bronze shaped by tribal artisans into gods, beasts and ornaments.</p>
+            <div class="hero-tags">
+                <span class="hero-tag">🪔 Cire Perdue Casting</span>
+                <span class="hero-tag">🏺 Indus Valley Roots</span>
+                <span class="hero-tag">🧑‍🎨 Bastar · Dhenkanal · Bankura</span>
+            </div>
+        </section>
+
+        <section>
+            <h2 class="section-title">At a Glance</h2>
+            <p class="section-intro">Dokra (or Dhokra) is one of India's oldest living metal crafts — a seamless, one-piece bronze cast whose every example is unique.</p>
+            <div id="quick-stats" class="stats-grid"></div>
+        </section>
+
+        <section>
+            <h2 class="section-title">Historical Background</h2>
+            <p class="section-intro">From the bronzes of Mohenjo-daro to the village furnaces of the Dokra Damar — the 4,500-year journey of the lost-wax craft.</p>
+            <div id="history-timeline" class="history-timeline"></div>
+        </section>
+
+        <section>
+            <h2 class="section-title">The Lost-Wax Process</h2>
+            <p class="section-intro">Six steps of cire perdue casting — the ancient recipe of wax, clay, fire and bronze that makes every Dokra piece a one-off.</p>
+            <div id="process-steps" class="process-steps"></div>
+        </section>
+
+        <section>
+            <h2 class="section-title">Artisan Communities</h2>
+            <p class="section-intro">The tribal smiths and regional schools that keep the lost-wax flame burning across India's heartland.</p>
+            <div id="communities-grid" class="communities-grid"></div>
+        </section>
+
+        <section>
+            <h2 class="section-title">Craft Gallery</h2>
+            <p class="section-intro">From the Dancing Girl of Mohenjo-daro to the anklets of Odisha — Dokra in bronze, brass and bell metal.</p>
+            <div id="gallery-grid" class="gallery-grid"></div>
+        </section>
+
+        <section>
+            <h2 class="section-title">References & Further Reading</h2>
+            <ul id="references" class="references-list"></ul>
+        </section>
+
+        <footer class="dokra-footer">
+            <p>Part of Incredible India Explorer — handcrafted heritage collection.</p>
+            <a class="back-link" href="../handicrafts-showcase/index.html">← Back to Indian Handicrafts Showcase</a>
+        </footer>
+    </main>
+
+    <script src="dokra-data.js"></script>
+    <script src="dokra.js"></script>
+</body>
+</html>

--- a/frontend/handicrafts-showcase/script.js
+++ b/frontend/handicrafts-showcase/script.js
@@ -1,6 +1,17 @@
 // ---------- Handicrafts Data (16 crafts across UP districts) ----------
 const allCrafts = [
   {
+    name: "Dokra Art",
+    icon: "🪔",
+    district: "Bastar, Dhenkanal & Bankura",
+    category: "metal",
+    tags: ["Lost-Wax Casting", "Tribal Art", "Indus Valley Roots"],
+    description: "India's ancient lost-wax metal casting craft — seamless bronze and brass figures of gods, beasts and ornaments by tribal artisans.",
+    history: "Traced to the Indus Valley 'Dancing Girl' of Mohenjo-daro (c. 2500 BCE), Dokra keeps a 4,500-year-old casting lineage alive in Bastar, Dhenkanal and Bankura.",
+    artisan: "Dokra Damar and Kamar tribal smiths who shape beeswax models, encase them in clay and pour molten bronze into the cavity left behind.",
+    detailsUrl: "../dokra-art-explorer/index.html"
+  },
+  {
     name: "Chhau Dance Masks",
     icon: "🎭",
     district: "Purulia & Charida",
@@ -10,7 +21,8 @@ const allCrafts = [
     history: "Centuries-old folk performance mask art created by Sutradhar artisans depicting Ramayana, Mahabharata, and Puranic deities.",
     artisan: "Charida village artisans in Purulia crafting lightweight paper-mache shells embellished with peacock feathers and zari crowns.",
     detailsUrl: "../chhau-masks-explorer/index.html"
-},
+  },
+  {
     name: "Bidriware Metal Inlay",
     icon: "✨",
     district: "Bidar, Karnataka",
@@ -20,7 +32,8 @@ const allCrafts = [
     history: "14th-century Bahmani Sultanate metalcraft developed in Bidar using unique nitrate-rich Bidar Fort soil for oxidation.",
     artisan: "Master Bidri engravers hammering pure silver wire into zinc-copper castings.",
     detailsUrl: "../bidriware-craftsmanship-explorer/index.html"
-},
+  },
+  {
     name: "Bastar Iron Craft (Loha Shilp)",
     icon: "🔨",
     district: "Bastar & Kondagaon",

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -1505,6 +1505,13 @@ window.indiaSearchIndex = [
     description: "Explore Chhau Masks Heritage — UNESCO Intangible Cultural Heritage of Purulia and Seraikela, paper-mache mask making, divine/asura mask types, and folk dance performance gallery.",
     url: "frontend/chhau-masks-explorer/index.html"
   },
+  // --- Dokra Art Explorer ---
+  {
+    title: "Dokra Art Explorer",
+    category: "Arts & Culture",
+    description: "Explore Dokra Art — ancient lost-wax metal casting by tribal artisans, Indus Valley roots, the cire-perdue process, artisan communities of Bastar, Dhenkanal and Bankura, and gallery.",
+    url: "frontend/dokra-art-explorer/index.html"
+  },
   // --- Bidriware Craftsmanship Explorer ---
   {
     title: "Bidriware Craftsmanship Explorer",

--- a/frontend/tests/unit/dokra-art-explorer.test.js
+++ b/frontend/tests/unit/dokra-art-explorer.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadDokraData() {
+    const code = readFileSync(
+        resolve(__dirname, '../../dokra-art-explorer/dokra-data.js'),
+        'utf-8'
+    );
+    const fn = new Function(
+        code + '\nreturn { DOKRA_INFO, HISTORY_CHAPTERS, LOST_WAX_PROCESS, ARTISAN_COMMUNITIES, GALLERY_IMAGES, REFERENCES };'
+    );
+    return fn();
+}
+
+describe('Dokra Art Explorer — Data Tests', () => {
+    let data;
+
+    beforeAll(() => {
+        data = loadDokraData();
+    });
+
+    describe('DOKRA_INFO metadata', () => {
+        it('contains correct Dokra metadata', () => {
+            expect(data.DOKRA_INFO.id).toBe('dokra-art');
+            expect(data.DOKRA_INFO.title).toContain('Dokra');
+            expect(data.DOKRA_INFO.technique).toContain('Lost-Wax');
+            expect(data.DOKRA_INFO.eraOrigin).toContain('Indus Valley');
+        });
+
+        it('has quickStats array with 6 items', () => {
+            expect(Array.isArray(data.DOKRA_INFO.quickStats)).toBe(true);
+            expect(data.DOKRA_INFO.quickStats.length).toBe(6);
+        });
+    });
+
+    describe('HISTORY_CHAPTERS & LOST_WAX_PROCESS', () => {
+        it('contains history chapters and lost-wax process steps', () => {
+            expect(Array.isArray(data.HISTORY_CHAPTERS)).toBe(true);
+            expect(data.HISTORY_CHAPTERS.length).toBeGreaterThanOrEqual(4);
+            expect(Array.isArray(data.LOST_WAX_PROCESS)).toBe(true);
+            expect(data.LOST_WAX_PROCESS.length).toBeGreaterThanOrEqual(5);
+        });
+    });
+
+    describe('ARTISAN_COMMUNITIES', () => {
+        it('contains multiple artisan communities', () => {
+            expect(Array.isArray(data.ARTISAN_COMMUNITIES)).toBe(true);
+            expect(data.ARTISAN_COMMUNITIES.length).toBeGreaterThanOrEqual(3);
+            expect(data.ARTISAN_COMMUNITIES.some(c => c.name.includes('Dokra Damar'))).toBe(true);
+        });
+    });
+
+    describe('GALLERY_IMAGES & REFERENCES', () => {
+        it('has non-empty gallery and references', () => {
+            expect(Array.isArray(data.GALLERY_IMAGES)).toBe(true);
+            expect(data.GALLERY_IMAGES.length).toBeGreaterThanOrEqual(2);
+            expect(Array.isArray(data.REFERENCES)).toBe(true);
+            expect(data.REFERENCES.length).toBeGreaterThanOrEqual(2);
+        });
+    });
+});


### PR DESCRIPTION
## feat: Highlight Dokra metal art through an interactive craftsmanship explorer

Closes #1707

### Overview
Adds a fully self-contained **Dokra Art Explorer** page — an interactive showcase of India's ancient lost-wax (cire perdue) metal casting craft, practised by tribal artisans from the Indus Valley era to today.

### What's included
- **New explorer page** `frontend/dokra-art-explorer/` with 4 files:
  - `index.html` — page structure
  - `dokra-data.js` — data module (info, quick stats, history, lost-wax process, artisan communities, gallery, references)
  - `dokra.js` — controller (renders all sections + theme toggle)
  - `dokra.css` — themed styling with dark-mode support
- **Landing page integration** — new Dokra Art card in `frontend/handicrafts-showcase/script.js` linking to the explorer.
- **Search index integration** — new entry in `frontend/search-index.js` (Arts & Culture).
- **Unit tests** — `frontend/tests/unit/dokra-art-explorer.test.js` (5 tests, all passing).

### Features per the issue
- **Historical background** — a 5-chapter timeline from the Mohenjo-daro 'Dancing Girl' (c. 2500 BCE) through the Dokra Damar smelters, regional schools, ritual iconography and modern revival
- **Craft gallery** — 6 real Dokra artworks from Wikimedia Commons (Bastar figures, Bankura 19th-century brass, Odisha bell-metal anklets, the Dancing Girl)
- **Lost-wax process** — 6-step walkthrough of cire perdue casting (wax model → clay mould → dewaxing → pouring bronze → finishing)
- **Artisan communities** — Dokra Damar tribes, the Kamar of Bastar, and the Dhenkanal & Bankura schools
- **References** — Britannica, Sahapedia, DCH Handicrafts, National Museum Delhi

### Verification
- `node --check` passes on all modified/new JS files.
- `vitest` unit test passes (5/5); `search.test.js` and `smoke.test.js` also pass.

### Note
Also fixes a pre-existing syntax error in `frontend/handicrafts-showcase/script.js` where the Bidriware and Bastar entries were missing opening braces (introduced by earlier PRs), which made the file fail to parse.
