### PR TITLE
feat: Introduce Channapatna toys with an interactive wooden craft explorer

### DIFF
--- a/frontend/channapatna-toys-explorer/channapatna-data.js
+++ b/frontend/channapatna-toys-explorer/channapatna-data.js
@@ -1,0 +1,123 @@
+/**
+ * Channapatna Toys Explorer — Data Module
+ * Comprehensive dataset on Channapatna wooden toys, Karnataka's traditional lacquerware
+ * craftsmanship: history, crafting process, sustainable materials, traditional designs, gallery, and references.
+ */
+
+const CHANNAPATNA_INFO = {
+    id: "channapatna-toys",
+    title: "Channapatna Toys — Karnataka's Lacquerware Craft",
+    originRegion: "Channapatna, Ramanagara District, Karnataka",
+    eraOrigin: "18th Century (Tipu Sultan's Patronage)",
+    giTagStatus: "Geographical Indication (GI) Certified — Channapatna Toys & Dolls (2005)",
+    quickStats: [
+        { label: "Birthplace", value: "Channapatna, Karnataka", icon: "📍" },
+        { label: "GI Tagged", value: "Channapatna Toys & Dolls (2005)", icon: "🏷️" },
+        { label: "Wood Used", value: "Ivory Wood (Aale Mara)", icon: "🪵" },
+        { label: "Finish", value: "Natural Lacquer (Lac Resin)", icon: "✨" },
+        { label: "Technique", value: "Bow-Lathe Turnery", icon: "🛠️" },
+        { label: "Nickname", value: "'Gombegala Ooru' — City of Toys", icon: "🎠" }
+    ]
+};
+
+const HISTORY_CHAPTERS = [
+    {
+        title: "The City of Toys",
+        period: "Channapatna, Karnataka",
+        description: "Sixty kilometres from Bengaluru, the town of Channapatna in Ramanagara district is lovingly called 'Gombegala Ooru' — the City of Toys — and is today the heart of India's wooden-toy tradition."
+    },
+    {
+        title: "Tipu Sultan's Patronage",
+        period: "18th Century",
+        description: "Legend holds that the Tiger of Mysore, Tipu Sultan, invited Persian artisans to Channapatna to teach the region's craftsmen the art of lacquerware — a cross-cultural spark that shaped the craft's signature glossy finish."
+    },
+    {
+        title: "The Lac-Turnery Craft",
+        period: "Generational",
+        description: "The technique — turning soft ivory wood on a bow-powered lathe and sealing it with molten natural lac — passed down through artisan families of Channapatna and its surrounding villages."
+    },
+    {
+        title: "GI Recognition",
+        period: "2005 – 2006",
+        description: "'Channapatna Toys and Dolls' earned the Geographical Indication tag, legally protecting the craft's identity and the livelihoods of the town's toymakers."
+    },
+    {
+        title: "Organic Revival",
+        period: "Present Day",
+        description: "Modern workshops blend tradition with child-safety: natural vegetable and food-grade dyes, non-toxic lac, and export to more than twenty countries worldwide."
+    }
+];
+
+const CRAFTING_PROCESS = [
+    { step: 1, title: "Seasoning the Wood", description: "Logs of aale mara (ivory wood, Wrightia tinctoria) are felled and dried in the sun for months until light, stable and ready for the lathe." },
+    { step: 2, title: "Turning on the Bow Lathe", description: "The artisan spins the wooden blank with a traditional bow-string lathe, controlling speed with a treadle while shaping the toy." },
+    { step: 3, title: "Smoothing & Shaping", description: "Sharp chisels carve the rotating wood into elephants, bells, tops and dolls — each contour cut freehand." },
+    { step: 4, title: "Applying the Lacquer", description: "Sticks of natural lac resin are pressed against the spinning toy; the friction heat melts the lac and fuses it evenly onto the wood." },
+    { step: 5, title: "Hand Painting & Detailing", description: "Fine lines, eyes and patterns are painted by hand — often by women artisans — using natural and food-grade dyes." },
+    { step: 6, title: "Polishing & Inspection", description: "Each toy is polished to a soft sheen and inspected for safety, ensuring every piece is smooth, non-toxic and child-friendly." }
+];
+
+const SUSTAINABLE_MATERIALS = [
+    { name: "Ivory Wood (Aale Mara)", description: "Wrightia tinctoria is a fast-growing local timber — light, fine-grained and sustainably harvested from Karnataka's woodlands.", icon: "🪵" },
+    { name: "Natural Lac Resin", description: "The glossy finish comes from lac, a natural resin secreted by the lac insect — biodegradable and completely non-toxic.", icon: "🐛" },
+    { name: "Vegetable & Food-Grade Dyes", description: "Colours are drawn from turmeric, indigo, kumkuma and other natural sources, keeping the toys safe for babies to handle.", icon: "🌿" },
+    { name: "No Plastic, No Toxins", description: "Every Channapatna toy is free of plastic, synthetic paints and sharp edges — renewable, biodegradable play that lasts generations.", icon: "♻️" }
+];
+
+const TRADITIONAL_DESIGNS = [
+    { name: "The Channapatna Elephant", description: "The iconic red-and-gold lacquered elephant, stacked in graded sizes — the postcard of the craft.", icon: "🐘" },
+    { name: "Buguri (Spinning Top)", description: "The classic lattoo, spun on floors across Indian childhoods, painted in bold bands of lacquer.", icon: "🪀" },
+    { name: "Gilike (Rattle Bell)", description: "A little bell with a wooden handle and beads — the first toy of countless infants.", icon: "🔔" },
+    { name: "Miniature Kitchen Sets", description: "Play kitchens, utensils and fruit that taught generations of children household rhythms.", icon: "🍽️" },
+    { name: "Bangles & Ornaments", description: "Lacquered bangles and jewellery echoing the same warm, glossy palette of the toys.", icon: "📿" },
+    { name: "Toy Trains & Rattles", description: "Modern classics — trains, cars and rattles — reinterpreted in traditional ivory-wood lacquer.", icon: "🚂" }
+];
+
+const ARTISAN_COMMUNITY = {
+    title: "The Toymakers of Gombegala Ooru",
+    description: "Thousands of artisans — men at the lathes and women at the paintbrushes — carry the craft across Channapatna town and its villages. Organised under bodies like the Channapatna Toys Manufacturers' Association, they have turned a centuries-old skill into a sustainable rural industry, exporting handmade, eco-friendly toys to homes around the world."
+};
+
+const GALLERY_IMAGES = [
+    {
+        url: "https://commons.wikimedia.org/wiki/Special:FilePath/Channapatna-toys.jpg",
+        caption: "Classic Channapatna toys — elephants, bells and doll sets in the craft's warm lacquer palette.",
+        category: "Classic"
+    },
+    {
+        url: "https://commons.wikimedia.org/wiki/Special:FilePath/Channapatna_artist_making_toy.jpg",
+        caption: "An artisan shaping a toy on the traditional bow-powered lathe.",
+        category: "Crafting"
+    },
+    {
+        url: "https://commons.wikimedia.org/wiki/Special:FilePath/Channapatna_artist_coloring_toy.jpg",
+        caption: "Hand colouring a lacquered toy — fine detailing done by artisans, many of them women.",
+        category: "Crafting"
+    },
+    {
+        url: "https://commons.wikimedia.org/wiki/Special:FilePath/Finished_Channapatna_toys.jpg",
+        caption: "Finished Channapatna toys ready for market — glossy, seamless and child-safe.",
+        category: "Classic"
+    },
+    {
+        url: "https://commons.wikimedia.org/wiki/Special:FilePath/Toy_flute_from_Channapatna,_Karnataka,_India.jpg",
+        caption: "A traditional toy flute from Channapatna — musical play in ivory wood and lacquer.",
+        category: "Designs"
+    },
+    {
+        url: "https://commons.wikimedia.org/wiki/Special:FilePath/Channapatna_Bangles_(4784914041).jpg",
+        caption: "Lacquered bangles among Channapatna toys — the glossy finish that crowns the craft.",
+        category: "Designs"
+    }
+];
+
+const REFERENCES = [
+    { text: "Geographical Indications Registry — Channapatna Toys and Dolls (GI certified).", link: "https://ipindia.gov.in" },
+    { text: "Office of the Development Commissioner (Handicrafts) — Channapatna wooden toys.", link: "https://handicrafts.nic.in" },
+    { text: "Karnataka Handicrafts Development Corporation (KHDC) — Channapatna toys.", link: "https://karnatakahandicrafts.com" },
+    { text: "Sahapedia — The lacquerware toys of Channapatna.", link: "https://www.sahapedia.org/channapatna-toys" }
+];
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { CHANNAPATNA_INFO, HISTORY_CHAPTERS, CRAFTING_PROCESS, SUSTAINABLE_MATERIALS, TRADITIONAL_DESIGNS, ARTISAN_COMMUNITY, GALLERY_IMAGES, REFERENCES };
+}

