### PR TITLE
Introduce the Battle of Devagiri as a featured battle explorer

### DIFF
--- a/frontend/battle-of-devagiri-explorer/index.html
+++ b/frontend/battle-of-devagiri-explorer/index.html
@@ -1,0 +1,432 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore the Battle of Devagiri (1296 CE): Alauddin Khalji's secret Deccan campaign against King Ramachandra of the Yadava Dynasty and its historical impact on medieval India.">
+  <title>Battle of Devagiri Explorer | Incredible India</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css">
+
+  <!-- Open Graph / Social Media Tags -->
+  <meta property="og:title" content="Battle of Devagiri Explorer | Incredible India Explorer">
+  <meta property="og:description" content="Relive the audacious 1296 CE Deccan expedition of Alauddin Khalji against the Yadavas of Devagiri, which unlocked the treasures of South India and altered Delhi Sultanate history.">
+  <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/frontend/assets/Warlitr.png">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/battle-of-devagiri-explorer/index.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Incredible India Explorer">
+  <meta property="og:locale" content="en_IN">
+
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/battle-of-devagiri-explorer/index.html">
+</head>
+<body>
+  <script>
+    (function() {
+      const theme = localStorage.getItem('theme') || 'dark';
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+
+  <!-- Sticky Navigation Bar -->
+  <header class="navbar" id="navbar">
+    <div class="nav-container">
+        <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+            <span class="saffron">Incredible</span>
+            <span class="gold">India</span>
+            <span class="green">Explorer</span>
+        </a>
+        <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+            <span class="bar"></span>
+            <span class="bar"></span>
+            <span class="bar"></span>
+        </button>
+        <nav class="nav-menu" id="nav-menu">
+            <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
+                    <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                    <a href="../../frontend/islands/islands.html" class="dropdown-item">Islands of India</a>
+                    <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    <a href="../../frontend/route-planner/route-planner.html" class="dropdown-item">Route Planner</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+                    <a href="../../frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
+                    <a href="../../frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
+                    <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
+                    <a href="../../frontend/national-symbols-gallery/national-symbols-gallery.html" class="dropdown-item">National Symbols</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Nature ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/national-parks-explorer/index.html" class="dropdown-item">National Parks</a>
+                    <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                    <a href="../../frontend/wildlife-rescue/wildlife-rescue.html" class="dropdown-item">Wildlife Rescue</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Games ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/passport-quest/passport-quest.html" class="dropdown-item">Passport Quest</a>
+                    <a href="../../frontend/culinary-game/culinary-game.html" class="dropdown-item">Culinary Challenge</a>
+                    <a href="../../frontend/monsoon-game/monsoon-game.html" class="dropdown-item">Monsoon Game</a>
+                </div>
+            </div>
+
+            <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+        </nav>
+    </div>
+  </header>
+
+  <!-- SPA Router Target Container -->
+  <main id="app-root" class="devagiri-main">
+
+    <!-- Hero Banner -->
+    <section class="devagiri-hero">
+      <div class="devagiri-hero-content">
+        <span class="devagiri-kicker">⚔️ Deccan Plateau (Devagiri / Daulatabad) · 1296 CE</span>
+        <h1>Battle of Devagiri <span>Explorer</span></h1>
+        <p>In 1296 CE, Alauddin Khalji launched a daring, secret expedition across the Vindhya Mountains into the Deccan, targeting Devagiri—the prosperous capital of King Ramachandra of the Yadava Dynasty. Combining rapid cavalry movement, psychological warfare, and tactical surprise, Alauddin breached the Deccan barrier, extracted immense riches, and paved his path to the throne of Delhi.</p>
+        <div class="devagiri-bookmark-container">
+          <button class="devagiri-bookmark-btn journey-bookmark-btn" type="button" data-bookmark-id="battle-of-devagiri-main" aria-pressed="false" aria-label="Bookmark Battle of Devagiri">
+            ♡ Save to Journey
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Navigation Sub-Menu -->
+    <nav class="devagiri-nav-tabs" aria-label="Explorer Sections Navigation">
+      <a href="#background" class="devagiri-tab-link active">Background</a>
+      <a href="#timeline" class="devagiri-tab-link">Timeline</a>
+      <a href="#belligerents" class="devagiri-tab-link">Belligerents</a>
+      <a href="#military-strategy" class="devagiri-tab-link">Military Strategy</a>
+      <a href="#outcome" class="devagiri-tab-link">Outcome</a>
+      <a href="#references" class="devagiri-tab-link">References</a>
+    </nav>
+
+    <!-- Section 1: Historical Background -->
+    <section class="devagiri-section" id="background">
+      <div class="devagiri-container devagiri-grid-2col">
+        <div class="devagiri-text-block">
+          <span class="devagiri-eyebrow">Historical Context</span>
+          <h2>The Audacious Deccan Raid</h2>
+          <p>By 1296 CE, Alauddin Khalji served as the governor of Kara and Awadh under his uncle, Sultan Jalaluddin Khalji. Ambitious and seeking financial independence to claim the Delhi throne, Alauddin learned of the immense wealth of the Yadava (Seuna) Kingdom of Devagiri in the Deccan plateau, which had never been breached by northern armies.</p>
+          <p>Keeping his true target hidden from the Delhi court, Alauddin announced he was marching to raid Chanderi. Instead, he led 8,000 elite horsemen south across the formidable Vindhya mountain range. Taking advantage of the fact that Yadava Prince Singhana (Shankaradeva) was away on a pilgrimage with the main army, Alauddin arrived outside Devagiri, catching King Ramachandra off guard.</p>
+        </div>
+        <div class="devagiri-highlight-box">
+          <h3>🏛️ At a Glance</h3>
+          <ul>
+            <li><strong>Date:</strong> Early 1296 CE</li>
+            <li><strong>Location:</strong> Devagiri (Modern Daulatabad, Maharashtra)</li>
+            <li><strong>Belligerents:</strong> Delhi Sultanate (Kara Forces) vs Yadava (Seuna) Kingdom</li>
+            <li><strong>Key Leaders:</strong> Alauddin Khalji vs King Ramachandra & Prince Singhana</li>
+            <li><strong>Outcome:</strong> Sultanate Victory; Devagiri becomes a tributary state.</li>
+            <li><strong>Historical Impact:</strong> Opened South India to northern expeditions; funded Alauddin's usurpation of the Delhi throne.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 2: Timeline -->
+    <section class="devagiri-section devagiri-alt-bg" id="timeline">
+      <div class="seleucid-container">
+        <div class="devagiri-section-header">
+          <span class="devagiri-eyebrow">Chronology of Events</span>
+          <h2>Timeline of the Campaign</h2>
+          <p>Trace the march across the Vindhyas, the siege of Devagiri, and the political aftermath.</p>
+        </div>
+
+        <div class="devagiri-timeline">
+          <div class="timeline-item">
+            <div class="timeline-marker"></div>
+            <div class="timeline-content">
+              <span class="timeline-date">February 1296 CE</span>
+              <h3>Departure from Kara</h3>
+              <p>Alauddin Khalji departs Kara with 8,000 elite cavalry under the pretext of raiding Chanderi, concealing his true destination from Sultan Jalaluddin.</p>
+            </div>
+          </div>
+
+          <div class="timeline-item">
+            <div class="timeline-marker"></div>
+            <div class="timeline-content">
+              <span class="timeline-date">March 1296 CE</span>
+              <h3>Crossing the Vindhyas & Arrival at Ellichpur</h3>
+              <p>Navigating difficult mountain passes and dense forests, Alauddin's cavalry arrives at Ellichpur in Berar, spreading rumors that they were seeking service under a regional ruler.</p>
+            </div>
+          </div>
+
+          <div class="timeline-item">
+            <div class="timeline-marker"></div>
+            <div class="timeline-content">
+              <span class="timeline-date">Late March 1296 CE</span>
+              <h3>Surprise Siege of Devagiri</h3>
+              <p>Alauddin reaches Devagiri. King Ramachandra retreats into the hilltop fort. Alauddin besieges the lower city and spreads false rumors of a 20,000-man main army following behind.</p>
+            </div>
+          </div>
+
+          <div class="timeline-item">
+            <div class="timeline-marker"></div>
+            <div class="timeline-content">
+              <span class="timeline-date">April 1296 CE</span>
+              <h3>Clash with Prince Singhana’s Relief Force</h3>
+              <p>Prince Singhana returns with the main Yadava army and attacks Alauddin's troops. Alauddin's reserve detachment under Malik Nusrat breaks the Yadava lines, securing victory.</p>
+            </div>
+          </div>
+
+          <div class="timeline-item">
+            <div class="timeline-marker"></div>
+            <div class="timeline-content">
+              <span class="timeline-date">Late April 1296 CE</span>
+              <h3>Surrender & Immense Indemnity</h3>
+              <p>Facing food shortages (bags of salt had been mistaken for grain in the fort storehouses), King Ramachandra surrenders, handing over vast quantities of gold, silver, pearls, and 40 elephants.</p>
+            </div>
+          </div>
+
+          <div class="timeline-item">
+            <div class="timeline-marker"></div>
+            <div class="timeline-content">
+              <span class="timeline-date">July 1296 CE</span>
+              <h3>Assassination of Jalaluddin & Accession</h3>
+              <p>Alauddin returns to Kara with the Devagiri treasure. When Sultan Jalaluddin visits to congratulate him, Alauddin assassinates him and ascends the throne of Delhi.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 3: Belligerents -->
+    <section class="devagiri-section" id="belligerents">
+      <div class="devagiri-container">
+        <div class="devagiri-section-header">
+          <span class="devagiri-eyebrow">Armies & Order of Battle</span>
+          <h2>Belligerents & Leaders</h2>
+          <p>Examine the contrasting military structures of Alauddin's expeditionary force and the Yadava Kingdom.</p>
+        </div>
+
+        <div class="devagiri-belligerents-grid">
+          <!-- Sultanate Expedition -->
+          <div class="belligerent-card sultanate-card">
+            <div class="card-header">
+              <span class="card-badge sultanate-badge">Delhi Sultanate (Kara)</span>
+              <h3>Alauddin’s Expeditionary Force</h3>
+              <span class="card-subhead">Commanders: Alauddin Khalji & Malik Nusrat</span>
+            </div>
+            <div class="card-stats">
+              <div class="stat-item">
+                <span class="stat-value">8,000</span>
+                <span class="stat-label">Elite Cavalry</span>
+              </div>
+              <div class="stat-item">
+                <span class="stat-value">High</span>
+                <span class="stat-label">Mobility & Stealth</span>
+              </div>
+            </div>
+            <ul class="card-list">
+              <li><strong>Mounted Shock Cavalry:</strong> Fast-moving armored horsemen trained for swift mountain crossings.</li>
+              <li><strong>Experienced Officers:</strong> Veteran commanders including Malik Nusrat Khan and Alauddin.</li>
+              <li><strong>Psychological Warfare:</strong> Skilled in spreading disinformation and feigned reinforcements.</li>
+            </ul>
+          </div>
+
+          <!-- Yadava Kingdom -->
+          <div class="belligerent-card yadava-card">
+            <div class="card-header">
+              <span class="card-badge yadava-badge">Yadava (Seuna) Dynasty</span>
+              <h3>Yadava Kingdom Forces</h3>
+              <span class="card-subhead">Commanders: King Ramachandra & Prince Singhana</span>
+            </div>
+            <div class="card-stats">
+              <div class="stat-item">
+                <span class="stat-value">15,000+</span>
+                <span class="stat-label">Infantry & Cavalry</span>
+              </div>
+              <div class="stat-item">
+                <span class="stat-value">Fortress</span>
+                <span class="stat-label">Devagiri Citadel</span>
+              </div>
+            </div>
+            <ul class="card-list">
+              <li><strong>Citadel Garrison:</strong> Defending the famous rock-cut fortress of Devagiri.</li>
+              <li><strong>Yadava Heavy Cavalry:</strong> Armored cavalry led by Prince Singhana (Shankaradeva).</li>
+              <li><strong>Feudal Infantry:</strong> Regional levies protecting the lower city and granaries.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 4: Military Strategy -->
+    <section class="devagiri-section devagiri-alt-bg" id="military-strategy">
+      <div class="devagiri-container">
+        <div class="devagiri-section-header">
+          <span class="devagiri-eyebrow">Tactics & Doctrine</span>
+          <h2>Military Strategy</h2>
+          <p>How secrecy, psychological deception, and tactical speed secured victory against superior numbers.</p>
+        </div>
+
+        <div id="strategy" class="devagiri-strategy-grid">
+          
+          <div class="strategy-card">
+            <div class="strategy-icon">🏔️</div>
+            <h3>Vindhya Mountain Crossing</h3>
+            <p>Alauddin kept his march concealed by choosing difficult mountain passes across the Vindhya range, avoiding established highways where Delhi spies or Deccan scouts could report his advance.</p>
+          </div>
+
+          <div class="strategy-card">
+            <div class="strategy-icon">🗣️</div>
+            <h3>Psychological Disinformation</h3>
+            <p>Upon reaching Devagiri, Alauddin intentionally spread false news that his 8,000 cavalry was merely the vanguard of a 20,000-man royal army led by Sultan Jalaluddin, terrifying the Yadava defenders.</p>
+          </div>
+
+          <div class="strategy-card">
+            <div class="strategy-icon">🌾</div>
+            <h3>Granary Encirclement</h3>
+            <p>Alauddin quickly seized the lower city and surrounded the citadel. Due to the haste of their retreat, the Yadavas had mistakenly loaded bags of salt instead of grain into the fort's granaries, causing rapid famine.</p>
+          </div>
+
+          <div class="strategy-card">
+            <div class="strategy-icon">⚔️</div>
+            <h3>Reserve Counter-Attack</h3>
+            <p>When Prince Singhana's relief army attacked, Alauddin kept 1,000 cavalry in reserve under Malik Nusrat. At the height of battle, Nusrat's charge appeared to be the rumored 20,000-man main army, breaking Yadava morale.</p>
+          </div>
+
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 5: Outcome -->
+    <section class="devagiri-section" id="outcome">
+      <div class="devagiri-container devagiri-grid-2col">
+        <div class="devagiri-text-block">
+          <span class="devagiri-eyebrow">Consequences & Legacy</span>
+          <h2>Outcome & Historical Impact</h2>
+          <p>The Battle of Devagiri ended in a complete victory for Alauddin Khalji. King Ramachandra was forced to sign a humiliating treaty, paying an unprecedented ransom including 600 maunds of gold, 1,000 maunds of silver, 7 maunds of pearls, 2 maunds of precious gems, 400 silk cloths, and 40 war elephants.</p>
+          <p>The historical impact of the campaign was monumental. The vast wealth extracted from Devagiri enabled Alauddin to bribe the nobles of Delhi and assassinate Sultan Jalaluddin in July 1296 CE. Furthermore, by proving that the Vindhya range could be crossed, the battle opened the door for subsequent Delhi Sultanate campaigns into Warangal, Dwarasamudra, and Madurai, permanently altering South Asian history.</p>
+        </div>
+        <div class="devagiri-highlight-box outcome-box">
+          <h3>📜 Key Outcomes</h3>
+          <ul>
+            <li><strong>Colossal Indemnity:</strong> Thousands of kilograms of gold, pearls, and precious gems extracted.</li>
+            <li><strong>Rise of Alauddin:</strong> Funded Alauddin's accession to the throne of Delhi.</li>
+            <li><strong>Vassalage of Devagiri:</strong> King Ramachandra became a tributary ruler to the Delhi Sultanate.</li>
+            <li><strong>Gateway to the Deccan:</strong> Paved the way for Malik Kafur's southern campaigns.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Interactive Artifact Highlights -->
+    <section class="devagiri-section devagiri-alt-bg" id="gallery-highlights">
+      <div class="devagiri-container">
+        <div class="devagiri-section-header">
+          <span class="devagiri-eyebrow">Artifact Highlights</span>
+          <h2>Historical Relics & Monuments</h2>
+          <p>Click on any card to explore fortress architecture, coinage, and court chronicles.</p>
+        </div>
+
+        <div class="devagiri-gallery-grid">
+          <div class="devagiri-gallery-item" data-title="Devagiri (Daulatabad) Fort Citadel" data-desc="The impenetrable 200-meter high conical hill fortress featuring steep rock-cut moats, dark subterranean passages (Andhari), and formidable bastions.">
+            <div class="gallery-badge">Fortress</div>
+            <h4>Devagiri Rock Citadel</h4>
+            <p>Impregnable hill fort of the Yadavas later renamed Daulatabad.</p>
+          </div>
+
+          <div class="devagiri-gallery-item" data-title="Gold Coinage of Ramachandra" data-desc="Gold fanams and pagodas minted by the Yadavas of Devagiri, showcasing the immense commercial wealth accumulated from Deccan trade routes.">
+            <div class="gallery-badge">Numismatics</div>
+            <h4>Yadava Gold Coinage</h4>
+            <p>Gold coins minted by King Ramachandra illustrating Devagiri's immense prosperity.</p>
+          </div>
+
+          <div class="devagiri-gallery-item" data-title="Tarikh-i Firoz Shahi Account" data-desc="Court chronicle by Ziauddin Barani providing a vivid description of Alauddin's secret march, false rumor strategies, and the Devagiri treasure.">
+            <div class="gallery-badge">Chronicle</div>
+            <h4>Barani’s Historical Account</h4>
+            <p>Primary Persian source recording the 1296 CE Deccan expedition.</p>
+          </div>
+
+          <div class="devagiri-gallery-item" data-title="Ellichpur Gateway Landmark" data-desc="The historic transit city in Berar where Alauddin halted his cavalry to spread rumors before descending upon Devagiri.">
+            <div class="gallery-badge">Landmark</div>
+            <h4>Ellichpur Transit Post</h4>
+            <p>Key staging post during Alauddin's march across the Vindhya range.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 6: References -->
+    <section class="devagiri-section" id="references">
+      <div class="devagiri-container">
+        <div class="devagiri-section-header">
+          <span class="devagiri-eyebrow">Bibliography & Sources</span>
+          <h2>References & Further Reading</h2>
+          <p>Primary medieval chronicles and modern historical analyses of the Deccan campaigns.</p>
+        </div>
+
+        <div class="devagiri-references-grid">
+          <div class="reference-card">
+            <h4>Tarikh-i Firoz Shahi</h4>
+            <p><strong>Author:</strong> Ziauddin Barani</p>
+            <p>Primary 14th-century chronicle describing Alauddin's secret march from Kara, the siege of Devagiri, and the gold plunder.</p>
+          </div>
+
+          <div class="reference-card">
+            <h4>Khazainul-Futuh (Treasures of Victory)</h4>
+            <p><strong>Author:</strong> Amir Khusrau</p>
+            <p>Court history documenting Alauddin's campaigns in Central and Southern India and the subjection of the Yadavas.</p>
+          </div>
+
+          <div class="reference-card">
+            <h4>History of the Khaljis (1290–1320)</h4>
+            <p><strong>Author:</strong> K.S. Lal</p>
+            <p>Definitive modern historical monograph detailing the military tactics, routes, and consequences of the 1296 CE Devagiri raid.</p>
+          </div>
+
+          <div class="reference-card">
+            <h4>A History of South India</h4>
+            <p><strong>Author:</strong> K.A. Nilakanta Sastri</p>
+            <p>Standard reference work analyzing the political impact of northern Sultanate expeditions on the Yadavas and southern dynasties.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Interactive Modal -->
+    <div id="devagiri-modal" class="devagiri-modal" aria-hidden="true" role="dialog" aria-labelledby="modal-title">
+      <div class="modal-content">
+        <button id="devagiri-modal-close" class="modal-close-btn" aria-label="Close dialog">&times;</button>
+        <span id="modal-title" class="modal-badge">Artifact Highlight</span>
+        <h3 id="modal-heading">Detail Title</h3>
+        <p id="modal-description">Detailed description will appear here.</p>
+      </div>
+    </div>
+
+  </main>
+
+  <footer class="footer">
+    <div class="container text-center">
+      <p>© 2026 Incredible India Explorer. Dedicated to historical preservation and interactive learning.</p>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+  <script src="../js-modules/page-progress/page-progress.js"></script>
+</body>
+</html>

--- a/frontend/battle-of-devagiri-explorer/script.js
+++ b/frontend/battle-of-devagiri-explorer/script.js
@@ -1,0 +1,173 @@
+function initDevagiriExplorer() {
+  const bookmarkButtons = [...document.querySelectorAll(".journey-bookmark-btn")];
+  const galleryItems = [...document.querySelectorAll(".devagiri-gallery-item")];
+
+  const modal = document.getElementById("devagiri-modal");
+  const modalClose = document.getElementById("devagiri-modal-close");
+  const modalTitle = document.getElementById("modal-title");
+  const modalHeading = document.getElementById("modal-heading");
+  const modalDescription = document.getElementById("modal-description");
+
+  // --- Welcome Toast (auto-dismisses) -------------------------------
+  function showWelcomeToast() {
+    if (document.getElementById("devagiri-welcome-toast")) return;
+
+    const toast = document.createElement("div");
+    toast.id = "devagiri-welcome-toast";
+    toast.className = "devagiri-welcome-toast";
+    toast.setAttribute("role", "status");
+    toast.setAttribute("aria-live", "polite");
+    toast.innerHTML = "<strong>⚔️ Battle of Devagiri</strong> — 1296 CE. Alauddin Khalji's secret Deccan campaign against King Ramachandra of Devagiri.";
+    document.body.appendChild(toast);
+
+    requestAnimationFrame(() => toast.classList.add("is-visible"));
+
+    setTimeout(() => {
+      toast.classList.remove("is-visible");
+      toast.addEventListener("transitionend", () => toast.remove(), { once: true });
+      setTimeout(() => toast.remove(), 500);
+    }, 3200);
+  }
+
+  showWelcomeToast();
+
+  // --- Journey Integration (Bookmarks & Global Search) -------------
+  function initJourney() {
+    if (!window.Journey) return;
+
+    // 1. Bookmark functionality
+    bookmarkButtons.forEach((btn) => {
+      const id = btn.dataset.bookmarkId || "battle-of-devagiri-main";
+      const title = "Battle of Devagiri Explorer";
+      const thumbnail = "frontend/assets/Warlitr.png";
+      const category = "history";
+
+      const updateBookmarkUI = () => {
+        const isSaved = window.Journey.isSaved(id);
+        btn.classList.toggle("is-saved", isSaved);
+        btn.setAttribute("aria-pressed", String(isSaved));
+        btn.innerHTML = isSaved ? "♥ Saved to Journey" : "♡ Save to Journey";
+      };
+
+      updateBookmarkUI();
+
+      btn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        window.Journey.toggle({
+          id,
+          explorerPage: "frontend/battle-of-devagiri-explorer/index.html",
+          title,
+          thumbnail,
+          category
+        });
+        updateBookmarkUI();
+      });
+    });
+
+    // 2. Global search index registration
+    window.Journey.registerSearchItems("frontend/battle-of-devagiri-explorer/index.html", [
+      {
+        id: "battle-of-devagiri-main",
+        title: "Battle of Devagiri Explorer",
+        description: "Explore the Battle of Devagiri (1296 CE): Alauddin Khalji's secret campaign across the Vindhyas against the Yadavas of Devagiri.",
+        link: "frontend/battle-of-devagiri-explorer/index.html"
+      },
+      {
+        id: "battle-of-devagiri-timeline",
+        title: "Battle of Devagiri Timeline",
+        description: "Chronology of the 1296 CE campaign from the departure from Kara and Vindhya crossing to the siege, treaty, and Alauddin's coronation.",
+        link: "frontend/battle-of-devagiri-explorer/index.html#timeline"
+      },
+      {
+        id: "battle-of-devagiri-belligerents",
+        title: "Belligerents of Devagiri",
+        description: "Alauddin Khalji's expeditionary force vs the Yadava Kingdom forces under King Ramachandra and Prince Singhana.",
+        link: "frontend/battle-of-devagiri-explorer/index.html#belligerents"
+      },
+      {
+        id: "battle-of-devagiri-strategy",
+        title: "Military Strategy at Devagiri",
+        description: "Secret mountain routes, psychological disinformation, granary encirclement, and tactical reserves.",
+        link: "frontend/battle-of-devagiri-explorer/index.html#military-strategy"
+      },
+      {
+        id: "battle-of-devagiri-outcome",
+        title: "Outcome & Impact of Devagiri",
+        description: "Massive gold plunder, vassalage of Devagiri, funding Alauddin's Delhi throne usurpation, and opening South India to northern campaigns.",
+        link: "frontend/battle-of-devagiri-explorer/index.html#outcome"
+      }
+    ]);
+  }
+
+  // --- Gallery Modal Logic -----------------------------------------
+  let lastFocusedElement = null;
+
+  function openModal(item) {
+    lastFocusedElement = item;
+
+    if (modalTitle) modalTitle.textContent = item.dataset.title || "Artifact Highlight";
+    if (modalHeading) modalHeading.textContent = item.querySelector("h4")?.textContent || "Gallery Highlight";
+    if (modalDescription) modalDescription.textContent = item.dataset.desc || "";
+
+    if (modal) {
+      modal.classList.add("open");
+      modal.setAttribute("aria-hidden", "false");
+      document.body.classList.add("modal-open");
+    }
+
+    if (modalClose) modalClose.focus();
+  }
+
+  function closeModal() {
+    if (modal) {
+      modal.classList.remove("open");
+      modal.setAttribute("aria-hidden", "true");
+      document.body.classList.remove("modal-open");
+    }
+
+    if (lastFocusedElement) {
+      lastFocusedElement.focus();
+    }
+  }
+
+  galleryItems.forEach((item) => {
+    item.setAttribute("tabindex", "0");
+    item.addEventListener("click", () => openModal(item));
+    item.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        openModal(item);
+      }
+    });
+  });
+
+  if (modalClose) {
+    modalClose.addEventListener("click", closeModal);
+  }
+
+  if (modal) {
+    modal.addEventListener("click", (e) => {
+      if (e.target === modal) {
+        closeModal();
+      }
+    });
+  }
+
+  document.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && modal && modal.classList.contains("open")) {
+      closeModal();
+    }
+  });
+
+  // Run Journey initialization
+  initJourney();
+}
+
+// Support both standalone DOM loads & SPA route changes
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initDevagiriExplorer);
+} else {
+  initDevagiriExplorer();
+}
+
+document.addEventListener("app:route-changed", initDevagiriExplorer);

