### PR TITLE
feat: Add Ollywood (Odia Cinema) Explorer page

### DIFF
--- a/frontend/assets/ollywood_cinema_hall.svg
+++ b/frontend/assets/ollywood_cinema_hall.svg
@@ -1,0 +1,90 @@
+<svg viewBox="0 0 1024 640" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Stylised illustration of a vintage cinema hall marquee in Odisha">
+  <defs>
+    <linearGradient id="chSky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1a120a"/>
+      <stop offset="55%" stop-color="#3a1f14"/>
+      <stop offset="100%" stop-color="#c1442d"/>
+    </linearGradient>
+    <linearGradient id="chWall" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#e8cba0"/>
+      <stop offset="100%" stop-color="#b89060"/>
+    </linearGradient>
+    <radialGradient id="chGlow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#f0cc7a"/>
+      <stop offset="100%" stop-color="#d9a441" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="1024" height="640" fill="url(#chSky)"/>
+  <circle cx="512" cy="220" r="220" fill="url(#chGlow)" opacity="0.5"/>
+
+  <!-- ground -->
+  <rect y="500" width="1024" height="140" fill="#120e08"/>
+  <rect y="500" width="1024" height="18" fill="#1f1710"/>
+
+  <!-- cinema hall facade -->
+  <rect x="260" y="260" width="504" height="240" fill="url(#chWall)" stroke="#5c3a24" stroke-width="3"/>
+
+  <!-- marquee canopy -->
+  <path d="M230 260 L794 260 L764 210 L260 210 Z" fill="#8a2e1c" stroke="#3b1a10" stroke-width="2"/>
+  <g fill="#f0cc7a">
+    <circle cx="270" cy="235" r="4"/>
+    <circle cx="310" cy="235" r="4"/>
+    <circle cx="350" cy="235" r="4"/>
+    <circle cx="390" cy="235" r="4"/>
+    <circle cx="430" cy="235" r="4"/>
+    <circle cx="470" cy="235" r="4"/>
+    <circle cx="510" cy="235" r="4"/>
+    <circle cx="550" cy="235" r="4"/>
+    <circle cx="590" cy="235" r="4"/>
+    <circle cx="630" cy="235" r="4"/>
+    <circle cx="670" cy="235" r="4"/>
+    <circle cx="710" cy="235" r="4"/>
+    <circle cx="750" cy="235" r="4"/>
+  </g>
+
+  <!-- marquee sign board -->
+  <rect x="360" y="215" width="304" height="40" rx="4" fill="#120e08" stroke="#d9a441" stroke-width="2"/>
+  <text x="512" y="242" font-family="Georgia, serif" font-size="22" fill="#f0cc7a" text-anchor="middle" letter-spacing="4">OLLYWOOD</text>
+
+  <!-- entrance doors -->
+  <g fill="#3b1a10">
+    <rect x="420" y="380" width="70" height="120" rx="4"/>
+    <rect x="534" y="380" width="70" height="120" rx="4"/>
+  </g>
+  <g stroke="#d9a441" stroke-width="2" opacity="0.6">
+    <line x1="455" y1="380" x2="455" y2="500"/>
+    <line x1="569" y1="380" x2="569" y2="500"/>
+  </g>
+
+  <!-- windows -->
+  <g fill="#120e08" opacity="0.85">
+    <rect x="300" y="300" width="50" height="60" rx="6"/>
+    <rect x="674" y="300" width="50" height="60" rx="6"/>
+  </g>
+
+  <!-- film reel decoration above entrance -->
+  <circle cx="512" cy="330" r="30" fill="none" stroke="#d9a441" stroke-width="6"/>
+  <circle cx="512" cy="330" r="8" fill="#d9a441"/>
+  <g fill="#f0cc7a">
+    <circle cx="512" cy="308" r="4"/>
+    <circle cx="530" cy="320" r="4"/>
+    <circle cx="530" cy="342" r="4"/>
+    <circle cx="512" cy="354" r="4"/>
+    <circle cx="494" cy="342" r="4"/>
+    <circle cx="494" cy="320" r="4"/>
+  </g>
+
+  <!-- palm trees flanking -->
+  <g stroke="#3b1a10" stroke-width="6" stroke-linecap="round">
+    <path d="M150 500 q10 -70 4 -130"/>
+    <path d="M874 500 q-10 -65 -4 -120"/>
+  </g>
+  <g fill="#1f6b52">
+    <path d="M154 370 q-42 -10 -58 12 q37 6 58 -12 Z"/>
+    <path d="M154 370 q42 -10 58 10 q-37 8 -58 -10 Z"/>
+    <path d="M154 370 q-10 -38 10 -55 q10 32 -10 55 Z"/>
+    <path d="M870 380 q-40 -8 -55 12 q35 6 55 -12 Z"/>
+    <path d="M870 380 q40 -8 55 10 q-35 8 -55 -10 Z"/>
+  </g>
+</svg>

--- a/frontend/assets/ollywood_film_reel.svg
+++ b/frontend/assets/ollywood_film_reel.svg
@@ -1,0 +1,59 @@
+<svg viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Stylised illustration of a film reel and vintage movie camera">
+  <defs>
+    <linearGradient id="frBg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#211810"/>
+      <stop offset="100%" stop-color="#140f0a"/>
+    </linearGradient>
+    <linearGradient id="frMetal" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c99a5c"/>
+      <stop offset="100%" stop-color="#8f6a24"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#frBg)"/>
+  <circle cx="600" cy="150" r="90" fill="#d9a441" opacity="0.08"/>
+
+  <!-- large film reel -->
+  <circle cx="300" cy="300" r="140" fill="none" stroke="url(#frMetal)" stroke-width="14"/>
+  <circle cx="300" cy="300" r="40" fill="url(#frMetal)"/>
+  <circle cx="300" cy="300" r="14" fill="#140f0a"/>
+  <g fill="#140f0a">
+    <circle cx="300" cy="210" r="20"/>
+    <circle cx="378" cy="255" r="20"/>
+    <circle cx="378" cy="345" r="20"/>
+    <circle cx="300" cy="390" r="20"/>
+    <circle cx="222" cy="345" r="20"/>
+    <circle cx="222" cy="255" r="20"/>
+  </g>
+
+  <!-- unspooling film strip -->
+  <g fill="#1f1710" stroke="#8f6a24" stroke-width="2">
+    <rect x="430" y="360" width="220" height="60" rx="4"/>
+  </g>
+  <g fill="#140f0a">
+    <rect x="440" y="370" width="14" height="14"/>
+    <rect x="440" y="396" width="14" height="14"/>
+    <rect x="470" y="370" width="14" height="14"/>
+    <rect x="470" y="396" width="14" height="14"/>
+    <rect x="500" y="370" width="14" height="14"/>
+    <rect x="500" y="396" width="14" height="14"/>
+    <rect x="530" y="370" width="14" height="14"/>
+    <rect x="530" y="396" width="14" height="14"/>
+    <rect x="560" y="370" width="14" height="14"/>
+    <rect x="560" y="396" width="14" height="14"/>
+    <rect x="590" y="370" width="14" height="14"/>
+    <rect x="590" y="396" width="14" height="14"/>
+    <rect x="620" y="370" width="14" height="14"/>
+    <rect x="620" y="396" width="14" height="14"/>
+  </g>
+
+  <!-- vintage camera body -->
+  <g>
+    <rect x="480" y="220" width="140" height="90" rx="8" fill="url(#frMetal)" stroke="#5c3a24" stroke-width="2"/>
+    <rect x="590" y="180" width="70" height="60" rx="6" fill="url(#frMetal)" stroke="#5c3a24" stroke-width="2"/>
+    <circle cx="625" cy="210" r="20" fill="#140f0a" stroke="#d9a441" stroke-width="4"/>
+    <circle cx="625" cy="210" r="9" fill="#c1442d"/>
+    <rect x="460" y="240" width="26" height="50" rx="4" fill="#8f6a24"/>
+    <circle cx="500" cy="240" r="16" fill="#140f0a" stroke="#8f6a24" stroke-width="3"/>
+    <circle cx="540" cy="240" r="16" fill="#140f0a" stroke="#8f6a24" stroke-width="3"/>
+  </g>
+</svg>

