### PR TITLE
feat: Create Vakataka Dynasty Explorer (#1508)

### DIFF
--- a/frontend/history/dynasties/components/DynastyCard.js
+++ b/frontend/history/dynasties/components/DynastyCard.js
@@ -16,7 +16,7 @@ export function DynastyCard({ dynastyId, onExpand }) {
       </div>
       <span class="dynasty-card-period">${d.period}</span>
 <span class="dynasty-card-capital">Capital: ${d.capital}</span>
-      ${d.link ? `<a class="dynasty-card-link" href="${d.link}">View Full Explorer →</a>` : ''}
+      ${d.link ? `<a class="dynasty-card-link" href="${d.link}">View Full Explorer →</a>` : ''}      ${d.link ? `<a class="dynasty-card-link" href="${d.link}">View Full Explorer →</a>` : ''}
     </div>    <div class="dynasty-card-body">
       <div class="dynasty-card-stats">
         <div class="stat">

--- a/frontend/history/dynasties/components/DynastyCard.js
+++ b/frontend/history/dynasties/components/DynastyCard.js
@@ -16,6 +16,7 @@ export function DynastyCard({ dynastyId, onExpand }) {
       </div>
       <span class="dynasty-card-period">${d.period}</span>
 <span class="dynasty-card-capital">Capital: ${d.capital}</span>
+      ${d.link ? `<a class="dynasty-card-link" href="${d.link}">View Full Explorer →</a>` : ''}
       ${d.link ? `<a class="dynasty-card-link" href="${d.link}">View Full Explorer →</a>` : ''}      ${d.link ? `<a class="dynasty-card-link" href="${d.link}">View Full Explorer →</a>` : ''}
     </div>    <div class="dynasty-card-body">
       <div class="dynasty-card-stats">

--- a/frontend/history/dynasties/components/DynastyCard.js
+++ b/frontend/history/dynasties/components/DynastyCard.js
@@ -15,9 +15,9 @@ export function DynastyCard({ dynastyId, onExpand }) {
         <button class="expand-btn" aria-label="Expand details for ${d.name}">+</button>
       </div>
       <span class="dynasty-card-period">${d.period}</span>
-      <span class="dynasty-card-capital">Capital: ${d.capital}</span>
-    </div>
-    <div class="dynasty-card-body">
+<span class="dynasty-card-capital">Capital: ${d.capital}</span>
+      ${d.link ? `<a class="dynasty-card-link" href="${d.link}">View Full Explorer →</a>` : ''}
+    </div>    <div class="dynasty-card-body">
       <div class="dynasty-card-stats">
         <div class="stat">
           <span class="stat-label">Founder</span>

--- a/frontend/history/dynasties/data.js
+++ b/frontend/history/dynasties/data.js
@@ -229,6 +229,36 @@ art: "Bronze Nataraja, Brihadeshwara Temple, Thanjavur paintings, Chola bronzes"
     mapPosition: { top: "70%", left: "55%" }
   },
   {
+    id: "kanva",
+    name: "Kanva Dynasty",
+    period: "73–28 BCE",
+    startYear: -73,
+    endYear: -28,
+    capital: "Pataliputra (coins also found around Vidisha)",
+    founders: "Vasudeva Kanva",
+    notableRulers: [
+      { name: "Vasudeva Kanva", reign: "73–64 BCE", achievement: "Overthrew the last Shunga king Devabhuti and founded the Kanva dynasty" },
+      { name: "Bhumimitra", reign: "64–52 BCE", achievement: "Consolidated Kanva rule, coins found across Panchala, Vidisha, and Kaushambi" },
+      { name: "Susarman", reign: "40–28 BCE", achievement: "Last Kanva ruler, defeated by the Satavahana king Simuka" }
+    ],
+    territory: "Magadha, with influence extending into parts of central India",
+    peakExtent: "Pataliputra and the Magadha region, with coin evidence near Vidisha",
+    governance: "Continuation of the Shunga administrative system under a Brahmin ruling house",
+    military: "Limited historical record; relied on inherited Shunga-era forces",
+    decline: "Weak later rulers and rising Satavahana power; Susarman was overthrown by Simuka around 28 BCE",
+    contributions: [
+      "Preserved Brahmanical and Vedic traditions in Magadha after Shunga rule",
+      "Maintained continuity of administration during a fragmented post-Mauryan era",
+      "Patronized Sanskrit literature and scholarship",
+      "Numismatic evidence (Kanva coinage) provides key insight into post-Mauryan political geography",
+      "Served as a historical bridge between the Shunga and Satavahana periods"
+    ],
+    art: "Limited surviving material record; primarily known through coinage rather than monuments",
+    era: "ancient",
+    color: "#34495e",
+    mapPosition: { top: "33%", left: "58%" },
+    link: "kanva/index.html"
+  }  {
     id: "sena",
     name: "Sena Dynasty",
     period: "1070–1230 CE",
@@ -289,7 +319,10 @@ export const timelineEvents = [
   { year: 1720, event: "Peshwa Baji Rao I expands Maratha Empire", dynasty: "maratha" },
   { year: 1761, event: "Third Battle of Panipat — Maratha decline", dynasty: "maratha" },
 { year: 1857, event: "Fall of Mughal Empire — Bahadur Shah Zafar deposed", dynasty: "mughal" },
-  { year: 1096, event: "Vijaya Sena founds the Sena dynasty by deposing the Palas", dynasty: "sena" },
+  { year: -73, event: "Vasudeva Kanva overthrows the last Shunga king Devabhuti", dynasty: "kanva" },
+  { year: -64, event: "Bhumimitra succeeds Vasudeva Kanva as Kanva ruler", dynasty: "kanva" },
+  { year: -40, event: "Susarman, the last Kanva ruler, ascends the throne", dynasty: "kanva" },
+  { year: -28, event: "Satavahana ruler Simuka overthrows Susarman, ending Kanva rule", dynasty: "kanva" }  { year: 1096, event: "Vijaya Sena founds the Sena dynasty by deposing the Palas", dynasty: "sena" },
   { year: 1160, event: "Ballala Sena introduces Kulinism and ends Pala rule in Bengal", dynasty: "sena" },
   { year: 1178, event: "Lakshmana Sena ascends the throne, patronizes poet Jayadeva", dynasty: "sena" },
   { year: 1204, event: "Bakhtiyar Khalji invades Nabadwip, Sena capital falls", dynasty: "sena" },

--- a/frontend/history/dynasties/data.js
+++ b/frontend/history/dynasties/data.js
@@ -223,13 +223,44 @@ export const dynasties = [
       "Tamil literature and art flourished",
       "Chola bronze casting technique"
     ],
-    art: "Bronze Nataraja, Brihadeshwara Temple, Thanjavur paintings, Chola bronzes",
+art: "Bronze Nataraja, Brihadeshwara Temple, Thanjavur paintings, Chola bronzes",
     era: "medieval",
     color: "#1abc9c",
     mapPosition: { top: "70%", left: "55%" }
+  },
+  {
+    id: "sena",
+    name: "Sena Dynasty",
+    period: "1070–1230 CE",
+    startYear: 1070,
+    endYear: 1230,
+    capital: "Vikramapura, later Nabadwip (Nadia)",
+    founders: "Samanta Sena (progenitor); Vijaya Sena (established sovereign rule)",
+    notableRulers: [
+      { name: "Vijaya Sena", reign: "1096–1160 CE", achievement: "Deposed the Palas, founded the Sena kingdom, built the Pradyumneshvara temple" },
+      { name: "Ballala Sena", reign: "1160–1178 CE", achievement: "Ended Pala rule in Bengal, introduced the Kulinism social system" },
+      { name: "Lakshmana Sena", reign: "1178–1206 CE", achievement: "Greatest Sena king, patron of poet Jayadeva, expanded into Bihar and Odisha" }
+    ],
+    territory: "Bengal, extending into Bihar and Odisha at its peak",
+    peakExtent: "From north Bengal to coastal Odisha, west into Bihar and near Varanasi",
+    governance: "Feudal monarchy with land grants recorded on copper plates",
+    military: "Riverine navy along the Ganges, cavalry and infantry",
+    decline: "Muhammad Bakhtiyar Khalji's invasion of Nabadwip (c. 1204) captured northwest Bengal; the dynasty ended by 1230 with the rise of the Deva dynasty",
+    contributions: [
+      "Revival of orthodox Hinduism after Buddhist Pala rule",
+      "Kulinism — a lasting social classification system among Bengali Brahmins and Kayasthas",
+      "Patronage of Sanskrit court poetry, including Jayadeva's Gita Govinda",
+      "Deopara and Barrackpur copper-plate inscriptions documenting land grants",
+      "Bengal school of black basalt stone sculpture",
+      "Establishment of Nabadwip (Nadia) as a centre of learning and culture"
+    ],
+    art: "Sena-era black basalt sculpture, Sanskrit court poetry, temple architecture at Deopara",
+    era: "medieval",
+    color: "#c0392b",
+    mapPosition: { top: "38%", left: "78%" },
+    link: "sena/index.html"
   }
 ];
-
 export const eraInfo = {
   ancient: { label: "Ancient", color: "#e74c3c", description: "322 BCE – 550 CE" },
   medieval: { label: "Medieval", color: "#3498db", description: "1206 – 1700 CE" },
@@ -257,5 +288,10 @@ export const timelineEvents = [
   { year: 1674, event: "Shivaji Maharaj crowned Chhatrapati", dynasty: "maratha" },
   { year: 1720, event: "Peshwa Baji Rao I expands Maratha Empire", dynasty: "maratha" },
   { year: 1761, event: "Third Battle of Panipat — Maratha decline", dynasty: "maratha" },
-  { year: 1857, event: "Fall of Mughal Empire — Bahadur Shah Zafar deposed", dynasty: "mughal" }
+{ year: 1857, event: "Fall of Mughal Empire — Bahadur Shah Zafar deposed", dynasty: "mughal" },
+  { year: 1096, event: "Vijaya Sena founds the Sena dynasty by deposing the Palas", dynasty: "sena" },
+  { year: 1160, event: "Ballala Sena introduces Kulinism and ends Pala rule in Bengal", dynasty: "sena" },
+  { year: 1178, event: "Lakshmana Sena ascends the throne, patronizes poet Jayadeva", dynasty: "sena" },
+  { year: 1204, event: "Bakhtiyar Khalji invades Nabadwip, Sena capital falls", dynasty: "sena" },
+  { year: 1230, event: "Keshava Sena's reign ends — the Sena dynasty concludes", dynasty: "sena" }
 ];

--- a/frontend/history/dynasties/data.js
+++ b/frontend/history/dynasties/data.js
@@ -93,6 +93,7 @@ export const dynasties = [
       "Market regulation and price control systems",
       "Postal and intelligence networks"
     ],
+    
     art: "Indo-Islamic architecture, minarets, domes, arches, calligraphy, geometric patterns",
     era: "medieval",
     color: "#9b59b6",
@@ -223,12 +224,45 @@ export const dynasties = [
       "Tamil literature and art flourished",
       "Chola bronze casting technique"
     ],
-art: "Bronze Nataraja, Brihadeshwara Temple, Thanjavur paintings, Chola bronzes",
+ art: "Bronze Nataraja, Brihadeshwara Temple, Thanjavur paintings, Chola bronzes",
     era: "medieval",
     color: "#1abc9c",
     mapPosition: { top: "70%", left: "55%" }
   },
   {
+    id: "vakataka",
+    name: "Vakataka Dynasty",
+    period: "250–510 CE",
+    startYear: 250,
+    endYear: 510,
+    capital: "Nandivardhana, later Pravarapura; Vatsagulma (Washim) for the second branch",
+    founders: "Vindhyashakti",
+    notableRulers: [
+      { name: "Vindhyashakti", reign: "c. 250–270 CE", achievement: "Founded the Vakataka dynasty in the Deccan" },
+      { name: "Pravarasena I", reign: "c. 270–330 CE", achievement: "First Vakataka ruler to claim the title Samrat, greatly expanded the kingdom" },
+      { name: "Pravarasena II", reign: "c. 400–440 CE", achievement: "Composed the Setubandha, moved the capital to Pravarapura, issued numerous land grants" },
+      { name: "Harishena", reign: "c. 475–500 CE", achievement: "Greatest patron of the Ajanta Caves, extended the Vatsagulma branch to its peak" }
+    ],
+    territory: "Central India and the Deccan, primarily the Vidarbha region",
+    peakExtent: "From Malwa in the north to the Kuntala region in the south under Harishena",
+    governance: "Kingdom divided into provinces (rashtras) administered by Rajyadhikritas; extensive land-grant system",
+    military: "Regional Deccan power; matrimonial alliance rather than conflict with the Gupta Empire",
+    decline: "Rapid decline after Harishena's death around 500–510 CE; territories absorbed by neighbouring powers, paving the way for the rise of the Chalukyas",
+    contributions: [
+      "Patronage of the Ajanta Caves — UNESCO World Heritage rock-cut Buddhist monastery",
+      "Renowned Ajanta cave paintings and frescoes depicting Jataka tales",
+      "Sanskrit and Prakrit literary patronage, including Pravarasena II's Setubandha",
+      "Blend of indigenous, Gupta, and Satavahana architectural styles",
+      "Numerous land-grant copper-plate inscriptions documenting administration",
+      "Temple architecture, including a temple dedicated to Rama built by Pravarasena II"
+    ],
+    art: "Ajanta cave viharas and chaityas, Buddhist murals and sculpture, Vakataka-style temple architecture",
+    era: "ancient",
+    color: "#d35400",
+    mapPosition: { top: "55%", left: "50%" },
+    link: "vakataka/index.html"
+  },
+    {
     id: "kanva",
     name: "Kanva Dynasty",
     period: "73–28 BCE",
@@ -319,6 +353,11 @@ export const timelineEvents = [
   { year: 1720, event: "Peshwa Baji Rao I expands Maratha Empire", dynasty: "maratha" },
   { year: 1761, event: "Third Battle of Panipat — Maratha decline", dynasty: "maratha" },
 { year: 1857, event: "Fall of Mughal Empire — Bahadur Shah Zafar deposed", dynasty: "mughal" },
+  { year: 270, event: "Pravarasena I becomes the first Vakataka ruler to take the title Samrat", dynasty: "vakataka" },
+  { year: 385, event: "Rudrasena II marries Prabhavatigupta, daughter of Gupta emperor Chandragupta II", dynasty: "vakataka" },
+  { year: 405, event: "Pravarasena II composes the Setubandha and moves the capital to Pravarapura", dynasty: "vakataka" },
+  { year: 475, event: "Harishena becomes ruler and sponsors the finest phase of the Ajanta Caves", dynasty: "vakataka" },
+  { year: 510, event: "Vakataka dynasty declines after Harishena's death", dynasty: "vakataka" }
   { year: -73, event: "Vasudeva Kanva overthrows the last Shunga king Devabhuti", dynasty: "kanva" },
   { year: -64, event: "Bhumimitra succeeds Vasudeva Kanva as Kanva ruler", dynasty: "kanva" },
   { year: -40, event: "Susarman, the last Kanva ruler, ascends the throne", dynasty: "kanva" },

--- a/frontend/history/dynasties/kanva/index.html
+++ b/frontend/history/dynasties/kanva/index.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Kanva Dynasty Explorer - Discover the Kanva dynasty of Magadha (73-28 BCE), a brief but significant Brahmin dynasty that succeeded the Shunga Empire.">
+    <title>Kanva Dynasty Explorer | Incredible India Explorer</title>
+    <link rel="icon" href="data:,">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:wght@500;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="../../../styles.css">
+    <link rel="stylesheet" href="style.css">
+
+    <meta property="og:title" content="Kanva Dynasty Explorer | Incredible India Explorer">
+    <meta property="og:description" content="The Kanva dynasty of Magadha — rulers, timeline, contributions, and legacy following the Shunga Empire.">
+    <meta property="og:type" content="website">
+    <meta property="og:locale" content="en_IN">
+</head>
+
+<body class="kanva-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../../index.html#home" class="nav-link">Home</a>
+                <a href="../index.html" class="nav-link">Indian Dynasties</a>
+                <a href="index.html" class="nav-link active" style="color: #34495e">Kanva Dynasty</a>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+            </nav>
+        </div>
+    </header>
+
+    <main class="kanva-main">
+        <!-- Hero Banner -->
+        <section class="kanva-hero">
+            <span class="kanva-kicker">🏛️ Post-Mauryan Magadha Dynasty</span>
+            <h1>Kanva Dynasty Explorer</h1>
+            <p>The <strong>Kanva dynasty</strong> ruled Magadha from around 73 to 28 BCE — a brief, four-ruler Brahmin dynasty that rose from the ashes of the Shunga Empire and quietly bridged the gap before the Satavahanas overtook them.</p>
+
+            <div class="kanva-hero-stats">
+                <div class="kanva-hero-stat">
+                    <strong>73–28 BCE</strong>
+                    <span>Dynasty Period</span>
+                </div>
+                <div class="kanva-hero-stat">
+                    <strong>Magadha</strong>
+                    <span>Core Region</span>
+                </div>
+                <div class="kanva-hero-stat">
+                    <strong>4</strong>
+                    <span>Rulers</span>
+                </div>
+                <div class="kanva-hero-stat">
+                    <strong>Pataliputra</strong>
+                    <span>Capital</span>
+                </div>
+            </div>
+        </section>
+
+        <!-- Navigation Tabs -->
+        <div class="kanva-nav-tabs">
+            <button class="kanva-tab active" data-tab="overview">📜 Historical Overview</button>
+            <button class="kanva-tab" data-tab="timeline">🕰️ Timeline</button>
+            <button class="kanva-tab" data-tab="rulers">👑 Major Rulers</button>
+            <button class="kanva-tab" data-tab="contributions">🎨 Contributions</button>
+            <button class="kanva-tab" data-tab="gallery">🖼️ Gallery</button>
+            <button class="kanva-tab" data-tab="references">📚 References</button>
+        </div>
+
+        <!-- Historical Overview -->
+        <section id="overview" class="kanva-section active">
+            <div class="kanva-content-card">
+                <h2>📜 Historical Overview</h2>
+                <div class="kanva-content">
+                    <p>The <strong>Kanva dynasty</strong> (also called the Kanvayana dynasty) was a short-lived Brahmin ruling house that governed the Magadha region of ancient India from roughly <strong>73 BCE to 28 BCE</strong>. It emerged directly from the decline of the Shunga Empire, which had itself succeeded the mighty Maurya Empire a century earlier.</p>
+                    <p>Its founder, <strong>Vasudeva Kanva</strong>, was originally a Brahmana minister (Amatya) serving the last Shunga ruler, Devabhuti. According to Banabhatta's <em>Harshacharita</em>, Vasudeva orchestrated a palace coup, assassinating Devabhuti and seizing the throne for himself around 73 BCE — a transfer of power achieved through court intrigue rather than conquest.</p>
+                    <p>Puranic sources such as the Vishnu Purana and Matsya Purana record only <strong>four Kanva kings</strong> across roughly 45 years: Vasudeva, Bhumimitra, Narayana, and Susarman. While tradition places their capital at Pataliputra, surviving Kanva coinage is concentrated around Vidisha in central India, suggesting their real sphere of influence extended well beyond Magadha itself. The dynasty ended when Susarman was overthrown by Simuka, the founding king of the rising Satavahana dynasty, around 28 BCE — after which Magadha's era as an imperial seat faded until the Guptas revived it centuries later.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Timeline -->
+        <section id="timeline" class="kanva-section">
+            <div class="kanva-content-card">
+                <h2>🕰️ Timeline</h2>
+                <div class="kanva-content">
+                    <div class="kanva-timeline">
+                        <div class="kanva-timeline-item">
+                            <span class="kanva-timeline-year">c. 73 BCE</span>
+                            <p>Vasudeva Kanva, minister to the Shunga king Devabhuti, assassinates him and founds the Kanva dynasty.</p>
+                        </div>
+                        <div class="kanva-timeline-item">
+                            <span class="kanva-timeline-year">c. 64 BCE</span>
+                            <p>Bhumimitra succeeds his father Vasudeva Kanva; coins bearing his name appear across Panchala, Vidisha, and Kaushambi.</p>
+                        </div>
+                        <div class="kanva-timeline-item">
+                            <span class="kanva-timeline-year">c. 52 BCE</span>
+                            <p>Narayana becomes king, continuing Brahmanical traditions through a relatively undocumented reign.</p>
+                        </div>
+                        <div class="kanva-timeline-item">
+                            <span class="kanva-timeline-year">c. 40 BCE</span>
+                            <p>Susarman, the fourth and final Kanva ruler, ascends to the throne of a weakening kingdom.</p>
+                        </div>
+                        <div class="kanva-timeline-item">
+                            <span class="kanva-timeline-year">c. 28 BCE</span>
+                            <p>Simuka, founder of the Satavahana dynasty, overthrows Susarman — ending Kanva rule and Magadha's imperial standing for centuries.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Major Rulers -->
+        <section id="rulers" class="kanva-section">
+            <div class="kanva-content-card">
+                <h2>👑 Major Rulers</h2>
+                <div class="kanva-content">
+                    <div class="ruler-list">
+                        <div class="ruler-item">
+                            <h3>Vasudeva Kanva <span class="ruler-reign">(c. 73–64 BCE)</span></h3>
+                            <p>Founder of the dynasty. A Brahmana minister of Kanva gotra who served under the last Shunga king, Devabhuti, before assassinating him and taking the throne — an episode recorded in Banabhatta's <em>Harshacharita</em>.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Bhumimitra <span class="ruler-reign">(c. 64–52 BCE)</span></h3>
+                            <p>Son and successor of Vasudeva Kanva. Coins bearing his name have been found across Panchala, Vidisha, and Kaushambi, pointing to a kingdom that reached well beyond Magadha's borders.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Narayana <span class="ruler-reign">(c. 52–40 BCE)</span></h3>
+                            <p>Successor of Bhumimitra. His roughly twelve-year reign is thinly documented, though he appears to have maintained the kingdom's stability and Brahmanical traditions.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Susarman <span class="ruler-reign">(c. 40–28 BCE)</span></h3>
+                            <p>The fourth and last Kanva ruler. He was defeated and overthrown by Simuka, the founding king of the Satavahana dynasty, bringing the Kanva line to a close.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Contributions -->
+        <section id="contributions" class="kanva-section">
+            <div class="kanva-content-card">
+                <h2>🎨 Contributions</h2>
+                <div class="kanva-content">
+                    <ul class="kanva-list">
+                        <li><strong>Continuity of Brahmanical tradition:</strong> Preserved Vedic religious and administrative practices in Magadha after Shunga rule</li>
+                        <li><strong>Political bridge:</strong> Maintained a functioning, if reduced, state during the politically fragmented decades between the Shungas and the rise of the Satavahanas</li>
+                        <li><strong>Patronage of Sanskrit learning:</strong> Supported Sanskrit literature and scholarship, in keeping with their priestly Kanva-gotra background</li>
+                        <li><strong>Numismatic legacy:</strong> Kanva-era coinage remains the primary surviving evidence of the dynasty and has helped historians map post-Mauryan political geography around Vidisha</li>
+                        <li><strong>Administrative continuity:</strong> Largely retained the governance structures inherited from the Shunga period rather than overhauling them</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <!-- Gallery -->
+        <section id="gallery" class="kanva-section">
+            <div class="kanva-content-card">
+                <h2>🖼️ Gallery</h2>
+                <div class="kanva-content">
+                    <p>A visual look at the sparse but telling material record of the Kanva period.</p>
+                    <div class="gallery-grid">
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🪙</div>
+                            <h3>Kanva Coinage</h3>
+                            <p>Coins bearing rulers' names, found chiefly around Vidisha, remain the main surviving evidence of the dynasty.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">📜</div>
+                            <h3>Puranic Genealogies</h3>
+                            <p>The Vishnu Purana and Matsya Purana are the principal textual sources recording the four Kanva kings.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🏛️</div>
+                            <h3>Pataliputra</h3>
+                            <p>The traditional Kanva capital, inherited from the Shungas and Mauryas before them.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">📖</div>
+                            <h3>Harshacharita</h3>
+                            <p>Banabhatta's court chronicle, which records Vasudeva Kanva's coup against Devabhuti.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🕉️</div>
+                            <h3>Brahmanical Tradition</h3>
+                            <p>The Kanvas' priestly lineage tied them to the Kanva Shakha of the Shukla Yajurveda.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🗺️</div>
+                            <h3>Magadha & Vidisha</h3>
+                            <p>The dual centres of Kanva presence — Pataliputra in tradition, Vidisha in the archaeological record.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- References -->
+        <section id="references" class="kanva-section">
+            <div class="kanva-content-card">
+                <h2>📚 References</h2>
+                <div class="kanva-content">
+                    <ul class="kanva-list kanva-references">
+                        <li>Wikipedia — Kanva dynasty. <a href="https://en.wikipedia.org/wiki/Kanva_dynasty" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>Wikipedia — Vasudeva Kanva. <a href="https://en.wikipedia.org/wiki/Vasudeva_Kanva" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>Wikipedia — Devabhuti. <a href="https://en.wikipedia.org/wiki/Devabhuti" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>Encyclopaedia Britannica — Kanva dynasty. <a href="https://www.britannica.com/topic/Kanva-dynasty" target="_blank" rel="noopener noreferrer">britannica.com</a></li>
+                        <li>Raychaudhuri, H.C. (2006). <em>Political History of Ancient India</em>. Oxford University Press.</li>
+                        <li>GKToday — Kanva Dynasty overview. <a href="https://www.gktoday.in/kanva-dynasty/" target="_blank" rel="noopener noreferrer">gktoday.in</a></li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="kanva-footer">
+        <p>Part of <a href="../../../index.html" style="color: #FF9933;">Incredible India Explorer</a> · <a href="../index.html" style="color: #34495e;">Indian Dynasties Explorer</a></p>
+    </footer>
+
+    <script type="module" src="script.js"></script>
+</body>
+</html>

--- a/frontend/history/dynasties/kanva/script.js
+++ b/frontend/history/dynasties/kanva/script.js
@@ -1,0 +1,92 @@
+/**
+ * Kanva Dynasty Explorer - Interactive Script
+ * Handles tab navigation, smooth scrolling, theme toggle, and mobile menu
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    initTabNavigation();
+    initThemeToggle();
+    initMobileMenu();
+});
+
+/**
+ * Initialize tab navigation for different sections
+ */
+function initTabNavigation() {
+    const tabs = document.querySelectorAll('.kanva-tab');
+    const sections = document.querySelectorAll('.kanva-section');
+
+    tabs.forEach(tab => {
+        tab.addEventListener('click', () => {
+            const targetTab = tab.dataset.tab;
+
+            tabs.forEach(t => t.classList.remove('active'));
+            sections.forEach(s => s.classList.remove('active'));
+
+            tab.classList.add('active');
+            const targetSection = document.getElementById(targetTab);
+            if (targetSection) {
+                targetSection.classList.add('active');
+                targetSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+        });
+    });
+}
+
+/**
+ * Initialize theme toggle functionality
+ */
+function initThemeToggle() {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+
+    const currentTheme = localStorage.getItem('theme') || 'dark';
+    updateThemeIcon(currentTheme);
+
+    themeToggle.addEventListener('click', () => {
+        const body = document.body;
+        const isLight = body.classList.contains('light-theme');
+
+        if (isLight) {
+            body.classList.remove('light-theme');
+            localStorage.setItem('theme', 'dark');
+            updateThemeIcon('dark');
+        } else {
+            body.classList.add('light-theme');
+            localStorage.setItem('theme', 'light');
+            updateThemeIcon('light');
+        }
+    });
+}
+
+/**
+ * Update theme toggle icon
+ */
+function updateThemeIcon(theme) {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+    themeToggle.textContent = theme === 'light' ? '🌙' : '☀️';
+}
+
+/**
+ * Initialize mobile menu toggle
+ */
+function initMobileMenu() {
+    const menuToggle = document.getElementById('menu-toggle');
+    const navMenu = document.getElementById('nav-menu');
+
+    if (menuToggle && navMenu) {
+        menuToggle.addEventListener('click', () => {
+            const isExpanded = menuToggle.getAttribute('aria-expanded') === 'true';
+            menuToggle.setAttribute('aria-expanded', !isExpanded);
+            navMenu.classList.toggle('active');
+        });
+
+        document.addEventListener('click', (e) => {
+            if (!menuToggle.contains(e.target) && !navMenu.contains(e.target)) {
+                navMenu.classList.remove('active');
+                menuToggle.setAttribute('aria-expanded', 'false');
+            }
+        });
+    }
+}

--- a/frontend/history/dynasties/kanva/style.css
+++ b/frontend/history/dynasties/kanva/style.css
@@ -1,0 +1,341 @@
+/* ==========================================================================
+   Kanva Dynasty Explorer Styling
+   Post-Mauryan Magadha dynasty (c. 73-28 BCE)
+   ========================================================================== */
+
+.kanva-page-body {
+    background-color: var(--bg-primary, #0B0F19);
+    color: var(--text-primary, #E2E8F0);
+    font-family: 'Outfit', system-ui, -apple-system, sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+}
+
+.kanva-main {
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: 80px 20px 60px;
+}
+
+/* --- Hero Banner --- */
+.kanva-hero {
+    text-align: center;
+    padding: 48px 24px;
+    background: linear-gradient(135deg, rgba(11, 15, 25, 0.95) 0%, rgba(20, 27, 38, 0.9) 100%);
+    border: 1px solid rgba(52, 73, 94, 0.4);
+    border-radius: 16px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+    margin-bottom: 32px;
+    position: relative;
+    overflow: hidden;
+}
+
+.kanva-hero::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: linear-gradient(90deg, #FF9933 0%, #D4AF37 50%, #34495e 100%);
+}
+
+.kanva-kicker {
+    display: inline-block;
+    padding: 6px 16px;
+    background: rgba(52, 73, 94, 0.25);
+    color: #8ea3b8;
+    border: 1px solid rgba(52, 73, 94, 0.5);
+    border-radius: 20px;
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 16px;
+}
+
+.kanva-hero h1 {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 2.6rem;
+    font-weight: 700;
+    color: var(--text-heading, #F8FAFC);
+    margin: 0 0 12px;
+}
+
+.kanva-hero p {
+    font-size: 1.1rem;
+    color: var(--text-secondary, #94A3B8);
+    max-width: 850px;
+    margin: 0 auto 24px;
+}
+
+.kanva-hero-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 16px;
+    margin-top: 24px;
+}
+
+.kanva-hero-stat {
+    background: rgba(15, 23, 42, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    padding: 16px;
+    text-align: center;
+}
+
+.kanva-hero-stat strong {
+    display: block;
+    font-size: 1.4rem;
+    color: #FF9933;
+    font-family: 'Playfair Display', Georgia, serif;
+}
+
+.kanva-hero-stat span {
+    font-size: 0.8rem;
+    color: var(--text-secondary, #94A3B8);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+/* --- Navigation Tabs --- */
+.kanva-nav-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: center;
+    margin-bottom: 32px;
+    padding: 12px;
+    background: rgba(15, 23, 42, 0.5);
+    border-radius: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.kanva-tab {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: var(--text-secondary, #94A3B8);
+    padding: 8px 16px;
+    border-radius: 20px;
+    font-size: 0.88rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.25s ease;
+    white-space: nowrap;
+}
+
+.kanva-tab:hover {
+    border-color: rgba(52, 73, 94, 0.6);
+    color: #8ea3b8;
+}
+
+.kanva-tab.active {
+    background: linear-gradient(135deg, #34495e, #212f3c);
+    border-color: #34495e;
+    color: #fff;
+}
+
+.kanva-tab:focus-visible {
+    outline: 2px solid #FF9933;
+    outline-offset: 2px;
+}
+
+/* --- Content Sections --- */
+.kanva-section {
+    display: none;
+    animation: fadeIn 0.4s ease;
+}
+
+.kanva-section.active {
+    display: block;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.kanva-content-card {
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 16px;
+    padding: 32px;
+}
+
+.kanva-content-card h2 {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 1.8rem;
+    color: var(--text-heading, #F8FAFC);
+    margin: 0 0 20px;
+}
+
+.kanva-content h3 {
+    color: #8ea3b8;
+    font-size: 1.1rem;
+    margin: 0 0 6px;
+}
+
+.kanva-content p {
+    color: var(--text-secondary, #CBD5E1);
+    margin: 0 0 14px;
+}
+
+.kanva-list {
+    color: var(--text-secondary, #CBD5E1);
+    padding-left: 20px;
+    margin: 0 0 14px;
+}
+
+.kanva-list li {
+    margin-bottom: 8px;
+}
+
+.kanva-references a {
+    color: #8ea3b8;
+    text-decoration: none;
+}
+
+.kanva-references a:hover {
+    text-decoration: underline;
+}
+
+/* --- Timeline --- */
+.kanva-timeline {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    border-left: 2px solid rgba(52, 73, 94, 0.6);
+    padding-left: 20px;
+    margin-top: 8px;
+}
+
+.kanva-timeline-item {
+    position: relative;
+}
+
+.kanva-timeline-item::before {
+    content: '';
+    position: absolute;
+    left: -26px;
+    top: 4px;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: #34495e;
+}
+
+.kanva-timeline-year {
+    display: block;
+    font-weight: 700;
+    color: #FF9933;
+    font-family: 'Playfair Display', Georgia, serif;
+    margin-bottom: 4px;
+}
+
+.kanva-timeline-item p {
+    margin: 0;
+}
+
+/* --- Rulers --- */
+.ruler-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 16px;
+}
+
+.ruler-item {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 12px;
+    padding: 18px;
+}
+
+.ruler-reign {
+    font-size: 0.85rem;
+    color: var(--text-secondary, #94A3B8);
+    font-weight: 400;
+}
+
+/* --- Gallery --- */
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+    margin-top: 16px;
+}
+
+.gallery-item {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 12px;
+    padding: 20px;
+    text-align: center;
+    transition: transform 0.25s ease;
+}
+
+.gallery-item:hover {
+    transform: translateY(-4px);
+    border-color: rgba(52, 73, 94, 0.6);
+}
+
+.gallery-placeholder {
+    font-size: 2.6rem;
+    margin-bottom: 10px;
+}
+
+.gallery-item h3 {
+    margin: 0 0 6px;
+}
+
+.gallery-item p {
+    font-size: 0.9rem;
+    margin: 0;
+}
+
+/* --- Footer --- */
+.kanva-footer {
+    text-align: center;
+    padding: 30px 20px;
+    color: var(--text-secondary, #94A3B8);
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* --- Responsive --- */
+@media (max-width: 768px) {
+    .kanva-hero h1 {
+        font-size: 2rem;
+    }
+
+    .kanva-content-card {
+        padding: 20px;
+    }
+
+    .kanva-nav-tabs {
+        justify-content: flex-start;
+        overflow-x: auto;
+        flex-wrap: nowrap;
+    }
+
+    .kanva-timeline {
+        padding-left: 16px;
+    }
+}
+
+/* --- Light Theme Overrides --- */
+body.light-theme.kanva-page-body {
+    background-color: #F8FAFC;
+    color: #0F172A;
+}
+
+body.light-theme .kanva-content-card,
+body.light-theme .kanva-hero {
+    background: rgba(255, 255, 255, 0.85);
+    border-color: rgba(0, 0, 0, 0.08);
+}
+
+body.light-theme .kanva-content p,
+body.light-theme .kanva-list,
+body.light-theme .ruler-reign {
+    color: #334155;
+}

--- a/frontend/history/dynasties/sena/index.html
+++ b/frontend/history/dynasties/sena/index.html
@@ -1,0 +1,258 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Sena Dynasty Explorer - Discover the Sena dynasty of Bengal (c. 1070-1230 CE), its rulers, cultural achievements, and role in medieval Indian history.">
+    <title>Sena Dynasty Explorer | Incredible India Explorer</title>
+    <link rel="icon" href="data:,">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:wght@500;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="../../../styles.css">
+    <link rel="stylesheet" href="style.css">
+
+    <meta property="og:title" content="Sena Dynasty Explorer | Incredible India Explorer">
+    <meta property="og:description" content="The Sena dynasty of Bengal — rulers, timeline, contributions, and legacy.">
+    <meta property="og:type" content="website">
+    <meta property="og:locale" content="en_IN">
+</head>
+
+<body class="sena-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../../index.html#home" class="nav-link">Home</a>
+                <a href="../index.html" class="nav-link">Indian Dynasties</a>
+                <a href="index.html" class="nav-link active" style="color: #c0392b">Sena Dynasty</a>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+            </nav>
+        </div>
+    </header>
+
+    <main class="sena-main">
+        <!-- Hero Banner -->
+        <section class="sena-hero">
+            <span class="sena-kicker">🏛️ Medieval Bengal Dynasty</span>
+            <h1>Sena Dynasty Explorer</h1>
+            <p>The <strong>Sena dynasty</strong> ruled Bengal from roughly 1070 to 1230 CE, ending Buddhist Pala rule and ushering in an orthodox Hindu revival, a golden age of Sanskrit court poetry, and lasting social reform.</p>
+
+            <div class="sena-hero-stats">
+                <div class="sena-hero-stat">
+                    <strong>1070–1230 CE</strong>
+                    <span>Dynasty Period</span>
+                </div>
+                <div class="sena-hero-stat">
+                    <strong>Bengal</strong>
+                    <span>Core Region</span>
+                </div>
+                <div class="sena-hero-stat">
+                    <strong>6</strong>
+                    <span>Rulers</span>
+                </div>
+                <div class="sena-hero-stat">
+                    <strong>Nabadwip</strong>
+                    <span>Later Capital</span>
+                </div>
+            </div>
+        </section>
+
+        <!-- Navigation Tabs -->
+        <div class="sena-nav-tabs">
+            <button class="sena-tab active" data-tab="overview">📜 Historical Overview</button>
+            <button class="sena-tab" data-tab="timeline">🕰️ Timeline</button>
+            <button class="sena-tab" data-tab="rulers">👑 Major Rulers</button>
+            <button class="sena-tab" data-tab="contributions">🎨 Contributions</button>
+            <button class="sena-tab" data-tab="gallery">🖼️ Gallery</button>
+            <button class="sena-tab" data-tab="references">📚 References</button>
+        </div>
+
+        <!-- Historical Overview -->
+        <section id="overview" class="sena-section active">
+            <div class="sena-content-card">
+                <h2>📜 Historical Overview</h2>
+                <div class="sena-content">
+                    <p>The Sena dynasty traced its origins to a family of Karnataka-descended chieftains who had settled in the Rarh region of Bengal and served as feudatories under the declining Pala Empire. <strong>Samanta Sena</strong> was the family's progenitor, and his son <strong>Hemanta Sena</strong> was the first to claim royal status, around 1095 CE, as Pala authority crumbled.</p>
+                    <p>It was Hemanta's son, <strong>Vijaya Sena</strong>, who truly established Sena sovereignty — deposing the last effective Pala ruler, Madanapala, and consolidating control over Bengal during a reign of more than sixty years. His successors, <strong>Ballala Sena</strong> and <strong>Lakshmana Sena</strong>, expanded the kingdom and presided over its cultural high point, with Lakshmana Sena's court becoming a celebrated centre of Sanskrit learning and poetry.</p>
+                    <p>Unlike the Buddhist-leaning Palas before them, the Senas were devout Hindus, and their rule marked a decisive religious and cultural shift in Bengal. The dynasty's political power weakened sharply after Muhammad Bakhtiyar Khalji's invasion of Nabadwip around 1204 CE, though Sena rulers clung on in eastern Bengal for another quarter-century before the line ended with Keshava Sena around 1230 CE.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Timeline -->
+        <section id="timeline" class="sena-section">
+            <div class="sena-content-card">
+                <h2>🕰️ Timeline</h2>
+                <div class="sena-content">
+                    <div class="sena-timeline">
+                        <div class="sena-timeline-item">
+                            <span class="sena-timeline-year">c. 1070</span>
+                            <p>Samanta Sena, the dynasty's progenitor, is active as a local chieftain in the Rarh region under Pala overlordship.</p>
+                        </div>
+                        <div class="sena-timeline-item">
+                            <span class="sena-timeline-year">c. 1095</span>
+                            <p>Hemanta Sena becomes the first of the family to claim royal status as Pala power declines.</p>
+                        </div>
+                        <div class="sena-timeline-item">
+                            <span class="sena-timeline-year">1096–1160</span>
+                            <p>Vijaya Sena deposes the Palas, founds the Sena kingdom in earnest, and builds the Pradyumneshvara temple.</p>
+                        </div>
+                        <div class="sena-timeline-item">
+                            <span class="sena-timeline-year">1160–1178</span>
+                            <p>Ballala Sena ends Pala rule entirely, introduces Kulinism, and moves the capital toward Nadia.</p>
+                        </div>
+                        <div class="sena-timeline-item">
+                            <span class="sena-timeline-year">1178–1206</span>
+                            <p>Lakshmana Sena presides over the dynasty's cultural peak, patronising the poet Jayadeva and expanding into Bihar and Odisha.</p>
+                        </div>
+                        <div class="sena-timeline-item">
+                            <span class="sena-timeline-year">c. 1204</span>
+                            <p>Muhammad Bakhtiyar Khalji invades Nabadwip, capturing north-western Bengal and severely weakening Sena authority.</p>
+                        </div>
+                        <div class="sena-timeline-item">
+                            <span class="sena-timeline-year">1206–1230</span>
+                            <p>Vishvarupa Sena and Keshava Sena hold on to eastern Bengal until the dynasty ends and the Deva dynasty rises in its place.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Major Rulers -->
+        <section id="rulers" class="sena-section">
+            <div class="sena-content-card">
+                <h2>👑 Major Rulers</h2>
+                <div class="sena-content">
+                    <div class="ruler-list">
+                        <div class="ruler-item">
+                            <h3>Vijaya Sena <span class="ruler-reign">(1096–1160 CE)</span></h3>
+                            <p>The true founder of Sena sovereignty. He deposed the Pala king Madanapala, defeated rival rulers of Gauda, Kamarupa, and Kalinga, and commemorated his reign with the Deopara inscription and the Pradyumneshvara temple.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Ballala Sena <span class="ruler-reign">(1160–1178 CE)</span></h3>
+                            <p>Son of Vijaya Sena, he finally ended Pala rule by defeating Govindapala. He is best remembered for introducing <strong>Kulinism</strong>, a system of social ranking among Bengali Brahmins and Kayasthas that endured for centuries.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Lakshmana Sena <span class="ruler-reign">(1178–1206 CE)</span></h3>
+                            <p>Widely regarded as the greatest Sena king. He was the first to adopt the title <em>Gaudeshvara</em> ("Lord of Gauda"), extended Sena influence into Bihar, Odisha, and near Varanasi, and patronised the celebrated Sanskrit poet Jayadeva, author of the <em>Gita Govinda</em>.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Vishvarupa Sena <span class="ruler-reign">(1206–1225 CE)</span></h3>
+                            <p>Son of Lakshmana Sena, he ruled over the reduced eastern Bengal territories that remained after the loss of Nabadwip to Bakhtiyar Khalji's forces.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Keshava Sena <span class="ruler-reign">(1225–1230 CE)</span></h3>
+                            <p>The last known Sena ruler. After his reign, the dynasty came to an end, with the Deva dynasty rising to prominence in eastern Bengal.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Contributions -->
+        <section id="contributions" class="sena-section">
+            <div class="sena-content-card">
+                <h2>🎨 Contributions</h2>
+                <div class="sena-content">
+                    <ul class="sena-list">
+                        <li><strong>Religious revival:</strong> Restored orthodox Hinduism as Bengal's dominant faith after centuries of Buddhist Pala patronage</li>
+                        <li><strong>Kulinism:</strong> A social ranking system for Brahmins and Kayasthas, introduced by Ballala Sena, that shaped Bengali society for generations</li>
+                        <li><strong>Sanskrit literature:</strong> Royal patronage of poets and scholars, most famously Jayadeva, whose <em>Gita Govinda</em> remains a landmark of devotional Sanskrit poetry</li>
+                        <li><strong>Epigraphy:</strong> The Deopara and Barrackpur copper-plate inscriptions, which record land grants and provide key historical detail on Sena rule</li>
+                        <li><strong>Sculpture:</strong> Development of the distinctive Bengal school of black basalt stone image-making</li>
+                        <li><strong>Centre of learning:</strong> Establishment of Nabadwip (Nadia) as a seat of culture and scholarship, laying groundwork for its later fame as a hub of Sanskrit and Nyaya studies</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <!-- Gallery -->
+        <section id="gallery" class="sena-section">
+            <div class="sena-content-card">
+                <h2>🖼️ Gallery</h2>
+                <div class="sena-content">
+                    <p>A visual look at Sena-era Bengal and its cultural legacy.</p>
+                    <div class="gallery-grid">
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🗿</div>
+                            <h3>Black Basalt Sculpture</h3>
+                            <p>The distinctive Sena-era stone sculpture style associated with Bengal temple art.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">📜</div>
+                            <h3>Copper-Plate Inscriptions</h3>
+                            <p>The Deopara and Barrackpur inscriptions record land grants and royal genealogy.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🕉️</div>
+                            <h3>Temple Architecture</h3>
+                            <p>The Pradyumneshvara temple built by Vijaya Sena near present-day Rajshahi.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">📖</div>
+                            <h3>Gita Govinda</h3>
+                            <p>Jayadeva's celebrated Sanskrit poem, composed under Lakshmana Sena's patronage.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🌊</div>
+                            <h3>The Ganges Delta</h3>
+                            <p>The riverine heartland of Bengal that the Sena navy patrolled and controlled.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🗺️</div>
+                            <h3>Sena Territory</h3>
+                            <p>The kingdom's reach across Bengal into parts of Bihar and Odisha at its height.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- References -->
+        <section id="references" class="sena-section">
+            <div class="sena-content-card">
+                <h2>📚 References</h2>
+                <div class="sena-content">
+                    <ul class="sena-list sena-references">
+                        <li>Wikipedia — Sena dynasty. <a href="https://en.wikipedia.org/wiki/Sena_dynasty" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>Wikipedia — Vijaya Sena. <a href="https://en.wikipedia.org/wiki/Vijaya_Sena" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>Wikipedia — Ballāla Sena. <a href="https://en.wikipedia.org/wiki/Ball%C4%81la_Sena" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>Wikipedia — Lakshmana Sena. <a href="https://en.wikipedia.org/wiki/Lakshmana_Sena" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>Sen, Sailendra Nath (1999). <em>Ancient Indian History and Civilization</em>. New Age International.</li>
+                        <li>UGC NET / UPSC history notes — The Senas of Bengal. <a href="https://testbook.com/ias-preparation/senas-of-bengal" target="_blank" rel="noopener noreferrer">testbook.com</a></li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="sena-footer">
+        <p>Part of <a href="../../../index.html" style="color: #FF9933;">Incredible India Explorer</a> · <a href="../index.html" style="color: #c0392b;">Indian Dynasties Explorer</a></p>
+    </footer>
+
+    <script type="module" src="script.js"></script>
+</body>
+</html>

--- a/frontend/history/dynasties/sena/script.js
+++ b/frontend/history/dynasties/sena/script.js
@@ -1,0 +1,92 @@
+/**
+ * Sena Dynasty Explorer - Interactive Script
+ * Handles tab navigation, smooth scrolling, theme toggle, and mobile menu
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    initTabNavigation();
+    initThemeToggle();
+    initMobileMenu();
+});
+
+/**
+ * Initialize tab navigation for different sections
+ */
+function initTabNavigation() {
+    const tabs = document.querySelectorAll('.sena-tab');
+    const sections = document.querySelectorAll('.sena-section');
+
+    tabs.forEach(tab => {
+        tab.addEventListener('click', () => {
+            const targetTab = tab.dataset.tab;
+
+            tabs.forEach(t => t.classList.remove('active'));
+            sections.forEach(s => s.classList.remove('active'));
+
+            tab.classList.add('active');
+            const targetSection = document.getElementById(targetTab);
+            if (targetSection) {
+                targetSection.classList.add('active');
+                targetSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+        });
+    });
+}
+
+/**
+ * Initialize theme toggle functionality
+ */
+function initThemeToggle() {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+
+    const currentTheme = localStorage.getItem('theme') || 'dark';
+    updateThemeIcon(currentTheme);
+
+    themeToggle.addEventListener('click', () => {
+        const body = document.body;
+        const isLight = body.classList.contains('light-theme');
+
+        if (isLight) {
+            body.classList.remove('light-theme');
+            localStorage.setItem('theme', 'dark');
+            updateThemeIcon('dark');
+        } else {
+            body.classList.add('light-theme');
+            localStorage.setItem('theme', 'light');
+            updateThemeIcon('light');
+        }
+    });
+}
+
+/**
+ * Update theme toggle icon
+ */
+function updateThemeIcon(theme) {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+    themeToggle.textContent = theme === 'light' ? '🌙' : '☀️';
+}
+
+/**
+ * Initialize mobile menu toggle
+ */
+function initMobileMenu() {
+    const menuToggle = document.getElementById('menu-toggle');
+    const navMenu = document.getElementById('nav-menu');
+
+    if (menuToggle && navMenu) {
+        menuToggle.addEventListener('click', () => {
+            const isExpanded = menuToggle.getAttribute('aria-expanded') === 'true';
+            menuToggle.setAttribute('aria-expanded', !isExpanded);
+            navMenu.classList.toggle('active');
+        });
+
+        document.addEventListener('click', (e) => {
+            if (!menuToggle.contains(e.target) && !navMenu.contains(e.target)) {
+                navMenu.classList.remove('active');
+                menuToggle.setAttribute('aria-expanded', 'false');
+            }
+        });
+    }
+}

--- a/frontend/history/dynasties/sena/style.css
+++ b/frontend/history/dynasties/sena/style.css
@@ -1,0 +1,341 @@
+/* ==========================================================================
+   Sena Dynasty Explorer Styling
+   Medieval Bengal dynasty (c. 1070-1230 CE)
+   ========================================================================== */
+
+.sena-page-body {
+    background-color: var(--bg-primary, #0B0F19);
+    color: var(--text-primary, #E2E8F0);
+    font-family: 'Outfit', system-ui, -apple-system, sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+}
+
+.sena-main {
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: 80px 20px 60px;
+}
+
+/* --- Hero Banner --- */
+.sena-hero {
+    text-align: center;
+    padding: 48px 24px;
+    background: linear-gradient(135deg, rgba(11, 15, 25, 0.95) 0%, rgba(45, 15, 12, 0.85) 100%);
+    border: 1px solid rgba(192, 57, 43, 0.3);
+    border-radius: 16px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+    margin-bottom: 32px;
+    position: relative;
+    overflow: hidden;
+}
+
+.sena-hero::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: linear-gradient(90deg, #FF9933 0%, #D4AF37 50%, #c0392b 100%);
+}
+
+.sena-kicker {
+    display: inline-block;
+    padding: 6px 16px;
+    background: rgba(192, 57, 43, 0.2);
+    color: #e57368;
+    border: 1px solid rgba(192, 57, 43, 0.4);
+    border-radius: 20px;
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 16px;
+}
+
+.sena-hero h1 {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 2.6rem;
+    font-weight: 700;
+    color: var(--text-heading, #F8FAFC);
+    margin: 0 0 12px;
+}
+
+.sena-hero p {
+    font-size: 1.1rem;
+    color: var(--text-secondary, #94A3B8);
+    max-width: 850px;
+    margin: 0 auto 24px;
+}
+
+.sena-hero-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 16px;
+    margin-top: 24px;
+}
+
+.sena-hero-stat {
+    background: rgba(15, 23, 42, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    padding: 16px;
+    text-align: center;
+}
+
+.sena-hero-stat strong {
+    display: block;
+    font-size: 1.4rem;
+    color: #FF9933;
+    font-family: 'Playfair Display', Georgia, serif;
+}
+
+.sena-hero-stat span {
+    font-size: 0.8rem;
+    color: var(--text-secondary, #94A3B8);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+/* --- Navigation Tabs --- */
+.sena-nav-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: center;
+    margin-bottom: 32px;
+    padding: 12px;
+    background: rgba(15, 23, 42, 0.5);
+    border-radius: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.sena-tab {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: var(--text-secondary, #94A3B8);
+    padding: 8px 16px;
+    border-radius: 20px;
+    font-size: 0.88rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.25s ease;
+    white-space: nowrap;
+}
+
+.sena-tab:hover {
+    border-color: rgba(192, 57, 43, 0.5);
+    color: #e57368;
+}
+
+.sena-tab.active {
+    background: linear-gradient(135deg, #c0392b, #922016);
+    border-color: #c0392b;
+    color: #fff;
+}
+
+.sena-tab:focus-visible {
+    outline: 2px solid #FF9933;
+    outline-offset: 2px;
+}
+
+/* --- Content Sections --- */
+.sena-section {
+    display: none;
+    animation: fadeIn 0.4s ease;
+}
+
+.sena-section.active {
+    display: block;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.sena-content-card {
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 16px;
+    padding: 32px;
+}
+
+.sena-content-card h2 {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 1.8rem;
+    color: var(--text-heading, #F8FAFC);
+    margin: 0 0 20px;
+}
+
+.sena-content h3 {
+    color: #e57368;
+    font-size: 1.1rem;
+    margin: 0 0 6px;
+}
+
+.sena-content p {
+    color: var(--text-secondary, #CBD5E1);
+    margin: 0 0 14px;
+}
+
+.sena-list {
+    color: var(--text-secondary, #CBD5E1);
+    padding-left: 20px;
+    margin: 0 0 14px;
+}
+
+.sena-list li {
+    margin-bottom: 8px;
+}
+
+.sena-references a {
+    color: #e57368;
+    text-decoration: none;
+}
+
+.sena-references a:hover {
+    text-decoration: underline;
+}
+
+/* --- Timeline --- */
+.sena-timeline {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    border-left: 2px solid rgba(192, 57, 43, 0.4);
+    padding-left: 20px;
+    margin-top: 8px;
+}
+
+.sena-timeline-item {
+    position: relative;
+}
+
+.sena-timeline-item::before {
+    content: '';
+    position: absolute;
+    left: -26px;
+    top: 4px;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: #c0392b;
+}
+
+.sena-timeline-year {
+    display: block;
+    font-weight: 700;
+    color: #FF9933;
+    font-family: 'Playfair Display', Georgia, serif;
+    margin-bottom: 4px;
+}
+
+.sena-timeline-item p {
+    margin: 0;
+}
+
+/* --- Rulers --- */
+.ruler-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 16px;
+}
+
+.ruler-item {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 12px;
+    padding: 18px;
+}
+
+.ruler-reign {
+    font-size: 0.85rem;
+    color: var(--text-secondary, #94A3B8);
+    font-weight: 400;
+}
+
+/* --- Gallery --- */
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+    margin-top: 16px;
+}
+
+.gallery-item {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 12px;
+    padding: 20px;
+    text-align: center;
+    transition: transform 0.25s ease;
+}
+
+.gallery-item:hover {
+    transform: translateY(-4px);
+    border-color: rgba(192, 57, 43, 0.4);
+}
+
+.gallery-placeholder {
+    font-size: 2.6rem;
+    margin-bottom: 10px;
+}
+
+.gallery-item h3 {
+    margin: 0 0 6px;
+}
+
+.gallery-item p {
+    font-size: 0.9rem;
+    margin: 0;
+}
+
+/* --- Footer --- */
+.sena-footer {
+    text-align: center;
+    padding: 30px 20px;
+    color: var(--text-secondary, #94A3B8);
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* --- Responsive --- */
+@media (max-width: 768px) {
+    .sena-hero h1 {
+        font-size: 2rem;
+    }
+
+    .sena-content-card {
+        padding: 20px;
+    }
+
+    .sena-nav-tabs {
+        justify-content: flex-start;
+        overflow-x: auto;
+        flex-wrap: nowrap;
+    }
+
+    .sena-timeline {
+        padding-left: 16px;
+    }
+}
+
+/* --- Light Theme Overrides --- */
+body.light-theme.sena-page-body {
+    background-color: #F8FAFC;
+    color: #0F172A;
+}
+
+body.light-theme .sena-content-card,
+body.light-theme .sena-hero {
+    background: rgba(255, 255, 255, 0.85);
+    border-color: rgba(0, 0, 0, 0.08);
+}
+
+body.light-theme .sena-content p,
+body.light-theme .sena-list,
+body.light-theme .ruler-reign {
+    color: #334155;
+}

--- a/frontend/history/dynasties/styles.css
+++ b/frontend/history/dynasties/styles.css
@@ -84,6 +84,20 @@
   text-decoration: underline;
 }
 
+.dynasty-card-body {
+.dynasty-card-link {
+  display: inline-block;
+  margin-top: 8px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--dynasty-color, #fff);
+  text-decoration: none;
+}
+
+.dynasty-card-link:hover {
+  text-decoration: underline;
+}
+
 .dynasty-card-link {
   display: inline-block;
   margin-top: 8px;

--- a/frontend/history/dynasties/styles.css
+++ b/frontend/history/dynasties/styles.css
@@ -71,8 +71,20 @@
   margin-top: 2px;
 }
 
-.dynasty-card-body {
-  padding: 16px 24px 20px;
+.dynasty-card-link {
+  display: inline-block;
+  margin-top: 8px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--dynasty-color, #fff);
+  text-decoration: none;
+}
+
+.dynasty-card-link:hover {
+  text-decoration: underline;
+}
+
+.dynasty-card-body {  padding: 16px 24px 20px;
 }
 
 .dynasty-card-stats {

--- a/frontend/history/dynasties/styles.css
+++ b/frontend/history/dynasties/styles.css
@@ -84,6 +84,19 @@
   text-decoration: underline;
 }
 
+.dynasty-card-link {
+  display: inline-block;
+  margin-top: 8px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--dynasty-color, #fff);
+  text-decoration: none;
+}
+
+.dynasty-card-link:hover {
+  text-decoration: underline;
+}
+
 .dynasty-card-body {  padding: 16px 24px 20px;
 }
 

--- a/frontend/history/dynasties/vakataka/index.html
+++ b/frontend/history/dynasties/vakataka/index.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Vakataka Dynasty Explorer - Discover the Vakataka dynasty of the Deccan (c. 250-510 CE), renowned for its patronage of the Ajanta Caves and Sanskrit literature.">
+    <title>Vakataka Dynasty Explorer | Incredible India Explorer</title>
+    <link rel="icon" href="data:,">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:wght@500;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="../../../styles.css">
+    <link rel="stylesheet" href="style.css">
+
+    <meta property="og:title" content="Vakataka Dynasty Explorer | Incredible India Explorer">
+    <meta property="og:description" content="The Vakataka dynasty of the Deccan — rulers, timeline, art and architecture, and the legacy of the Ajanta Caves.">
+    <meta property="og:type" content="website">
+    <meta property="og:locale" content="en_IN">
+</head>
+
+<body class="vak-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../../index.html#home" class="nav-link">Home</a>
+                <a href="../index.html" class="nav-link">Indian Dynasties</a>
+                <a href="index.html" class="nav-link active" style="color: #d35400">Vakataka Dynasty</a>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+            </nav>
+        </div>
+    </header>
+
+    <main class="vak-main">
+        <!-- Hero Banner -->
+        <section class="vak-hero">
+            <span class="vak-kicker">🎨 Deccan Dynasty & Patrons of Ajanta</span>
+            <h1>Vakataka Dynasty Explorer</h1>
+            <p>The <strong>Vakataka dynasty</strong> ruled the Deccan and central India from roughly 250 to 510 CE. Allied by marriage to the Guptas and remembered above all for sponsoring the breathtaking rock-cut art of the <strong>Ajanta Caves</strong>, the Vakatakas left one of ancient India's greatest cultural legacies.</p>
+
+            <div class="vak-hero-stats">
+                <div class="vak-hero-stat">
+                    <strong>250–510 CE</strong>
+                    <span>Dynasty Period</span>
+                </div>
+                <div class="vak-hero-stat">
+                    <strong>Deccan</strong>
+                    <span>Core Region</span>
+                </div>
+                <div class="vak-hero-stat">
+                    <strong>2</strong>
+                    <span>Ruling Branches</span>
+                </div>
+                <div class="vak-hero-stat">
+                    <strong>Ajanta</strong>
+                    <span>UNESCO Legacy</span>
+                </div>
+            </div>
+        </section>
+
+        <!-- Navigation Tabs -->
+        <div class="vak-nav-tabs">
+            <button class="vak-tab active" data-tab="overview">📜 Historical Overview</button>
+            <button class="vak-tab" data-tab="timeline">🕰️ Timeline</button>
+            <button class="vak-tab" data-tab="rulers">👑 Major Rulers</button>
+            <button class="vak-tab" data-tab="art">🏛️ Art & Architecture</button>
+            <button class="vak-tab" data-tab="gallery">🖼️ Gallery</button>
+            <button class="vak-tab" data-tab="references">📚 References</button>
+        </div>
+
+        <!-- Historical Overview -->
+        <section id="overview" class="vak-section active">
+            <div class="vak-content-card">
+                <h2>📜 Historical Overview</h2>
+                <div class="vak-content">
+                    <p>The <strong>Vakataka dynasty</strong> rose in the Deccan region of central India around 250 CE, in the political space left by the declining Satavahanas. Its founder, <strong>Vindhyashakti</strong>, was a Brahmin chieftain whose son, <strong>Pravarasena I</strong>, became the first Vakataka ruler to claim the imperial title <em>Samrat</em>, extending the kingdom's reach across a large part of the Deccan and into northern India.</p>
+                    <p>After Pravarasena I, the dynasty split into two main branches: the <strong>Pravarapura-Nandivardhana branch</strong> and the <strong>Vatsagulma branch</strong>. The Nandivardhana branch grew especially close to the Gupta Empire when <strong>Rudrasena II</strong> married <strong>Prabhavatigupta</strong>, daughter of the great Gupta emperor Chandragupta II — Prabhavatigupta later ruled as regent for two decades, tying Vakataka court culture closely to Gupta traditions.</p>
+                    <p>It was the <strong>Vatsagulma branch</strong>, however, that produced the dynasty's most enduring legacy. Under its last powerful ruler, <strong>Harishena</strong>, the kingdom reached its greatest extent and became the chief patron of the <strong>Ajanta Caves</strong> — the rock-cut Buddhist viharas and chaityas whose paintings are counted among the finest surviving works of ancient Indian art. The dynasty declined rapidly after Harishena's death around 500–510 CE, its territories eventually absorbed by neighbouring powers as the Chalukyas rose to prominence in the Deccan.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Timeline -->
+        <section id="timeline" class="vak-section">
+            <div class="vak-content-card">
+                <h2>🕰️ Timeline</h2>
+                <div class="vak-content">
+                    <div class="vak-timeline">
+                        <div class="vak-timeline-item">
+                            <span class="vak-timeline-year">c. 250 CE</span>
+                            <p>Vindhyashakti founds the Vakataka dynasty in the Deccan.</p>
+                        </div>
+                        <div class="vak-timeline-item">
+                            <span class="vak-timeline-year">c. 270 CE</span>
+                            <p>Pravarasena I becomes the first Vakataka ruler to take the imperial title <em>Samrat</em>, greatly expanding the kingdom.</p>
+                        </div>
+                        <div class="vak-timeline-item">
+                            <span class="vak-timeline-year">c. 385 CE</span>
+                            <p>Rudrasena II marries Prabhavatigupta, daughter of the Gupta emperor Chandragupta II, linking the Vakatakas closely to the Gupta Empire.</p>
+                        </div>
+                        <div class="vak-timeline-item">
+                            <span class="vak-timeline-year">c. 405 CE</span>
+                            <p>Pravarasena II composes the Sanskrit-Prakrit epic <em>Setubandha</em> and moves the capital to his newly founded city, Pravarapura.</p>
+                        </div>
+                        <div class="vak-timeline-item">
+                            <span class="vak-timeline-year">c. 475 CE</span>
+                            <p>Harishena becomes ruler of the Vatsagulma branch and sponsors the finest phase of construction and painting at the Ajanta Caves.</p>
+                        </div>
+                        <div class="vak-timeline-item">
+                            <span class="vak-timeline-year">c. 500–510 CE</span>
+                            <p>The Vakataka dynasty declines rapidly after Harishena's death, its territory absorbed by rising regional powers.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Major Rulers -->
+        <section id="rulers" class="vak-section">
+            <div class="vak-content-card">
+                <h2>👑 Major Rulers</h2>
+                <div class="vak-content">
+                    <div class="ruler-list">
+                        <div class="ruler-item">
+                            <h3>Vindhyashakti <span class="ruler-reign">(c. 250–270 CE)</span></h3>
+                            <p>Founder of the Vakataka dynasty, remembered in inscriptions as an outstanding warrior who established the family's power in the Deccan.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Pravarasena I <span class="ruler-reign">(c. 270–330 CE)</span></h3>
+                            <p>Widely regarded as the dynasty's greatest early ruler. The first Vakataka king to claim the title <em>Samrat</em>, he expanded the kingdom across a large part of the Deccan and northern India.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Rudrasena II <span class="ruler-reign">(c. 380–385 CE)</span></h3>
+                            <p>Ruler of the Pravarapura-Nandivardhana branch, whose marriage to the Gupta princess Prabhavatigupta forged a lasting alliance between the two dynasties.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Pravarasena II <span class="ruler-reign">(c. 400–440 CE)</span></h3>
+                            <p>Son of Prabhavatigupta, he composed the celebrated Prakrit poem <em>Setubandha</em>, founded the city of Pravarapura, and issued numerous land-grant inscriptions — making him one of the best-documented rulers of ancient India after Ashoka.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Harishena <span class="ruler-reign">(c. 475–500 CE)</span></h3>
+                            <p>The most powerful ruler of the Vatsagulma branch and a great patron of Buddhist art and architecture. His reign produced the finest surviving work at the Ajanta Caves, his most enduring legacy.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Art & Architecture -->
+        <section id="art" class="vak-section">
+            <div class="vak-content-card">
+                <h2>🏛️ Art & Architecture</h2>
+                <div class="vak-content">
+                    <p>The Vakatakas are remembered above all as <strong>patrons of the arts</strong>, and their architectural style blended indigenous Deccan traditions with influences from the Gupta and Satavahana periods.</p>
+                    <ul class="vak-list">
+                        <li><strong>Ajanta Caves:</strong> Under the Vatsagulma branch, especially Harishena, rock-cut Buddhist viharas (monasteries) and chaityas (prayer halls) were carved into the cliffs at Ajanta, decorated with murals depicting Jataka tales — now a UNESCO World Heritage Site</li>
+                        <li><strong>Cave painting and sculpture:</strong> The "second phase" of Ajanta's paintings and sculpture corresponds directly to the Vakataka period, considered among the finest examples of ancient Indian art</li>
+                        <li><strong>Sanskrit and Prakrit literature:</strong> Pravarasena II's Maharashtri Prakrit poem <em>Setubandha</em> stands among the dynasty's major literary contributions</li>
+                        <li><strong>Temple architecture:</strong> Pravarasena II is credited with building a temple dedicated to Rama at his new capital, Pravarapura</li>
+                        <li><strong>Epigraphy:</strong> Around 35 recorded land grants, inscribed on copper plates, provide detailed insight into Vakataka administration and patronage — Pravarasena II alone issued about 20 of them</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <!-- Gallery -->
+        <section id="gallery" class="vak-section">
+            <div class="vak-content-card">
+                <h2>🖼️ Gallery</h2>
+                <div class="vak-content">
+                    <p>A visual look at the Vakataka dynasty's artistic and architectural legacy.</p>
+                    <div class="gallery-grid">
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🕌</div>
+                            <h3>Ajanta Cave Facades</h3>
+                            <p>Rock-cut viharas and chaityas carved into the cliffs above the Waghora River.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🖌️</div>
+                            <h3>Ajanta Murals</h3>
+                            <p>Buddhist frescoes depicting Jataka tales, among the finest surviving ancient Indian paintings.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🗿</div>
+                            <h3>Buddhist Sculpture</h3>
+                            <p>Sculpted Buddha images and reliefs from the Vakataka-era caves.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">📜</div>
+                            <h3>Copper-Plate Grants</h3>
+                            <p>Inscriptions recording land grants, a key source for Vakataka history.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">📖</div>
+                            <h3>Setubandha</h3>
+                            <p>Pravarasena II's Prakrit epic poem, composed at the Vakataka court.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🗺️</div>
+                            <h3>Deccan Territory</h3>
+                            <p>The Vakataka realm stretching across Vidarbha and neighbouring central Indian regions.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- References -->
+        <section id="references" class="vak-section">
+            <div class="vak-content-card">
+                <h2>📚 References</h2>
+                <div class="vak-content">
+                    <ul class="vak-list vak-references">
+                        <li>Wikipedia — Vakataka dynasty. <a href="https://en.wikipedia.org/wiki/Vakataka_dynasty" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>Wikipedia — Harishena. <a href="https://en.wikipedia.org/wiki/Harishena" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>Wikipedia — Ajanta Caves. <a href="https://en.wikipedia.org/wiki/Ajanta_Caves" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>ClearIAS — Vakataka Dynasty overview. <a href="https://www.clearias.com/vakataka-dynasty/" target="_blank" rel="noopener noreferrer">clearias.com</a></li>
+                        <li>Testbook — NCERT Notes on the Vakatakas. <a href="https://testbook.com/ias-preparation/ncert-notes-vakatakas" target="_blank" rel="noopener noreferrer">testbook.com</a></li>
+                        <li>UNESCO World Heritage Centre — Ajanta Caves. <a href="https://whc.unesco.org/en/list/242/" target="_blank" rel="noopener noreferrer">whc.unesco.org</a></li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="vak-footer">
+        <p>Part of <a href="../../../index.html" style="color: #FF9933;">Incredible India Explorer</a> · <a href="../index.html" style="color: #d35400;">Indian Dynasties Explorer</a></p>
+    </footer>
+
+    <script type="module" src="script.js"></script>
+</body>
+</html>

--- a/frontend/history/dynasties/vakataka/script.js
+++ b/frontend/history/dynasties/vakataka/script.js
@@ -1,0 +1,92 @@
+/**
+ * Vakataka Dynasty Explorer - Interactive Script
+ * Handles tab navigation, smooth scrolling, theme toggle, and mobile menu
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    initTabNavigation();
+    initThemeToggle();
+    initMobileMenu();
+});
+
+/**
+ * Initialize tab navigation for different sections
+ */
+function initTabNavigation() {
+    const tabs = document.querySelectorAll('.vak-tab');
+    const sections = document.querySelectorAll('.vak-section');
+
+    tabs.forEach(tab => {
+        tab.addEventListener('click', () => {
+            const targetTab = tab.dataset.tab;
+
+            tabs.forEach(t => t.classList.remove('active'));
+            sections.forEach(s => s.classList.remove('active'));
+
+            tab.classList.add('active');
+            const targetSection = document.getElementById(targetTab);
+            if (targetSection) {
+                targetSection.classList.add('active');
+                targetSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+        });
+    });
+}
+
+/**
+ * Initialize theme toggle functionality
+ */
+function initThemeToggle() {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+
+    const currentTheme = localStorage.getItem('theme') || 'dark';
+    updateThemeIcon(currentTheme);
+
+    themeToggle.addEventListener('click', () => {
+        const body = document.body;
+        const isLight = body.classList.contains('light-theme');
+
+        if (isLight) {
+            body.classList.remove('light-theme');
+            localStorage.setItem('theme', 'dark');
+            updateThemeIcon('dark');
+        } else {
+            body.classList.add('light-theme');
+            localStorage.setItem('theme', 'light');
+            updateThemeIcon('light');
+        }
+    });
+}
+
+/**
+ * Update theme toggle icon
+ */
+function updateThemeIcon(theme) {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+    themeToggle.textContent = theme === 'light' ? '🌙' : '☀️';
+}
+
+/**
+ * Initialize mobile menu toggle
+ */
+function initMobileMenu() {
+    const menuToggle = document.getElementById('menu-toggle');
+    const navMenu = document.getElementById('nav-menu');
+
+    if (menuToggle && navMenu) {
+        menuToggle.addEventListener('click', () => {
+            const isExpanded = menuToggle.getAttribute('aria-expanded') === 'true';
+            menuToggle.setAttribute('aria-expanded', !isExpanded);
+            navMenu.classList.toggle('active');
+        });
+
+        document.addEventListener('click', (e) => {
+            if (!menuToggle.contains(e.target) && !navMenu.contains(e.target)) {
+                navMenu.classList.remove('active');
+                menuToggle.setAttribute('aria-expanded', 'false');
+            }
+        });
+    }
+}

--- a/frontend/history/dynasties/vakataka/style.css
+++ b/frontend/history/dynasties/vakataka/style.css
@@ -1,0 +1,341 @@
+/* ==========================================================================
+   Vakataka Dynasty Explorer Styling
+   Deccan dynasty and patrons of the Ajanta Caves (c. 250-510 CE)
+   ========================================================================== */
+
+.vak-page-body {
+    background-color: var(--bg-primary, #0B0F19);
+    color: var(--text-primary, #E2E8F0);
+    font-family: 'Outfit', system-ui, -apple-system, sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+}
+
+.vak-main {
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: 80px 20px 60px;
+}
+
+/* --- Hero Banner --- */
+.vak-hero {
+    text-align: center;
+    padding: 48px 24px;
+    background: linear-gradient(135deg, rgba(11, 15, 25, 0.95) 0%, rgba(45, 26, 8, 0.85) 100%);
+    border: 1px solid rgba(211, 84, 0, 0.35);
+    border-radius: 16px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+    margin-bottom: 32px;
+    position: relative;
+    overflow: hidden;
+}
+
+.vak-hero::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: linear-gradient(90deg, #FF9933 0%, #D4AF37 50%, #d35400 100%);
+}
+
+.vak-kicker {
+    display: inline-block;
+    padding: 6px 16px;
+    background: rgba(211, 84, 0, 0.2);
+    color: #f0975c;
+    border: 1px solid rgba(211, 84, 0, 0.4);
+    border-radius: 20px;
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 16px;
+}
+
+.vak-hero h1 {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 2.6rem;
+    font-weight: 700;
+    color: var(--text-heading, #F8FAFC);
+    margin: 0 0 12px;
+}
+
+.vak-hero p {
+    font-size: 1.1rem;
+    color: var(--text-secondary, #94A3B8);
+    max-width: 850px;
+    margin: 0 auto 24px;
+}
+
+.vak-hero-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 16px;
+    margin-top: 24px;
+}
+
+.vak-hero-stat {
+    background: rgba(15, 23, 42, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    padding: 16px;
+    text-align: center;
+}
+
+.vak-hero-stat strong {
+    display: block;
+    font-size: 1.4rem;
+    color: #FF9933;
+    font-family: 'Playfair Display', Georgia, serif;
+}
+
+.vak-hero-stat span {
+    font-size: 0.8rem;
+    color: var(--text-secondary, #94A3B8);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+/* --- Navigation Tabs --- */
+.vak-nav-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: center;
+    margin-bottom: 32px;
+    padding: 12px;
+    background: rgba(15, 23, 42, 0.5);
+    border-radius: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.vak-tab {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: var(--text-secondary, #94A3B8);
+    padding: 8px 16px;
+    border-radius: 20px;
+    font-size: 0.88rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.25s ease;
+    white-space: nowrap;
+}
+
+.vak-tab:hover {
+    border-color: rgba(211, 84, 0, 0.5);
+    color: #f0975c;
+}
+
+.vak-tab.active {
+    background: linear-gradient(135deg, #d35400, #a34000);
+    border-color: #d35400;
+    color: #fff;
+}
+
+.vak-tab:focus-visible {
+    outline: 2px solid #FF9933;
+    outline-offset: 2px;
+}
+
+/* --- Content Sections --- */
+.vak-section {
+    display: none;
+    animation: fadeIn 0.4s ease;
+}
+
+.vak-section.active {
+    display: block;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.vak-content-card {
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 16px;
+    padding: 32px;
+}
+
+.vak-content-card h2 {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 1.8rem;
+    color: var(--text-heading, #F8FAFC);
+    margin: 0 0 20px;
+}
+
+.vak-content h3 {
+    color: #f0975c;
+    font-size: 1.1rem;
+    margin: 0 0 6px;
+}
+
+.vak-content p {
+    color: var(--text-secondary, #CBD5E1);
+    margin: 0 0 14px;
+}
+
+.vak-list {
+    color: var(--text-secondary, #CBD5E1);
+    padding-left: 20px;
+    margin: 0 0 14px;
+}
+
+.vak-list li {
+    margin-bottom: 8px;
+}
+
+.vak-references a {
+    color: #f0975c;
+    text-decoration: none;
+}
+
+.vak-references a:hover {
+    text-decoration: underline;
+}
+
+/* --- Timeline --- */
+.vak-timeline {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    border-left: 2px solid rgba(211, 84, 0, 0.5);
+    padding-left: 20px;
+    margin-top: 8px;
+}
+
+.vak-timeline-item {
+    position: relative;
+}
+
+.vak-timeline-item::before {
+    content: '';
+    position: absolute;
+    left: -26px;
+    top: 4px;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: #d35400;
+}
+
+.vak-timeline-year {
+    display: block;
+    font-weight: 700;
+    color: #FF9933;
+    font-family: 'Playfair Display', Georgia, serif;
+    margin-bottom: 4px;
+}
+
+.vak-timeline-item p {
+    margin: 0;
+}
+
+/* --- Rulers --- */
+.ruler-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 16px;
+}
+
+.ruler-item {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 12px;
+    padding: 18px;
+}
+
+.ruler-reign {
+    font-size: 0.85rem;
+    color: var(--text-secondary, #94A3B8);
+    font-weight: 400;
+}
+
+/* --- Gallery --- */
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+    margin-top: 16px;
+}
+
+.gallery-item {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 12px;
+    padding: 20px;
+    text-align: center;
+    transition: transform 0.25s ease;
+}
+
+.gallery-item:hover {
+    transform: translateY(-4px);
+    border-color: rgba(211, 84, 0, 0.5);
+}
+
+.gallery-placeholder {
+    font-size: 2.6rem;
+    margin-bottom: 10px;
+}
+
+.gallery-item h3 {
+    margin: 0 0 6px;
+}
+
+.gallery-item p {
+    font-size: 0.9rem;
+    margin: 0;
+}
+
+/* --- Footer --- */
+.vak-footer {
+    text-align: center;
+    padding: 30px 20px;
+    color: var(--text-secondary, #94A3B8);
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* --- Responsive --- */
+@media (max-width: 768px) {
+    .vak-hero h1 {
+        font-size: 2rem;
+    }
+
+    .vak-content-card {
+        padding: 20px;
+    }
+
+    .vak-nav-tabs {
+        justify-content: flex-start;
+        overflow-x: auto;
+        flex-wrap: nowrap;
+    }
+
+    .vak-timeline {
+        padding-left: 16px;
+    }
+}
+
+/* --- Light Theme Overrides --- */
+body.light-theme.vak-page-body {
+    background-color: #F8FAFC;
+    color: #0F172A;
+}
+
+body.light-theme .vak-content-card,
+body.light-theme .vak-hero {
+    background: rgba(255, 255, 255, 0.85);
+    border-color: rgba(0, 0, 0, 0.08);
+}
+
+body.light-theme .vak-content p,
+body.light-theme .vak-list,
+body.light-theme .ruler-reign {
+    color: #334155;
+}


### PR DESCRIPTION
## What this PR does

Adds a dedicated explorer page for the Vakataka Dynasty, which ruled
the Deccan and central India from c. 250-510 CE and is best known
for its patronage of the Ajanta Caves, and integrates it into the
existing Indian Dynasties Explorer landing page.

### New files
- history/dynasties/vakataka/index.html
- history/dynasties/vakataka/style.css
- history/dynasties/vakataka/script.js

### Modified files
- history/dynasties/data.js — added a Vakataka Dynasty entry to the
  dynasties array and five events to the timelineEvents array
- history/dynasties/components/DynastyCard.js — added an optional
  "View Full Explorer" link, shown only when a dynasty entry
  includes a `link` field (backward-compatible with existing cards)
- history/dynasties/styles.css — styled the new card link

### Note for reviewers
The Indian Dynasties Explorer landing page (history/dynasties/) is
already data-driven, so adding the Vakataka Dynasty to data.js
automatically surfaces it in the card grid (under "Ancient"), the
map, the timeline, and the site-wide Contributions view. The new
dedicated page adds the deeper content the issue asks for — full
historical overview, ruler biographies, a dedicated Art &
Architecture section, and a references list — that the compact card
format doesn't have room for.

### Sections covered on the dedicated page
Historical Overview, Timeline, Major Rulers, Art & Architecture,
Gallery, and References — content is based on Wikipedia, UNESCO, and
standard ancient Indian history references, linked in the
References tab.

### Testing
- Verified navigation from the landing page card to the Vakataka
  Dynasty page via the new "View Full Explorer" link
- Checked script.js for syntax errors (node --check)
- Confirmed the new Vakataka entries render correctly in the landing
  page's Timeline, Map, and Contributions tabs
- Confirmed responsive layout at mobile and desktop breakpoints

Closes #1508 

@Eshajha19 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.