### PR TITLE
feat: Create Pushyabhuti (Vardhana) Dynasty Explorer (#1515)

### DIFF
--- a/frontend/history/dynasties/data.js
+++ b/frontend/history/dynasties/data.js
@@ -322,13 +322,45 @@ art: "Bilingual Greek-Kharosthi coin portraiture, Hellenistic-Indian sculptural 
       "Facilitated maritime trade through the port of Barygaza (Bharuch), linking western India to Roman and Mediterranean trade networks",
       "A coinage style that influenced later western Indian dynasties, including the Traikutakas and the kingdom of Valabhi"
     ],
-    art: "Dated silver drachm coinage with royal portraiture, Brahmi epigraphy, Junagadh rock inscription",
+art: "Dated silver drachm coinage with royal portraiture, Brahmi epigraphy, Junagadh rock inscription",
     era: "ancient",
     color: "#16a085",
     mapPosition: { top: "45%", left: "40%" },
     link: "western-kshatrapas/index.html"
   },
-      {
+  {
+    id: "pushyabhuti",
+    name: "Pushyabhuti (Vardhana) Dynasty",
+    period: "c. 500–647 CE",
+    startYear: 500,
+    endYear: 647,
+    capital: "Sthanvishvara (Thanesar), later Kanyakubja (Kannauj)",
+    founders: "Pushyabhuti (legendary founder); Naravardhana (first historical ruler)",
+    notableRulers: [
+      { name: "Prabhakaravardhana", reign: "c. 580–605 CE", achievement: "First independent monarch of the dynasty; took the title Maharajadhiraja and resisted Huna invasions" },
+      { name: "Rajyavardhana", reign: "605–606 CE", achievement: "Avenged his brother-in-law's murder but was killed by the Gauda king Shashanka shortly after" },
+      { name: "Harshavardhana", reign: "606–647 CE", achievement: "Greatest ruler of the dynasty; united northern India from Punjab to Bengal, moved the capital to Kannauj, and patronized art, literature, and Buddhism" }
+    ],
+    territory: "Northern India, from Punjab to Bengal and the Himalayas to the Narmada River at its peak",
+    peakExtent: "Stretching across the Gangetic plains under Harshavardhana, though his southward expansion was checked by the Chalukya king Pulakesin II at the Narmada",
+    governance: "Centralized administration inheriting Gupta-era traditions, documented through copper-plate land grants such as the Madhuban, Sonepat, and Banskhera inscriptions",
+    military: "A large standing army supporting imperial ambitions, though defeated by the Chalukyas of Badami at the Narmada River around 618–620 CE",
+    decline: "Harshavardhana died in 647 CE without an heir; his minister Arunashva briefly usurped the throne before the kingdom rapidly fragmented into regional successor states",
+    contributions: [
+      "Political revival and unification of much of northern India after the decline of the Gupta Empire",
+      "Religious tolerance and patronage of Hinduism, Buddhism, and Jainism alike, including the famous Kannauj assembly held in honour of the Chinese pilgrim Xuanzang",
+      "Harsha's own Sanskrit plays — Ratnavali, Priyadarshika, and Nagananda — mark him as a notable royal playwright",
+      "Patronage of the court poet Banabhatta, whose Harshacharita and Kadambari remain landmark works of Sanskrit prose",
+      "Continued support for Nalanda University as a major center of Buddhist learning",
+      "Diplomatic exchanges with Tang China, including missions that shaped early Sino-Indian relations"
+    ],
+    art: "Sanskrit court literature and drama, copper-plate epigraphy, continued patronage of Buddhist monastic art at Nalanda",
+    era: "ancient",
+    color: "#8e44ad",
+    mapPosition: { top: "26%", left: "52%" },
+    link: "pushyabhuti/index.html"
+  },
+        {
     id: "kushan",
     name: "Kushan Empire",
     period: "c. 30–375 CE",
@@ -501,7 +533,13 @@ export const timelineEvents = [
   { year: 150, event: "Rudradaman I issues the Junagadh rock inscription and repairs the Sudarshana lake", dynasty: "western-kshatrapas" },
   { year: 197, event: "Rudrasimha I's reign as Mahakshatrapa ends, having minted an extensive series of dated coins", dynasty: "western-kshatrapas" },
   { year: 232, event: "Damasena mints coins precisely dated to the Saka era, exemplifying the dynasty's dating system", dynasty: "western-kshatrapas" },
-  { year: 415, event: "Rudrasimha III is defeated by Gupta emperor Chandragupta II, ending Western Kshatrapa rule", dynasty: "western-kshatrapas" },
+{ year: 415, event: "Rudrasimha III is defeated by Gupta emperor Chandragupta II, ending Western Kshatrapa rule", dynasty: "western-kshatrapas" },
+  { year: 580, event: "Prabhakaravardhana becomes king, later taking the title Maharajadhiraja", dynasty: "pushyabhuti" },
+  { year: 605, event: "Rajyavardhana ascends the throne after his father's death", dynasty: "pushyabhuti" },
+  { year: 606, event: "Harshavardhana becomes king after his brother Rajyavardhana is killed by Shashanka of Gauda", dynasty: "pushyabhuti" },
+  { year: 619, event: "Chalukya king Pulakesin II defeats Harshavardhana at the Narmada River, halting his southward expansion", dynasty: "pushyabhuti" },
+  { year: 643, event: "Harsha holds the Kannauj assembly in honour of the Chinese pilgrim Xuanzang", dynasty: "pushyabhuti" },
+  { year: 647, event: "Harshavardhana dies without an heir, and the Pushyabhuti dynasty rapidly disintegrates", dynasty: "pushyabhuti" },
   { year: 105, event: "Vima Kadphises conquers Gandhara and expands Kushan trade with Rome", dynasty: "kushan" },
   { year: 127, event: "Kanishka I ascends the throne; the Kushan Empire reaches its greatest extent", dynasty: "kushan" },
   { year: 150, event: "Huvishka succeeds Kanishka, continuing patronage of Buddhism and Zoroastrianism", dynasty: "kushan" },

--- a/frontend/history/dynasties/pushyabhuti/index.html
+++ b/frontend/history/dynasties/pushyabhuti/index.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Pushyabhuti (Vardhana) Dynasty Explorer - Discover the dynasty of Emperor Harshavardhana (c. 500-647 CE), which briefly reunited and revived northern India after the fall of the Gupta Empire.">
+    <title>Pushyabhuti Dynasty Explorer | Incredible India Explorer</title>
+    <link rel="icon" href="data:,">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:wght@500;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="../../../styles.css">
+    <link rel="stylesheet" href="style.css">
+
+    <meta property="og:title" content="Pushyabhuti Dynasty Explorer | Incredible India Explorer">
+    <meta property="og:description" content="The Pushyabhuti (Vardhana) Dynasty — Emperor Harshavardhana and the revival of northern India.">
+    <meta property="og:type" content="website">
+    <meta property="og:locale" content="en_IN">
+</head>
+
+<body class="pv-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../../index.html#home" class="nav-link">Home</a>
+                <a href="../index.html" class="nav-link">Indian Dynasties</a>
+                <a href="index.html" class="nav-link active" style="color: #8e44ad">Pushyabhuti Dynasty</a>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+            </nav>
+        </div>
+    </header>
+
+    <main class="pv-main">
+        <!-- Hero Banner -->
+        <section class="pv-hero">
+            <span class="pv-kicker">👑 Northern India's Last Great Unifier</span>
+            <h1>Pushyabhuti (Vardhana) Dynasty Explorer</h1>
+            <p>The <strong>Pushyabhuti dynasty</strong>, also called the <strong>Vardhana dynasty</strong>, briefly reunited much of northern India after the fall of the Gupta Empire. Its most celebrated ruler, <strong>Emperor Harshavardhana</strong>, is remembered as a warrior, playwright, and patron of religious tolerance whose court hosted the famous Chinese pilgrim Xuanzang.</p>
+
+            <div class="pv-hero-stats">
+                <div class="pv-hero-stat">
+                    <strong>c. 500–647 CE</strong>
+                    <span>Dynasty Period</span>
+                </div>
+                <div class="pv-hero-stat">
+                    <strong>Kannauj</strong>
+                    <span>Later Capital</span>
+                </div>
+                <div class="pv-hero-stat">
+                    <strong>3</strong>
+                    <span>Sanskrit Plays by Harsha</span>
+                </div>
+                <div class="pv-hero-stat">
+                    <strong>Xuanzang</strong>
+                    <span>Famous Visitor</span>
+                </div>
+            </div>
+        </section>
+
+        <!-- Navigation Tabs -->
+        <div class="pv-nav-tabs">
+            <button class="pv-tab active" data-tab="overview">📜 Historical Overview</button>
+            <button class="pv-tab" data-tab="timeline">🕰️ Timeline</button>
+            <button class="pv-tab" data-tab="rulers">👑 Major Rulers</button>
+            <button class="pv-tab" data-tab="contributions">🎨 Contributions</button>
+            <button class="pv-tab" data-tab="gallery">🖼️ Gallery</button>
+            <button class="pv-tab" data-tab="references">📚 References</button>
+        </div>
+
+        <!-- Historical Overview -->
+        <section id="overview" class="pv-section active">
+            <div class="pv-content-card">
+                <h2>📜 Historical Overview</h2>
+                <div class="pv-content">
+                    <p>The <strong>Pushyabhuti dynasty</strong> (also known as the Vardhana dynasty) rose in northern India around 500 CE, in the political vacuum left by the declining Gupta Empire. According to the <em>Harshacharita</em>, the court biography written by the poet Banabhatta, the dynasty traced its origins to a devotee of Shiva named <strong>Pushyabhuti</strong>, ruling from <strong>Sthanvishvara</strong> (modern Thanesar, Haryana).</p>
+                    <p>For its first century, the dynasty ruled as a minor feudatory power — first under the Guptas, later under the powerful Maukhari kings of Kannauj. That changed under <strong>Prabhakaravardhana</strong>, who took the title <em>Maharajadhiraja</em> and pushed back Huna invaders, becoming the family's first fully independent monarch. After his death, his elder son <strong>Rajyavardhana</strong> briefly took the throne but was killed within a year by Shashanka, the king of Gauda in Bengal.</p>
+                    <p>The throne then passed to Rajyavardhana's younger brother, <strong>Harshavardhana</strong>, who became one of ancient India's most celebrated rulers. Over a 41-year reign, Harsha united territory stretching from Punjab to Bengal and moved his capital to Kannauj, though his ambitions south of the Narmada River were checked by the Chalukya king Pulakesin II. Renowned for his religious tolerance, literary talent, and patronage of scholarship, Harsha's court welcomed the Chinese Buddhist pilgrim Xuanzang, whose writings remain a vital source on the period. When Harsha died in 647 CE without an heir, the empire he had built quickly fragmented, marking the end of both his dynasty and the last major unified empire of ancient northern India.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Timeline -->
+        <section id="timeline" class="pv-section">
+            <div class="pv-content-card">
+                <h2>🕰️ Timeline</h2>
+                <div class="pv-content">
+                    <div class="pv-timeline">
+                        <div class="pv-timeline-item">
+                            <span class="pv-timeline-year">c. 580 CE</span>
+                            <p>Prabhakaravardhana becomes king, later taking the title Maharajadhiraja and resisting Huna invasions.</p>
+                        </div>
+                        <div class="pv-timeline-item">
+                            <span class="pv-timeline-year">605 CE</span>
+                            <p>Rajyavardhana ascends the throne of Thanesar following his father's death.</p>
+                        </div>
+                        <div class="pv-timeline-item">
+                            <span class="pv-timeline-year">606 CE</span>
+                            <p>Harshavardhana becomes king after his brother Rajyavardhana is killed by Shashanka, the king of Gauda.</p>
+                        </div>
+                        <div class="pv-timeline-item">
+                            <span class="pv-timeline-year">c. 619 CE</span>
+                            <p>The Chalukya king Pulakesin II defeats Harshavardhana at the Narmada River, halting his southward expansion.</p>
+                        </div>
+                        <div class="pv-timeline-item">
+                            <span class="pv-timeline-year">643 CE</span>
+                            <p>Harsha holds the great Kannauj assembly in honour of the visiting Chinese pilgrim Xuanzang.</p>
+                        </div>
+                        <div class="pv-timeline-item">
+                            <span class="pv-timeline-year">647 CE</span>
+                            <p>Harshavardhana dies without an heir, and the Pushyabhuti dynasty rapidly disintegrates.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Major Rulers -->
+        <section id="rulers" class="pv-section">
+            <div class="pv-content-card">
+                <h2>👑 Major Rulers</h2>
+                <div class="pv-content">
+                    <div class="ruler-list">
+                        <div class="ruler-item">
+                            <h3>Prabhakaravardhana <span class="ruler-reign">(c. 580–605 CE)</span></h3>
+                            <p>The dynasty's first fully independent monarch. He took the imperial title Maharajadhiraja, resisted Huna incursions, and formed an alliance with the neighbouring Maukhari kingdom.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Rajyavardhana <span class="ruler-reign">(605–606 CE)</span></h3>
+                            <p>Eldest son of Prabhakaravardhana. He marched to avenge his brother-in-law's murder but was killed on his return journey by Shashanka, the king of Gauda.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Harshavardhana <span class="ruler-reign">(606–647 CE)</span></h3>
+                            <p>The dynasty's greatest ruler. He united much of northern India, moved the capital to Kannauj, took the titles Sakalottarapathanatha and Shiladitya, and became known for his religious tolerance, literary works, and patronage of scholars and pilgrims alike.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Contributions -->
+        <section id="contributions" class="pv-section">
+            <div class="pv-content-card">
+                <h2>🎨 Contributions</h2>
+                <div class="pv-content">
+                    <ul class="pv-list">
+                        <li><strong>Political revival:</strong> Reunified much of northern India after the fragmentation that followed the Gupta Empire's decline, restoring a degree of imperial order for over four decades</li>
+                        <li><strong>Religious tolerance:</strong> Harsha patronized Hinduism, Buddhism, and Jainism alike, most famously convening the Kannauj assembly in 643 CE to honour the Chinese pilgrim Xuanzang</li>
+                        <li><strong>Royal literature:</strong> Harsha is credited as the author of three Sanskrit plays — <em>Ratnavali</em>, <em>Priyadarshika</em>, and <em>Nagananda</em> — an unusual accomplishment for a reigning emperor</li>
+                        <li><strong>Court literature:</strong> Patronage of the poet Banabhatta, whose <em>Harshacharita</em> and <em>Kadambari</em> remain landmark works of classical Sanskrit prose</li>
+                        <li><strong>Support for learning:</strong> Continued royal patronage of Nalanda University, which flourished as a major center of Buddhist scholarship during his reign</li>
+                        <li><strong>Diplomacy:</strong> Exchanged missions with Tang-dynasty China, helping establish some of the earliest recorded diplomatic contact between the two civilizations</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <!-- Gallery -->
+        <section id="gallery" class="pv-section">
+            <div class="pv-content-card">
+                <h2>🖼️ Gallery</h2>
+                <div class="pv-content">
+                    <p>A visual look at the Pushyabhuti dynasty's political, literary, and religious legacy.</p>
+                    <div class="gallery-grid">
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🏛️</div>
+                            <h3>Thanesar & Kannauj</h3>
+                            <p>The dynasty's two capitals, at the heart of its northern Indian domain.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">📜</div>
+                            <h3>Copper-Plate Inscriptions</h3>
+                            <p>The Madhuban, Sonepat, and Banskhera grants recording the dynasty's administration.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🎭</div>
+                            <h3>Harsha's Sanskrit Plays</h3>
+                            <p>Ratnavali, Priyadarshika, and Nagananda — court dramas attributed to the emperor himself.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🧳</div>
+                            <h3>Xuanzang's Travels</h3>
+                            <p>The Chinese pilgrim's account of Harsha's court remains a key historical source.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">📖</div>
+                            <h3>Harshacharita</h3>
+                            <p>Banabhatta's biography of Harsha, a landmark of classical Sanskrit prose.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🗺️</div>
+                            <h3>Empire at its Height</h3>
+                            <p>Territory stretching from Punjab to Bengal and the Himalayas to the Narmada River.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- References -->
+        <section id="references" class="pv-section">
+            <div class="pv-content-card">
+                <h2>📚 References</h2>
+                <div class="pv-content">
+                    <ul class="pv-list pv-references">
+                        <li>Wikipedia — Harsha. <a href="https://en.wikipedia.org/wiki/Harsha" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>Wikipedia — Pushyabhuti dynasty. <a href="https://en.wikipedia.org/wiki/Pushyabhuti_dynasty" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>Wikipedia — Prabhakaravardhana. <a href="https://en.wikipedia.org/wiki/Prabhakaravardhana" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>World History Encyclopedia — Timeline: Pushyabhuti Dynasty. <a href="https://www.worldhistory.org/timeline/Pushyabhuti_Dynasty/" target="_blank" rel="noopener noreferrer">worldhistory.org</a></li>
+                        <li>LotusArise — Pushyabhuti Dynasty (Vardhana Dynasty) UPSC Notes. <a href="https://lotusarise.com/pushyabhuti-dynasty-upsc/" target="_blank" rel="noopener noreferrer">lotusarise.com</a></li>
+                        <li>Devahuti, D. <em>Harsha: A Political Study.</em> Oxford University Press.</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="pv-footer">
+        <p>Part of <a href="../../../index.html" style="color: #FF9933;">Incredible India Explorer</a> · <a href="../index.html" style="color: #8e44ad;">Indian Dynasties Explorer</a></p>
+    </footer>
+
+    <script type="module" src="script.js"></script>
+</body>
+</html>

--- a/frontend/history/dynasties/pushyabhuti/script.js
+++ b/frontend/history/dynasties/pushyabhuti/script.js
@@ -1,0 +1,92 @@
+/**
+ * Pushyabhuti (Vardhana) Dynasty Explorer - Interactive Script
+ * Handles tab navigation, smooth scrolling, theme toggle, and mobile menu
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    initTabNavigation();
+    initThemeToggle();
+    initMobileMenu();
+});
+
+/**
+ * Initialize tab navigation for different sections
+ */
+function initTabNavigation() {
+    const tabs = document.querySelectorAll('.pv-tab');
+    const sections = document.querySelectorAll('.pv-section');
+
+    tabs.forEach(tab => {
+        tab.addEventListener('click', () => {
+            const targetTab = tab.dataset.tab;
+
+            tabs.forEach(t => t.classList.remove('active'));
+            sections.forEach(s => s.classList.remove('active'));
+
+            tab.classList.add('active');
+            const targetSection = document.getElementById(targetTab);
+            if (targetSection) {
+                targetSection.classList.add('active');
+                targetSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+        });
+    });
+}
+
+/**
+ * Initialize theme toggle functionality
+ */
+function initThemeToggle() {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+
+    const currentTheme = localStorage.getItem('theme') || 'dark';
+    updateThemeIcon(currentTheme);
+
+    themeToggle.addEventListener('click', () => {
+        const body = document.body;
+        const isLight = body.classList.contains('light-theme');
+
+        if (isLight) {
+            body.classList.remove('light-theme');
+            localStorage.setItem('theme', 'dark');
+            updateThemeIcon('dark');
+        } else {
+            body.classList.add('light-theme');
+            localStorage.setItem('theme', 'light');
+            updateThemeIcon('light');
+        }
+    });
+}
+
+/**
+ * Update theme toggle icon
+ */
+function updateThemeIcon(theme) {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+    themeToggle.textContent = theme === 'light' ? '🌙' : '☀️';
+}
+
+/**
+ * Initialize mobile menu toggle
+ */
+function initMobileMenu() {
+    const menuToggle = document.getElementById('menu-toggle');
+    const navMenu = document.getElementById('nav-menu');
+
+    if (menuToggle && navMenu) {
+        menuToggle.addEventListener('click', () => {
+            const isExpanded = menuToggle.getAttribute('aria-expanded') === 'true';
+            menuToggle.setAttribute('aria-expanded', !isExpanded);
+            navMenu.classList.toggle('active');
+        });
+
+        document.addEventListener('click', (e) => {
+            if (!menuToggle.contains(e.target) && !navMenu.contains(e.target)) {
+                navMenu.classList.remove('active');
+                menuToggle.setAttribute('aria-expanded', 'false');
+            }
+        });
+    }
+}

--- a/frontend/history/dynasties/pushyabhuti/style.css
+++ b/frontend/history/dynasties/pushyabhuti/style.css
@@ -1,0 +1,341 @@
+/* ==========================================================================
+   Pushyabhuti (Vardhana) Dynasty Explorer Styling
+   Emperor Harshavardhana and the revival of northern India (c. 500-647 CE)
+   ========================================================================== */
+
+.pv-page-body {
+    background-color: var(--bg-primary, #0B0F19);
+    color: var(--text-primary, #E2E8F0);
+    font-family: 'Outfit', system-ui, -apple-system, sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+}
+
+.pv-main {
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: 80px 20px 60px;
+}
+
+/* --- Hero Banner --- */
+.pv-hero {
+    text-align: center;
+    padding: 48px 24px;
+    background: linear-gradient(135deg, rgba(11, 15, 25, 0.95) 0%, rgba(35, 15, 42, 0.85) 100%);
+    border: 1px solid rgba(142, 68, 173, 0.35);
+    border-radius: 16px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+    margin-bottom: 32px;
+    position: relative;
+    overflow: hidden;
+}
+
+.pv-hero::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: linear-gradient(90deg, #FF9933 0%, #D4AF37 50%, #8e44ad 100%);
+}
+
+.pv-kicker {
+    display: inline-block;
+    padding: 6px 16px;
+    background: rgba(142, 68, 173, 0.2);
+    color: #c188da;
+    border: 1px solid rgba(142, 68, 173, 0.4);
+    border-radius: 20px;
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 16px;
+}
+
+.pv-hero h1 {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 2.6rem;
+    font-weight: 700;
+    color: var(--text-heading, #F8FAFC);
+    margin: 0 0 12px;
+}
+
+.pv-hero p {
+    font-size: 1.1rem;
+    color: var(--text-secondary, #94A3B8);
+    max-width: 850px;
+    margin: 0 auto 24px;
+}
+
+.pv-hero-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 16px;
+    margin-top: 24px;
+}
+
+.pv-hero-stat {
+    background: rgba(15, 23, 42, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    padding: 16px;
+    text-align: center;
+}
+
+.pv-hero-stat strong {
+    display: block;
+    font-size: 1.3rem;
+    color: #FF9933;
+    font-family: 'Playfair Display', Georgia, serif;
+}
+
+.pv-hero-stat span {
+    font-size: 0.8rem;
+    color: var(--text-secondary, #94A3B8);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+/* --- Navigation Tabs --- */
+.pv-nav-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: center;
+    margin-bottom: 32px;
+    padding: 12px;
+    background: rgba(15, 23, 42, 0.5);
+    border-radius: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.pv-tab {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: var(--text-secondary, #94A3B8);
+    padding: 8px 16px;
+    border-radius: 20px;
+    font-size: 0.88rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.25s ease;
+    white-space: nowrap;
+}
+
+.pv-tab:hover {
+    border-color: rgba(142, 68, 173, 0.5);
+    color: #c188da;
+}
+
+.pv-tab.active {
+    background: linear-gradient(135deg, #8e44ad, #5f2d73);
+    border-color: #8e44ad;
+    color: #fff;
+}
+
+.pv-tab:focus-visible {
+    outline: 2px solid #FF9933;
+    outline-offset: 2px;
+}
+
+/* --- Content Sections --- */
+.pv-section {
+    display: none;
+    animation: fadeIn 0.4s ease;
+}
+
+.pv-section.active {
+    display: block;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.pv-content-card {
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 16px;
+    padding: 32px;
+}
+
+.pv-content-card h2 {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 1.8rem;
+    color: var(--text-heading, #F8FAFC);
+    margin: 0 0 20px;
+}
+
+.pv-content h3 {
+    color: #c188da;
+    font-size: 1.1rem;
+    margin: 0 0 6px;
+}
+
+.pv-content p {
+    color: var(--text-secondary, #CBD5E1);
+    margin: 0 0 14px;
+}
+
+.pv-list {
+    color: var(--text-secondary, #CBD5E1);
+    padding-left: 20px;
+    margin: 0 0 14px;
+}
+
+.pv-list li {
+    margin-bottom: 8px;
+}
+
+.pv-references a {
+    color: #c188da;
+    text-decoration: none;
+}
+
+.pv-references a:hover {
+    text-decoration: underline;
+}
+
+/* --- Timeline --- */
+.pv-timeline {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    border-left: 2px solid rgba(142, 68, 173, 0.5);
+    padding-left: 20px;
+    margin-top: 8px;
+}
+
+.pv-timeline-item {
+    position: relative;
+}
+
+.pv-timeline-item::before {
+    content: '';
+    position: absolute;
+    left: -26px;
+    top: 4px;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: #8e44ad;
+}
+
+.pv-timeline-year {
+    display: block;
+    font-weight: 700;
+    color: #FF9933;
+    font-family: 'Playfair Display', Georgia, serif;
+    margin-bottom: 4px;
+}
+
+.pv-timeline-item p {
+    margin: 0;
+}
+
+/* --- Rulers --- */
+.ruler-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 16px;
+}
+
+.ruler-item {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 12px;
+    padding: 18px;
+}
+
+.ruler-reign {
+    font-size: 0.85rem;
+    color: var(--text-secondary, #94A3B8);
+    font-weight: 400;
+}
+
+/* --- Gallery --- */
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+    margin-top: 16px;
+}
+
+.gallery-item {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 12px;
+    padding: 20px;
+    text-align: center;
+    transition: transform 0.25s ease;
+}
+
+.gallery-item:hover {
+    transform: translateY(-4px);
+    border-color: rgba(142, 68, 173, 0.5);
+}
+
+.gallery-placeholder {
+    font-size: 2.6rem;
+    margin-bottom: 10px;
+}
+
+.gallery-item h3 {
+    margin: 0 0 6px;
+}
+
+.gallery-item p {
+    font-size: 0.9rem;
+    margin: 0;
+}
+
+/* --- Footer --- */
+.pv-footer {
+    text-align: center;
+    padding: 30px 20px;
+    color: var(--text-secondary, #94A3B8);
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* --- Responsive --- */
+@media (max-width: 768px) {
+    .pv-hero h1 {
+        font-size: 2rem;
+    }
+
+    .pv-content-card {
+        padding: 20px;
+    }
+
+    .pv-nav-tabs {
+        justify-content: flex-start;
+        overflow-x: auto;
+        flex-wrap: nowrap;
+    }
+
+    .pv-timeline {
+        padding-left: 16px;
+    }
+}
+
+/* --- Light Theme Overrides --- */
+body.light-theme.pv-page-body {
+    background-color: #F8FAFC;
+    color: #0F172A;
+}
+
+body.light-theme .pv-content-card,
+body.light-theme .pv-hero {
+    background: rgba(255, 255, 255, 0.85);
+    border-color: rgba(0, 0, 0, 0.08);
+}
+
+body.light-theme .pv-content p,
+body.light-theme .pv-list,
+body.light-theme .ruler-reign {
+    color: #334155;
+}


### PR DESCRIPTION
## What this PR does

Adds a dedicated explorer page for the Pushyabhuti (Vardhana)
Dynasty, the dynasty of Emperor Harshavardhana, which briefly
reunited and revived northern India (c. 500-647 CE) after the fall
of the Gupta Empire, and integrates it into the existing Indian
Dynasties Explorer landing page.

### New files
- history/dynasties/pushyabhuti/index.html
- history/dynasties/pushyabhuti/style.css
- history/dynasties/pushyabhuti/script.js

### Modified files
- history/dynasties/data.js — added a Pushyabhuti (Vardhana) Dynasty
  entry to the dynasties array and six events to the timelineEvents
  array

### Note for reviewers
This builds on the already-data-driven Indian Dynasties Explorer
landing page (history/dynasties/), including the "View Full Explorer"
card-link mechanism added in earlier dynasty PRs — no changes to
DynastyCard.js or styles.css were needed this time. Adding the
Pushyabhuti Dynasty to data.js automatically surfaces it in the card
grid, the map, the timeline, and the site-wide Contributions view.

### Sections covered on the dedicated page
Historical Overview, Timeline, Major Rulers, Contributions, Gallery,
and References — content is based on Wikipedia, World History
Encyclopedia, and standard ancient Indian history references, linked
in the References tab.

### Testing
- Verified navigation from the landing page card to the Pushyabhuti
  Dynasty page via the "View Full Explorer" link
- Checked script.js for syntax errors (node --check)
- Confirmed the new entries render correctly in the landing page's
  Timeline, Map, and Contributions tabs
- Confirmed responsive layout at mobile and desktop breakpoints

Closes #1515 

@Eshajha19 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.