--- a/frontend/assets/ollywood_national_award.svg
+++ b/frontend/assets/ollywood_national_award.svg
@@ -1,0 +1,48 @@
+<svg viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Stylised illustration of the Rajat Kamal (Silver Lotus) National Film Award">
+  <defs>
+    <linearGradient id="awBg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1f1710"/>
+      <stop offset="100%" stop-color="#140f0a"/>
+    </linearGradient>
+    <linearGradient id="awLotus" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#f4f6f5"/>
+      <stop offset="50%" stop-color="#cfd6d4"/>
+      <stop offset="100%" stop-color="#9aa3a1"/>
+    </linearGradient>
+    <linearGradient id="awBase" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c99a5c"/>
+      <stop offset="100%" stop-color="#8f6a24"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#awBg)"/>
+  <circle cx="400" cy="230" r="160" fill="#d9a441" opacity="0.08"/>
+
+  <!-- pedestal -->
+  <rect x="330" y="470" width="140" height="26" rx="4" fill="url(#awBase)"/>
+  <rect x="360" y="420" width="80" height="55" fill="url(#awBase)"/>
+
+  <!-- lotus stem -->
+  <rect x="393" y="330" width="14" height="95" fill="#8a8f8d"/>
+
+  <!-- lotus petals (Rajat Kamal / Silver Lotus) -->
+  <g fill="url(#awLotus)" stroke="#7a827f" stroke-width="1.5">
+    <ellipse cx="400" cy="300" rx="26" ry="60"/>
+    <ellipse cx="400" cy="300" rx="26" ry="60" transform="rotate(45 400 300)"/>
+    <ellipse cx="400" cy="300" rx="26" ry="60" transform="rotate(90 400 300)"/>
+    <ellipse cx="400" cy="300" rx="26" ry="60" transform="rotate(135 400 300)"/>
+    <ellipse cx="400" cy="300" rx="26" ry="60" transform="rotate(180 400 300)"/>
+    <ellipse cx="400" cy="300" rx="26" ry="60" transform="rotate(225 400 300)"/>
+    <ellipse cx="400" cy="300" rx="26" ry="60" transform="rotate(270 400 300)"/>
+    <ellipse cx="400" cy="300" rx="26" ry="60" transform="rotate(315 400 300)"/>
+  </g>
+  <circle cx="400" cy="300" r="22" fill="#e8cba0" stroke="#8f6a24" stroke-width="2"/>
+
+  <!-- sparkle accents -->
+  <g stroke="#f0cc7a" stroke-width="2" opacity="0.8">
+    <path d="M270 220 v16 M262 228 h16"/>
+    <path d="M540 240 v16 M532 248 h16"/>
+    <path d="M400 150 v16 M392 158 h16"/>
+  </g>
+
+  <text x="400" y="555" font-family="Georgia, serif" font-size="20" fill="#f0cc7a" text-anchor="middle" letter-spacing="2">NATIONAL FILM AWARD</text>
+</svg>

--- a/frontend/assets/ollywood_sita_bibaha.svg
+++ b/frontend/assets/ollywood_sita_bibaha.svg
@@ -1,0 +1,73 @@
+<svg viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Stylised illustration inspired by Sita Bibaha, the first Odia film of 1936">
+  <defs>
+    <linearGradient id="sbBg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#211810"/>
+      <stop offset="100%" stop-color="#140f0a"/>
+    </linearGradient>
+    <linearGradient id="sbFrame" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c99a5c"/>
+      <stop offset="100%" stop-color="#8f6a24"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#sbBg)"/>
+
+  <!-- vintage film frame border -->
+  <rect x="60" y="60" width="680" height="480" fill="none" stroke="url(#sbFrame)" stroke-width="8"/>
+  <g fill="#8f6a24">
+    <rect x="60" y="80" width="16" height="24"/>
+    <rect x="60" y="150" width="16" height="24"/>
+    <rect x="60" y="220" width="16" height="24"/>
+    <rect x="60" y="290" width="16" height="24"/>
+    <rect x="60" y="360" width="16" height="24"/>
+    <rect x="60" y="430" width="16" height="24"/>
+    <rect x="60" y="500" width="16" height="24"/>
+    <rect x="724" y="80" width="16" height="24"/>
+    <rect x="724" y="150" width="16" height="24"/>
+    <rect x="724" y="220" width="16" height="24"/>
+    <rect x="724" y="290" width="16" height="24"/>
+    <rect x="724" y="360" width="16" height="24"/>
+    <rect x="724" y="430" width="16" height="24"/>
+    <rect x="724" y="500" width="16" height="24"/>
+  </g>
+
+  <!-- ground -->
+  <rect x="120" y="430" width="560" height="90" fill="#3b2c18" opacity="0.7"/>
+
+  <!-- two figures suggesting a wedding scene (Sita-Ram marriage motif) -->
+  <g>
+    <!-- groom figure -->
+    <path d="M340 300 q0 -30 20 -30 q20 0 20 30 v140 h-40 Z" fill="#d9a441"/>
+    <circle cx="360" cy="255" r="18" fill="#e8cba0"/>
+    <polygon points="345,242 360,220 375,242" fill="#c1442d"/>
+
+    <!-- bride figure -->
+    <path d="M420 300 q0 -30 20 -30 q20 0 20 30 v140 h-40 Z" fill="#c1442d"/>
+    <circle cx="440" cy="255" r="18" fill="#e8cba0"/>
+    <path d="M425 240 q15 -18 30 0" fill="none" stroke="#8f6a24" stroke-width="4"/>
+  </g>
+
+  <!-- ceremonial arch above the figures -->
+  <path d="M300 210 Q400 140 500 210" fill="none" stroke="#d9a441" stroke-width="4"/>
+  <g fill="#f0cc7a">
+    <circle cx="320" cy="200" r="5"/>
+    <circle cx="360" cy="168" r="5"/>
+    <circle cx="400" cy="155" r="5"/>
+    <circle cx="440" cy="168" r="5"/>
+    <circle cx="480" cy="200" r="5"/>
+  </g>
+
+  <!-- oil lamps flanking the scene -->
+  <g fill="#8f6a24">
+    <rect x="210" y="420" width="10" height="40"/>
+    <ellipse cx="215" cy="415" rx="16" ry="8"/>
+    <rect x="580" y="420" width="10" height="40"/>
+    <ellipse cx="585" cy="415" rx="16" ry="8"/>
+  </g>
+  <g fill="#f0cc7a" opacity="0.85">
+    <ellipse cx="215" cy="405" rx="5" ry="9"/>
+    <ellipse cx="585" cy="405" rx="5" ry="9"/>
+  </g>
+
+  <!-- title card text -->
+  <text x="400" y="560" font-family="Georgia, serif" font-size="20" fill="#f0cc7a" text-anchor="middle" letter-spacing="3">SITA BIBAHA · 1936</text>
+</svg>

