### PR TITLE
 explorer page for the Battle of the Hydaspes

### DIFF
--- a/frontend/battle-of-hydaspes-explorer/index.html
+++ b/frontend/battle-of-hydaspes-explorer/index.html
@@ -1,0 +1,438 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore the Battle of the Hydaspes (326 BCE): Alexander the Great's tactical masterstroke against King Porus and his formidable war elephants on the banks of the Hydaspes (Jhelum) River.">
+  <title>Battle of the Hydaspes Explorer | Incredible India</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css">
+
+  <!-- Open Graph / Social Media Tags -->
+  <meta property="og:title" content="Battle of the Hydaspes Explorer | Incredible India Explorer">
+  <meta property="og:description" content="Relive the epic clash of 326 BCE between Alexander the Great and King Porus along the monsoon-swollen Hydaspes River.">
+  <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/frontend/assets/Warlitr.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/battle-of-hydaspes-explorer/index.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Incredible India Explorer">
+  <meta property="og:locale" content="en_IN">
+
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/battle-of-hydaspes-explorer/index.html">
+</head>
+<body>
+  <script>
+    (function() {
+      const theme = localStorage.getItem('theme') || 'dark';
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+
+  <!-- Sticky Navigation Bar -->
+  <header class="navbar" id="navbar">
+    <div class="nav-container">
+        <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+            <span class="saffron">Incredible</span>
+            <span class="gold">India</span>
+            <span class="green">Explorer</span>
+        </a>
+        <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+            <span class="bar"></span>
+            <span class="bar"></span>
+            <span class="bar"></span>
+        </button>
+        <nav class="nav-menu" id="nav-menu">
+            <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
+                    <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                    <a href="../../frontend/islands/islands.html" class="dropdown-item">Islands of India</a>
+                    <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    <a href="../../frontend/route-planner/route-planner.html" class="dropdown-item">Route Planner</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+                    <a href="../../frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
+                    <a href="../../frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
+                    <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
+                    <a href="../../frontend/national-symbols-gallery/national-symbols-gallery.html" class="dropdown-item">National Symbols</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Nature ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/national-parks-explorer/index.html" class="dropdown-item">National Parks</a>
+                    <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                    <a href="../../frontend/wildlife-rescue/wildlife-rescue.html" class="dropdown-item">Wildlife Rescue</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Games ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/passport-quest/passport-quest.html" class="dropdown-item">Passport Quest</a>
+                    <a href="../../frontend/culinary-game/culinary-game.html" class="dropdown-item">Culinary Challenge</a>
+                    <a href="../../frontend/monsoon-game/monsoon-game.html" class="dropdown-item">Monsoon Game</a>
+                </div>
+            </div>
+
+            <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+        </nav>
+    </div>
+  </header>
+
+  <!-- SPA Router Target Container -->
+  <main id="app-root" class="hydaspes-main">
+
+    <!-- Hero Banner -->
+    <section class="hydaspes-hero">
+      <div class="hydaspes-hero-content">
+        <span class="hydaspes-kicker">⚔️ Punjab (Hydaspes / Jhelum River) · May 326 BCE</span>
+        <h1>Battle of the Hydaspes <span>Explorer</span></h1>
+        <p>In the torrential monsoon of May 326 BCE, Alexander the Great faced King Porus of the Paurava Kingdom in his easternmost campaign. Fought across the swollen Hydaspes River, it became legendary for Alexander's daring night crossing, Porus's terrifying war elephant vanguard, and the heroic mutual respect between two grand military rulers.</p>
+        <div class="hydaspes-bookmark-container">
+          <button class="hydaspes-bookmark-btn journey-bookmark-btn" type="button" data-bookmark-id="battle-of-hydaspes-main" aria-pressed="false" aria-label="Bookmark Battle of the Hydaspes">
+            ♡ Save to Journey
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Navigation Sub-Menu -->
+    <nav class="hydaspes-nav-tabs" aria-label="Explorer Sections Navigation">
+      <a href="#overview" class="hydaspes-tab-link active">Overview</a>
+      <a href="#opposing-forces" class="hydaspes-tab-link">Opposing Forces</a>
+      <a href="#military-tactics" class="hydaspes-tab-link">Military Tactics</a>
+      <a href="#timeline" class="hydaspes-tab-link">Timeline</a>
+      <a href="#aftermath" class="hydaspes-tab-link">Aftermath</a>
+      <a href="#references" class="hydaspes-tab-link">References</a>
+    </nav>
+
+    <!-- Section 1: Overview -->
+    <section class="hydaspes-section" id="overview">
+      <div class="hydaspes-container hydaspes-grid-2col">
+        <div class="hydaspes-text-block">
+          <span class="hydaspes-eyebrow">Historical Context</span>
+          <h2>The Climax of Alexander’s Indian Campaign</h2>
+          <p>Following his conquest of the Achaemenid Persian Empire, Alexander the Great marched into the Punjab region of ancient India in 326 BCE. While Taxiles (King Omphis of Taxila) submitted willingly and sought Alexander's aid against rivals, King Porus (Puru) of the powerful Paurava Kingdom refused to surrender, challenging the Macedonian king to meet him on the field of battle.</p>
+          <p>The stage was set along the Hydaspes River (modern-day Jhelum River). Porus assembled a dense defense along the eastern bank, deploying a formidable wall of war elephants that struck fear into Alexander's cavalry horses. The swelling monsoon rains transformed the river into a roaring barrier, turning the engagement into a masterclass in military deception and tactical endurance.</p>
+        </div>
+        <div class="hydaspes-highlight-box">
+          <h3>🏛️ Historical Snapshot</h3>
+          <ul>
+            <li><strong>Date:</strong> May 326 BCE (Monsoon season)</li>
+            <li><strong>Location:</strong> Hydaspes River (Jhelum River, Punjab region)</li>
+            <li><strong>Belligerents:</strong> Macedonian Empire vs Paurava Kingdom</li>
+            <li><strong>Macedonian Commanders:</strong> Alexander the Great, Craterus, Coenus, Hephaestion</li>
+            <li><strong>Paurava Commanders:</strong> King Porus (Purushottama), Prince Porus Jr.</li>
+            <li><strong>Key Significance:</strong> Alexander's most costly victory; first major encounter with Indian war elephant tactics.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 2: Opposing Forces -->
+    <section class="hydaspes-section hydaspes-alt-bg" id="opposing-forces">
+      <div class="hydaspes-container">
+        <div class="hydaspes-section-header">
+          <span class="hydaspes-eyebrow">Armies & Order of Battle</span>
+          <h2>Opposing Forces</h2>
+          <p>Compare the elite Macedonian combined-arms force with the massive Indian armaments and elephant corps of the Paurava Kingdom.</p>
+        </div>
+
+        <div id="forces" class="hydaspes-forces-grid">
+          <!-- Macedonian Card -->
+          <div class="hydaspes-force-card macedonian-card">
+            <div class="force-card-header">
+              <span class="force-badge">Macedonian Alliance</span>
+              <h3>Macedonian & Allied Army</h3>
+              <span class="force-commander">Commander: Alexander the Great</span>
+            </div>
+            <div class="force-stats">
+              <div class="stat-item">
+                <span class="stat-value">~34,000–40,000</span>
+                <span class="stat-label">Total Strength</span>
+              </div>
+              <div class="stat-item">
+                <span class="stat-value">5,000+</span>
+                <span class="stat-label">Cavalry</span>
+              </div>
+            </div>
+            <ul class="force-unit-list">
+              <li><strong>Companion Cavalry (Hetairoi):</strong> Alexander's strike force armed with heavy Xyston lances.</li>
+              <li><strong>Macedonian Phalanx (Pezhetairoi):</strong> Formidable infantry wielding 18-foot <em>sarissa</em> pikes.</li>
+              <li><strong>Agrianian Javelin-Throwers:</strong> Light infantry specialized in skirmishing and targeting elephant riders.</li>
+              <li><strong>Dahae Horse Archers:</strong> Nomadic archers providing mobile ranged harassment.</li>
+              <li><strong>Indian Allies:</strong> ~5,000 troops sent by King Omphis of Taxila.</li>
+            </ul>
+          </div>
+
+          <!-- Paurava Card -->
+          <div class="hydaspes-force-card paurava-card">
+            <div class="force-card-header">
+              <span class="force-badge paurava-badge">Paurava Kingdom</span>
+              <h3>Paurava Royal Army</h3>
+              <span class="force-commander">Commander: King Porus</span>
+            </div>
+            <div class="force-stats">
+              <div class="stat-item">
+                <span class="stat-value">~30,000–50,000</span>
+                <span class="stat-label">Total Infantry</span>
+              </div>
+              <div class="stat-item">
+                <span class="stat-value">80–200</span>
+                <span class="stat-label">War Elephants</span>
+              </div>
+            </div>
+            <ul class="force-unit-list">
+              <li><strong>War Elephant Corps:</strong> Heavy living fortresses stationed at 50-foot intervals to terrify cavalry.</li>
+              <li><strong>Paurava Heavy Chariots:</strong> ~300 four-horse chariots carrying archers and spearmen.</li>
+              <li><strong>Paurava Cavalry:</strong> ~4,000 armored horsemen protecting the flanks.</li>
+              <li><strong>Longbow Infantry:</strong> Skilled archers wielding massive bamboo bows requiring foot bracing.</li>
+              <li><strong>Royal Vanguard:</strong> Led by Prince Porus Jr., deployed as the initial reaction force.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 3: Military Tactics -->
+    <section class="hydaspes-section" id="military-tactics">
+      <div class="hydaspes-container">
+        <div class="hydaspes-section-header">
+          <span class="hydaspes-eyebrow">Doctrine & Strategy</span>
+          <h2>Military Tactics</h2>
+          <p>Explore the brilliant tactical moves, night crossings, and counter-elephant tactics that decided the battle.</p>
+        </div>
+
+        <div id="tactics" class="hydaspes-tactics-wrapper">
+          <div id="strategy" class="hydaspes-tactics-grid">
+
+            <div class="tactic-card">
+              <div class="tactic-icon">🌊</div>
+              <h3>Deception & Night River Crossing</h3>
+              <p>Porus guarded every potential crossing along the swollen Hydaspes. Alexander staged nightly troop movements and false alarms until Porus stopped reacting. Under cover of a fierce thunderstorm 17 miles upstream at Jalalpur island, Alexander secretly ferried ~11,000 elite troops across the river on skin boats and rafts.</p>
+            </div>
+
+            <div class="tactic-card">
+              <div class="tactic-icon">🎯</div>
+              <h3>Pinning the Chariots in Mud</h3>
+              <p>When Porus sent his son with 2,000 cavalry and 120 chariots to intercept the crossing, heavy rain had turned the battleground into a quagmire. The heavy Indian four-horse chariots got stuck in the mud, allowing Alexander's horse archers and Companion Cavalry to swiftly defeat the detachment.</p>
+            </div>
+
+            <div class="tactic-card">
+              <div class="tactic-icon">🐘</div>
+              <h3>Neutralizing War Elephants</h3>
+              <p>Porus anchored his main line with war elephants spaced between infantry blocks. Knowing horses feared elephants, Alexander kept his cavalry clear of the center and ordered light Agrianian skirmishers and phalangites to target the elephant handlers (mahouts) and use axes to hamstring the beasts.</p>
+            </div>
+
+            <div class="tactic-card">
+              <div class="tactic-icon">⚔️</div>
+              <h3>Double Envelopment Maneuver</h3>
+              <p>Alexander massed his cavalry on his right wing to draw Porus's horsemen. Simultaneously, he dispatched Coenus with a cavalry wing around the Paurava rear. Caught in a double envelopment, Porus's cavalry was driven back into their own panic-stricken elephants, trampling their own infantry.</p>
+            </div>
+
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 4: Timeline -->
+    <section class="hydaspes-section hydaspes-alt-bg" id="timeline">
+      <div class="hydaspes-container">
+        <div class="hydaspes-section-header">
+          <span class="hydaspes-eyebrow">Chronology of Events</span>
+          <h2>Timeline of the Battle</h2>
+          <p>Follow the sequence of events from Alexander’s entry into Taxila to the peaceful aftermath along the Hydaspes.</p>
+        </div>
+
+        <div class="hydaspes-timeline">
+          <div class="timeline-item">
+            <div class="timeline-marker"></div>
+            <div class="timeline-content">
+              <span class="timeline-date">Early 326 BCE</span>
+              <h3>Alliance at Taxila</h3>
+              <p>Alexander crosses the Indus River and enters Taxila. King Omphis of Taxila submits peacefully and provides supplies and 5,000 auxiliary troops for Alexander's march toward the Paurava kingdom.</p>
+            </div>
+          </div>
+
+          <div class="timeline-item">
+            <div class="timeline-marker"></div>
+            <div class="timeline-content">
+              <span class="timeline-date">May 326 BCE (Monsoon Onset)</span>
+              <h3>Standoff at the Hydaspes</h3>
+              <p>Alexander arrives at the western bank of the swollen Hydaspes River. King Porus establishes a fortified camp on the opposite bank with 200 war elephants guarding all landing points.</p>
+            </div>
+          </div>
+
+          <div class="timeline-item">
+            <div class="timeline-marker"></div>
+            <div class="timeline-content">
+              <span class="timeline-date">May 326 BCE (Night)</span>
+              <h3>The Secret Storm Crossing</h3>
+              <p>During a torrential monsoon storm, Alexander leads 11,000 elite soldiers 17 miles upstream to a wooded island. They cross the roaring river undetected on floats and dismantled boats.</p>
+            </div>
+          </div>
+
+          <div class="timeline-item">
+            <div class="timeline-marker"></div>
+            <div class="timeline-content">
+              <span class="timeline-date">May 326 BCE (Morning)</span>
+              <h3>Skirmish with Prince Porus Jr.</h3>
+              <p>Porus dispatches his son with 2,000 horsemen and 120 chariots. The heavy chariots get bogged down in rain-soaked mud; Alexander's cavalry routes the force and kills Prince Porus Jr.</p>
+            </div>
+          </div>
+
+          <div class="timeline-item">
+            <div class="timeline-marker"></div>
+            <div class="timeline-content">
+              <span class="timeline-date">May 326 BCE (Midday)</span>
+              <h3>The Main Clash & Elephant Rampage</h3>
+              <p>Porus lines up his main army with war elephants fronting the center. Alexander executes a cavalry envelopment. Targeted by Agrianian skirmishers, blinded elephants panic and trample Paurava ranks.</p>
+            </div>
+          </div>
+
+          <div class="timeline-item">
+            <div class="timeline-marker"></div>
+            <div class="timeline-content">
+              <span class="timeline-date">Late Afternoon 326 BCE</span>
+              <h3>Surrender & The Royal Encounter</h3>
+              <p>Badly wounded and riding his imperial elephant to the end, Porus surrenders. Impressed by his courage, Alexander asks how he wishes to be treated. Porus famously replies: <em>"Treat me like a king."</em></p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Gallery & Artifact Highlights -->
+    <section class="hydaspes-section" id="gallery-highlights">
+      <div class="hydaspes-container">
+        <div class="hydaspes-section-header">
+          <span class="hydaspes-eyebrow">Interactive Artifacts</span>
+          <h2>Battle Artifacts & Icons</h2>
+          <p>Click on any highlight to explore tactical weaponry, commemorative coinage, and historic markers.</p>
+        </div>
+
+        <div class="hydaspes-gallery-grid">
+          <div class="hydaspes-gallery-item" data-title="Porus War Elephant Decadrachm" data-desc="Silver decadrachm minted by Alexander depicting a Macedonian horseman attacking Porus atop a war elephant. It is one of the rarest numismatic relics of ancient India.">
+            <div class="gallery-badge">Coinage</div>
+            <h4>Silver Decadrachm Coin</h4>
+            <p>Commemorative coin struck after the battle illustrating the clash of cavalry vs elephant.</p>
+          </div>
+
+          <div class="hydaspes-gallery-item" data-title="Macedonian Sarissa Spear" data-desc="The 18-foot iron-tipped pike of the Macedonian phalanx used to form impenetrable spear walls and keep war elephants at bay during infantry engagements.">
+            <div class="gallery-badge">Weaponry</div>
+            <h4>The Macedonian Sarissa</h4>
+            <p>Long pikes used by Pezhetairoi phalangites to confront opposing lines.</p>
+          </div>
+
+          <div class="hydaspes-gallery-item" data-title="Bucephalus Memorial" data-desc="Alexander's beloved warhorse Bucephalus died of exhaustion after the battle. Alexander founded the city of Bucephala (modern Jhelum area) in his memory.">
+            <div class="gallery-badge">City Foundation</div>
+            <h4>City of Bucephala</h4>
+            <p>One of two cities founded by Alexander on the banks of the Hydaspes following victory.</p>
+          </div>
+
+          <div class="hydaspes-gallery-item" data-title="City of Nicaea (Victory)" data-desc="Founded on the eastern battle site to commemorate the Macedonian victory and serve as an administrative post along the Jhelum river trade route.">
+            <div class="gallery-badge">City Foundation</div>
+            <h4>City of Nicaea</h4>
+            <p>Greek settlement established on the site of victory opposite Bucephala.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 5: Aftermath -->
+    <section class="hydaspes-section hydaspes-alt-bg" id="aftermath">
+      <div class="hydaspes-container hydaspes-grid-2col">
+        <div class="hydaspes-text-block">
+          <span class="hydaspes-eyebrow">Consequences & Legacy</span>
+          <h2>Aftermath & Historic Impact</h2>
+          <p>The Battle of the Hydaspes resulted in heavy casualties for both sides. An estimated 12,000–20,000 Indian infantry and 3,000 cavalry perished, while Alexander suffered his highest casualties in any major battle (~1,000 dead and thousands wounded).</p>
+          <p>Rather than deposing Porus, Alexander reinstated him as satrap and enlarged his kingdom to include territory stretching to the Hyphasis (Beas) River. However, the battle severely weakened Macedonian troop morale. When Alexander reached the Hyphasis, his soldiers—terrified of rumors of the mighty Nanda Empire's 200,000 infantry and 6,000 war elephants—mutinied and forced Alexander to turn back, marking the outer limit of his empire.</p>
+        </div>
+        <div id="outcome" class="hydaspes-highlight-box outcome-box">
+          <h3>📜 Key Outcomes</h3>
+          <ul>
+            <li><strong>Porus Reinstated:</strong> Retained as ruler and made governor over expanded territories.</li>
+            <li><strong>Limit of Expansion:</strong> Macedonian army mutinied at the Hyphasis (Beas) River soon after.</li>
+            <li><strong>Founding of Cities:</strong> Nicaea and Bucephala established on opposite banks.</li>
+            <li><strong>Indo-Greek Cultural Contact:</strong> Initiated centuries of trade, artistic exchange (Gandhara art), and diplomatic relations.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 6: References -->
+    <section class="hydaspes-section" id="references">
+      <div class="hydaspes-container">
+        <div class="hydaspes-section-header">
+          <span class="hydaspes-eyebrow">Bibliography & Sources</span>
+          <h2>References & Further Reading</h2>
+          <p>Primary classical histories and modern scholarly accounts of Alexander’s Indian campaign.</p>
+        </div>
+
+        <div class="hydaspes-references-grid">
+          <div class="reference-card">
+            <h4>Anabasis of Alexander</h4>
+            <p><strong>Author:</strong> Arrian (Lucius Flavius Arrianus)</p>
+            <p>Primary classical account detailing troop movements, night river crossings, and tactical deployment at Hydaspes.</p>
+          </div>
+
+          <div class="reference-card">
+            <h4>Life of Alexander</h4>
+            <p><strong>Author:</strong> Plutarch</p>
+            <p>Biographical history documenting Alexander's famous exchange with Porus and the death of Bucephalus.</p>
+          </div>
+
+          <div class="reference-card">
+            <h4>Bibliotheca Historica (Book XVII)</h4>
+            <p><strong>Author:</strong> Diodorus Siculus</p>
+            <p>Detailed historical survey of Alexander's engagements with Indian kings and war elephant tactics.</p>
+          </div>
+
+          <div class="reference-card">
+            <h4>Alexander the Great & The Conquest of the East</h4>
+            <p><strong>Author:</strong> Robin Lane Fox & A.B. Bosworth</p>
+            <p>Modern military historiography of the campaign, geographical analysis of the Jhelum crossing, and tactical assessments.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Interactive Modal -->
+    <div id="hydaspes-modal" class="hydaspes-modal" aria-hidden="true" role="dialog" aria-labelledby="modal-title">
+      <div class="modal-content">
+        <button id="hydaspes-modal-close" class="modal-close-btn" aria-label="Close dialog">&times;</button>
+        <span id="modal-title" class="modal-badge">Artifact Highlight</span>
+        <h3 id="modal-heading">Detail Title</h3>
+        <p id="modal-description">Detailed description will appear here.</p>
+      </div>
+    </div>
+
+  </main>
+
+  <footer class="footer">
+    <div class="container text-center">
+      <p>© 2026 Incredible India Explorer. Dedicated to historical preservation and interactive learning.</p>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+  <script src="../js-modules/page-progress/page-progress.js"></script>
+</body>
+</html>

--- a/frontend/battle-of-hydaspes-explorer/script.js
+++ b/frontend/battle-of-hydaspes-explorer/script.js
@@ -1,0 +1,173 @@
+function initHydaspesExplorer() {
+  const bookmarkButtons = [...document.querySelectorAll(".journey-bookmark-btn")];
+  const galleryItems = [...document.querySelectorAll(".hydaspes-gallery-item")];
+
+  const modal = document.getElementById("hydaspes-modal");
+  const modalClose = document.getElementById("hydaspes-modal-close");
+  const modalTitle = document.getElementById("modal-title");
+  const modalHeading = document.getElementById("modal-heading");
+  const modalDescription = document.getElementById("modal-description");
+
+  // --- Welcome Toast (auto-dismisses) -------------------------------
+  function showWelcomeToast() {
+    if (document.getElementById("hydaspes-welcome-toast")) return;
+
+    const toast = document.createElement("div");
+    toast.id = "hydaspes-welcome-toast";
+    toast.className = "hydaspes-welcome-toast";
+    toast.setAttribute("role", "status");
+    toast.setAttribute("aria-live", "polite");
+    toast.innerHTML = "<strong>⚔️ Battle of the Hydaspes</strong> — May 326 BCE. Alexander the Great's tactical triumph against King Porus and his war elephants.";
+    document.body.appendChild(toast);
+
+    requestAnimationFrame(() => toast.classList.add("is-visible"));
+
+    setTimeout(() => {
+      toast.classList.remove("is-visible");
+      toast.addEventListener("transitionend", () => toast.remove(), { once: true });
+      setTimeout(() => toast.remove(), 500);
+    }, 3200);
+  }
+
+  showWelcomeToast();
+
+  // --- Journey Integration (Bookmarks & Global Search) -------------
+  function initJourney() {
+    if (!window.Journey) return;
+
+    // 1. Bookmark functionality
+    bookmarkButtons.forEach((btn) => {
+      const id = btn.dataset.bookmarkId || "battle-of-hydaspes-main";
+      const title = "Battle of the Hydaspes Explorer";
+      const thumbnail = "frontend/assets/Warlitr.png";
+      const category = "history";
+
+      const updateBookmarkUI = () => {
+        const isSaved = window.Journey.isSaved(id);
+        btn.classList.toggle("is-saved", isSaved);
+        btn.setAttribute("aria-pressed", String(isSaved));
+        btn.innerHTML = isSaved ? "♥ Saved to Journey" : "♡ Save to Journey";
+      };
+
+      updateBookmarkUI();
+
+      btn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        window.Journey.toggle({
+          id,
+          explorerPage: "frontend/battle-of-hydaspes-explorer/index.html",
+          title,
+          thumbnail,
+          category
+        });
+        updateBookmarkUI();
+      });
+    });
+
+    // 2. Global search index registration
+    window.Journey.registerSearchItems("frontend/battle-of-hydaspes-explorer/index.html", [
+      {
+        id: "battle-of-hydaspes-main",
+        title: "Battle of the Hydaspes Explorer",
+        description: "Explore the Battle of the Hydaspes (May 326 BCE): Alexander the Great's epic encounter with King Porus along the Jhelum River.",
+        link: "frontend/battle-of-hydaspes-explorer/index.html"
+      },
+      {
+        id: "battle-of-hydaspes-forces",
+        title: "Opposing Forces at the Hydaspes",
+        description: "Comparative order of battle: Macedonian phalanx and Companion cavalry vs King Porus's war elephant vanguard, heavy chariots, and infantry.",
+        link: "frontend/battle-of-hydaspes-explorer/index.html#opposing-forces"
+      },
+      {
+        id: "battle-of-hydaspes-tactics",
+        title: "Military Tactics at the Hydaspes",
+        description: "Alexander's night river crossing in a monsoon storm, double cavalry envelopment, and counter-elephant tactics.",
+        link: "frontend/battle-of-hydaspes-explorer/index.html#military-tactics"
+      },
+      {
+        id: "battle-of-hydaspes-timeline",
+        title: "Battle of the Hydaspes Timeline",
+        description: "Chronology of the 326 BCE campaign from the Taxila alliance and river standoff to the storm crossing and surrender of Porus.",
+        link: "frontend/battle-of-hydaspes-explorer/index.html#timeline"
+      },
+      {
+        id: "battle-of-hydaspes-aftermath",
+        title: "Aftermath of the Hydaspes",
+        description: "Alexander's famous dialogue with Porus ('Treat me like a king'), founding of Nicaea and Bucephala, and soldier mutiny at the Beas River.",
+        link: "frontend/battle-of-hydaspes-explorer/index.html#aftermath"
+      }
+    ]);
+  }
+
+  // --- Gallery Modal Logic -----------------------------------------
+  let lastFocusedElement = null;
+
+  function openModal(item) {
+    lastFocusedElement = item;
+
+    if (modalTitle) modalTitle.textContent = item.dataset.title || "Artifact Highlight";
+    if (modalHeading) modalHeading.textContent = item.querySelector("h4")?.textContent || "Gallery Highlight";
+    if (modalDescription) modalDescription.textContent = item.dataset.desc || "";
+
+    if (modal) {
+      modal.classList.add("open");
+      modal.setAttribute("aria-hidden", "false");
+      document.body.classList.add("modal-open");
+    }
+
+    if (modalClose) modalClose.focus();
+  }
+
+  function closeModal() {
+    if (modal) {
+      modal.classList.remove("open");
+      modal.setAttribute("aria-hidden", "true");
+      document.body.classList.remove("modal-open");
+    }
+
+    if (lastFocusedElement) {
+      lastFocusedElement.focus();
+    }
+  }
+
+  galleryItems.forEach((item) => {
+    item.setAttribute("tabindex", "0");
+    item.addEventListener("click", () => openModal(item));
+    item.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        openModal(item);
+      }
+    });
+  });
+
+  if (modalClose) {
+    modalClose.addEventListener("click", closeModal);
+  }
+
+  if (modal) {
+    modal.addEventListener("click", (e) => {
+      if (e.target === modal) {
+        closeModal();
+      }
+    });
+  }
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && modal && modal.classList.contains("open")) {
+      closeModal();
+    }
+  });
+
+  // Run Journey initialization
+  initJourney();
+}
+
+// Support both standalone DOM loads & SPA route changes
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initHydaspesExplorer);
+} else {
+  initHydaspesExplorer();
+}
+
+document.addEventListener("app:route-changed", initHydaspesExplorer);

