### PR TITLE
feat: Create Western Kshatrapas Explorer (#1514)

### DIFF
--- a/frontend/history/dynasties/data.js
+++ b/frontend/history/dynasties/data.js
@@ -289,13 +289,46 @@ art: "Bilingual Greek-Kharosthi coin portraiture, Hellenistic-Indian sculptural 
       "Patronage of Buddhist art, including the Bimaran casket, one of the earliest images of the standing Buddha",
       "Facilitated trade and cultural exchange along Silk Road routes linking India, Central Asia, and the Mediterranean"
     ],
-    art: "Bimaran casket and Buddhist reliquary art, bilingual Greek-Kharosthi-Brahmi coinage, early classical Sanskrit epigraphy",
+ art: "Bimaran casket and Buddhist reliquary art, bilingual Greek-Kharosthi-Brahmi coinage, early classical Sanskrit epigraphy",
     era: "ancient",
     color: "#7f8c8d",
     mapPosition: { top: "25%", left: "42%" },
     link: "indo-scythian/index.html"
   },
-    {
+  {
+    id: "western-kshatrapas",
+    name: "Western Kshatrapas",
+    period: "c. 35–415 CE",
+    startYear: 35,
+    endYear: 415,
+    capital: "Ujjain and Junagadh (Kardamaka line); earlier centres under the Kshaharatas near Bharuch",
+    founders: "Bhumaka (Kshaharata line); Chashtana (Kardamaka line)",
+    notableRulers: [
+      { name: "Nahapana", reign: "late 1st century CE", achievement: "Powerful Kshaharata ruler who expanded across Malwa and Gujarat before his defeat by the Satavahana king Gautamiputra Satakarni" },
+      { name: "Chashtana", reign: "c. 78–130 CE", achievement: "Founded the Kardamaka line of Western Kshatrapas; his accession traditionally marks the start of the Saka Era" },
+      { name: "Rudradaman I", reign: "c. 130–150 CE", achievement: "Greatest Western Kshatrapa ruler; issued the Junagadh rock inscription and repaired the Sudarshana lake" },
+      { name: "Rudrasimha III", reign: "c. 388–415 CE", achievement: "Last Western Kshatrapa ruler, defeated by the Gupta emperor Chandragupta II, ending Saka rule in western India" }
+    ],
+    territory: "Gujarat, Saurashtra, and Malwa, extending at times into Maharashtra, Rajasthan, and Madhya Pradesh",
+    peakExtent: "From Sindh and Rajasthan through Gujarat and Malwa to parts of the western Deccan under Rudradaman I",
+    governance: "Administered by rulers holding the titles Kshatrapa (Satrap) and Mahakshatrapa (Great Satrap), continuing a Central Asian-derived satrapal system",
+    military: "Repeated conflict with the Satavahanas over the western Deccan, and later sustained warfare against the expanding Gupta Empire",
+    decline: "Weakened by succession disputes; finally conquered by the Gupta emperor Chandragupta II around 395–415 CE, with the last ruler Rudrasimha III killed in the campaign",
+    contributions: [
+      "An unmatched system of precisely dated silver coinage — nearly every coin records the king's name, his father's name, and a Saka Era date, letting historians reconstruct the dynasty almost year by year",
+      "Rudradaman I's Junagadh rock inscription, the earliest known major inscription in classical Sanskrit",
+      "Popularized the Saka Era calendar, begun in 78 CE and later adopted as India's official civil calendar",
+      "Engineering achievements such as the repair of the Sudarshana lake reservoir under Rudradaman I",
+      "Facilitated maritime trade through the port of Barygaza (Bharuch), linking western India to Roman and Mediterranean trade networks",
+      "A coinage style that influenced later western Indian dynasties, including the Traikutakas and the kingdom of Valabhi"
+    ],
+    art: "Dated silver drachm coinage with royal portraiture, Brahmi epigraphy, Junagadh rock inscription",
+    era: "ancient",
+    color: "#16a085",
+    mapPosition: { top: "45%", left: "40%" },
+    link: "western-kshatrapas/index.html"
+  },
+      {
     id: "kushan",
     name: "Kushan Empire",
     period: "c. 30–375 CE",
@@ -463,11 +496,16 @@ export const timelineEvents = [
   { year: 10, event: "Rajuvula rules as Great Satrap of Mathura, commemorated on the Mathura Lion Capital", dynasty: "indo-scythian" },
   { year: 78, event: "The Saka Era calendar begins, later adopted as India's official civil calendar", dynasty: "indo-scythian" },
   { year: 150, event: "Rudradaman I issues the Junagadh rock inscription, a landmark in classical Sanskrit epigraphy", dynasty: "indo-scythian" },
-  { year: 400, event: "Western Satrap rule ends after defeat by the Gupta emperor Chandragupta II", dynasty: "indo-scythian" }    { year: 30, event: "Kujula Kadphises unites the Yuezhi tribes and founds the Kushan Empire", dynasty: "kushan" },
+{ year: 400, event: "Western Satrap rule ends after defeat by the Gupta emperor Chandragupta II", dynasty: "indo-scythian" },
+  { year: 78, event: "Chashtana founds the Kardamaka line of Western Kshatrapas; the Saka Era calendar begins", dynasty: "western-kshatrapas" },
+  { year: 150, event: "Rudradaman I issues the Junagadh rock inscription and repairs the Sudarshana lake", dynasty: "western-kshatrapas" },
+  { year: 197, event: "Rudrasimha I's reign as Mahakshatrapa ends, having minted an extensive series of dated coins", dynasty: "western-kshatrapas" },
+  { year: 232, event: "Damasena mints coins precisely dated to the Saka era, exemplifying the dynasty's dating system", dynasty: "western-kshatrapas" },
+  { year: 415, event: "Rudrasimha III is defeated by Gupta emperor Chandragupta II, ending Western Kshatrapa rule", dynasty: "western-kshatrapas" },
   { year: 105, event: "Vima Kadphises conquers Gandhara and expands Kushan trade with Rome", dynasty: "kushan" },
   { year: 127, event: "Kanishka I ascends the throne; the Kushan Empire reaches its greatest extent", dynasty: "kushan" },
   { year: 150, event: "Huvishka succeeds Kanishka, continuing patronage of Buddhism and Zoroastrianism", dynasty: "kushan" },
-  { year: 230, event: "Death of Vasudeva I, the last powerful Kushan ruler, marks the start of decline", dynasty: "kushan" }
+  { year: 230, event: "Death of Vasudeva I, the last powerful Kushan ruler, marks the start of decline", dynasty: "kushan" },
     { year: 270, event: "Pravarasena I becomes the first Vakataka ruler to take the title Samrat", dynasty: "vakataka" },
   { year: 385, event: "Rudrasena II marries Prabhavatigupta, daughter of Gupta emperor Chandragupta II", dynasty: "vakataka" },
   { year: 405, event: "Pravarasena II composes the Setubandha and moves the capital to Pravarapura", dynasty: "vakataka" },

--- a/frontend/history/dynasties/data.js
+++ b/frontend/history/dynasties/data.js
@@ -256,13 +256,46 @@ art: "Bronze Nataraja, Brihadeshwara Temple, Thanjavur paintings, Chola bronzes"
       "Cultural and trade contact linking the Hellenistic Mediterranean world with India",
       "Greek loanwords and astronomical concepts that influenced later Indian astrology and astronomy"
     ],
-    art: "Bilingual Greek-Kharosthi coin portraiture, Hellenistic-Indian sculptural fusion, early Greco-Buddhist iconography",
+art: "Bilingual Greek-Kharosthi coin portraiture, Hellenistic-Indian sculptural fusion, early Greco-Buddhist iconography",
     era: "ancient",
     color: "#2980b9",
     mapPosition: { top: "20%", left: "45%" },
     link: "indo-greek/index.html"
   },
   {
+    id: "indo-scythian",
+    name: "Indo-Scythian Dynasty",
+    period: "c. 80 BCE – 400 CE",
+    startYear: -80,
+    endYear: 400,
+    capital: "Sirkap (Taxila), later Mathura (Northern Satraps) and Ujjain (Western Satraps)",
+    founders: "Maues (Moga)",
+    notableRulers: [
+      { name: "Maues (Moga)", reign: "c. 85–60 BCE", achievement: "First Indo-Scythian king; conquered Gandhara and Taxila, founding Saka rule in India" },
+      { name: "Azes I", reign: "c. 55–35 BCE", achievement: "Completed the Saka takeover of the remaining Indo-Greek territories in the northwest" },
+      { name: "Rajuvula", reign: "c. early 1st century CE", achievement: "Great Satrap of Mathura; commemorated on the famous Mathura Lion Capital inscription" },
+      { name: "Rudradaman I", reign: "c. 130–150 CE", achievement: "Greatest Western Satrap ruler; issued the Junagadh rock inscription, the earliest major Sanskrit royal inscription" }
+    ],
+    territory: "Northwestern India (Gandhara, Taxila), Mathura, and western India (Gujarat, Malwa, Sindh)",
+    peakExtent: "From Taxila and Gandhara in the northwest to Mathura in the north and Gujarat-Malwa in the west, under separate satrapies",
+    governance: "Divided into semi-independent satrapies (Taxila, Mathura/Northern Satraps, and Western Satraps) each ruled by a Kshatrapa or Mahakshatrapa (Satrap/Great Satrap)",
+    military: "Cavalry-based nomadic warfare tradition combined with fortified garrison cities such as Sirkap",
+    decline: "Gradual absorption by the Kushans in the north and defeat of the Western Satraps by the Gupta emperor Chandragupta II around 395–415 CE, with the last ruler Rudrasimha III marking the end of Saka rule in India",
+    contributions: [
+      "Introduced the title and administrative system of Kshatrapa (Satrap), which shaped regional governance for centuries",
+      "Established the Saka Era calendar in 78 CE, later adopted as India's official civil calendar",
+      "Rudradaman I's Junagadh rock inscription — the earliest known major inscription in classical Sanskrit",
+      "Continued and enriched bilingual/trilingual coinage traditions inherited from the Indo-Greeks",
+      "Patronage of Buddhist art, including the Bimaran casket, one of the earliest images of the standing Buddha",
+      "Facilitated trade and cultural exchange along Silk Road routes linking India, Central Asia, and the Mediterranean"
+    ],
+    art: "Bimaran casket and Buddhist reliquary art, bilingual Greek-Kharosthi-Brahmi coinage, early classical Sanskrit epigraphy",
+    era: "ancient",
+    color: "#7f8c8d",
+    mapPosition: { top: "25%", left: "42%" },
+    link: "indo-scythian/index.html"
+  },
+    {
     id: "kushan",
     name: "Kushan Empire",
     period: "c. 30–375 CE",
@@ -424,8 +457,13 @@ export const timelineEvents = [
   { year: -180, event: "Apollodotus I extends Indo-Greek territory into Sindh and Gujarat", dynasty: "indo-greek" },
   { year: -155, event: "Menander I becomes king and expands the realm to its greatest extent, reaching Mathura", dynasty: "indo-greek" },
   { year: -130, event: "Death of Menander I; the Milinda Panha later records his dialogue with the monk Nagasena", dynasty: "indo-greek" },
-  { year: 10, event: "Strato II, the last Indo-Greek king, disappears as the Indo-Scythians take control", dynasty: "indo-greek" }
-    { year: 30, event: "Kujula Kadphises unites the Yuezhi tribes and founds the Kushan Empire", dynasty: "kushan" },
+{ year: 10, event: "Strato II, the last Indo-Greek king, disappears as the Indo-Scythians take control", dynasty: "indo-greek" },
+  { year: -85, event: "Maues conquers Gandhara and Taxila, founding Indo-Scythian rule in India", dynasty: "indo-scythian" },
+  { year: -55, event: "Azes I defeats the last Indo-Greek king Hippostratos, completing Saka control of the northwest", dynasty: "indo-scythian" },
+  { year: 10, event: "Rajuvula rules as Great Satrap of Mathura, commemorated on the Mathura Lion Capital", dynasty: "indo-scythian" },
+  { year: 78, event: "The Saka Era calendar begins, later adopted as India's official civil calendar", dynasty: "indo-scythian" },
+  { year: 150, event: "Rudradaman I issues the Junagadh rock inscription, a landmark in classical Sanskrit epigraphy", dynasty: "indo-scythian" },
+  { year: 400, event: "Western Satrap rule ends after defeat by the Gupta emperor Chandragupta II", dynasty: "indo-scythian" }    { year: 30, event: "Kujula Kadphises unites the Yuezhi tribes and founds the Kushan Empire", dynasty: "kushan" },
   { year: 105, event: "Vima Kadphises conquers Gandhara and expands Kushan trade with Rome", dynasty: "kushan" },
   { year: 127, event: "Kanishka I ascends the throne; the Kushan Empire reaches its greatest extent", dynasty: "kushan" },
   { year: 150, event: "Huvishka succeeds Kanishka, continuing patronage of Buddhism and Zoroastrianism", dynasty: "kushan" },

--- a/frontend/history/dynasties/indo-scythian/index.html
+++ b/frontend/history/dynasties/indo-scythian/index.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Indo-Scythian Dynasty Explorer - Discover the Indo-Scythians (Sakas), Central Asian rulers of northwestern and western India from c. 80 BCE to 400 CE, and their lasting administrative and cultural legacy.">
+    <title>Indo-Scythian Dynasty Explorer | Incredible India Explorer</title>
+    <link rel="icon" href="data:,">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:wght@500;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="../../../styles.css">
+    <link rel="stylesheet" href="style.css">
+
+    <meta property="og:title" content="Indo-Scythian Dynasty Explorer | Incredible India Explorer">
+    <meta property="og:description" content="The Indo-Scythian Dynasty — Saka rulers, satrap administration, and lasting influence on ancient India.">
+    <meta property="og:type" content="website">
+    <meta property="og:locale" content="en_IN">
+</head>
+
+<body class="isc-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../../index.html#home" class="nav-link">Home</a>
+                <a href="../index.html" class="nav-link">Indian Dynasties</a>
+                <a href="index.html" class="nav-link active" style="color: #7f8c8d">Indo-Scythian Dynasty</a>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+            </nav>
+        </div>
+    </header>
+
+    <main class="isc-main">
+        <!-- Hero Banner -->
+        <section class="isc-hero">
+            <span class="isc-kicker">🐎 Central Asian Rulers of Ancient India</span>
+            <h1>Indo-Scythian Dynasty Explorer</h1>
+            <p>The <strong>Indo-Scythians</strong>, or Sakas, were nomadic Central Asian rulers who governed parts of northwestern and western India from around 80 BCE to 400 CE. Ruling through a network of satraps, they left behind an administrative and cultural legacy — from the Saka calendar to classical Sanskrit epigraphy — that outlasted their political power.</p>
+
+            <div class="isc-hero-stats">
+                <div class="isc-hero-stat">
+                    <strong>c. 80 BCE–400 CE</strong>
+                    <span>Dynasty Period</span>
+                </div>
+                <div class="isc-hero-stat">
+                    <strong>Sirkap</strong>
+                    <span>First Capital</span>
+                </div>
+                <div class="isc-hero-stat">
+                    <strong>3</strong>
+                    <span>Major Satrapies</span>
+                </div>
+                <div class="isc-hero-stat">
+                    <strong>78 CE</strong>
+                    <span>Saka Era Begins</span>
+                </div>
+            </div>
+        </section>
+
+        <!-- Navigation Tabs -->
+        <div class="isc-nav-tabs">
+            <button class="isc-tab active" data-tab="overview">📜 Historical Overview</button>
+            <button class="isc-tab" data-tab="timeline">🕰️ Timeline</button>
+            <button class="isc-tab" data-tab="rulers">👑 Major Rulers</button>
+            <button class="isc-tab" data-tab="legacy">🏺 Legacy</button>
+            <button class="isc-tab" data-tab="gallery">🖼️ Gallery</button>
+            <button class="isc-tab" data-tab="references">📚 References</button>
+        </div>
+
+        <!-- Historical Overview -->
+        <section id="overview" class="isc-section active">
+            <div class="isc-content-card">
+                <h2>📜 Historical Overview</h2>
+                <div class="isc-content">
+                    <p>The <strong>Indo-Scythians</strong>, known in Indian sources as the <strong>Sakas</strong>, were a nomadic Iranian people of Scythian ancestry who migrated south from Central Asia into the northern and western reaches of ancient India between the 2nd century BCE and the 4th century CE. Their arrival followed the same Central Asian upheavals that had earlier pushed the Yuezhi (who became the Kushans) into the region.</p>
+                    <p>Indo-Scythian rule in India began in earnest around 85–80 BCE, when their first king, <strong>Maues</strong> (also called Moga), conquered Gandhara and Taxila, ruling from the fortified city of Sirkap. His successors, including <strong>Azes I</strong>, completed the takeover of the remaining Indo-Greek territories in the northwest. Over time, the Sakas organized their realm into several satrapies: the <strong>Sakas of Taxila</strong> in the northwest, the <strong>Northern Satraps</strong> centered on Mathura, and the <strong>Western Satraps</strong> ruling Gujarat, Malwa, and neighbouring regions.</p>
+                    <p>As Kushan power grew, the Taxila and Mathura satraps gradually became vassals of the Kushan emperors. The Western Satraps, however, endured far longer as an independent power, reaching their peak under <strong>Rudradaman I</strong> in the 2nd century CE. Their rule finally ended around 395–415 CE, when the Gupta emperor <strong>Chandragupta II</strong> defeated the last Western Satrap ruler, Rudrasimha III, absorbing Saka territory into the expanding Gupta Empire.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Timeline -->
+        <section id="timeline" class="isc-section">
+            <div class="isc-content-card">
+                <h2>🕰️ Timeline</h2>
+                <div class="isc-content">
+                    <div class="isc-timeline">
+                        <div class="isc-timeline-item">
+                            <span class="isc-timeline-year">c. 85 BCE</span>
+                            <p>Maues conquers Gandhara and Taxila, founding Indo-Scythian rule in India.</p>
+                        </div>
+                        <div class="isc-timeline-item">
+                            <span class="isc-timeline-year">c. 55 BCE</span>
+                            <p>Azes I defeats the last Indo-Greek king Hippostratos, completing Saka control of the northwest.</p>
+                        </div>
+                        <div class="isc-timeline-item">
+                            <span class="isc-timeline-year">c. 10 CE</span>
+                            <p>Rajuvula rules as Great Satrap of Mathura, commemorated on the Mathura Lion Capital inscription.</p>
+                        </div>
+                        <div class="isc-timeline-item">
+                            <span class="isc-timeline-year">78 CE</span>
+                            <p>The Saka Era calendar begins, later adopted as independent India's official civil calendar.</p>
+                        </div>
+                        <div class="isc-timeline-item">
+                            <span class="isc-timeline-year">c. 150 CE</span>
+                            <p>Rudradaman I issues the Junagadh rock inscription, a landmark in classical Sanskrit epigraphy.</p>
+                        </div>
+                        <div class="isc-timeline-item">
+                            <span class="isc-timeline-year">c. 400 CE</span>
+                            <p>Western Satrap rule ends after defeat by the Gupta emperor Chandragupta II.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Major Rulers -->
+        <section id="rulers" class="isc-section">
+            <div class="isc-content-card">
+                <h2>👑 Major Rulers</h2>
+                <div class="isc-content">
+                    <div class="ruler-list">
+                        <div class="ruler-item">
+                            <h3>Maues (Moga) <span class="ruler-reign">(c. 85–60 BCE)</span></h3>
+                            <p>The first Indo-Scythian king. He conquered Gandhara and Taxila, ruling from the city of Sirkap and issuing coinage that blended Greek, Buddhist, and Hindu symbolism.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Azes I <span class="ruler-reign">(c. 55–35 BCE)</span></h3>
+                            <p>Completed the Saka conquest of the remaining Indo-Greek territories by defeating king Hippostratos, consolidating Indo-Scythian control of the northwest.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Rajuvula <span class="ruler-reign">(c. early 1st century CE)</span></h3>
+                            <p>Great Satrap (Mahakshatrapa) of Mathura and founder of the Northern Satraps' local power, commemorated alongside his queen on the Mathura Lion Capital inscription.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Nahapana <span class="ruler-reign">(late 1st–early 2nd century CE)</span></h3>
+                            <p>A powerful Western Satrap of the Kshaharata line, ruling Gujarat and Malwa, before being defeated by the Satavahana king Gautamiputra Satakarni.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Rudradaman I <span class="ruler-reign">(c. 130–150 CE)</span></h3>
+                            <p>The greatest Western Satrap ruler. He is remembered for the Junagadh rock inscription — the earliest known major inscription written in classical Sanskrit — and for repairing the Sudarshana lake irrigation system.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Legacy -->
+        <section id="legacy" class="isc-section">
+            <div class="isc-content-card">
+                <h2>🏺 Legacy</h2>
+                <div class="isc-content">
+                    <ul class="isc-list">
+                        <li><strong>Administrative innovation:</strong> The Indo-Scythians introduced the title and system of <em>Kshatrapa</em> (Satrap) and <em>Mahakshatrapa</em> (Great Satrap), a form of regional governance that influenced Indian administration for centuries</li>
+                        <li><strong>The Saka Era:</strong> Established in 78 CE, this calendar system was later adopted as independent India's official civil calendar, still used alongside the Gregorian calendar today</li>
+                        <li><strong>Classical Sanskrit epigraphy:</strong> Rudradaman I's Junagadh rock inscription is the earliest known major inscription composed in polished classical Sanskrit, setting a model for later royal praise-inscriptions</li>
+                        <li><strong>Coinage traditions:</strong> Continued and enriched the bilingual and trilingual (Greek, Kharosthi, Brahmi) coinage inherited from the Indo-Greeks</li>
+                        <li><strong>Buddhist art patronage:</strong> The Bimaran casket, discovered with coins of Azes II, is one of the earliest known images of the standing Buddha in human form</li>
+                        <li><strong>Trade and cultural exchange:</strong> Their satrapies sat astride Silk Road trade routes, helping connect India with Central Asia and the wider Hellenistic and Persian worlds</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <!-- Gallery -->
+        <section id="gallery" class="isc-section">
+            <div class="isc-content-card">
+                <h2>🖼️ Gallery</h2>
+                <div class="isc-content">
+                    <p>A visual look at the Indo-Scythian dynasty's coinage, inscriptions, and artistic legacy.</p>
+                    <div class="gallery-grid">
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🪙</div>
+                            <h3>Saka Coinage</h3>
+                            <p>Coins blending Greek, Buddhist, and Hindu symbolism across Kharosthi and Brahmi legends.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🦁</div>
+                            <h3>Mathura Lion Capital</h3>
+                            <p>An inscribed capital commemorating Rajuvula and his queen, a key source on the Northern Satraps.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">📜</div>
+                            <h3>Junagadh Rock Inscription</h3>
+                            <p>Rudradaman I's landmark inscription, among the earliest major texts in classical Sanskrit.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🏺</div>
+                            <h3>Bimaran Casket</h3>
+                            <p>A gold reliquary featuring one of the earliest images of the standing Buddha.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🏛️</div>
+                            <h3>Sirkap, Taxila</h3>
+                            <p>The fortified city that served as Maues's capital in the northwest.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🗺️</div>
+                            <h3>The Three Satrapies</h3>
+                            <p>Taxila, Mathura, and the Western Satraps — the dynasty's three main centres of power.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- References -->
+        <section id="references" class="isc-section">
+            <div class="isc-content-card">
+                <h2>📚 References</h2>
+                <div class="isc-content">
+                    <ul class="isc-list isc-references">
+                        <li>Wikipedia — Indo-Scythians. <a href="https://en.wikipedia.org/wiki/Indo-Scythians" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>Wikipedia — Western Kshatrapas. <a href="https://en.wikipedia.org/wiki/Western_Kshatrapas" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>Encyclopaedia Iranica — Indo-Scythian Dynasty. <a href="https://www.iranicaonline.org/articles/indo-scythian-dynasty-1/" target="_blank" rel="noopener noreferrer">iranicaonline.org</a></li>
+                        <li>ClearIAS — Sakas Dynasty (Indo-Scythians and Indo-Parthians). <a href="https://www.clearias.com/sakas-indo-scythians-indo-parthians/" target="_blank" rel="noopener noreferrer">clearias.com</a></li>
+                        <li>IAS Exam Notes — The Shakas of Ancient India. <a href="https://prepp.in/news/e-492-the-shakas-ancient-india-history-notes" target="_blank" rel="noopener noreferrer">prepp.in</a></li>
+                        <li>Rapson, E.J. <em>Ancient India: From the Earliest Times to the First Century A.D.</em> Cambridge University Press.</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="isc-footer">
+        <p>Part of <a href="../../../index.html" style="color: #FF9933;">Incredible India Explorer</a> · <a href="../index.html" style="color: #7f8c8d;">Indian Dynasties Explorer</a></p>
+    </footer>
+
+    <script type="module" src="script.js"></script>
+</body>
+</html>

--- a/frontend/history/dynasties/indo-scythian/script.js
+++ b/frontend/history/dynasties/indo-scythian/script.js
@@ -1,0 +1,92 @@
+/**
+ * Indo-Scythian Dynasty Explorer - Interactive Script
+ * Handles tab navigation, smooth scrolling, theme toggle, and mobile menu
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    initTabNavigation();
+    initThemeToggle();
+    initMobileMenu();
+});
+
+/**
+ * Initialize tab navigation for different sections
+ */
+function initTabNavigation() {
+    const tabs = document.querySelectorAll('.isc-tab');
+    const sections = document.querySelectorAll('.isc-section');
+
+    tabs.forEach(tab => {
+        tab.addEventListener('click', () => {
+            const targetTab = tab.dataset.tab;
+
+            tabs.forEach(t => t.classList.remove('active'));
+            sections.forEach(s => s.classList.remove('active'));
+
+            tab.classList.add('active');
+            const targetSection = document.getElementById(targetTab);
+            if (targetSection) {
+                targetSection.classList.add('active');
+                targetSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+        });
+    });
+}
+
+/**
+ * Initialize theme toggle functionality
+ */
+function initThemeToggle() {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+
+    const currentTheme = localStorage.getItem('theme') || 'dark';
+    updateThemeIcon(currentTheme);
+
+    themeToggle.addEventListener('click', () => {
+        const body = document.body;
+        const isLight = body.classList.contains('light-theme');
+
+        if (isLight) {
+            body.classList.remove('light-theme');
+            localStorage.setItem('theme', 'dark');
+            updateThemeIcon('dark');
+        } else {
+            body.classList.add('light-theme');
+            localStorage.setItem('theme', 'light');
+            updateThemeIcon('light');
+        }
+    });
+}
+
+/**
+ * Update theme toggle icon
+ */
+function updateThemeIcon(theme) {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+    themeToggle.textContent = theme === 'light' ? '🌙' : '☀️';
+}
+
+/**
+ * Initialize mobile menu toggle
+ */
+function initMobileMenu() {
+    const menuToggle = document.getElementById('menu-toggle');
+    const navMenu = document.getElementById('nav-menu');
+
+    if (menuToggle && navMenu) {
+        menuToggle.addEventListener('click', () => {
+            const isExpanded = menuToggle.getAttribute('aria-expanded') === 'true';
+            menuToggle.setAttribute('aria-expanded', !isExpanded);
+            navMenu.classList.toggle('active');
+        });
+
+        document.addEventListener('click', (e) => {
+            if (!menuToggle.contains(e.target) && !navMenu.contains(e.target)) {
+                navMenu.classList.remove('active');
+                menuToggle.setAttribute('aria-expanded', 'false');
+            }
+        });
+    }
+}

--- a/frontend/history/dynasties/indo-scythian/style.css
+++ b/frontend/history/dynasties/indo-scythian/style.css
@@ -1,0 +1,341 @@
+/* ==========================================================================
+   Indo-Scythian Dynasty Explorer Styling
+   Central Asian rulers of northwestern and western India (c. 80 BCE-400 CE)
+   ========================================================================== */
+
+.isc-page-body {
+    background-color: var(--bg-primary, #0B0F19);
+    color: var(--text-primary, #E2E8F0);
+    font-family: 'Outfit', system-ui, -apple-system, sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+}
+
+.isc-main {
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: 80px 20px 60px;
+}
+
+/* --- Hero Banner --- */
+.isc-hero {
+    text-align: center;
+    padding: 48px 24px;
+    background: linear-gradient(135deg, rgba(11, 15, 25, 0.95) 0%, rgba(30, 33, 36, 0.9) 100%);
+    border: 1px solid rgba(127, 140, 141, 0.4);
+    border-radius: 16px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+    margin-bottom: 32px;
+    position: relative;
+    overflow: hidden;
+}
+
+.isc-hero::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: linear-gradient(90deg, #FF9933 0%, #D4AF37 50%, #7f8c8d 100%);
+}
+
+.isc-kicker {
+    display: inline-block;
+    padding: 6px 16px;
+    background: rgba(127, 140, 141, 0.25);
+    color: #b6c0c1;
+    border: 1px solid rgba(127, 140, 141, 0.5);
+    border-radius: 20px;
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 16px;
+}
+
+.isc-hero h1 {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 2.6rem;
+    font-weight: 700;
+    color: var(--text-heading, #F8FAFC);
+    margin: 0 0 12px;
+}
+
+.isc-hero p {
+    font-size: 1.1rem;
+    color: var(--text-secondary, #94A3B8);
+    max-width: 850px;
+    margin: 0 auto 24px;
+}
+
+.isc-hero-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 16px;
+    margin-top: 24px;
+}
+
+.isc-hero-stat {
+    background: rgba(15, 23, 42, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    padding: 16px;
+    text-align: center;
+}
+
+.isc-hero-stat strong {
+    display: block;
+    font-size: 1.3rem;
+    color: #FF9933;
+    font-family: 'Playfair Display', Georgia, serif;
+}
+
+.isc-hero-stat span {
+    font-size: 0.8rem;
+    color: var(--text-secondary, #94A3B8);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+/* --- Navigation Tabs --- */
+.isc-nav-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: center;
+    margin-bottom: 32px;
+    padding: 12px;
+    background: rgba(15, 23, 42, 0.5);
+    border-radius: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.isc-tab {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: var(--text-secondary, #94A3B8);
+    padding: 8px 16px;
+    border-radius: 20px;
+    font-size: 0.88rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.25s ease;
+    white-space: nowrap;
+}
+
+.isc-tab:hover {
+    border-color: rgba(127, 140, 141, 0.6);
+    color: #b6c0c1;
+}
+
+.isc-tab.active {
+    background: linear-gradient(135deg, #7f8c8d, #5d6667);
+    border-color: #7f8c8d;
+    color: #fff;
+}
+
+.isc-tab:focus-visible {
+    outline: 2px solid #FF9933;
+    outline-offset: 2px;
+}
+
+/* --- Content Sections --- */
+.isc-section {
+    display: none;
+    animation: fadeIn 0.4s ease;
+}
+
+.isc-section.active {
+    display: block;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.isc-content-card {
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 16px;
+    padding: 32px;
+}
+
+.isc-content-card h2 {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 1.8rem;
+    color: var(--text-heading, #F8FAFC);
+    margin: 0 0 20px;
+}
+
+.isc-content h3 {
+    color: #b6c0c1;
+    font-size: 1.1rem;
+    margin: 0 0 6px;
+}
+
+.isc-content p {
+    color: var(--text-secondary, #CBD5E1);
+    margin: 0 0 14px;
+}
+
+.isc-list {
+    color: var(--text-secondary, #CBD5E1);
+    padding-left: 20px;
+    margin: 0 0 14px;
+}
+
+.isc-list li {
+    margin-bottom: 8px;
+}
+
+.isc-references a {
+    color: #b6c0c1;
+    text-decoration: none;
+}
+
+.isc-references a:hover {
+    text-decoration: underline;
+}
+
+/* --- Timeline --- */
+.isc-timeline {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    border-left: 2px solid rgba(127, 140, 141, 0.6);
+    padding-left: 20px;
+    margin-top: 8px;
+}
+
+.isc-timeline-item {
+    position: relative;
+}
+
+.isc-timeline-item::before {
+    content: '';
+    position: absolute;
+    left: -26px;
+    top: 4px;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: #7f8c8d;
+}
+
+.isc-timeline-year {
+    display: block;
+    font-weight: 700;
+    color: #FF9933;
+    font-family: 'Playfair Display', Georgia, serif;
+    margin-bottom: 4px;
+}
+
+.isc-timeline-item p {
+    margin: 0;
+}
+
+/* --- Rulers --- */
+.ruler-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 16px;
+}
+
+.ruler-item {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 12px;
+    padding: 18px;
+}
+
+.ruler-reign {
+    font-size: 0.85rem;
+    color: var(--text-secondary, #94A3B8);
+    font-weight: 400;
+}
+
+/* --- Gallery --- */
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+    margin-top: 16px;
+}
+
+.gallery-item {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 12px;
+    padding: 20px;
+    text-align: center;
+    transition: transform 0.25s ease;
+}
+
+.gallery-item:hover {
+    transform: translateY(-4px);
+    border-color: rgba(127, 140, 141, 0.6);
+}
+
+.gallery-placeholder {
+    font-size: 2.6rem;
+    margin-bottom: 10px;
+}
+
+.gallery-item h3 {
+    margin: 0 0 6px;
+}
+
+.gallery-item p {
+    font-size: 0.9rem;
+    margin: 0;
+}
+
+/* --- Footer --- */
+.isc-footer {
+    text-align: center;
+    padding: 30px 20px;
+    color: var(--text-secondary, #94A3B8);
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* --- Responsive --- */
+@media (max-width: 768px) {
+    .isc-hero h1 {
+        font-size: 2rem;
+    }
+
+    .isc-content-card {
+        padding: 20px;
+    }
+
+    .isc-nav-tabs {
+        justify-content: flex-start;
+        overflow-x: auto;
+        flex-wrap: nowrap;
+    }
+
+    .isc-timeline {
+        padding-left: 16px;
+    }
+}
+
+/* --- Light Theme Overrides --- */
+body.light-theme.isc-page-body {
+    background-color: #F8FAFC;
+    color: #0F172A;
+}
+
+body.light-theme .isc-content-card,
+body.light-theme .isc-hero {
+    background: rgba(255, 255, 255, 0.85);
+    border-color: rgba(0, 0, 0, 0.08);
+}
+
+body.light-theme .isc-content p,
+body.light-theme .isc-list,
+body.light-theme .ruler-reign {
+    color: #334155;
+}

--- a/frontend/history/dynasties/western-kshatrapas/index.html
+++ b/frontend/history/dynasties/western-kshatrapas/index.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Western Kshatrapas Explorer - Discover the Western Kshatrapas (c. 35-415 CE), Saka rulers of Gujarat, Saurashtra, and Malwa renowned for precisely dated coinage and the Junagadh rock inscription.">
+    <title>Western Kshatrapas Explorer | Incredible India Explorer</title>
+    <link rel="icon" href="data:,">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:wght@500;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="../../../styles.css">
+    <link rel="stylesheet" href="style.css">
+
+    <meta property="og:title" content="Western Kshatrapas Explorer | Incredible India Explorer">
+    <meta property="og:description" content="The Western Kshatrapas — governance, dated coinage, and regional influence in western India.">
+    <meta property="og:type" content="website">
+    <meta property="og:locale" content="en_IN">
+</head>
+
+<body class="wk-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../../index.html#home" class="nav-link">Home</a>
+                <a href="../index.html" class="nav-link">Indian Dynasties</a>
+                <a href="index.html" class="nav-link active" style="color: #16a085">Western Kshatrapas</a>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+            </nav>
+        </div>
+    </header>
+
+    <main class="wk-main">
+        <!-- Hero Banner -->
+        <section class="wk-hero">
+            <span class="wk-kicker">🪙 Rulers of Ancient Gujarat & Malwa</span>
+            <h1>Western Kshatrapas Explorer</h1>
+            <p>The <strong>Western Kshatrapas</strong> (also called the Western Satraps) ruled Gujarat, Saurashtra, and Malwa from around 35 to 415 CE. Descended from Saka satraps, they are remembered today for a coinage system so precisely dated that historians can trace their dynasty almost year by year — a feat unmatched by any other ancient Indian ruling house.</p>
+
+            <div class="wk-hero-stats">
+                <div class="wk-hero-stat">
+                    <strong>c. 35–415 CE</strong>
+                    <span>Dynasty Period</span>
+                </div>
+                <div class="wk-hero-stat">
+                    <strong>Ujjain</strong>
+                    <span>Main Capital</span>
+                </div>
+                <div class="wk-hero-stat">
+                    <strong>2</strong>
+                    <span>Ruling Lines</span>
+                </div>
+                <div class="wk-hero-stat">
+                    <strong>200+ yrs</strong>
+                    <span>Dated Coinage</span>
+                </div>
+            </div>
+        </section>
+
+        <!-- Navigation Tabs -->
+        <div class="wk-nav-tabs">
+            <button class="wk-tab active" data-tab="overview">📜 Historical Overview</button>
+            <button class="wk-tab" data-tab="timeline">🕰️ Timeline</button>
+            <button class="wk-tab" data-tab="rulers">👑 Major Rulers</button>
+            <button class="wk-tab" data-tab="contributions">🎨 Contributions</button>
+            <button class="wk-tab" data-tab="gallery">🖼️ Gallery</button>
+            <button class="wk-tab" data-tab="references">📚 References</button>
+        </div>
+
+        <!-- Historical Overview -->
+        <section id="overview" class="wk-section active">
+            <div class="wk-content-card">
+                <h2>📜 Historical Overview</h2>
+                <div class="wk-content">
+                    <p>The <strong>Western Kshatrapas</strong> were Saka (Indo-Scythian) rulers who governed western and central India — modern Gujarat, Saurashtra, and Malwa — from around 35 CE to 415 CE. Unlike the Sakas of Taxila and Mathura further north, this branch endured for nearly four centuries, outlasting every other Indo-Scythian line.</p>
+                    <p>The dynasty is generally divided into two ruling families. The earlier <strong>Kshaharata line</strong>, founded by Bhumaka, reached its height under <strong>Nahapana</strong>, who controlled a large stretch of Malwa and Gujarat before being defeated by the Satavahana king Gautamiputra Satakarni. A second, longer-lived family — the <strong>Kardamaka line</strong> — was founded by <strong>Chashtana</strong> around 78 CE, an accession year that traditionally marks the beginning of the <strong>Saka Era</strong> calendar.</p>
+                    <p>Chashtana's grandson, <strong>Rudradaman I</strong>, brought the dynasty to its greatest strength in the 2nd century CE, and his successors continued to rule from Ujjain for over two more centuries, issuing an unbroken series of precisely dated silver coins. The dynasty finally came to an end around 395–415 CE, when the Gupta emperor <strong>Chandragupta II</strong> defeated the last ruler, Rudrasimha III, absorbing western India into the growing Gupta Empire and closing the final chapter of Saka rule on the subcontinent.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Timeline -->
+        <section id="timeline" class="wk-section">
+            <div class="wk-content-card">
+                <h2>🕰️ Timeline</h2>
+                <div class="wk-content">
+                    <div class="wk-timeline">
+                        <div class="wk-timeline-item">
+                            <span class="wk-timeline-year">78 CE</span>
+                            <p>Chashtana founds the Kardamaka line of Western Kshatrapas; his accession marks the traditional start of the Saka Era calendar.</p>
+                        </div>
+                        <div class="wk-timeline-item">
+                            <span class="wk-timeline-year">c. 150 CE</span>
+                            <p>Rudradaman I issues the Junagadh rock inscription and repairs the Sudarshana lake reservoir.</p>
+                        </div>
+                        <div class="wk-timeline-item">
+                            <span class="wk-timeline-year">197 CE</span>
+                            <p>Rudrasimha I's reign as Mahakshatrapa ends, having minted an extensive series of dated coins.</p>
+                        </div>
+                        <div class="wk-timeline-item">
+                            <span class="wk-timeline-year">232 CE</span>
+                            <p>Damasena mints coins precisely dated to the Saka era, exemplifying the dynasty's remarkable dating system.</p>
+                        </div>
+                        <div class="wk-timeline-item">
+                            <span class="wk-timeline-year">415 CE</span>
+                            <p>Rudrasimha III is defeated by the Gupta emperor Chandragupta II, ending Western Kshatrapa rule.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Major Rulers -->
+        <section id="rulers" class="wk-section">
+            <div class="wk-content-card">
+                <h2>👑 Major Rulers</h2>
+                <div class="wk-content">
+                    <div class="ruler-list">
+                        <div class="ruler-item">
+                            <h3>Nahapana <span class="ruler-reign">(late 1st century CE)</span></h3>
+                            <p>The most powerful ruler of the earlier Kshaharata line, controlling a wide territory across Malwa and Gujarat until his defeat by the Satavahana king Gautamiputra Satakarni.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Chashtana <span class="ruler-reign">(c. 78–130 CE)</span></h3>
+                            <p>Founder of the Kardamaka line of Western Kshatrapas, ruling from Ujjain. His accession is traditionally taken as the starting point of the Saka Era.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Rudradaman I <span class="ruler-reign">(c. 130–150 CE)</span></h3>
+                            <p>The dynasty's greatest ruler. Remembered for the Junagadh rock inscription — the earliest known major inscription in classical Sanskrit — and for repairing the Sudarshana lake irrigation system.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Rudrasimha I <span class="ruler-reign">(178–197 CE)</span></h3>
+                            <p>Grandson of Rudradaman I. His reign saw the dynasty's dated coinage system become firmly established, with mint years recorded in Brahmi numerals on nearly every coin.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Rudrasimha III <span class="ruler-reign">(c. 388–415 CE)</span></h3>
+                            <p>The last Western Kshatrapa ruler. He was defeated and killed by the Gupta emperor Chandragupta II, bringing nearly four centuries of Saka rule in western India to a close.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Contributions -->
+        <section id="contributions" class="wk-section">
+            <div class="wk-content-card">
+                <h2>🎨 Contributions</h2>
+                <div class="wk-content">
+                    <ul class="wk-list">
+                        <li><strong>Precisely dated coinage:</strong> Nearly every Western Kshatrapa silver coin records the king's name, his father's name, and a Saka Era mint date — letting historians reconstruct the dynasty's chronology with a precision unmatched by any other ancient Indian dynasty</li>
+                        <li><strong>Classical Sanskrit epigraphy:</strong> Rudradaman I's Junagadh rock inscription is the earliest known major inscription composed in polished classical Sanskrit</li>
+                        <li><strong>The Saka Era calendar:</strong> Popularized from Chashtana's 78 CE accession, later adopted as India's official civil calendar</li>
+                        <li><strong>Public engineering:</strong> Rudradaman I's repair of the Sudarshana lake reservoir stands as one of ancient India's earliest recorded infrastructure projects</li>
+                        <li><strong>Maritime trade:</strong> Control of the port of Barygaza (Bharuch) linked western India to Roman and Mediterranean trade networks</li>
+                        <li><strong>Numismatic influence:</strong> Their coinage style and dating conventions shaped later western Indian dynasties, including the Traikutakas and the kingdom of Valabhi</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <!-- Gallery -->
+        <section id="gallery" class="wk-section">
+            <div class="wk-content-card">
+                <h2>🖼️ Gallery</h2>
+                <div class="wk-content">
+                    <p>A visual look at the Western Kshatrapas' coinage, inscriptions, and administrative legacy.</p>
+                    <div class="gallery-grid">
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🪙</div>
+                            <h3>Dated Silver Drachms</h3>
+                            <p>Coins bearing the king's portrait, mint date, and a Brahmi inscription naming his father.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">📜</div>
+                            <h3>Junagadh Rock Inscription</h3>
+                            <p>Rudradaman I's landmark inscription, a milestone of classical Sanskrit literature.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🏞️</div>
+                            <h3>Sudarshana Lake</h3>
+                            <p>The reservoir near Girnar repaired under Rudradaman I's orders.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">⚓</div>
+                            <h3>Port of Barygaza</h3>
+                            <p>The bustling trade port (modern Bharuch) linking the Kshatrapas to Roman trade routes.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🏛️</div>
+                            <h3>Ujjain</h3>
+                            <p>The Kardamaka line's capital, a major centre of governance and culture.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🗺️</div>
+                            <h3>Gujarat, Saurashtra & Malwa</h3>
+                            <p>The dynasty's core territory across western and central India.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- References -->
+        <section id="references" class="wk-section">
+            <div class="wk-content-card">
+                <h2>📚 References</h2>
+                <div class="wk-content">
+                    <ul class="wk-list wk-references">
+                        <li>Wikipedia — Western Kshatrapas. <a href="https://en.wikipedia.org/wiki/Western_Kshatrapas" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>Wikipedia — Rudradaman I. <a href="https://en.wikipedia.org/wiki/Rudradaman_I" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>Wikipedia — Rudrasimha I. <a href="https://en.wikipedia.org/wiki/Rudrasimha_I" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>Resources for Collectors — Western Kshatrapa Coinage Catalogue. <a href="http://www.ancientcoins.ca/fake_kshatrapas/fake_kshatrapas.htm" target="_blank" rel="noopener noreferrer">ancientcoins.ca</a></li>
+                        <li>Fishman, R. (2013). <em>Polity and Economy: A Study of the Coinage of the Western Kshatrapas.</em></li>
+                        <li>NumisMall — Western Kshatrapas (Satraps) Coin Reference. <a href="https://www.numismall.com/collections/western-kshatrapas-satraps-c-50-450-ad" target="_blank" rel="noopener noreferrer">numismall.com</a></li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="wk-footer">
+        <p>Part of <a href="../../../index.html" style="color: #FF9933;">Incredible India Explorer</a> · <a href="../index.html" style="color: #16a085;">Indian Dynasties Explorer</a></p>
+    </footer>
+
+    <script type="module" src="script.js"></script>
+</body>
+</html>

--- a/frontend/history/dynasties/western-kshatrapas/script.js
+++ b/frontend/history/dynasties/western-kshatrapas/script.js
@@ -1,0 +1,92 @@
+/**
+ * Western Kshatrapas Explorer - Interactive Script
+ * Handles tab navigation, smooth scrolling, theme toggle, and mobile menu
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    initTabNavigation();
+    initThemeToggle();
+    initMobileMenu();
+});
+
+/**
+ * Initialize tab navigation for different sections
+ */
+function initTabNavigation() {
+    const tabs = document.querySelectorAll('.wk-tab');
+    const sections = document.querySelectorAll('.wk-section');
+
+    tabs.forEach(tab => {
+        tab.addEventListener('click', () => {
+            const targetTab = tab.dataset.tab;
+
+            tabs.forEach(t => t.classList.remove('active'));
+            sections.forEach(s => s.classList.remove('active'));
+
+            tab.classList.add('active');
+            const targetSection = document.getElementById(targetTab);
+            if (targetSection) {
+                targetSection.classList.add('active');
+                targetSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+        });
+    });
+}
+
+/**
+ * Initialize theme toggle functionality
+ */
+function initThemeToggle() {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+
+    const currentTheme = localStorage.getItem('theme') || 'dark';
+    updateThemeIcon(currentTheme);
+
+    themeToggle.addEventListener('click', () => {
+        const body = document.body;
+        const isLight = body.classList.contains('light-theme');
+
+        if (isLight) {
+            body.classList.remove('light-theme');
+            localStorage.setItem('theme', 'dark');
+            updateThemeIcon('dark');
+        } else {
+            body.classList.add('light-theme');
+            localStorage.setItem('theme', 'light');
+            updateThemeIcon('light');
+        }
+    });
+}
+
+/**
+ * Update theme toggle icon
+ */
+function updateThemeIcon(theme) {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+    themeToggle.textContent = theme === 'light' ? '🌙' : '☀️';
+}
+
+/**
+ * Initialize mobile menu toggle
+ */
+function initMobileMenu() {
+    const menuToggle = document.getElementById('menu-toggle');
+    const navMenu = document.getElementById('nav-menu');
+
+    if (menuToggle && navMenu) {
+        menuToggle.addEventListener('click', () => {
+            const isExpanded = menuToggle.getAttribute('aria-expanded') === 'true';
+            menuToggle.setAttribute('aria-expanded', !isExpanded);
+            navMenu.classList.toggle('active');
+        });
+
+        document.addEventListener('click', (e) => {
+            if (!menuToggle.contains(e.target) && !navMenu.contains(e.target)) {
+                navMenu.classList.remove('active');
+                menuToggle.setAttribute('aria-expanded', 'false');
+            }
+        });
+    }
+}

--- a/frontend/history/dynasties/western-kshatrapas/style.css
+++ b/frontend/history/dynasties/western-kshatrapas/style.css
@@ -1,0 +1,341 @@
+/* ==========================================================================
+   Western Kshatrapas Explorer Styling
+   Saka rulers of Gujarat, Saurashtra, and Malwa (c. 35-415 CE)
+   ========================================================================== */
+
+.wk-page-body {
+    background-color: var(--bg-primary, #0B0F19);
+    color: var(--text-primary, #E2E8F0);
+    font-family: 'Outfit', system-ui, -apple-system, sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+}
+
+.wk-main {
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: 80px 20px 60px;
+}
+
+/* --- Hero Banner --- */
+.wk-hero {
+    text-align: center;
+    padding: 48px 24px;
+    background: linear-gradient(135deg, rgba(11, 15, 25, 0.95) 0%, rgba(8, 34, 30, 0.9) 100%);
+    border: 1px solid rgba(22, 160, 133, 0.35);
+    border-radius: 16px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+    margin-bottom: 32px;
+    position: relative;
+    overflow: hidden;
+}
+
+.wk-hero::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: linear-gradient(90deg, #FF9933 0%, #D4AF37 50%, #16a085 100%);
+}
+
+.wk-kicker {
+    display: inline-block;
+    padding: 6px 16px;
+    background: rgba(22, 160, 133, 0.18);
+    color: #4fd6b8;
+    border: 1px solid rgba(22, 160, 133, 0.4);
+    border-radius: 20px;
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 16px;
+}
+
+.wk-hero h1 {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 2.6rem;
+    font-weight: 700;
+    color: var(--text-heading, #F8FAFC);
+    margin: 0 0 12px;
+}
+
+.wk-hero p {
+    font-size: 1.1rem;
+    color: var(--text-secondary, #94A3B8);
+    max-width: 850px;
+    margin: 0 auto 24px;
+}
+
+.wk-hero-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 16px;
+    margin-top: 24px;
+}
+
+.wk-hero-stat {
+    background: rgba(15, 23, 42, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    padding: 16px;
+    text-align: center;
+}
+
+.wk-hero-stat strong {
+    display: block;
+    font-size: 1.3rem;
+    color: #FF9933;
+    font-family: 'Playfair Display', Georgia, serif;
+}
+
+.wk-hero-stat span {
+    font-size: 0.8rem;
+    color: var(--text-secondary, #94A3B8);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+/* --- Navigation Tabs --- */
+.wk-nav-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: center;
+    margin-bottom: 32px;
+    padding: 12px;
+    background: rgba(15, 23, 42, 0.5);
+    border-radius: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.wk-tab {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: var(--text-secondary, #94A3B8);
+    padding: 8px 16px;
+    border-radius: 20px;
+    font-size: 0.88rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.25s ease;
+    white-space: nowrap;
+}
+
+.wk-tab:hover {
+    border-color: rgba(22, 160, 133, 0.5);
+    color: #4fd6b8;
+}
+
+.wk-tab.active {
+    background: linear-gradient(135deg, #16a085, #0e6b59);
+    border-color: #16a085;
+    color: #fff;
+}
+
+.wk-tab:focus-visible {
+    outline: 2px solid #FF9933;
+    outline-offset: 2px;
+}
+
+/* --- Content Sections --- */
+.wk-section {
+    display: none;
+    animation: fadeIn 0.4s ease;
+}
+
+.wk-section.active {
+    display: block;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.wk-content-card {
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 16px;
+    padding: 32px;
+}
+
+.wk-content-card h2 {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 1.8rem;
+    color: var(--text-heading, #F8FAFC);
+    margin: 0 0 20px;
+}
+
+.wk-content h3 {
+    color: #4fd6b8;
+    font-size: 1.1rem;
+    margin: 0 0 6px;
+}
+
+.wk-content p {
+    color: var(--text-secondary, #CBD5E1);
+    margin: 0 0 14px;
+}
+
+.wk-list {
+    color: var(--text-secondary, #CBD5E1);
+    padding-left: 20px;
+    margin: 0 0 14px;
+}
+
+.wk-list li {
+    margin-bottom: 8px;
+}
+
+.wk-references a {
+    color: #4fd6b8;
+    text-decoration: none;
+}
+
+.wk-references a:hover {
+    text-decoration: underline;
+}
+
+/* --- Timeline --- */
+.wk-timeline {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    border-left: 2px solid rgba(22, 160, 133, 0.5);
+    padding-left: 20px;
+    margin-top: 8px;
+}
+
+.wk-timeline-item {
+    position: relative;
+}
+
+.wk-timeline-item::before {
+    content: '';
+    position: absolute;
+    left: -26px;
+    top: 4px;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: #16a085;
+}
+
+.wk-timeline-year {
+    display: block;
+    font-weight: 700;
+    color: #FF9933;
+    font-family: 'Playfair Display', Georgia, serif;
+    margin-bottom: 4px;
+}
+
+.wk-timeline-item p {
+    margin: 0;
+}
+
+/* --- Rulers --- */
+.ruler-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 16px;
+}
+
+.ruler-item {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 12px;
+    padding: 18px;
+}
+
+.ruler-reign {
+    font-size: 0.85rem;
+    color: var(--text-secondary, #94A3B8);
+    font-weight: 400;
+}
+
+/* --- Gallery --- */
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+    margin-top: 16px;
+}
+
+.gallery-item {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 12px;
+    padding: 20px;
+    text-align: center;
+    transition: transform 0.25s ease;
+}
+
+.gallery-item:hover {
+    transform: translateY(-4px);
+    border-color: rgba(22, 160, 133, 0.5);
+}
+
+.gallery-placeholder {
+    font-size: 2.6rem;
+    margin-bottom: 10px;
+}
+
+.gallery-item h3 {
+    margin: 0 0 6px;
+}
+
+.gallery-item p {
+    font-size: 0.9rem;
+    margin: 0;
+}
+
+/* --- Footer --- */
+.wk-footer {
+    text-align: center;
+    padding: 30px 20px;
+    color: var(--text-secondary, #94A3B8);
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* --- Responsive --- */
+@media (max-width: 768px) {
+    .wk-hero h1 {
+        font-size: 2rem;
+    }
+
+    .wk-content-card {
+        padding: 20px;
+    }
+
+    .wk-nav-tabs {
+        justify-content: flex-start;
+        overflow-x: auto;
+        flex-wrap: nowrap;
+    }
+
+    .wk-timeline {
+        padding-left: 16px;
+    }
+}
+
+/* --- Light Theme Overrides --- */
+body.light-theme.wk-page-body {
+    background-color: #F8FAFC;
+    color: #0F172A;
+}
+
+body.light-theme .wk-content-card,
+body.light-theme .wk-hero {
+    background: rgba(255, 255, 255, 0.85);
+    border-color: rgba(0, 0, 0, 0.08);
+}
+
+body.light-theme .wk-content p,
+body.light-theme .wk-list,
+body.light-theme .ruler-reign {
+    color: #334155;
+}


### PR DESCRIPTION
## What this PR does

Adds a dedicated explorer page for the Western Kshatrapas (Western
Satraps), Saka rulers who governed Gujarat, Saurashtra, and Malwa
from c. 35-415 CE and are best known for their precisely dated
coinage system, and integrates it into the existing Indian Dynasties
Explorer landing page.

### New files
- history/dynasties/western-kshatrapas/index.html
- history/dynasties/western-kshatrapas/style.css
- history/dynasties/western-kshatrapas/script.js

### Modified files
- history/dynasties/data.js — added a Western Kshatrapas entry to
  the dynasties array and five events to the timelineEvents array

### Note for reviewers
This builds on the already-data-driven Indian Dynasties Explorer
landing page (history/dynasties/), including the "View Full Explorer"
card-link mechanism added in earlier dynasty PRs — no changes to
DynastyCard.js or styles.css were needed this time. The
Indo-Scythian Dynasty entry (from a previous PR) covers the Sakas
broadly; this new entry is scoped specifically to the Western
Kshatrapas branch, the longest-lived Saka line, with its own
dedicated page covering governance, coinage, and regional influence
in depth as this issue requires.

### Sections covered on the dedicated page
Historical Overview, Timeline, Major Rulers, Contributions, Gallery,
and References — content is based on Wikipedia and specialist
numismatic references on Western Kshatrapa coinage, linked in the
References tab.

### Testing
- Verified navigation from the landing page card to the Western
  Kshatrapas page via the "View Full Explorer" link
- Checked script.js for syntax errors (node --check)
- Confirmed the new entries render correctly in the landing page's
  Timeline, Map, and Contributions tabs
- Confirmed responsive layout at mobile and desktop breakpoints

Closes #1514 

@Eshajha19 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.