--- a/frontend/battle-of-devagiri-explorer/style.css
+++ b/frontend/battle-of-devagiri-explorer/style.css
@@ -1,0 +1,600 @@
+/* ==========================================================================
+   Battle of Devagiri Explorer — Custom Styling
+   Aesthetic: Deccan Gold, Sultanate Crimson, Rock Basalt, Dark Mode Glassmorphism
+   ========================================================================== */
+
+:root {
+  --devagiri-bg: #0b0d18;
+  --devagiri-card-bg: rgba(22, 28, 48, 0.78);
+  --devagiri-card-border: rgba(220, 168, 42, 0.22);
+  --devagiri-card-hover-border: rgba(220, 168, 42, 0.55);
+  --devagiri-gold: #dca82a;
+  --devagiri-gold-light: #fbe6a3;
+  --devagiri-crimson: #dc2626;
+  --devagiri-purple: #9333ea;
+  --devagiri-text-main: #f3f4f6;
+  --devagiri-text-muted: #9ca3af;
+  --devagiri-shadow: 0 10px 30px rgba(0, 0, 0, 0.6);
+}
+
+.devagiri-main {
+  background-color: var(--devagiri-bg);
+  color: var(--devagiri-text-main);
+  font-family: 'Outfit', sans-serif;
+  min-height: 100vh;
+  padding-bottom: 4rem;
+}
+
+/* --- Hero Section --- */
+.devagiri-hero {
+  position: relative;
+  background: linear-gradient(135deg, #090b14 0%, #201a36 50%, #0d1222 100%);
+  padding: 5rem 1.5rem 4rem;
+  border-bottom: 1px solid var(--devagiri-card-border);
+  text-align: center;
+  overflow: hidden;
+}
+
+.devagiri-hero::before {
+  content: '';
+  position: absolute;
+  top: -50%;
+  left: -50%;
+  width: 200%;
+  height: 200%;
+  background: radial-gradient(circle, rgba(220, 168, 42, 0.08) 0%, transparent 60%);
+  pointer-events: none;
+}
+
+.devagiri-hero-content {
+  max-width: 900px;
+  margin: 0 auto;
+  position: relative;
+  z-index: 1;
+}
+
+.devagiri-kicker {
+  display: inline-block;
+  background: rgba(220, 168, 42, 0.15);
+  color: var(--devagiri-gold);
+  border: 1px solid rgba(220, 168, 42, 0.4);
+  padding: 0.4rem 1.2rem;
+  border-radius: 50px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-bottom: 1.25rem;
+}
+
+.devagiri-hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: 3rem;
+  font-weight: 700;
+  color: #ffffff;
+  margin-bottom: 1.25rem;
+  line-height: 1.2;
+}
+
+.devagiri-hero h1 span {
+  color: var(--devagiri-gold);
+  font-style: italic;
+}
+
+.devagiri-hero p {
+  font-size: 1.15rem;
+  color: var(--devagiri-text-muted);
+  line-height: 1.7;
+  margin-bottom: 2rem;
+}
+
+/* Bookmark Button */
+.devagiri-bookmark-btn {
+  background: linear-gradient(135deg, rgba(220, 168, 42, 0.2), rgba(147, 51, 234, 0.2));
+  color: var(--devagiri-gold-light);
+  border: 1px solid var(--devagiri-gold);
+  padding: 0.75rem 1.75rem;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.devagiri-bookmark-btn:hover {
+  background: var(--devagiri-gold);
+  color: #0b0d18;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 15px rgba(220, 168, 42, 0.4);
+}
+
+.devagiri-bookmark-btn.is-saved {
+  background: var(--devagiri-gold);
+  color: #0b0d18;
+}
+
+/* --- Nav Tabs --- */
+.devagiri-nav-tabs {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  background: rgba(15, 20, 35, 0.9);
+  backdrop-filter: blur(10px);
+  padding: 1rem;
+  position: sticky;
+  top: 70px;
+  z-index: 100;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.devagiri-tab-link {
+  color: var(--devagiri-text-muted);
+  text-decoration: none;
+  padding: 0.5rem 1.25rem;
+  border-radius: 6px;
+  font-weight: 500;
+  font-size: 0.95rem;
+  transition: all 0.25s ease;
+}
+
+.devagiri-tab-link:hover,
+.devagiri-tab-link.active {
+  color: var(--devagiri-gold);
+  background: rgba(220, 168, 42, 0.12);
+}
+
+/* --- General Section Layouts --- */
+.devagiri-section {
+  padding: 4.5rem 1.5rem;
+}
+
+.devagiri-alt-bg {
+  background: rgba(15, 23, 42, 0.45);
+}
+
+.devagiri-container {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.devagiri-grid-2col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 3rem;
+  align-items: center;
+}
+
+@media (max-width: 868px) {
+  .devagiri-grid-2col {
+    grid-template-columns: 1fr;
+  }
+}
+
+.devagiri-section-header {
+  text-align: center;
+  max-width: 750px;
+  margin: 0 auto 3rem;
+}
+
+.devagiri-eyebrow {
+  color: var(--devagiri-gold);
+  font-weight: 700;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.devagiri-section-header h2,
+.devagiri-text-block h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: 2.25rem;
+  color: #ffffff;
+  margin-bottom: 1rem;
+}
+
+.devagiri-section-header p,
+.devagiri-text-block p {
+  color: var(--devagiri-text-muted);
+  line-height: 1.7;
+  font-size: 1.05rem;
+  margin-bottom: 1rem;
+}
+
+/* Highlight Box */
+.devagiri-highlight-box {
+  background: var(--devagiri-card-bg);
+  border: 1px solid var(--devagiri-card-border);
+  border-radius: 12px;
+  padding: 2rem;
+  box-shadow: var(--devagiri-shadow);
+  backdrop-filter: blur(10px);
+}
+
+.devagiri-highlight-box h3 {
+  color: var(--devagiri-gold);
+  font-size: 1.35rem;
+  margin-bottom: 1.25rem;
+  font-family: 'Playfair Display', serif;
+}
+
+.devagiri-highlight-box ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.devagiri-highlight-box li {
+  padding: 0.6rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--devagiri-text-main);
+  font-size: 0.95rem;
+}
+
+.devagiri-highlight-box li:last-child {
+  border-bottom: none;
+}
+
+/* --- Timeline --- */
+.devagiri-timeline {
+  position: relative;
+  max-width: 850px;
+  margin: 0 auto;
+  padding-left: 2rem;
+  border-left: 2px solid var(--devagiri-card-border);
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: 2.5rem;
+}
+
+.timeline-item:last-child {
+  margin-bottom: 0;
+}
+
+.timeline-marker {
+  position: absolute;
+  left: -2.55rem;
+  top: 0.25rem;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: var(--devagiri-gold);
+  box-shadow: 0 0 10px var(--devagiri-gold);
+}
+
+.timeline-content {
+  background: var(--devagiri-card-bg);
+  border: 1px solid var(--devagiri-card-border);
+  border-radius: 10px;
+  padding: 1.5rem;
+}
+
+.timeline-date {
+  color: var(--devagiri-gold);
+  font-weight: 700;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  display: block;
+  margin-bottom: 0.4rem;
+}
+
+.timeline-content h3 {
+  color: #ffffff;
+  font-size: 1.3rem;
+  margin-bottom: 0.5rem;
+}
+
+.timeline-content p {
+  color: var(--devagiri-text-muted);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* --- Belligerents Grid --- */
+.devagiri-belligerents-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+
+@media (max-width: 768px) {
+  .devagiri-belligerents-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.belligerent-card {
+  background: var(--devagiri-card-bg);
+  border: 1px solid var(--devagiri-card-border);
+  border-radius: 12px;
+  padding: 2rem;
+  transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.belligerent-card:hover {
+  transform: translateY(-5px);
+  border-color: var(--devagiri-card-hover-border);
+}
+
+.card-badge {
+  display: inline-block;
+  font-size: 0.8rem;
+  font-weight: 700;
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  margin-bottom: 0.75rem;
+}
+
+.sultanate-badge {
+  background: rgba(220, 168, 42, 0.15);
+  color: var(--devagiri-gold);
+}
+
+.yadava-badge {
+  background: rgba(147, 51, 234, 0.18);
+  color: #c084fc;
+}
+
+.belligerent-card h3 {
+  font-size: 1.6rem;
+  color: #ffffff;
+  margin-bottom: 0.25rem;
+}
+
+.card-subhead {
+  display: block;
+  color: var(--devagiri-text-muted);
+  font-size: 0.9rem;
+  margin-bottom: 1.5rem;
+}
+
+.card-stats {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  background: rgba(0, 0, 0, 0.3);
+  padding: 1rem;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.stat-value {
+  display: block;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--devagiri-gold);
+}
+
+.stat-label {
+  font-size: 0.8rem;
+  color: var(--devagiri-text-muted);
+  text-transform: uppercase;
+}
+
+.card-list {
+  padding-left: 1.2rem;
+  margin: 0;
+  color: var(--devagiri-text-muted);
+}
+
+.card-list li {
+  margin-bottom: 0.6rem;
+  line-height: 1.5;
+  font-size: 0.95rem;
+}
+
+.card-list strong {
+  color: var(--devagiri-text-main);
+}
+
+/* --- Strategy Grid --- */
+.devagiri-strategy-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.strategy-card {
+  background: var(--devagiri-card-bg);
+  border: 1px solid var(--devagiri-card-border);
+  border-radius: 12px;
+  padding: 1.75rem;
+  transition: all 0.3s ease;
+}
+
+.strategy-card:hover {
+  border-color: var(--devagiri-gold);
+  box-shadow: 0 8px 25px rgba(220, 168, 42, 0.15);
+}
+
+.strategy-icon {
+  font-size: 2.2rem;
+  margin-bottom: 1rem;
+}
+
+.strategy-card h3 {
+  color: #ffffff;
+  font-size: 1.25rem;
+  margin-bottom: 0.75rem;
+}
+
+.strategy-card p {
+  color: var(--devagiri-text-muted);
+  font-size: 0.95rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* --- Gallery & Artifact Highlights --- */
+.devagiri-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 1.5rem;
+}
+
+.devagiri-gallery-item {
+  background: var(--devagiri-card-bg);
+  border: 1px solid var(--devagiri-card-border);
+  border-radius: 10px;
+  padding: 1.5rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.devagiri-gallery-item:hover,
+.devagiri-gallery-item:focus {
+  border-color: var(--devagiri-gold);
+  transform: translateY(-4px);
+  outline: none;
+}
+
+.gallery-badge {
+  display: inline-block;
+  background: rgba(220, 168, 42, 0.15);
+  color: var(--devagiri-gold);
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.2rem 0.6rem;
+  border-radius: 4px;
+  margin-bottom: 0.75rem;
+}
+
+.devagiri-gallery-item h4 {
+  color: #ffffff;
+  font-size: 1.1rem;
+  margin-bottom: 0.5rem;
+}
+
+.devagiri-gallery-item p {
+  color: var(--devagiri-text-muted);
+  font-size: 0.88rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+/* --- References Grid --- */
+.devagiri-references-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.reference-card {
+  background: var(--devagiri-card-bg);
+  border: 1px solid var(--devagiri-card-border);
+  border-radius: 10px;
+  padding: 1.5rem;
+}
+
+.reference-card h4 {
+  color: var(--devagiri-gold);
+  font-size: 1.15rem;
+  margin-bottom: 0.5rem;
+  font-family: 'Playfair Display', serif;
+}
+
+.reference-card p {
+  color: var(--devagiri-text-muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+  margin-bottom: 0.4rem;
+}
+
+/* --- Modal Dialog --- */
+.devagiri-modal {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(5px);
+  z-index: 1000;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+.devagiri-modal.open {
+  display: flex;
+}
+
+.modal-content {
+  background: #161a2e;
+  border: 1px solid var(--devagiri-gold);
+  border-radius: 12px;
+  padding: 2.5rem;
+  max-width: 550px;
+  width: 100%;
+  position: relative;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.8);
+}
+
+.modal-close-btn {
+  position: absolute;
+  top: 1rem;
+  right: 1.25rem;
+  background: none;
+  border: none;
+  color: var(--devagiri-text-muted);
+  font-size: 1.8rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.modal-close-btn:hover {
+  color: var(--devagiri-gold);
+}
+
+.modal-badge {
+  color: var(--devagiri-gold);
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  display: block;
+  margin-bottom: 0.5rem;
+}
+
+.modal-content h3 {
+  color: #ffffff;
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.modal-content p {
+  color: var(--devagiri-text-muted);
+  line-height: 1.7;
+  font-size: 1rem;
+  margin: 0;
+}
+
+/* --- Toast Notification --- */
+.devagiri-welcome-toast {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  background: #201a36;
+  border: 1px solid var(--devagiri-gold);
+  color: #ffffff;
+  padding: 1rem 1.5rem;
+  border-radius: 8px;
+  box-shadow: 0 10px 25px rgba(0,0,0,0.5);
+  z-index: 2000;
+  max-width: 400px;
+  font-size: 0.92rem;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: all 0.4s ease;
+}
+
+.devagiri-welcome-toast.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}

--- a/frontend/history/battles/index.html
+++ b/frontend/history/battles/index.html
@@ -167,6 +167,25 @@
                 <p>Immersive, interactive explorations of India's most consequential battles — brought to life with timelines, strategies, casualties, and legacy.</p>
             </div>
 
+            <!-- Featured Explorer: Battle of Devagiri (1296 CE) -->
+            <section class="featured-explorer-section reveal-up" aria-label="Featured battle explorer">
+                <div class="featured-explorer-card">
+                    <div class="featured-explorer-content">
+                        <span class="featured-explorer-badge">Featured Explorer</span>
+                        <h2>Battle of Devagiri (1296 CE)</h2>
+                        <p>Relive Alauddin Khalji's secret expedition across the Vindhyas against King Ramachandra of Devagiri — the high-stakes raid that yielded immense treasure and opened South India to northern campaigns.</p>
+                        <a href="../../battle-of-devagiri-explorer/index.html" class="featured-explorer-btn">
+                            Explore the Battle of Devagiri →
+                        </a>
+                    </div>
+                    <div class="featured-explorer-meta">
+                        <span class="featured-explorer-date">1296 CE</span>
+                        <span class="featured-explorer-outcome">Sultanate Victory</span>
+                        <span class="featured-explorer-treaty">Massive Tribute · Vassalage of Devagiri</span>
+                    </div>
+                </div>
+            </section>
+
             <!-- Featured Explorer: Battle of Buxar -->
             <section class="featured-explorer-section reveal-up" aria-label="Featured battle explorer">
                 <div class="featured-explorer-card">

--- a/tests/unit/battle-of-devagiri-explorer.test.js
+++ b/tests/unit/battle-of-devagiri-explorer.test.js
@@ -1,0 +1,125 @@
+/**
+ * battle-of-devagiri-explorer.test.js
+ * Unit tests for the Battle of Devagiri Explorer page.
+ * Validates required sections, key historical content, accessibility,
+ * and landing page card integration on the Historic Battles of India page.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function readExplorerFile(file) {
+    return readFileSync(
+        resolve(__dirname, '../../frontend/battle-of-devagiri-explorer', file),
+        'utf-8'
+    );
+}
+
+function readLandingPage() {
+    return readFileSync(
+        resolve(__dirname, '../../frontend/history/battles/index.html'),
+        'utf-8'
+    );
+}
+
+describe('Battle of Devagiri Explorer — Page Structure', () => {
+    let html;
+
+    beforeAll(() => {
+        html = readExplorerFile('index.html');
+    });
+
+    it('contains a hero section with page title and kicker', () => {
+        expect(html).toContain('class="devagiri-hero"');
+        expect(html).toContain('<h1>');
+        expect(html).toContain('Battle of Devagiri');
+        expect(html).toContain('1296 CE');
+    });
+
+    it('contains all required content sections from the issue', () => {
+        const sections = ['background', 'timeline', 'belligerents', 'military-strategy', 'outcome', 'references'];
+        sections.forEach(id => {
+            expect(html).toContain(`id="${id}"`);
+        });
+    });
+
+    it('contains all required section topics', () => {
+        ['Background', 'Timeline', 'Belligerents', 'Military Strategy', 'Outcome', 'References'].forEach(topic => {
+            expect(html).toContain(topic);
+        });
+    });
+
+    it('contains key historical and structural details', () => {
+        expect(html).toContain('Alauddin Khalji');
+        expect(html).toContain('Ramachandra');
+        expect(html).toContain('Devagiri');
+        expect(html).toContain('Yadava');
+        expect(html).toContain('Deccan');
+        expect(html).toContain('Vindhya');
+        expect(html).toContain('Singhana');
+        expect(html).toContain('Treasure');
+    });
+
+    it('has a semantic heading hierarchy (single h1, multiple section h2s)', () => {
+        const h1Count = (html.match(/<h1[\s>]/g) || []).length;
+        const h2Count = (html.match(/<h2[\s>]/g) || []).length;
+        expect(h1Count).toBe(1);
+        expect(h2Count).toBeGreaterThanOrEqual(5);
+    });
+
+    it('uses HTTPS OG image URLs', () => {
+        const ogImages = html.match(/property="og:image" content="([^"]*)"/g) || [];
+        expect(ogImages.length).toBeGreaterThanOrEqual(1);
+        ogImages.forEach(tag => {
+            expect(tag).toMatch(/https:\/\//);
+        });
+    });
+
+    it('links the shared stylesheet, page stylesheet, and script', () => {
+        expect(html).toContain('href="../../styles.css"');
+        expect(html).toContain('href="style.css"');
+        expect(html).toContain('src="script.js"');
+    });
+});
+
+describe('Battle of Devagiri Explorer — Assets', () => {
+    it('includes a non-empty stylesheet', () => {
+        const css = readExplorerFile('style.css');
+        expect(css.length).toBeGreaterThan(1000);
+        expect(css).toContain('.devagiri-hero');
+        expect(css).toContain('.devagiri-timeline');
+        expect(css).toContain('.devagiri-references');
+    });
+
+    it('includes a valid interactive script with required features', () => {
+        const js = readExplorerFile('script.js');
+        expect(js).toContain('registerSearchItems');
+        expect(js).toContain('Journey');
+        expect(js).toContain('devagiri-modal');
+        expect(js).toContain('app:route-changed');
+    });
+});
+
+describe('Battle of Devagiri — Landing Page Integration', () => {
+    it('is listed as a featured explorer card on the Historic Battles of India landing page', () => {
+        const index = readLandingPage();
+        expect(index).toContain('Battle of Devagiri');
+        expect(index).toContain('../../battle-of-devagiri-explorer/index.html');
+        expect(index).toContain('featured-explorer-card');
+    });
+
+    it('matches the existing featured card pattern (badge, heading, button)', () => {
+        const index = readLandingPage();
+        const cardLinkIndex = index.indexOf('battle-of-devagiri-explorer');
+        expect(cardLinkIndex).toBeGreaterThan(-1);
+        const sectionStart = index.lastIndexOf('featured-explorer-section', cardLinkIndex);
+        const card = index.slice(sectionStart, cardLinkIndex + 500);
+        expect(card).toContain('featured-explorer-badge');
+        expect(card).toContain('featured-explorer-btn');
+        expect(card).toContain('Ramachandra');
+    });
+});


### PR DESCRIPTION
Created Explorer Page (frontend/battle-of-devagiri-explorer/):



index.html
: Built a detailed HTML document containing all required sections:
Historical Background (#background / #overview): The secret 1296 CE expedition of Alauddin Khalji across the Vindhya Mountains into the Deccan targeting the wealthy Yadava (Seuna) Kingdom of Devagiri.
Timeline (#timeline): Chronology from departure from Kara, march across mountain passes, arrival at Ellichpur, siege of Devagiri, defeat of Prince Singhana's relief force, peace treaty, and coronation in Delhi.
Belligerents (#belligerents): Detailed comparison between Alauddin's expeditionary force (8,000 elite cavalry, Malik Nusrat Khan) and the Yadava Kingdom forces (King Ramachandra, Prince Singhana).
Military Strategy (#military-strategy / #strategy): Covert campaign planning, Vindhya mountain route selection, psychological disinformation (fake 20,000-man main army rumor), granary encirclement, and tactical reserves.
Outcome (#outcome): Surrender of King Ramachandra, massive extraction of gold, silver, gems, and war elephants, funding of Alauddin's accession to the Delhi throne, and initiation of northern invasions into South India.
References (#references): 14th-century court chronicles (Tarikh-i Firoz Shahi by Barani, Khazainul-Futuh by Amir Khusrau) and modern academic histories.


closes #1604