--- a/frontend/battle-of-hydaspes-explorer/style.css
+++ b/frontend/battle-of-hydaspes-explorer/style.css
@@ -1,0 +1,597 @@
+/* ==========================================================================
+   Battle of the Hydaspes Explorer — Custom Styling
+   Aesthetic: Ancient Royal Bronze, River Indigo, Greek Gold, Dark Mode Glassmorphism
+   ========================================================================== */
+
+:root {
+  --hydaspes-bg: #0b0f19;
+  --hydaspes-card-bg: rgba(21, 28, 44, 0.75);
+  --hydaspes-card-border: rgba(212, 175, 55, 0.2);
+  --hydaspes-card-hover-border: rgba(212, 175, 55, 0.5);
+  --hydaspes-gold: #d4af37;
+  --hydaspes-gold-light: #f7e7a1;
+  --hydaspes-bronze: #cd7f32;
+  --hydaspes-accent-blue: #3b82f6;
+  --hydaspes-text-main: #f1f5f9;
+  --hydaspes-text-muted: #94a3b8;
+  --hydaspes-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
+}
+
+.hydaspes-main {
+  background-color: var(--hydaspes-bg);
+  color: var(--hydaspes-text-main);
+  font-family: 'Outfit', sans-serif;
+  min-height: 100vh;
+  padding-bottom: 4rem;
+}
+
+/* --- Hero Section --- */
+.hydaspes-hero {
+  position: relative;
+  background: linear-gradient(135deg, #090d16 0%, #172033 50%, #0c1424 100%);
+  padding: 5rem 1.5rem 4rem;
+  border-bottom: 1px solid var(--hydaspes-card-border);
+  text-align: center;
+  overflow: hidden;
+}
+
+.hydaspes-hero::before {
+  content: '';
+  position: absolute;
+  top: -50%;
+  left: -50%;
+  width: 200%;
+  height: 200%;
+  background: radial-gradient(circle, rgba(212, 175, 55, 0.08) 0%, transparent 60%);
+  pointer-events: none;
+}
+
+.hydaspes-hero-content {
+  max-width: 900px;
+  margin: 0 auto;
+  position: relative;
+  z-index: 1;
+}
+
+.hydaspes-kicker {
+  display: inline-block;
+  background: rgba(212, 175, 55, 0.15);
+  color: var(--hydaspes-gold);
+  border: 1px solid rgba(212, 175, 55, 0.4);
+  padding: 0.4rem 1.2rem;
+  border-radius: 50px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-bottom: 1.25rem;
+}
+
+.hydaspes-hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: 3rem;
+  font-weight: 700;
+  color: #ffffff;
+  margin-bottom: 1.25rem;
+  line-height: 1.2;
+}
+
+.hydaspes-hero h1 span {
+  color: var(--hydaspes-gold);
+  font-style: italic;
+}
+
+.hydaspes-hero p {
+  font-size: 1.15rem;
+  color: var(--hydaspes-text-muted);
+  line-height: 1.7;
+  margin-bottom: 2rem;
+}
+
+/* Bookmark Button */
+.hydaspes-bookmark-btn {
+  background: linear-gradient(135deg, rgba(212, 175, 55, 0.2), rgba(205, 127, 50, 0.2));
+  color: var(--hydaspes-gold-light);
+  border: 1px solid var(--hydaspes-gold);
+  padding: 0.75rem 1.75rem;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.hydaspes-bookmark-btn:hover {
+  background: var(--hydaspes-gold);
+  color: #0b0f19;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 15px rgba(212, 175, 55, 0.4);
+}
+
+.hydaspes-bookmark-btn.is-saved {
+  background: var(--hydaspes-gold);
+  color: #0b0f19;
+}
+
+/* --- Nav Tabs --- */
+.hydaspes-nav-tabs {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  background: rgba(15, 23, 42, 0.9);
+  backdrop-filter: blur(10px);
+  padding: 1rem;
+  position: sticky;
+  top: 70px;
+  z-index: 100;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.hydaspes-tab-link {
+  color: var(--hydaspes-text-muted);
+  text-decoration: none;
+  padding: 0.5rem 1.25rem;
+  border-radius: 6px;
+  font-weight: 500;
+  font-size: 0.95rem;
+  transition: all 0.25s ease;
+}
+
+.hydaspes-tab-link:hover,
+.hydaspes-tab-link.active {
+  color: var(--hydaspes-gold);
+  background: rgba(212, 175, 55, 0.12);
+}
+
+/* --- General Section Layouts --- */
+.hydaspes-section {
+  padding: 4.5rem 1.5rem;
+}
+
+.hydaspes-alt-bg {
+  background: rgba(15, 23, 42, 0.4);
+}
+
+.hydaspes-container {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.hydaspes-grid-2col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 3rem;
+  align-items: center;
+}
+
+@media (max-width: 868px) {
+  .hydaspes-grid-2col {
+    grid-template-columns: 1fr;
+  }
+}
+
+.hydaspes-section-header {
+  text-align: center;
+  max-width: 750px;
+  margin: 0 auto 3rem;
+}
+
+.hydaspes-eyebrow {
+  color: var(--hydaspes-gold);
+  font-weight: 700;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.hydaspes-section-header h2,
+.hydaspes-text-block h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: 2.25rem;
+  color: #ffffff;
+  margin-bottom: 1rem;
+}
+
+.hydaspes-section-header p,
+.hydaspes-text-block p {
+  color: var(--hydaspes-text-muted);
+  line-height: 1.7;
+  font-size: 1.05rem;
+  margin-bottom: 1rem;
+}
+
+/* Highlight Box */
+.hydaspes-highlight-box {
+  background: var(--hydaspes-card-bg);
+  border: 1px solid var(--hydaspes-card-border);
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: var(--hydaspes-shadow);
+  backdrop-filter: blur(10px);
+}
+
+.hydaspes-highlight-box h3 {
+  color: var(--hydaspes-gold);
+  font-size: 1.35rem;
+  margin-bottom: 1.25rem;
+  font-family: 'Playfair Display', serif;
+}
+
+.hydaspes-highlight-box ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.hydaspes-highlight-box li {
+  padding: 0.6rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--hydaspes-text-main);
+  font-size: 0.95rem;
+}
+
+.hydaspes-highlight-box li:last-child {
+  border-bottom: none;
+}
+
+/* --- Opposing Forces Grid --- */
+.hydaspes-forces-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+
+@media (max-width: 768px) {
+  .hydaspes-forces-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.hydaspes-force-card {
+  background: var(--hydaspes-card-bg);
+  border: 1px solid var(--hydaspes-card-border);
+  border-radius: 12px;
+  padding: 2rem;
+  transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.hydaspes-force-card:hover {
+  transform: translateY(-5px);
+  border-color: var(--hydaspes-card-hover-border);
+}
+
+.force-badge {
+  display: inline-block;
+  background: rgba(59, 130, 246, 0.15);
+  color: #60a5fa;
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.paurava-badge {
+  background: rgba(212, 175, 55, 0.15);
+  color: var(--hydaspes-gold);
+}
+
+.hydaspes-force-card h3 {
+  font-size: 1.6rem;
+  color: #ffffff;
+  margin-bottom: 0.25rem;
+}
+
+.force-commander {
+  display: block;
+  color: var(--hydaspes-text-muted);
+  font-size: 0.9rem;
+  margin-bottom: 1.5rem;
+}
+
+.force-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 1rem;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.stat-value {
+  display: block;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--hydaspes-gold);
+}
+
+.stat-label {
+  font-size: 0.8rem;
+  color: var(--hydaspes-text-muted);
+  text-transform: uppercase;
+}
+
+.force-unit-list {
+  padding-left: 1.2rem;
+  margin: 0;
+  color: var(--hydaspes-text-muted);
+}
+
+.force-unit-list li {
+  margin-bottom: 0.6rem;
+  line-height: 1.5;
+  font-size: 0.95rem;
+}
+
+.force-unit-list strong {
+  color: var(--hydaspes-text-main);
+}
+
+/* --- Military Tactics --- */
+.hydaspes-tactics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.tactic-card {
+  background: var(--hydaspes-card-bg);
+  border: 1px solid var(--hydaspes-card-border);
+  border-radius: 12px;
+  padding: 1.75rem;
+  transition: all 0.3s ease;
+}
+
+.tactic-card:hover {
+  border-color: var(--hydaspes-gold);
+  box-shadow: 0 8px 25px rgba(212, 175, 55, 0.15);
+}
+
+.tactic-icon {
+  font-size: 2.2rem;
+  margin-bottom: 1rem;
+}
+
+.tactic-card h3 {
+  color: #ffffff;
+  font-size: 1.25rem;
+  margin-bottom: 0.75rem;
+}
+
+.tactic-card p {
+  color: var(--hydaspes-text-muted);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* --- Timeline --- */
+.hydaspes-timeline {
+  position: relative;
+  max-width: 850px;
+  margin: 0 auto;
+  padding-left: 2rem;
+  border-left: 2px solid var(--hydaspes-card-border);
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: 2.5rem;
+}
+
+.timeline-item:last-child {
+  margin-bottom: 0;
+}
+
+.timeline-marker {
+  position: absolute;
+  left: -2.55rem;
+  top: 0.25rem;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: var(--hydaspes-gold);
+  box-shadow: 0 0 10px var(--hydaspes-gold);
+}
+
+.timeline-content {
+  background: var(--hydaspes-card-bg);
+  border: 1px solid var(--hydaspes-card-border);
+  border-radius: 10px;
+  padding: 1.5rem;
+}
+
+.timeline-date {
+  color: var(--hydaspes-gold);
+  font-weight: 700;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  display: block;
+  margin-bottom: 0.4rem;
+}
+
+.timeline-content h3 {
+  color: #ffffff;
+  font-size: 1.3rem;
+  margin-bottom: 0.5rem;
+}
+
+.timeline-content p {
+  color: var(--hydaspes-text-muted);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* --- Gallery & Artifact Highlights --- */
+.hydaspes-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 1.5rem;
+}
+
+.hydaspes-gallery-item {
+  background: var(--hydaspes-card-bg);
+  border: 1px solid var(--hydaspes-card-border);
+  border-radius: 10px;
+  padding: 1.5rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.hydaspes-gallery-item:hover,
+.hydaspes-gallery-item:focus {
+  border-color: var(--hydaspes-gold);
+  transform: translateY(-4px);
+  outline: none;
+}
+
+.gallery-badge {
+  display: inline-block;
+  background: rgba(212, 175, 55, 0.15);
+  color: var(--hydaspes-gold);
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.2rem 0.6rem;
+  border-radius: 4px;
+  margin-bottom: 0.75rem;
+}
+
+.hydaspes-gallery-item h4 {
+  color: #ffffff;
+  font-size: 1.1rem;
+  margin-bottom: 0.5rem;
+}
+
+.hydaspes-gallery-item p {
+  color: var(--hydaspes-text-muted);
+  font-size: 0.88rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+/* --- References Grid --- */
+.hydaspes-references-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.reference-card {
+  background: var(--hydaspes-card-bg);
+  border: 1px solid var(--hydaspes-card-border);
+  border-radius: 10px;
+  padding: 1.5rem;
+}
+
+.reference-card h4 {
+  color: var(--hydaspes-gold);
+  font-size: 1.15rem;
+  margin-bottom: 0.5rem;
+  font-family: 'Playfair Display', serif;
+}
+
+.reference-card p {
+  color: var(--hydaspes-text-muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  margin-bottom: 0.4rem;
+}
+
+/* --- Modal Dialog --- */
+.hydaspes-modal {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(5px);
+  z-index: 1000;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+.hydaspes-modal.open {
+  display: flex;
+}
+
+.modal-content {
+  background: #151c2c;
+  border: 1px solid var(--hydaspes-gold);
+  border-radius: 12px;
+  padding: 2.5rem;
+  max-width: 550px;
+  width: 100%;
+  position: relative;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.8);
+}
+
+.modal-close-btn {
+  position: absolute;
+  top: 1rem;
+  right: 1.25rem;
+  background: none;
+  border: none;
+  color: var(--hydaspes-text-muted);
+  font-size: 1.8rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.modal-close-btn:hover {
+  color: var(--hydaspes-gold);
+}
+
+.modal-badge {
+  color: var(--hydaspes-gold);
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.modal-content h3 {
+  color: #ffffff;
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.modal-content p {
+  color: var(--hydaspes-text-muted);
+  line-height: 1.7;
+  font-size: 1rem;
+  margin: 0;
+}
+
+/* --- Toast Notification --- */
+.hydaspes-welcome-toast {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  background: #172033;
+  border: 1px solid var(--hydaspes-gold);
+  color: #ffffff;
+  padding: 1rem 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 10px 25px rgba(0,0,0,0.5);
+  z-index: 2000;
+  max-width: 400px;
+  font-size: 0.92rem;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: all 0.4s ease;
+}
+
+.hydaspes-welcome-toast.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}

--- a/frontend/history/battles/index.html
+++ b/frontend/history/battles/index.html
@@ -167,6 +167,25 @@
                 <p>Immersive, interactive explorations of India's most consequential battles — brought to life with timelines, strategies, casualties, and legacy.</p>
             </div>
 
+            <!-- Featured Explorer: Battle of the Hydaspes (326 BCE) -->
+            <section class="featured-explorer-section reveal-up" aria-label="Featured battle explorer">
+                <div class="featured-explorer-card">
+                    <div class="featured-explorer-content">
+                        <span class="featured-explorer-badge">Featured Explorer</span>
+                        <h2>Battle of the Hydaspes (326 BCE)</h2>
+                        <p>Relive the epic clash along the monsoon-swollen Hydaspes River between Alexander the Great and King Porus of the Paurava Kingdom — featuring war elephant charges, daring night river crossings, and mutual royal respect.</p>
+                        <a href="../../battle-of-hydaspes-explorer/index.html" class="featured-explorer-btn">
+                            Explore the Battle of the Hydaspes →
+                        </a>
+                    </div>
+                    <div class="featured-explorer-meta">
+                        <span class="featured-explorer-date">May 326 BCE</span>
+                        <span class="featured-explorer-outcome">Macedonian Victory</span>
+                        <span class="featured-explorer-treaty">King Porus Reinstated &amp; Expanded Kingdom</span>
+                    </div>
+                </div>
+            </section>
+
             <!-- Featured Explorer: Battle of Buxar -->
             <section class="featured-explorer-section reveal-up" aria-label="Featured battle explorer">
                 <div class="featured-explorer-card">

--- a/tests/unit/battle-of-hydaspes-explorer.test.js
+++ b/tests/unit/battle-of-hydaspes-explorer.test.js
@@ -1,0 +1,125 @@
+/**
+ * battle-of-hydaspes-explorer.test.js
+ * Unit tests for the Battle of the Hydaspes Explorer page.
+ * Validates required sections, key historical content, accessibility,
+ * and landing page card integration on the Historic Battles of India page.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function readExplorerFile(file) {
+    return readFileSync(
+        resolve(__dirname, '../../frontend/battle-of-hydaspes-explorer', file),
+        'utf-8'
+    );
+}
+
+function readLandingPage() {
+    return readFileSync(
+        resolve(__dirname, '../../frontend/history/battles/index.html'),
+        'utf-8'
+    );
+}
+
+describe('Battle of the Hydaspes Explorer — Page Structure', () => {
+    let html;
+
+    beforeAll(() => {
+        html = readExplorerFile('index.html');
+    });
+
+    it('contains a hero section with page title and kicker', () => {
+        expect(html).toContain('class="hydaspes-hero"');
+        expect(html).toContain('<h1>');
+        expect(html).toContain('Battle of the Hydaspes');
+        expect(html).toContain('326 BCE');
+    });
+
+    it('contains all required content sections from the issue', () => {
+        const sections = ['overview', 'timeline', 'opposing-forces', 'military-tactics', 'aftermath', 'references'];
+        sections.forEach(id => {
+            expect(html).toContain(`id="${id}"`);
+        });
+    });
+
+    it('contains all required section topics', () => {
+        ['Historical', 'Timeline', 'Opposing Forces', 'Military Tactics', 'Aftermath', 'References'].forEach(topic => {
+            expect(html).toContain(topic);
+        });
+    });
+
+    it('contains key historical and structural details', () => {
+        expect(html).toContain('Alexander');
+        expect(html).toContain('Porus');
+        expect(html).toContain('Hydaspes');
+        expect(html).toContain('Jhelum');
+        expect(html).toContain('Paurava');
+        expect(html).toContain('Elephant');
+        expect(html).toContain('Craterus');
+        expect(html).toContain('Taxila');
+    });
+
+    it('has a semantic heading hierarchy (single h1, multiple section h2s)', () => {
+        const h1Count = (html.match(/<h1[\s>]/g) || []).length;
+        const h2Count = (html.match(/<h2[\s>]/g) || []).length;
+        expect(h1Count).toBe(1);
+        expect(h2Count).toBeGreaterThanOrEqual(5);
+    });
+
+    it('uses HTTPS OG image URLs', () => {
+        const ogImages = html.match(/property="og:image" content="([^"]*)"/g) || [];
+        expect(ogImages.length).toBeGreaterThanOrEqual(1);
+        ogImages.forEach(tag => {
+            expect(tag).toMatch(/https:\/\//);
+        });
+    });
+
+    it('links the shared stylesheet, page stylesheet, and script', () => {
+        expect(html).toContain('href="../../styles.css"');
+        expect(html).toContain('href="style.css"');
+        expect(html).toContain('src="script.js"');
+    });
+});
+
+describe('Battle of the Hydaspes Explorer — Assets', () => {
+    it('includes a non-empty stylesheet', () => {
+        const css = readExplorerFile('style.css');
+        expect(css.length).toBeGreaterThan(1000);
+        expect(css).toContain('.hydaspes-hero');
+        expect(css).toContain('.hydaspes-timeline');
+        expect(css).toContain('.hydaspes-references');
+    });
+
+    it('includes a valid interactive script with required features', () => {
+        const js = readExplorerFile('script.js');
+        expect(js).toContain('registerSearchItems');
+        expect(js).toContain('Journey');
+        expect(js).toContain('hydaspes-modal');
+        expect(js).toContain('app:route-changed');
+    });
+});
+
+describe('Battle of the Hydaspes — Landing Page Integration', () => {
+    it('is listed as a featured explorer card on the Historic Battles of India landing page', () => {
+        const index = readLandingPage();
+        expect(index).toContain('Battle of the Hydaspes');
+        expect(index).toContain('../../battle-of-hydaspes-explorer/index.html');
+        expect(index).toContain('featured-explorer-card');
+    });
+
+    it('matches the existing featured card pattern (badge, heading, button)', () => {
+        const index = readLandingPage();
+        const cardLinkIndex = index.indexOf('battle-of-hydaspes-explorer');
+        expect(cardLinkIndex).toBeGreaterThan(-1);
+        const sectionStart = index.lastIndexOf('featured-explorer-section', cardLinkIndex);
+        const card = index.slice(sectionStart, cardLinkIndex + 500);
+        expect(card).toContain('featured-explorer-badge');
+        expect(card).toContain('featured-explorer-btn');
+        expect(card).toContain('Porus');
+    });
+});


### PR DESCRIPTION
🌟 Summary of Changes
Created Explorer Page (frontend/battle-of-hydaspes-explorer/):



index.html
: Built a semantic, accessible HTML document featuring all required sections:
Battle Overview (#overview): Detailed historical context of Alexander the Great's 326 BCE Indian campaign against King Porus along the monsoon-swollen Hydaspes (Jhelum) River.
Opposing Forces (#opposing-forces / #forces): Comparative order of battle detailing Macedonian combined arms (Phalanx sarissas, Companion Cavalry, Agrianian javelineers, Dahae horse archers) vs Paurava Kingdom forces (War Elephants, heavy chariots, longbow infantry, Prince Porus Jr.).
Military Tactics (#military-tactics / #tactics / #strategy): Breakdown of Alexander's deception operations, thunderstorm night crossing at Jalalpur island, counter-elephant tactics, and double envelopment maneuver.
Timeline (#timeline): Interactive chronology spanning the Taxila alliance, river standoff, night crossing, main battle, and surrender.
Aftermath (#aftermath / #outcome): Casualties, the famous dialogue between Alexander and Porus ("Treat me like a king"), Porus's reinstatement, foundation of Nicaea and Bucephala, and the army mutiny at the Beas River.
References (#references): Classical primary sources (Arrian, Plutarch, Diodorus Siculus) and modern historical scholarship.


style.css
: Styled with dark mode aesthetics (ancient Greek bronze, regal Indian gold, deep river indigo, glassmorphic cards, responsive flex/grid layouts, micro-animations, and modal/toast styling).


script.js
: Provides welcome toast notification, Journey bookmarking and global search registration, and modal gallery dialog.
Landing Page Integration (frontend/history/battles/index.html):

Added a Battle of the Hydaspes featured explorer card in 

frontend/history/battles/index.html
 matching existing design patterns (badge, title, description, link button, metadata tags).
Automated Unit Testing (tests/unit/battle-of-hydaspes-explorer.test.js):

Created unit test suite in 

tests/unit/battle-of-hydaspes-explorer.test.js
 asserting all section IDs, headings, assets, accessibility standards, and landing page card integration. All 11 tests pass.


closes #1582

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Battle of the Hydaspes Explorer with historical overview, opposing forces, tactics, timeline, artifacts, aftermath, references, and responsive navigation.
  * Added searchable journey entries, bookmark controls, welcome notification, and an accessible image gallery with modal viewing.
  * Added the Battle of the Hydaspes as a featured entry on the Historic Battles of India page.
* **Accessibility & Design**
  * Introduced a responsive dark bronze-and-indigo visual theme with keyboard-friendly gallery controls and mobile layouts.
* **Tests**
  * Added coverage for page content, structure, assets, metadata, and landing-page integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->