--- a/frontend/odia-cinema-explorer/index.html
+++ b/frontend/odia-cinema-explorer/index.html
@@ -367,13 +367,22 @@
   <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
 
   <!-- JS Dependencies -->
+  <!-- JS Dependencies -->
   <script src="../js-modules/config.js" defer></script>
+  <script src="../pages-common.js"></script>
+
   <script src="../app.js" defer></script>
+
   <script src="../../frontend/journey/journey.js" defer></script>
+
   <script src="script.js" defer></script>
+
   <script type="module" src="../firebase-config.js"></script>
+
   <script type="module" src="../auth.js"></script>
+
   <script src="../router.js" defer></script>
+
   <script src="../js-modules/page-progress/page-progress.js"></script>
 </body>
 </html>

--- a/frontend/odia-cinema-explorer/index.html
+++ b/frontend/odia-cinema-explorer/index.html
@@ -1,0 +1,379 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore Ollywood, the Odia film industry of Odisha: from Sita Bibaha (1936), the first Odia film, to National Award-winning classics like Maya Miriga, and the artists who built its legacy.">
+  <title>Ollywood (Odia Cinema) Explorer | Incredible India</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="../js-modules/page-progress/page-progress.css">
+
+  <!-- Open Graph / Social Media Tags -->
+  <meta property="og:title" content="Ollywood (Odia Cinema) Explorer | Incredible India Explorer">
+  <meta property="og:description" content="Discover Ollywood — the Odia film industry, from its 1936 origins with Sita Bibaha to National Award-winning classics and the artists behind them.">
+  <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/frontend/assets/ollywood_cinema_hall.svg">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/odia-cinema-explorer/index.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Incredible India Explorer">
+  <meta property="og:locale" content="en_IN">
+
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/odia-cinema-explorer/index.html">
+</head>
+<body>
+  <script>
+    (function() {
+      const theme = localStorage.getItem('theme') || 'dark';
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+
+  <!-- Sticky Navigation Bar -->
+  <header class="navbar" id="navbar">
+    <div class="nav-container">
+        <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+            <span class="saffron">Incredible</span>
+            <span class="gold">India</span>
+            <span class="green">Explorer</span>
+        </a>
+        <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+            <span class="bar"></span>
+            <span class="bar"></span>
+            <span class="bar"></span>
+        </button>
+        <nav class="nav-menu" id="nav-menu">
+            <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
+                    <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                    <a href="../../frontend/islands/islands.html" class="dropdown-item">Islands of India</a>
+                    <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    <a href="../../frontend/route-planner/route-planner.html" class="dropdown-item">Route Planner</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+                    <a href="../../frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
+                    <a href="../../frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
+                    <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
+                    <a href="../../frontend/indian-cinema-timeline/index.html" class="dropdown-item">Indian Cinema Timeline</a>
+                    <a href="index.html" class="dropdown-item" style="color: var(--saffron)">Ollywood (Odia Cinema)</a>
+                    <a href="../hoysala-dynasty-explorer/index.html" class="dropdown-item">Hoysala Dynasty</a>
+                    <a href="../kachwaha-dynasty-explorer/index.html" class="dropdown-item">Kachwaha Dynasty</a>
+                    <a href="../../frontend/national-symbols-gallery/national-symbols-gallery.html" class="dropdown-item">National Symbols</a>
+                    <a href="../../frontend/cuisine-discovery-hub/index.html" class="dropdown-item">UP Cuisine</a>
+                    <a href="../../frontend/handicrafts-showcase/index.html" class="dropdown-item">UP Handicrafts</a>
+                    <a href="../../frontend/national-days-calendar/index.html" class="dropdown-item">National Days</a>
+                    <a href="../../frontend/ganga-ghats-experience/index.html" class="dropdown-item">Ganga Ghats</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Nature ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/national-parks-explorer/index.html" class="dropdown-item">National Parks</a>
+                    <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                    <a href="../../frontend/wildlife-rescue/wildlife-rescue.html" class="dropdown-item">Wildlife Rescue</a>
+                    <a href="../../frontend/endemic-flora-fauna-explorer/index.html" class="dropdown-item">Endemic Flora & Fauna</a>
+                    <a href="../../frontend/harike-wetland/harike-wetland.html" class="dropdown-item">Harike Wetland</a>
+                    <a href="../../frontend/wular-lake/wular-lake.html" class="dropdown-item">Wular Lake</a>
+                    <a href="../../frontend/crowd-density/index.html" class="dropdown-item">Crowd Density Predictor</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Games ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/passport-quest/passport-quest.html" class="dropdown-item">Passport Quest</a>
+                    <a href="../../frontend/culinary-game/culinary-game.html" class="dropdown-item">Culinary Challenge</a>
+                    <a href="../../frontend/monsoon-game/monsoon-game.html" class="dropdown-item">Monsoon Game</a>
+                    <a href="../../frontend/river-game/river-game.html" class="dropdown-item">River Explorer</a>
+                    <a href="../../frontend/geo-guesser-india/index.html" class="dropdown-item">GeoGuesser</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Community ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/contributors/contributors.html" class="dropdown-item">Contributors</a>
+                    <a href="../../frontend/world-records-india/index.html" class="dropdown-item">World Records</a>
+                </div>
+            </div>
+
+            <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+        </nav>
+    </div>
+</header>
+
+  <!-- SPA Router Target Container -->
+  <main id="app-root" class="ollywood-main">
+
+    <!-- Hero Banner -->
+    <section class="ollywood-hero">
+      <div class="ollywood-hero-content">
+        <span class="ollywood-kicker">🎬 Odisha · 1936 – Present</span>
+        <h1>Ollywood <span>Explorer</span></h1>
+        <p>Step into Odia cinema, born on a single reel of celluloid in 1936. From a mythological love story shot on borrowed money to National Award-winning art house classics, discover the films and artists behind Odisha's own "Ollywood".</p>
+        <div class="ollywood-bookmark-container">
+          <button class="ollywood-bookmark-btn journey-bookmark-btn" type="button" data-bookmark-id="ollywood-cinema-main" aria-pressed="false" aria-label="Bookmark Ollywood Explorer">
+            ♡ Save to Journey
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Historical Overview -->
+    <section class="ollywood-section" id="overview">
+      <div class="ollywood-container ollywood-grid-2col">
+        <div class="ollywood-text-block">
+          <span class="ollywood-eyebrow">Where Hollywood Meets Odisha</span>
+          <h2>From Sita Bibaha to a State Film Industry</h2>
+          <p>Odia cinema began on 28 April 1936, when "Sita Bibaha" — a mythological retelling of Sita and Rama's wedding — opened at Laxmi Talkies in Puri. Directed, produced and partly acted in by Mohan Sundar Deb Goswami, who sold his own land to fund it, the film was made on a shoestring budget of around ₹30,000 with fourteen songs sung entirely by Odisha-based singers.</p>
+          <p>Growth was slow at first: only two more Odia films were made in the fifteen years after Sita Bibaha. It was not until 1974 that the Odisha government formally recognised filmmaking as an industry, followed in 1976 by the founding of the Odisha Film Development Corporation in Cuttack — the moment "Ollywood", a blend of "Odisha" and "Hollywood", truly came into its own.</p>
+        </div>
+        <div class="ollywood-highlight-box">
+          <h3>🎞️ At a Glance</h3>
+          <ul>
+            <li><strong>First film</strong>: Sita Bibaha (1936), directed by Mohan Sundar Deb Goswami.</li>
+            <li><strong>Industry hub</strong>: Cuttack and Bhubaneswar, Odisha.</li>
+            <li><strong>Name origin</strong>: "Ollywood" — a portmanteau of Odisha and Hollywood.</li>
+            <li><strong>Formal recognition</strong>: 1974–1976, with the founding of the Odisha Film Development Corporation.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Notable Films -->
+    <section class="ollywood-section" id="films">
+      <div class="ollywood-container">
+        <div class="ollywood-section-header">
+          <span class="ollywood-eyebrow">From Mythology to Art House</span>
+          <h2>Notable Films of Ollywood</h2>
+          <p>The films that marked Odia cinema's biggest milestones, from its founding reel to its national and international acclaim.</p>
+        </div>
+
+        <div class="ollywood-card-grid">
+          <div class="ollywood-card">
+            <span class="ollywood-card-icon">🎥</span>
+            <h3>Sita Bibaha (1936)</h3>
+            <p>The first Odia film, a mythological drama on the marriage of Sita and Rama, screened first at Laxmi Talkies, Puri.</p>
+          </div>
+          <div class="ollywood-card">
+            <span class="ollywood-card-icon">🏅</span>
+            <h3>Sri Lokanath (1960)</h3>
+            <p>Directed by Prafulla Kumar Sengupta, it won the first-ever National Award (President's Silver Medal) for Best Feature Film in Odia.</p>
+          </div>
+          <div class="ollywood-card">
+            <span class="ollywood-card-icon">🌾</span>
+            <h3>Sita Rati (1982)</h3>
+            <p>Winner of the National Film Award for Best Feature Film in Oriya, praised for its portrayal of rural struggles and social inequities.</p>
+          </div>
+          <div class="ollywood-card">
+            <span class="ollywood-card-icon">🎬</span>
+            <h3>Maya Miriga (1984)</h3>
+            <p>Nirad N. Mohapatra's landmark family drama won the National Award for Second Best Feature Film and screened at Cannes' Critics' Week.</p>
+          </div>
+          <div class="ollywood-card">
+            <span class="ollywood-card-icon">🐂</span>
+            <h3>Magunira Shagada (2002)</h3>
+            <p>Directed by Prafulla Mohanty, this National Film Development Corporation production won the National Award for Best Feature Film in Odia.</p>
+          </div>
+          <div class="ollywood-card">
+            <span class="ollywood-card-icon">🎭</span>
+            <h3>Hisab Nikas (1981)</h3>
+            <p>Directed by Prashanta Nanda, a socially themed drama exploring justice and familial bonds that drew audiences back to cinema halls.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Award-Winning Artists -->
+    <section class="ollywood-section" id="artists">
+      <div class="ollywood-container ollywood-grid-2col">
+        <div class="ollywood-highlight-box" style="background: rgba(193, 68, 45, 0.06); border-color: rgba(193, 68, 45, 0.22);">
+          <h3>🏆 Voices Behind the Camera</h3>
+          <ul>
+            <li><strong>Mohan Sundar Deb Goswami</strong>: Founding father of Odia cinema, director-producer of Sita Bibaha.</li>
+            <li><strong>Prasanta Nanda</strong>: Actor, director, lyricist and screenwriter — one of Ollywood's most versatile figures.</li>
+            <li><strong>Nirad N. Mohapatra</strong>: Director of Maya Miriga, celebrated at Cannes and international festivals.</li>
+            <li><strong>Manmohan Mohapatra</strong>: Director whose "Sitarati" was Odisha's first entry to the Indian Panorama in 1983.</li>
+          </ul>
+        </div>
+        <div class="ollywood-text-block">
+          <span class="ollywood-eyebrow">Directors, Writers &amp; Performers</span>
+          <h2>Award-Winning Artists of Ollywood</h2>
+          <p>Mohan Sundar Deb Goswami, a prominent figure in Rasa Leela performance and founder of the Annapurna Theatre, directed, produced and starred in Sita Bibaha, laying the foundation for everything that followed. Decades later, Prasanta Nanda emerged as Ollywood's most versatile talent — acting, writing, composing lyrics and directing across a long career that shaped the industry's popular voice.</p>
+          <p>The 1980s brought Odia cinema its widest recognition, led by Nirad N. Mohapatra, whose 1984 film Maya Miriga won a National Award for Second Best Feature Film, screened in Cannes' Critics' Week, and picked up honours at festivals in Germany and Hawaii. Alongside him, Manmohan Mohapatra became the first Odia director selected for the Indian Panorama, cementing Ollywood's place on the national stage.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Timeline -->
+    <section class="ollywood-section" id="timeline">
+      <div class="ollywood-container">
+        <div class="ollywood-section-header">
+          <span class="ollywood-eyebrow">Milestones</span>
+          <h2>Chronology of Odia Cinema</h2>
+          <p>From a single mythological drama to a recognised state film industry.</p>
+        </div>
+
+        <div class="ollywood-timeline">
+          <div class="ollywood-timeline-step">
+            <div class="ollywood-timeline-marker"></div>
+            <div class="ollywood-timeline-card">
+              <span class="ollywood-timeline-year">1936</span>
+              <h3>Sita Bibaha Releases</h3>
+              <p>Odia cinema's first film opens at Laxmi Talkies, Puri, on 28 April — a date still marked as the birthday of the Odia film industry.</p>
+            </div>
+          </div>
+          <div class="ollywood-timeline-step">
+            <div class="ollywood-timeline-marker"></div>
+            <div class="ollywood-timeline-card">
+              <span class="ollywood-timeline-year">1936–1951</span>
+              <h3>A Slow Beginning</h3>
+              <p>Only two more Odia films are produced in the fifteen years following Sita Bibaha, as the fledgling industry struggles to find its footing.</p>
+            </div>
+          </div>
+          <div class="ollywood-timeline-step">
+            <div class="ollywood-timeline-marker"></div>
+            <div class="ollywood-timeline-card">
+              <span class="ollywood-timeline-year">1960</span>
+              <h3>First National Recognition</h3>
+              <p>"Sri Lokanath" wins the first National Award for Best Feature Film in Odia, putting the industry on the national map.</p>
+            </div>
+          </div>
+          <div class="ollywood-timeline-step">
+            <div class="ollywood-timeline-marker"></div>
+            <div class="ollywood-timeline-card">
+              <span class="ollywood-timeline-year">1974–1976</span>
+              <h3>Ollywood is Born</h3>
+              <p>Odisha declares filmmaking an official industry in 1974, and founds the Odisha Film Development Corporation in Cuttack in 1976.</p>
+            </div>
+          </div>
+          <div class="ollywood-timeline-step">
+            <div class="ollywood-timeline-marker"></div>
+            <div class="ollywood-timeline-card">
+              <span class="ollywood-timeline-year">1984</span>
+              <h3>Maya Miriga's Global Acclaim</h3>
+              <p>Nirad N. Mohapatra's family drama wins a National Award and international honours, screening at Cannes' Critics' Week.</p>
+            </div>
+          </div>
+          <div class="ollywood-timeline-step">
+            <div class="ollywood-timeline-marker"></div>
+            <div class="ollywood-timeline-card">
+              <span class="ollywood-timeline-year">2000s–Present</span>
+              <h3>A Continuing Legacy</h3>
+              <p>Ollywood continues producing National Award winners like "Magunira Shagada" (2002) alongside a thriving commercial industry.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Gallery -->
+    <section class="ollywood-section" id="gallery">
+      <div class="ollywood-container">
+        <div class="ollywood-section-header">
+          <span class="ollywood-eyebrow">Visual Tour</span>
+          <h2>Reels, Awards &amp; the Marquee of Ollywood</h2>
+          <p>Illustrated impressions of the halls, honours and craft behind nearly nine decades of Odia cinema.</p>
+        </div>
+
+        <div class="ollywood-gallery-grid">
+          <div class="ollywood-gallery-item" data-title="A Vintage Cinema Hall" data-desc="An illustrated impression of an early Odisha cinema hall marquee, the kind of venue where Sita Bibaha and its earliest successors were first screened.">
+            <img src="../assets/ollywood_cinema_hall.svg" alt="Illustrated vintage cinema hall marquee in Odisha" loading="lazy">
+            <div class="ollywood-gallery-overlay">
+              <h4>Vintage Cinema Hall</h4>
+              <p>Where Ollywood Began</p>
+            </div>
+          </div>
+          <div class="ollywood-gallery-item" data-title="Sita Bibaha, 1936" data-desc="A stylised impression inspired by Sita Bibaha, Odia cinema's first film, retelling the wedding of Sita and Rama from the Ramayana.">
+            <img src="../assets/ollywood_sita_bibaha.svg" alt="Illustrated scene inspired by the 1936 film Sita Bibaha" loading="lazy">
+            <div class="ollywood-gallery-overlay">
+              <h4>Sita Bibaha</h4>
+              <p>The First Odia Film</p>
+            </div>
+          </div>
+          <div class="ollywood-gallery-item" data-title="The National Film Award" data-desc="An illustrated impression of the Rajat Kamal (Silver Lotus), the National Film Award trophy won by Ollywood classics like Sri Lokanath and Maya Miriga.">
+            <img src="../assets/ollywood_national_award.svg" alt="Illustrated Rajat Kamal National Film Award trophy" loading="lazy">
+            <div class="ollywood-gallery-overlay">
+              <h4>Rajat Kamal Award</h4>
+              <p>National Recognition</p>
+            </div>
+          </div>
+          <div class="ollywood-gallery-item" data-title="Reel &amp; Camera" data-desc="An illustrated impression of a film reel and vintage movie camera, representing the craft behind nearly nine decades of Odia filmmaking.">
+            <img src="../assets/ollywood_film_reel.svg" alt="Illustrated film reel and vintage movie camera" loading="lazy">
+            <div class="ollywood-gallery-overlay">
+              <h4>Reel &amp; Camera</h4>
+              <p>The Craft of Cinema</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: References -->
+    <section class="ollywood-section" id="references">
+      <div class="ollywood-container">
+        <div class="ollywood-references">
+          <h3>📚 References &amp; Further Reading</h3>
+          <ul>
+            <li><strong>National Film Development Corporation of India</strong>. <em>National Film Award for Best Odia Feature Film — Award History</em>.</li>
+            <li><strong>Odisha Bytes (2020)</strong>. <em>First Odia Film 'Sita Bibaha' Completes 84 Years Today</em>.</li>
+            <li><strong>Cinemaazi</strong>. <em>Nirad Mohapatra — Director Biography, Films and Legacy</em>.</li>
+            <li><strong>OdishaPlus (2019)</strong>. <em>Odia Film Scenario: The Past and the Future Possible</em>.</li>
+            <li><strong>Odisha Film Development Corporation, Cuttack</strong>. <em>Institutional History and Mandate</em>.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- Interactive Detail Modal -->
+  <div class="museum-modal" id="ollywood-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-hidden="true">
+    <div class="museum-modal-card">
+      <button class="museum-modal-close" id="ollywood-modal-close" type="button" aria-label="Close details">✕</button>
+      <span class="modal-category" id="modal-category">Gallery Highlight</span>
+      <h2 id="modal-title"></h2>
+      <p class="modal-location" style="color: var(--ollywood-gold-light);" id="modal-heading"></p>
+      <div style="border-top: 1px solid rgba(255,255,255,0.1); margin-top: 15px; padding-top: 15px;">
+        <p class="modal-description" id="modal-description"></p>
+      </div>
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <footer class="ollywood-footer">
+    <div class="ollywood-container">
+      <p>Part of <a href="../../index.html">Incredible India Explorer</a> · Explore the regional cinema traditions of India.</p>
+    </div>
+  </footer>
+
+  <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+
+  <!-- JS Dependencies -->
+  <script src="../js-modules/config.js" defer></script>
+  <script src="../app.js" defer></script>
+  <script src="../../frontend/journey/journey.js" defer></script>
+  <script src="script.js" defer></script>
+  <script type="module" src="../firebase-config.js"></script>
+  <script type="module" src="../auth.js"></script>
+  <script src="../router.js" defer></script>
+  <script src="../js-modules/page-progress/page-progress.js"></script>
+</body>
+</html>

--- a/frontend/odia-cinema-explorer/script.js
+++ b/frontend/odia-cinema-explorer/script.js
@@ -72,6 +72,7 @@ document.addEventListener("app:route-changed", () => {
 
   // --- Gallery Modal Logic -----------------------------------------
   let lastFocusedElement = null;
+  let ollywoodModalFocusTrap = null;
 
   function openModal(item) {
     lastFocusedElement = item;
@@ -84,6 +85,10 @@ document.addEventListener("app:route-changed", () => {
     modal.setAttribute("aria-hidden", "false");
     document.body.classList.add("modal-open");
 
+    if (typeof window.setupFocusTrap === "function") {
+      ollywoodModalFocusTrap = window.setupFocusTrap(modal);
+    }
+
     if (modalClose) modalClose.focus();
   }
 
@@ -91,6 +96,11 @@ document.addEventListener("app:route-changed", () => {
     modal.classList.remove("open");
     modal.setAttribute("aria-hidden", "true");
     document.body.classList.remove("modal-open");
+
+    if (ollywoodModalFocusTrap) {
+      ollywoodModalFocusTrap.deactivate();
+      ollywoodModalFocusTrap = null;
+    }
 
     if (lastFocusedElement) {
       lastFocusedElement.focus();
@@ -100,6 +110,9 @@ document.addEventListener("app:route-changed", () => {
   // Bind gallery click events
   galleryItems.forEach((item) => {
     item.setAttribute("tabindex", "0");
+    item.setAttribute("role", "button");
+    item.setAttribute("aria-haspopup", "dialog");
+    item.setAttribute("aria-controls", "ollywood-modal");
     item.addEventListener("click", () => openModal(item));
     item.addEventListener("keydown", (e) => {
       if (e.key === "Enter" || e.key === " ") {

--- a/frontend/odia-cinema-explorer/script.js
+++ b/frontend/odia-cinema-explorer/script.js
@@ -1,0 +1,132 @@
+document.addEventListener("app:route-changed", () => {
+  const bookmarkButtons = [...document.querySelectorAll(".journey-bookmark-btn")];
+  const galleryItems = [...document.querySelectorAll(".ollywood-gallery-item")];
+
+  const modal = document.getElementById("ollywood-modal");
+  const modalClose = document.getElementById("ollywood-modal-close");
+  const modalTitle = document.getElementById("modal-title");
+  const modalHeading = document.getElementById("modal-heading");
+  const modalDescription = document.getElementById("modal-description");
+
+  // --- Journey Integration (Bookmarks & Global Search) -------------
+  function initJourney() {
+    if (!window.Journey) return;
+
+    // 1. Bookmark functionality
+    bookmarkButtons.forEach((btn) => {
+      const id = btn.dataset.bookmarkId;
+      const title = "Ollywood (Odia Cinema) Explorer";
+      const thumbnail = "frontend/assets/ollywood_cinema_hall.svg";
+      const category = "culture";
+
+      const updateBookmarkUI = () => {
+        const isSaved = window.Journey.isSaved(id);
+        btn.classList.toggle("is-saved", isSaved);
+        btn.setAttribute("aria-pressed", String(isSaved));
+        btn.innerHTML = isSaved ? "♥ Saved to Journey" : "♡ Save to Journey";
+      };
+
+      updateBookmarkUI();
+
+      btn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        window.Journey.toggle({
+          id,
+          explorerPage: "frontend/odia-cinema-explorer/index.html",
+          title,
+          thumbnail,
+          category
+        });
+        updateBookmarkUI();
+      });
+    });
+
+    // 2. Global search index registration
+    window.Journey.registerSearchItems("frontend/odia-cinema-explorer/index.html", [
+      {
+        id: "ollywood-cinema-main",
+        title: "Ollywood (Odia Cinema) Explorer",
+        description: "Explore Ollywood, the Odia film industry: its 1936 origins with Sita Bibaha, notable National Award-winning films, and the artists who built its legacy.",
+        link: "frontend/odia-cinema-explorer/index.html"
+      },
+      {
+        id: "ollywood-cinema-films",
+        title: "Notable Films of Ollywood",
+        description: "From Sita Bibaha (1936) to Maya Miriga (1984) — the films that shaped Odia cinema and earned it national and international recognition.",
+        link: "frontend/odia-cinema-explorer/index.html#films"
+      },
+      {
+        id: "ollywood-cinema-artists",
+        title: "Award-Winning Artists of Ollywood",
+        description: "Meet Mohan Sundar Deb Goswami, Prasanta Nanda, Nirad N. Mohapatra and Manmohan Mohapatra — the filmmakers who defined Odia cinema.",
+        link: "frontend/odia-cinema-explorer/index.html#artists"
+      },
+      {
+        id: "ollywood-cinema-timeline",
+        title: "Ollywood Cinema Timeline",
+        description: "A chronology of Odia cinema from Sita Bibaha in 1936 to the founding of the Odisha Film Development Corporation and beyond.",
+        link: "frontend/odia-cinema-explorer/index.html#timeline"
+      }
+    ]);
+  }
+
+  // --- Gallery Modal Logic -----------------------------------------
+  let lastFocusedElement = null;
+
+  function openModal(item) {
+    lastFocusedElement = item;
+
+    modalTitle.textContent = item.dataset.title;
+    modalHeading.textContent = item.querySelector("p")?.textContent || "Gallery Highlight";
+    modalDescription.textContent = item.dataset.desc;
+
+    modal.classList.add("open");
+    modal.setAttribute("aria-hidden", "false");
+    document.body.classList.add("modal-open");
+
+    if (modalClose) modalClose.focus();
+  }
+
+  function closeModal() {
+    modal.classList.remove("open");
+    modal.setAttribute("aria-hidden", "true");
+    document.body.classList.remove("modal-open");
+
+    if (lastFocusedElement) {
+      lastFocusedElement.focus();
+    }
+  }
+
+  // Bind gallery click events
+  galleryItems.forEach((item) => {
+    item.setAttribute("tabindex", "0");
+    item.addEventListener("click", () => openModal(item));
+    item.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        openModal(item);
+      }
+    });
+  });
+
+  if (modalClose) {
+    modalClose.addEventListener("click", closeModal);
+  }
+
+  if (modal) {
+    modal.addEventListener("click", (e) => {
+      if (e.target === modal) {
+        closeModal();
+      }
+    });
+  }
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && modal && modal.classList.contains("open")) {
+      closeModal();
+    }
+  });
+
+  // Run initialization
+  initJourney();
+});

--- a/frontend/odia-cinema-explorer/style.css
+++ b/frontend/odia-cinema-explorer/style.css
@@ -1,0 +1,584 @@
+/* ==========================================================================
+   Ollywood (Odia Cinema) Explorer - Stylesheet
+   Pure Vanilla CSS matching the application's premium aesthetic.
+   ========================================================================== */
+
+:root {
+  --ollywood-stone: #140f0a;
+  --ollywood-stone-light: #211810;
+  --ollywood-gold: #d9a441;
+  --ollywood-gold-light: #f0cc7a;
+  --ollywood-gold-dark: #96631f;
+  --ollywood-sand: #e8cba0;
+  --ollywood-teal: #c1442d;
+  --ollywood-glass: rgba(33, 24, 16, 0.55);
+  --ollywood-border: rgba(193, 68, 45, 0.18);
+}
+
+/* Page Main Container */
+.ollywood-main {
+  background-color: var(--ollywood-stone);
+  color: #f1f5f9;
+  font-family: 'Outfit', sans-serif;
+  overflow-x: hidden;
+}
+
+/* Hero Section */
+.ollywood-hero {
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+  padding: 120px 0 60px;
+  background: linear-gradient(180deg, rgba(23, 14, 10, 0.4), rgba(23, 14, 10, 0.95)), 
+              url('../assets/ollywood_cinema_hall.svg') center/cover no-repeat;
+  text-align: center;
+}
+
+.ollywood-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 50%, rgba(233, 196, 106, 0.12), transparent 60%);
+  z-index: 1;
+}
+
+.ollywood-hero-content {
+  position: relative;
+  z-index: 2;
+  width: min(880px, 90%);
+}
+
+.ollywood-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 20px;
+  padding: 6px 16px;
+  background: rgba(233, 196, 106, 0.1);
+  border: 1px solid rgba(233, 196, 106, 0.3);
+  border-radius: 100px;
+  color: var(--ollywood-gold-light);
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  backdrop-filter: blur(8px);
+}
+
+.ollywood-hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2.5rem, 6vw, 4.5rem);
+  line-height: 1.1;
+  margin: 0 0 20px;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.ollywood-hero h1 span {
+  color: var(--ollywood-gold-light);
+  background: linear-gradient(135deg, var(--ollywood-gold-light), var(--ollywood-gold));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.ollywood-hero p {
+  font-size: clamp(1rem, 2vw, 1.2rem);
+  line-height: 1.6;
+  color: #cbd5e1;
+  margin: 0 auto;
+  max-width: 720px;
+}
+
+/* Sections General */
+.ollywood-section {
+  padding: 80px 0;
+}
+
+.ollywood-section:nth-of-type(even) {
+  background-color: rgba(255, 255, 255, 0.01);
+}
+
+.ollywood-container {
+  width: min(1200px, 90%);
+  margin: 0 auto;
+}
+
+.ollywood-section-header {
+  margin-bottom: 50px;
+  text-align: center;
+}
+
+.ollywood-eyebrow {
+  color: var(--ollywood-gold-light);
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.ollywood-section-header h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin: 0 0 16px;
+  color: #ffffff;
+}
+
+.ollywood-section-header p {
+  color: #94a3b8;
+  max-width: 650px;
+  margin: 0 auto;
+  line-height: 1.6;
+  font-size: 1.05rem;
+}
+
+/* Content Grid / Two Columns */
+.ollywood-grid-2col {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 50px;
+  align-items: center;
+}
+
+@media (max-width: 900px) {
+  .ollywood-grid-2col {
+    grid-template-columns: 1fr;
+    gap: 30px;
+  }
+}
+
+.ollywood-text-block p {
+  line-height: 1.75;
+  color: #cbd5e1;
+  margin-bottom: 20px;
+  font-size: 1.05rem;
+}
+
+.ollywood-text-block p:last-child {
+  margin-bottom: 0;
+}
+
+.ollywood-highlight-box {
+  background: var(--ollywood-glass);
+  border: 1px solid var(--ollywood-border);
+  border-radius: 16px;
+  padding: 30px;
+  backdrop-filter: blur(12px);
+}
+
+.ollywood-highlight-box h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.4rem;
+  margin: 0 0 16px;
+  color: var(--ollywood-gold-light);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.ollywood-highlight-box ul {
+  padding-left: 20px;
+  margin: 0;
+}
+
+.ollywood-highlight-box li {
+  color: #cbd5e1;
+  margin-bottom: 12px;
+  line-height: 1.6;
+}
+
+.ollywood-highlight-box li:last-child {
+  margin-bottom: 0;
+}
+
+/* Card Grid Styles for Rulers */
+.ollywood-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.ollywood-card {
+  background: var(--ollywood-glass);
+  border: 1px solid var(--ollywood-border);
+  border-radius: 16px;
+  padding: 30px;
+  transition: transform 0.3s, border-color 0.3s, box-shadow 0.3s;
+  backdrop-filter: blur(10px);
+}
+
+.ollywood-card:hover {
+  transform: translateY(-5px);
+  border-color: var(--ollywood-gold-light);
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
+}
+
+.ollywood-card-icon {
+  font-size: 2.2rem;
+  margin-bottom: 20px;
+  display: block;
+}
+
+.ollywood-card h3 {
+  margin: 0 0 12px;
+  font-family: 'Playfair Display', serif;
+  font-size: 1.3rem;
+  color: #ffffff;
+}
+
+.ollywood-card p {
+  margin: 0;
+  line-height: 1.6;
+  color: #cbd5e1;
+  font-size: 0.95rem;
+}
+
+/* Interactive Timeline */
+.ollywood-timeline {
+  position: relative;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 20px 0;
+}
+
+.ollywood-timeline::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(180deg, transparent, var(--ollywood-border) 10%, var(--ollywood-border) 90%, transparent);
+  transform: translateX(-50%);
+}
+
+.ollywood-timeline-step {
+  display: flex;
+  justify-content: flex-end;
+  padding-right: 50%;
+  position: relative;
+  margin-bottom: 40px;
+}
+
+.ollywood-timeline-step:nth-child(even) {
+  justify-content: flex-start;
+  padding-right: 0;
+  padding-left: 50%;
+}
+
+.ollywood-timeline-marker {
+  position: absolute;
+  left: 50%;
+  top: 15px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--ollywood-stone);
+  border: 3px solid var(--ollywood-gold-light);
+  transform: translateX(-50%);
+  z-index: 2;
+  transition: background 0.3s;
+}
+
+.ollywood-timeline-step:hover .ollywood-timeline-marker {
+  background: var(--ollywood-gold);
+  box-shadow: 0 0 10px var(--ollywood-gold);
+}
+
+.ollywood-timeline-card {
+  background: var(--ollywood-glass);
+  border: 1px solid var(--ollywood-border);
+  border-radius: 12px;
+  padding: 24px;
+  width: 85%;
+  margin-right: 40px;
+  position: relative;
+  transition: transform 0.3s, border-color 0.3s;
+}
+
+.ollywood-timeline-step:nth-child(even) .ollywood-timeline-card {
+  margin-right: 0;
+  margin-left: 40px;
+}
+
+.ollywood-timeline-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--ollywood-gold-light);
+}
+
+.ollywood-timeline-year {
+  color: var(--ollywood-gold);
+  font-weight: 800;
+  font-size: 1.25rem;
+  margin-bottom: 8px;
+  display: block;
+}
+
+.ollywood-timeline-card h3 {
+  margin: 0 0 8px;
+  font-size: 1.15rem;
+}
+
+.ollywood-timeline-card p {
+  margin: 0;
+  color: #94a3b8;
+  line-height: 1.6;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 768px) {
+  .ollywood-timeline::before {
+    left: 20px;
+  }
+  .ollywood-timeline-step {
+    justify-content: flex-start;
+    padding-left: 45px;
+    padding-right: 0;
+  }
+  .ollywood-timeline-step:nth-child(even) {
+    padding-left: 45px;
+  }
+  .ollywood-timeline-marker {
+    left: 20px;
+  }
+  .ollywood-timeline-card {
+    width: 100%;
+    margin-right: 0;
+  }
+  .ollywood-timeline-step:nth-child(even) .ollywood-timeline-card {
+    margin-left: 0;
+  }
+}
+
+/* Visual Gallery Grid */
+.ollywood-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 20px;
+}
+
+.ollywood-gallery-item {
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  aspect-ratio: 4 / 3;
+  border: 1px solid var(--ollywood-border);
+  cursor: pointer;
+}
+
+.ollywood-gallery-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.5s ease;
+}
+
+.ollywood-gallery-item:hover img {
+  transform: scale(1.08);
+}
+
+.ollywood-gallery-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(0deg, rgba(10, 12, 16, 0.95) 0%, rgba(10, 12, 16, 0.4) 60%, transparent 100%);
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding: 20px;
+  opacity: 0.9;
+  transition: opacity 0.3s;
+}
+
+.ollywood-gallery-overlay h4 {
+  margin: 0 0 4px;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.ollywood-gallery-overlay p {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--ollywood-gold-light);
+}
+
+/* References Section */
+.ollywood-references {
+  background: var(--ollywood-glass);
+  border: 1px solid var(--ollywood-border);
+  border-radius: 16px;
+  padding: 40px;
+}
+
+.ollywood-references h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.4rem;
+  margin: 0 0 20px;
+  color: #ffffff;
+}
+
+.ollywood-references ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.ollywood-references li {
+  position: relative;
+  padding-left: 24px;
+  margin-bottom: 16px;
+  line-height: 1.6;
+  color: #cbd5e1;
+  font-size: 0.98rem;
+}
+
+.ollywood-references li:last-child {
+  margin-bottom: 0;
+}
+
+.ollywood-references li::before {
+  content: '📖';
+  position: absolute;
+  left: 0;
+  top: 2px;
+  font-size: 0.9rem;
+}
+
+/* Page Footer */
+.ollywood-footer {
+  padding: 40px 0;
+  text-align: center;
+  color: #94a3b8;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.ollywood-footer a {
+  color: var(--ollywood-gold-light);
+  text-decoration: none;
+  font-weight: 600;
+  transition: color 0.2s;
+}
+
+.ollywood-footer a:hover {
+  color: var(--ollywood-gold);
+}
+
+/* Bookmark UI Integration */
+.ollywood-bookmark-container {
+  display: flex;
+  justify-content: center;
+  margin-top: 30px;
+}
+
+.ollywood-bookmark-btn {
+  background: var(--ollywood-glass);
+  border: 1px solid var(--ollywood-border);
+  color: var(--ollywood-gold-light);
+  padding: 10px 24px;
+  border-radius: 30px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: all 0.2s ease;
+}
+
+.ollywood-bookmark-btn:hover {
+  border-color: var(--ollywood-gold-light);
+  background: rgba(233, 196, 106, 0.1);
+  transform: translateY(-1px);
+}
+
+.ollywood-bookmark-btn.is-saved {
+  background: var(--ollywood-gold-light);
+  color: var(--ollywood-stone);
+  border-color: var(--ollywood-gold-light);
+}
+
+/* Interactive Detail Modal */
+.museum-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1600;
+  display: none;
+  place-items: center;
+  padding: 20px;
+  background: rgba(0, 0, 0, 0.78);
+  backdrop-filter: blur(10px);
+}
+
+.museum-modal.open {
+  display: grid;
+}
+
+.museum-modal-card {
+  position: relative;
+  width: min(680px, 96vw);
+  max-height: 90vh;
+  overflow: auto;
+  padding: 30px;
+  border: 1px solid var(--ollywood-border);
+  border-radius: 22px;
+  background: var(--ollywood-stone-light);
+  color: #f1f5f9;
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.45);
+}
+
+.museum-modal-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  width: 38px;
+  height: 38px;
+  border: 1px solid var(--ollywood-border);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.05);
+  color: #cbd5e1;
+  font-size: 1.45rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.museum-modal-close:hover {
+  background: rgba(255, 255, 255, 0.15);
+}
+
+.modal-category {
+  display: inline-block;
+  margin-bottom: 10px;
+  color: var(--ollywood-gold-light);
+  font-weight: 800;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+}
+
+.museum-modal-card h2 {
+  margin: 0 42px 7px 0;
+  font-family: "Playfair Display", serif;
+  font-size: clamp(1.9rem, 4vw, 2.7rem);
+}
+
+.modal-location {
+  margin: 0 0 20px;
+  color: #cbd5e1;
+  font-weight: 600;
+}
+
+.modal-description {
+  margin: 0;
+  color: #cbd5e1;
+  line-height: 1.75;
+}
+
+body.modal-open {
+  overflow: hidden;
+}