--- a/frontend/channapatna-toys-explorer/channapatna.css
+++ b/frontend/channapatna-toys-explorer/channapatna.css
@@ -1,0 +1,427 @@
+/* Channapatna Toys Explorer Styles */
+
+:root {
+    --lacquer-red: #b23a2f;
+    --lacquer-deep-red: #7d2219;
+    --lacquer-gold: #d9a03f;
+    --wood-brown: #8d5524;
+    --wood-dark: #5c3618;
+    --toy-cream: #f8f0df;
+    --toy-paper: #fdf9ee;
+    --toy-ink: #241c14;
+    --toy-text: #2b241f;
+    --toy-muted: #6b6157;
+    --toy-white: #ffffff;
+}
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Georgia', 'Times New Roman', serif;
+    background-color: var(--toy-cream);
+    color: var(--toy-text);
+    line-height: 1.7;
+}
+
+.channapatna-main {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 1.5rem 4rem;
+}
+
+.channapatna-nav {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 1.5rem;
+    background: linear-gradient(90deg, var(--wood-dark), var(--wood-brown));
+    color: var(--toy-cream);
+}
+
+.channapatna-nav h1 {
+    font-size: 1.15rem;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+}
+
+.theme-toggle-btn {
+    background: rgba(255, 255, 255, 0.15);
+    color: var(--toy-cream);
+    border: 1px solid rgba(255, 255, 255, 0.4);
+    border-radius: 999px;
+    padding: 0.4rem 0.9rem;
+    font-size: 0.85rem;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.theme-toggle-btn:hover {
+    background: rgba(255, 255, 255, 0.3);
+}
+
+.channapatna-hero {
+    background:
+        radial-gradient(circle at 80% 25%, rgba(217, 160, 63, 0.22) 0%, transparent 42%),
+        radial-gradient(circle at 15% 30%, rgba(255, 255, 255, 0.12) 0%, transparent 45%),
+        linear-gradient(120deg, var(--wood-dark), var(--lacquer-deep-red) 55%, var(--lacquer-red));
+    color: var(--toy-cream);
+    text-align: center;
+    padding: 4rem 1.5rem;
+    margin-bottom: 3rem;
+    border-bottom: 5px solid var(--lacquer-gold);
+}
+
+.channapatna-hero h2 {
+    font-size: 2.6rem;
+    line-height: 1.2;
+    margin-bottom: 0.8rem;
+}
+
+.channapatna-hero .tagline {
+    font-size: 1.15rem;
+    opacity: 0.92;
+    max-width: 740px;
+    margin: 0 auto 1.2rem;
+    font-style: italic;
+}
+
+.hero-tags {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.6rem;
+}
+
+.hero-tag {
+    background: rgba(255, 255, 255, 0.16);
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    border-radius: 999px;
+    padding: 0.3rem 0.9rem;
+    font-size: 0.85rem;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+    gap: 1rem;
+    margin: 2.5rem 0;
+}
+
+.stat-card {
+    background: var(--toy-paper);
+    border-left: 4px solid var(--lacquer-red);
+    border-radius: 10px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+    padding: 1rem 1.2rem;
+    display: flex;
+    align-items: center;
+    gap: 0.8rem;
+}
+
+.stat-icon {
+    font-size: 1.6rem;
+}
+
+.stat-card h4 {
+    font-size: 0.85rem;
+    color: var(--toy-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 0.15rem;
+}
+
+.stat-card p {
+    font-weight: 700;
+    font-size: 0.95rem;
+    color: var(--toy-text);
+}
+
+.section-title {
+    font-size: 1.8rem;
+    color: var(--wood-dark);
+    text-align: center;
+    margin: 3rem 0 1.5rem;
+    position: relative;
+}
+
+.section-title::after {
+    content: '';
+    display: block;
+    width: 80px;
+    height: 4px;
+    background: var(--lacquer-gold);
+    margin: 0.5rem auto 0;
+    border-radius: 2px;
+}
+
+.section-intro {
+    text-align: center;
+    max-width: 760px;
+    margin: 0 auto 2rem;
+    color: var(--toy-muted);
+}
+
+/* History Timeline */
+.history-timeline {
+    position: relative;
+    max-width: 860px;
+    margin: 0 auto;
+    padding-left: 1.6rem;
+    border-left: 3px solid var(--lacquer-red);
+}
+
+.history-entry {
+    position: relative;
+    background: var(--toy-paper);
+    border-radius: 10px;
+    padding: 1.2rem 1.4rem;
+    margin-bottom: 1.2rem;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+}
+
+.history-entry::before {
+    content: '';
+    position: absolute;
+    left: -1.9rem;
+    top: 1.5rem;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--lacquer-gold);
+    border: 3px solid var(--lacquer-red);
+}
+
+.history-period {
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--lacquer-red);
+    margin-bottom: 0.3rem;
+}
+
+.history-entry h4 {
+    color: var(--wood-dark);
+    margin-bottom: 0.3rem;
+}
+
+/* Crafting Process */
+.process-steps {
+    display: grid;
+    gap: 1.2rem;
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.process-step {
+    display: flex;
+    align-items: flex-start;
+    gap: 1.2rem;
+    background: var(--toy-paper);
+    border-radius: 10px;
+    padding: 1.2rem 1.4rem;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+}
+
+.step-number {
+    flex-shrink: 0;
+    width: 46px;
+    height: 46px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--lacquer-red);
+    color: var(--toy-cream);
+    font-weight: 700;
+    font-size: 1rem;
+    border-radius: 50%;
+}
+
+.step-content h4 {
+    color: var(--wood-dark);
+    margin-bottom: 0.3rem;
+}
+
+/* Materials & Designs */
+.materials-grid,
+.designs-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.2rem;
+}
+
+.material-card,
+.design-card {
+    background: var(--toy-paper);
+    border-radius: 10px;
+    padding: 1.3rem 1.4rem;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+    border-top: 4px solid var(--wood-brown);
+}
+
+.design-card {
+    border-top-color: var(--lacquer-red);
+}
+
+.material-icon,
+.design-icon {
+    font-size: 1.7rem;
+    margin-bottom: 0.5rem;
+}
+
+.material-card h4,
+.design-card h4 {
+    color: var(--wood-dark);
+    margin-bottom: 0.4rem;
+}
+
+/* Artisan Community */
+.artisan-section {
+    background: linear-gradient(120deg, var(--wood-dark), var(--lacquer-deep-red));
+    color: var(--toy-cream);
+    border-radius: 12px;
+    padding: 2.5rem 2rem;
+    margin: 2rem auto;
+    max-width: 900px;
+    text-align: center;
+}
+
+.artisan-section h2 {
+    margin-bottom: 0.8rem;
+    font-size: 1.6rem;
+}
+
+/* Gallery */
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.2rem;
+}
+
+.gallery-item {
+    background: var(--toy-paper);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
+.gallery-item img {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+    display: block;
+}
+
+.gallery-item figcaption {
+    padding: 0.8rem 1rem;
+    font-size: 0.85rem;
+    color: var(--toy-muted);
+}
+
+/* References */
+.references-list {
+    list-style: none;
+    max-width: 820px;
+    margin: 0 auto;
+}
+
+.references-list li {
+    background: var(--toy-paper);
+    border-radius: 8px;
+    margin-bottom: 0.7rem;
+    padding: 0.9rem 1.2rem;
+    border-left: 4px solid var(--lacquer-gold);
+}
+
+.references-list a {
+    color: var(--lacquer-deep-red);
+    text-decoration: none;
+    font-weight: 700;
+}
+
+.references-list a:hover {
+    text-decoration: underline;
+}
+
+.channapatna-footer {
+    text-align: center;
+    padding: 2rem 1.5rem 3rem;
+    color: var(--toy-muted);
+    font-size: 0.9rem;
+}
+
+.back-link {
+    display: inline-block;
+    margin-top: 0.8rem;
+    color: var(--lacquer-deep-red);
+    text-decoration: none;
+    font-weight: 700;
+}
+
+.back-link:hover {
+    text-decoration: underline;
+}
+
+@media (max-width: 640px) {
+    .channapatna-hero h2 {
+        font-size: 1.9rem;
+    }
+    .channapatna-nav h1 {
+        font-size: 0.95rem;
+    }
+    .process-step {
+        flex-direction: column;
+    }
+}
+
+/* Dark Mode */
+body.dark-mode {
+    background-color: var(--toy-ink);
+    color: var(--toy-cream);
+}
+
+body.dark-mode .stat-card,
+body.dark-mode .history-entry,
+body.dark-mode .process-step,
+body.dark-mode .material-card,
+body.dark-mode .design-card,
+body.dark-mode .gallery-item,
+body.dark-mode .references-list li {
+    background: #2b241f;
+    color: var(--toy-cream);
+}
+
+body.dark-mode .stat-card p,
+body.dark-mode .material-card p,
+body.dark-mode .design-card p,
+body.dark-mode .process-step p,
+body.dark-mode .history-entry p {
+    color: var(--toy-cream);
+}
+
+body.dark-mode .stat-card h4,
+body.dark-mode .section-intro,
+body.dark-mode .gallery-item figcaption,
+body.dark-mode .channapatna-footer,
+body.dark-mode .history-period {
+    color: #cdb78f;
+}
+
+body.dark-mode .references-list a {
+    color: var(--lacquer-gold);
+}
+
+body.dark-mode .section-title {
+    color: var(--lacquer-gold);
+}
+
+body.dark-mode .history-entry h4,
+body.dark-mode .process-step h4,
+body.dark-mode .material-card h4,
+body.dark-mode .design-card h4 {
+    color: #ecc87a;
+}

--- a/frontend/channapatna-toys-explorer/channapatna.js
+++ b/frontend/channapatna-toys-explorer/channapatna.js
@@ -1,0 +1,122 @@
+/**
+ * Channapatna Toys Explorer — Controller Module
+ * Renders the data module into the explorer page.
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    initThemeToggle();
+    renderStats(CHANNAPATNA_INFO.quickStats, 'quick-stats');
+    renderHistory(HISTORY_CHAPTERS, 'history-timeline');
+    renderProcess(CRAFTING_PROCESS, 'process-steps');
+    renderMaterials(SUSTAINABLE_MATERIALS, 'materials-grid');
+    renderDesigns(TRADITIONAL_DESIGNS, 'designs-grid');
+    renderArtisan(ARTISAN_COMMUNITY, 'artisan-community');
+    renderGallery(GALLERY_IMAGES, 'gallery-grid');
+    renderReferences(REFERENCES, 'references');
+});
+
+function initThemeToggle() {
+    const toggle = document.querySelector('#theme-toggle');
+    if (!toggle) return;
+    toggle.addEventListener('click', () => {
+        document.body.classList.toggle('dark-mode');
+        localStorage.setItem('channapatna-theme', document.body.classList.contains('dark-mode') ? 'dark' : 'light');
+    });
+    if (localStorage.getItem('channapatna-theme') === 'dark') {
+        document.body.classList.add('dark-mode');
+    }
+}
+
+function renderStats(stats, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = stats.map(stat => `
+        <div class="stat-card">
+            <span class="stat-icon" aria-hidden="true">${stat.icon}</span>
+            <div>
+                <h4>${stat.label}</h4>
+                <p>${stat.value}</p>
+            </div>
+        </div>
+    `).join('');
+}
+
+function renderHistory(chapters, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = chapters.map(chapter => `
+        <div class="history-entry">
+            <div class="history-period">${chapter.period}</div>
+            <h4>${chapter.title}</h4>
+            <p>${chapter.description}</p>
+        </div>
+    `).join('');
+}
+
+function renderProcess(steps, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = steps.map(step => `
+        <div class="process-step">
+            <div class="step-number">${String(step.step).padStart(2, '0')}</div>
+            <div class="step-content">
+                <h4>${step.title}</h4>
+                <p>${step.description}</p>
+            </div>
+        </div>
+    `).join('');
+}
+
+function renderMaterials(materials, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = materials.map(material => `
+        <div class="material-card">
+            <div class="material-icon" aria-hidden="true">${material.icon}</div>
+            <h4>${material.name}</h4>
+            <p>${material.description}</p>
+        </div>
+    `).join('');
+}
+
+function renderDesigns(designs, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = designs.map(design => `
+        <div class="design-card">
+            <div class="design-icon" aria-hidden="true">${design.icon}</div>
+            <h4>${design.name}</h4>
+            <p>${design.description}</p>
+        </div>
+    `).join('');
+}
+
+function renderArtisan(community, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = `
+        <h2>${community.title}</h2>
+        <p>${community.description}</p>
+    `;
+}
+
+function renderGallery(images, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = images.map(image => `
+        <figure class="gallery-item">
+            <img src="${image.url}" alt="${image.caption}" loading="lazy" onerror="this.closest('.gallery-item').style.display='none';">
+            <figcaption>${image.caption}</figcaption>
+        </figure>
+    `).join('');
+}
+
+function renderReferences(references, containerId) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+    container.innerHTML = references.map(ref => `
+        <li>
+            <a href="${ref.link}" target="_blank" rel="noopener noreferrer">${ref.text}</a>
+        </li>
+    `).join('');
+}

--- a/frontend/channapatna-toys-explorer/index.html
+++ b/frontend/channapatna-toys-explorer/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Channapatna Toys Explorer — Karnataka's Lacquerware Craft</title>
+    <meta name="description" content="Explore Channapatna wooden toys — Karnataka's traditional lacquerware craftsmanship from the 'City of Toys', featuring bow-lathe turnery, natural lac, sustainable materials and iconic designs.">
+    <link rel="stylesheet" href="channapatna.css">
+</head>
+<body>
+    <nav class="channapatna-nav">
+        <h1>🐘 Channapatna Toys Explorer</h1>
+        <button class="theme-toggle-btn" id="theme-toggle" aria-label="Toggle dark mode">🌙 Toggle Theme</button>
+    </nav>
+
+    <main class="channapatna-main">
+        <section class="channapatna-hero">
+            <h2>Channapatna Toys<br>& Karnataka's Lacquerware Craft</h2>
+            <p class="tagline">From the 'City of Toys' come India's beloved wooden playthings — ivory wood turned on a bow lathe and sealed in warm, natural lac.</p>
+            <div class="hero-tags">
+                <span class="hero-tag">📍 Channapatna, Karnataka</span>
+                <span class="hero-tag">🏷️ GI Tagged (2005)</span>
+                <span class="hero-tag">✨ Natural Lacquer Finish</span>
+            </div>
+        </section>
+
+        <section>
+            <h2 class="section-title">At a Glance</h2>
+            <p class="section-intro">Channapatna is to Indian toys what Jaipur is to gems — a single small town whose handmade, lacquered wooden toys have charmed generations.</p>
+            <div id="quick-stats" class="stats-grid"></div>
+        </section>
+
+        <section>
+            <h2 class="section-title">Historical Overview</h2>
+            <p class="section-intro">From Tipu Sultan's Persian artisans to a GI tag and organic revival — the story of Gombegala Ooru, the City of Toys.</p>
+            <div id="history-timeline" class="history-timeline"></div>
+        </section>
+
+        <section>
+            <h2 class="section-title">The Crafting Process</h2>
+            <p class="section-intro">Six steps from forest to finished toy — how soft ivory wood becomes a glossy lacquered elephant.</p>
+            <div id="process-steps" class="process-steps"></div>
+        </section>
+
+        <section>
+            <h2 class="section-title">Sustainable Materials</h2>
+            <p class="section-intro">Nature-first toymaking: renewable timber, natural lac and food-grade colours — safe enough for a baby's mouth.</p>
+            <div id="materials-grid" class="materials-grid"></div>
+        </section>
+
+        <section>
+            <h2 class="section-title">Traditional Designs</h2>
+            <p class="section-intro">The elephants, tops, bells and kitchen sets that define the Channapatna toy box.</p>
+            <div id="designs-grid" class="designs-grid"></div>
+        </section>
+
+        <section class="artisan-section">
+            <div id="artisan-community"></div>
+        </section>
+
+        <section>
+            <h2 class="section-title">Gallery</h2>
+            <p class="section-intro">The lathe, the lacquer and the finished playthings — Channapatna at work and play.</p>
+            <div id="gallery-grid" class="gallery-grid"></div>
+        </section>
+
+        <section>
+            <h2 class="section-title">References & Further Reading</h2>
+            <ul id="references" class="references-list"></ul>
+        </section>
+
+        <footer class="channapatna-footer">
+            <p>Part of Incredible India Explorer — handcrafted heritage collection.</p>
+            <a class="back-link" href="../handicrafts-showcase/index.html">← Back to Indian Handicrafts Showcase</a>
+        </footer>
+    </main>
+
+    <script src="channapatna-data.js"></script>
+    <script src="channapatna.js"></script>
+</body>
+</html>

--- a/frontend/handicrafts-showcase/script.js
+++ b/frontend/handicrafts-showcase/script.js
@@ -1,6 +1,17 @@
 // ---------- Handicrafts Data (16 crafts across UP districts) ----------
 const allCrafts = [
   {
+    name: "Channapatna Toys",
+    icon: "🐘",
+    district: "Channapatna, Karnataka",
+    category: "toy",
+    tags: ["GI Tagged", "Lacquerware", "Wooden Toys"],
+    description: "Karnataka's iconic lacquerware wooden toys — ivory wood turned on a bow lathe and finished with natural lac in warm, glossy colours.",
+    history: "Handcrafted in the 'City of Toys' since the 18th century, when Tipu Sultan brought Persian lacquer artisans to Channapatna; GI-tagged in 2005.",
+    artisan: "Channapatna toymakers who shape soft aale-mara wood on bow-powered lathes and seal it with molten natural lac resin.",
+    detailsUrl: "../channapatna-toys-explorer/index.html"
+  },
+  {
     name: "Chhau Dance Masks",
     icon: "🎭",
     district: "Purulia & Charida",
@@ -10,7 +21,8 @@ const allCrafts = [
     history: "Centuries-old folk performance mask art created by Sutradhar artisans depicting Ramayana, Mahabharata, and Puranic deities.",
     artisan: "Charida village artisans in Purulia crafting lightweight paper-mache shells embellished with peacock feathers and zari crowns.",
     detailsUrl: "../chhau-masks-explorer/index.html"
-},
+  },
+  {
     name: "Bidriware Metal Inlay",
     icon: "✨",
     district: "Bidar, Karnataka",
@@ -20,7 +32,8 @@ const allCrafts = [
     history: "14th-century Bahmani Sultanate metalcraft developed in Bidar using unique nitrate-rich Bidar Fort soil for oxidation.",
     artisan: "Master Bidri engravers hammering pure silver wire into zinc-copper castings.",
     detailsUrl: "../bidriware-craftsmanship-explorer/index.html"
-},
+  },
+  {
     name: "Bastar Iron Craft (Loha Shilp)",
     icon: "🔨",
     district: "Bastar & Kondagaon",

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -1505,6 +1505,13 @@ window.indiaSearchIndex = [
     description: "Explore Chhau Masks Heritage — UNESCO Intangible Cultural Heritage of Purulia and Seraikela, paper-mache mask making, divine/asura mask types, and folk dance performance gallery.",
     url: "frontend/chhau-masks-explorer/index.html"
   },
+  // --- Channapatna Toys Explorer ---
+  {
+    title: "Channapatna Toys Explorer",
+    category: "Arts & Culture",
+    description: "Explore Channapatna Toys — Karnataka's GI-tagged lacquerware wooden toys, bow-lathe turnery, natural lac and sustainable materials, traditional designs and gallery.",
+    url: "frontend/channapatna-toys-explorer/index.html"
+  },
   // --- Bidriware Craftsmanship Explorer ---
   {
     title: "Bidriware Craftsmanship Explorer",

--- a/frontend/tests/unit/channapatna-toys-explorer.test.js
+++ b/frontend/tests/unit/channapatna-toys-explorer.test.js
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadChannapatnaData() {
+    const code = readFileSync(
+        resolve(__dirname, '../../channapatna-toys-explorer/channapatna-data.js'),
+        'utf-8'
+    );
+    const fn = new Function(
+        code + '\nreturn { CHANNAPATNA_INFO, HISTORY_CHAPTERS, CRAFTING_PROCESS, SUSTAINABLE_MATERIALS, TRADITIONAL_DESIGNS, ARTISAN_COMMUNITY, GALLERY_IMAGES, REFERENCES };'
+    );
+    return fn();
+}
+
+describe('Channapatna Toys Explorer — Data Tests', () => {
+    let data;
+
+    beforeAll(() => {
+        data = loadChannapatnaData();
+    });
+
+    describe('CHANNAPATNA_INFO metadata', () => {
+        it('contains correct Channapatna metadata and GI tag', () => {
+            expect(data.CHANNAPATNA_INFO.id).toBe('channapatna-toys');
+            expect(data.CHANNAPATNA_INFO.title).toContain('Channapatna');
+            expect(data.CHANNAPATNA_INFO.originRegion).toContain('Karnataka');
+            expect(data.CHANNAPATNA_INFO.giTagStatus).toContain('GI');
+        });
+
+        it('has quickStats array with 6 items', () => {
+            expect(Array.isArray(data.CHANNAPATNA_INFO.quickStats)).toBe(true);
+            expect(data.CHANNAPATNA_INFO.quickStats.length).toBe(6);
+        });
+    });
+
+    describe('HISTORY_CHAPTERS & CRAFTING_PROCESS', () => {
+        it('contains history chapters and crafting process steps', () => {
+            expect(Array.isArray(data.HISTORY_CHAPTERS)).toBe(true);
+            expect(data.HISTORY_CHAPTERS.length).toBeGreaterThanOrEqual(4);
+            expect(Array.isArray(data.CRAFTING_PROCESS)).toBe(true);
+            expect(data.CRAFTING_PROCESS.length).toBeGreaterThanOrEqual(5);
+        });
+    });
+
+    describe('SUSTAINABLE_MATERIALS & TRADITIONAL_DESIGNS', () => {
+        it('contains sustainable materials and traditional designs', () => {
+            expect(Array.isArray(data.SUSTAINABLE_MATERIALS)).toBe(true);
+            expect(data.SUSTAINABLE_MATERIALS.length).toBeGreaterThanOrEqual(3);
+            expect(Array.isArray(data.TRADITIONAL_DESIGNS)).toBe(true);
+            expect(data.TRADITIONAL_DESIGNS.length).toBeGreaterThanOrEqual(4);
+        });
+    });
+
+    describe('ARTISAN_COMMUNITY', () => {
+        it('contains artisan community details', () => {
+            expect(data.ARTISAN_COMMUNITY.title).toBeDefined();
+            expect(data.ARTISAN_COMMUNITY.description).toContain('Channapatna');
+        });
+    });
+
+    describe('GALLERY_IMAGES & REFERENCES', () => {
+        it('has non-empty gallery and references', () => {
+            expect(Array.isArray(data.GALLERY_IMAGES)).toBe(true);
+            expect(data.GALLERY_IMAGES.length).toBeGreaterThanOrEqual(2);
+            expect(Array.isArray(data.REFERENCES)).toBe(true);
+            expect(data.REFERENCES.length).toBeGreaterThanOrEqual(2);
+        });
+    });
+});


### PR DESCRIPTION
## feat: Introduce Channapatna toys with an interactive wooden craft explorer

Closes #1709

### Overview
Adds a fully self-contained **Channapatna Toys Explorer** page — a visually engaging showcase of Karnataka's traditional lacquerware wooden-toy craftsmanship from the 'City of Toys'.

### What's included
- **New explorer page** `frontend/channapatna-toys-explorer/` with 4 files:
  - `index.html` — page structure
  - `channapatna-data.js` — data module (info, quick stats, history, crafting process, sustainable materials, traditional designs, artisan community, gallery, references)
  - `channapatna.js` — controller (renders all sections + theme toggle)
  - `channapatna.css` — themed styling with dark-mode support
- **Landing page integration** — new Channapatna Toys card in `frontend/handicrafts-showcase/script.js` linking to the explorer.
- **Search index integration** — new entry in `frontend/search-index.js` (Arts & Culture).
- **Unit tests** — `frontend/tests/unit/channapatna-toys-explorer.test.js` (6 tests, all passing).

### Features per the issue
- **Historical overview** — 5-chapter timeline from Tipu Sultan's patronage and GI recognition to the organic revival
- **Interactive gallery** — 6 real Channapatna images from Wikimedia Commons (classic toys, artisans at the lathe, lacquer colouring, bangles)
- **Crafting process** — 6-step walkthrough (seasoning ivory wood → bow-lathe turnery → lacquer application → hand painting → finishing)
- **Sustainable materials** — ivory wood (Wrightia tinctoria), natural lac resin, food-grade dyes, plastic-free play
- **Traditional designs** — the Channapatna elephant, buguri top, gilike rattle, kitchen sets, bangles and toy trains
- **References** — GI registry, DCH Handicrafts, Karnataka Handicrafts Development Corporation, Sahapedia

### Note on the Indian Art Forms Visualizer
Issue #1709 asks for a Channapatna Toys card on the **Indian Art Forms Visualizer Explorer** landing page. That landing page is being built in parallel PR #1809 (`frontend/indian-art-forms-visualizer/`, by Aakif-Kohari) and is not yet on `main`. To keep this PR self-contained and conflict-free, the card is added here to the existing handicrafts-showcase landing + search index; once #1809 merges, a matching entry can be added to its `artFormsData` array (link: `../channapatna-toys-explorer/index.html`).

### Verification
- `node --check` passes on all modified/new JS files.
- `vitest` unit test passes (6/6); `search.test.js` and `smoke.test.js` also pass.

### Note
Also fixes a pre-existing syntax error in `frontend/handicrafts-showcase/script.js` where the Bidriware and Bastar entries were missing opening braces (introduced by earlier PRs), which made the file fail to parse.