--- a/frontend/odia-cinema-explorer/style.css
+++ b/frontend/odia-cinema-explorer/style.css
@@ -19,7 +19,7 @@
 .ollywood-main {
   background-color: var(--ollywood-stone);
   color: #f1f5f9;
-  font-family: 'Outfit', sans-serif;
+  font-family: Outfit, sans-serif;
   overflow-x: hidden;
 }
 

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -644,6 +644,12 @@ window.indiaSearchIndex = [
     url: "frontend/river/frontend/river/river.html"
   },
   {
+    title: "Ollywood (Odia Cinema) Explorer",
+    category: "Culture",
+    description: "Discover Ollywood, the Odia film industry of Odisha — from Sita Bibaha (1936), the first Odia film, to National Award-winning classics and the artists who built its legacy.",
+    url: "frontend/odia-cinema-explorer/index.html"
+  },
+  {
     title: "River Krishna",
     category: "Rivers",
     description: "Major river of southern India, supporting agriculture across Maharashtra, Karnataka, and Andhra Pradesh.",

--- a/index.html
+++ b/index.html
@@ -378,7 +378,6 @@
         </button>
         <nav class="nav-menu" id="nav-menu">
             <a href="index.html#home" class="nav-link active" id="link-home">Home</a>
-            <a href="frontend/indian-art-forms-visualizer/index.html" class="nav-link" id="link-art" style="color: var(--saffron)">Art Forms</a>
 
             <div class="nav-dropdown">
                 <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
@@ -396,7 +395,6 @@
                 <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
                 <div class="dropdown-menu">
                     <a href="frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
-                    <a href="frontend/odia-cinema-explorer/index.html" class="dropdown-item">Ollywood (Odia Cinema)</a>
                     <a href="frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
                     <a href="frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
                     <a href="frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>

--- a/index.html
+++ b/index.html
@@ -396,6 +396,7 @@
                 <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
                 <div class="dropdown-menu">
                     <a href="frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+                    <a href="frontend/odia-cinema-explorer/index.html" class="dropdown-item">Ollywood (Odia Cinema)</a>
                     <a href="frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
                     <a href="frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
                     <a href="frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>


### PR DESCRIPTION
## Overview
Adds a new "Ollywood (Odia Cinema) Explorer" page to the Culture section, following the same design pattern as the existing Kachwaha/Hoysala dynasty explorer pages.
 Closes #1787


## What's included
- **New page**: `frontend/odia-cinema-explorer/index.html` — full explorer page with hero banner, historical overview, notable films grid, artists section, interactive timeline, and illustrated visual gallery
- **Styling**: `frontend/odia-cinema-explorer/style.css` — custom theme matching the app's premium dark aesthetic (gold/teal/sand palette)
- **Interactivity**: `frontend/odia-cinema-explorer/script.js` — gallery modal, Journey bookmark integration, global search registration
- **4 custom SVG illustrations**: vintage cinema hall, Sita Bibaha (1936) scene, National Film Award (Rajat Kamal), film reel & camera
- **Navigation**: added "Ollywood (Odia Cinema)" link to the Culture dropdown in root `index.html`
- **Search**: registered new entries in `frontend/search-index.js` for global search discoverability

## Content covered
- Odia cinema's origin with *Sita Bibaha* (1936), the first Odia film
- Notable films: Sri Lokanath, Sita Rati, Maya Miriga, Magunira Shagada, Hisab Nikas
- Key artists: Mohan Sundar Deb Goswami, Prasanta Nanda, Nirad N. Mohapatra, Manmohan Mohapatra
- Timeline of milestones from 1936 to present
- References & further reading section

## Testing done
- [x] Verified no console errors (fixed missing `AppConfig` script dependency)
- [x] Confirmed nav dropdown link routes correctly
- [x] Gallery modal open/close via click, keyboard (Enter/Space), and Escape
- [x] Journey bookmark save/unsave toggle works
- [x] Global search returns results for "Ollywood" / "Sita Bibaha"
- [x] Responsive layout checked on mobile widths
- [x] Dark/light theme toggle verified
- [x] HTML tag balance verified

## Screenshots
<img width="1440" height="852" alt="Screenshot 2026-08-07 115327" src="https://github.com/user-attachments/assets/8618531b-b720-4e84-a99d-fb402d980d73" />
<img width="1440" height="852" alt="Screenshot 2026-08-07 115353" src="https://github.com/user-attachments/assets/05dbcded-0e42-4efc-971a-c17f6ea1e60e" />
<img width="1440" height="852" alt="Screenshot 2026-08-07 115403" src="https://github.com/user-attachments/assets/62b2f91e-4c40-43f5-afda-0e7619aca133" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added an Ollywood (Odia Cinema) Explorer featuring history, notable films, artists, chronology, gallery, and references.
  * Added searchable content, bookmarking, theme support, responsive layouts, and accessible image-detail modals.
  * Added navigation and global search access under the Culture section.
  * Added scroll-to-top controls and mobile-friendly presentation.

* **Updates**
  * Removed the “Art Forms” link from the main navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->