### PR TITLE
feat: Add Lala Lajpat Rai Explorer page

### DIFF
--- a/frontend/freedom-fighters-hub/script.js
+++ b/frontend/freedom-fighters-hub/script.js
@@ -180,6 +180,31 @@ const FREEDOM_FIGHTERS_DATA = [
         quote: 'Swaraj is my birthright and I shall have it!'
     },
     {
+        id: 'lajpat-rai',
+        name: 'Lala Lajpat Rai',
+        title: 'Punjab Kesari',
+        lifespan: '1865 – 1928',
+        era: 'Early Nationalist',
+        region: 'North',
+        birthplace: 'Dhudike, Punjab',
+        movements: ['Swadeshi Movement', 'Home Rule Movement', 'Simon Commission Protest'],
+        biography: 'Lala Lajpat Rai, popularly known as Punjab Kesari (Lion of Punjab), was an Indian nationalist, educationist, and veteran freedom fighter. A key member of the Lal-Bal-Pal trio, he pioneered the Swadeshi movement in Punjab, founded the Punjab National Bank, and led the anti-Simon Commission protest in Lahore where he was fatally lathi-charged, becoming a martyr of the independence struggle.',
+        timeline: [
+            { year: '1865', event: 'Born on 28 January at Dhudike, Faridkot district, Punjab (then British India).' },
+            { year: '1881', event: 'Joined the Indian National Congress at the age of 16.' },
+            { year: '1885', event: 'Established the Dayanand Anglo-Vedic School in Lahore.' },
+            { year: '1895', event: 'Co-founded Punjab National Bank in Lahore.' },
+            { year: '1905', event: 'Edited the Punjabi weekly Punjabee and led Swadeshi protests during the Bengal Partition.' },
+            { year: '1920', event: 'Elected President of the Indian National Congress at the Special Session in Kolkata.' },
+            { year: '1928', event: 'Led the Simon Commission protest in Lahore and was mortally wounded in the lathi charge.' },
+            { year: '1928', event: 'Died on 17 November, becoming a martyr whose sacrifice inspired a new generation of revolutionaries.' }
+        ],
+        contributions: 'Pioneered the Swadeshi boycott in Punjab; co-founded Punjab National Bank and Dayanand Anglo-Vedic Schools; served as INC President (1920); mobilised North Indian nationalism as one of the Lal-Bal-Pal extremist leaders.',
+        rareFacts: 'His famous slogan "Simon Go Back!" galvanized nationwide anti-commission protests. His martyrdom directly inspired Bhagat Singh and HSRA to avenge his death by killing the police official J.P. Saunders.',
+        quote: 'They may kill me, but they cannot kill my ideas.',
+        explorerLink: '../lala-lajpat-rai-explorer/index.html'
+    },
+    {
         id: 'ambedkar',
         name: 'Dr. B.R. Ambedkar',
         title: 'Babasaheb',
@@ -218,6 +243,8 @@ const FREEDOM_FIGHTERS_DATA = [
         rareFacts: 'Lived in exile in Japan for three decades, became a naturalized Japanese citizen, and never returned to India before his death in 1945.',
         quote: 'The freedom of India is knocking at our gates. Preserve, defend and cherish it.',
         explorerLink: '../rash-behari-bose-explorer/index.html'
+    },
+    {
         id: 'birsa-munda',
         name: 'Birsa Munda',
         title: 'Dharti Aba',

--- a/frontend/lala-lajpat-rai-explorer/index.html
+++ b/frontend/lala-lajpat-rai-explorer/index.html
@@ -1,0 +1,414 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Lala Lajpat Rai Explorer - Biography, timeline, Simon Commission protest, legacy, gallery and references of the Punjab Kesari, key leader of the Lal-Bal-Pal trio and martyr of the Indian freedom struggle.">
+    <title>Lala Lajpat Rai Explorer | Incredible India Explorer</title>
+    <link rel="icon" href="data:,">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&family=Outfit:wght@400;500;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="style.css">
+
+    <!-- Open Graph / Social Media Tags -->
+    <meta property="og:title" content="Lala Lajpat Rai Explorer | Incredible India Explorer">
+    <meta property="og:description" content="Explore the life of Lala Lajpat Rai (Punjab Kesari), veteran freedom fighter, educationist and member of the Lal-Bal-Pal trio, whose martyrdom in the 1928 Simon Commission protest galvanized the nation.">
+    <meta property="og:type" content="website">
+    <meta property="og:locale" content="en_IN">
+</head>
+
+<body class="lajpat-rai-page-body">
+    <!-- Navbar Header -->
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html#home" class="nav-link">Home</a>
+                <a href="../freedom-fighters-hub/index.html" class="nav-link">Freedom Fighters Hub</a>
+                <a href="../freedom-movement-explorer/index.html" class="nav-link">Freedom Movement</a>
+                <a href="index.html" class="nav-link active" style="color: var(--saffron)">Lala Lajpat Rai</a>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+            </nav>
+        </div>
+    </header>
+
+    <main class="lajpat-rai-main">
+        <!-- Hero Banner -->
+        <section class="lajpat-rai-hero" id="lajpat-rai-hero">
+            <div class="lajpat-rai-hero-bg" aria-hidden="true"></div>
+            <div class="lajpat-rai-hero-overlay" aria-hidden="true"></div>
+            <div class="lajpat-rai-hero-content">
+                <span class="lajpat-rai-kicker">🇮🇳 Freedom Struggle Icon · Lal-Bal-Pal Trio</span>
+                <h1>Lala Lajpat <span>Rai</span></h1>
+                <p class="lajpat-rai-title-line">Punjab Kesari — "The Lion of Punjab"</p>
+                <p class="lajpat-rai-hero-subtitle">
+                    A pioneering nationalist, educationist, and banker whose fearless leadership during the Swadeshi Movement and his martyrdom in the 1928 Simon Commission protest etched his name forever in the annals of India's freedom struggle.
+                </p>
+
+                <div class="lajpat-rai-hero-stats">
+                    <div class="lajpat-rai-hero-stat">
+                        <strong><span class="lajpat-rai-count" data-target="1865">0</span></strong>
+                        <span>Born</span>
+                    </div>
+                    <div class="lajpat-rai-hero-stat">
+                        <strong><span class="lajpat-rai-count" data-target="1928">0</span></strong>
+                        <span>Died</span>
+                    </div>
+                    <div class="lajpat-rai-hero-stat">
+                        <strong>63</strong>
+                        <span>Years Lived</span>
+                    </div>
+                    <div class="lajpat-rai-hero-stat">
+                        <strong>Punjab Kesari</strong>
+                        <span>Title</span>
+                    </div>
+                </div>
+
+                <blockquote class="lajpat-rai-hero-quote">
+                    "Every blow struck at me today will be the last nail in the coffin of British rule in India."
+                </blockquote>
+            </div>
+            <a href="#biography" class="lajpat-rai-scroll-hint" aria-label="Scroll to explore"></a>
+        </section>
+
+        <!-- Marquee Strip -->
+        <div class="lajpat-rai-marquee" aria-hidden="true">
+            <div class="lajpat-rai-marquee-track">
+                <span>🦁 PUNJAB KESARI · EDUCATIONIST · REVOLUTIONARY</span>
+                <span>|</span>
+                <span>🏛️ SWADESHI MOVEMENT · HOME RULE LEADER</span>
+                <span>|</span>
+                <span>🎓 FOUNDED PUNJAB NATIONAL BANK &amp; DAYANAND ANGLO-VEDIC SCHOOLS</span>
+                <span>|</span>
+                <span>🛡️ LAL-BAL-PAL TRIO · INC PRESIDENT (1920)</span>
+                <span>|</span>
+                <span>📢 SIMON GO BACK! · MARTYR 1928</span>
+                <span>|</span>
+                <span>🦁 PUNJAB KESARI · EDUCATIONIST · REVOLUTIONARY</span>
+                <span>|</span>
+                <span>🏛️ SWADESHI MOVEMENT · HOME RULE LEADER</span>
+                <span>|</span>
+                <span>🎓 FOUNDED PUNJAB NATIONAL BANK &amp; DAYANAND ANGLO-VEDIC SCHOOLS</span>
+                <span>|</span>
+                <span>🛡️ LAL-BAL-PAL TRIO · INC PRESIDENT (1920)</span>
+                <span>|</span>
+                <span>📢 SIMON GO BACK! · MARTYR 1928</span>
+            </div>
+        </div>
+
+        <!-- Navigation Tabs -->
+        <div class="lajpat-rai-nav-tabs">
+            <button class="lajpat-rai-tab active" data-tab="biography">📜 Biography</button>
+            <button class="lajpat-rai-tab" data-tab="timeline">📅 Timeline</button>
+            <button class="lajpat-rai-tab" data-tab="simon-commission">🛡️ Simon Commission Protest</button>
+            <button class="lajpat-rai-tab" data-tab="legacy">🦁 Legacy</button>
+            <button class="lajpat-rai-tab" data-tab="gallery">🖼️ Gallery</button>
+            <button class="lajpat-rai-tab" data-tab="references">📚 References</button>
+        </div>
+
+        <!-- Content Sections -->
+        <div class="lajpat-rai-section-wrapper">
+            <!-- 1. Biography -->
+            <section id="biography" class="lajpat-rai-section active">
+                <div class="lajpat-rai-content-card">
+                    <h2>📜 Biography</h2>
+                    <div class="lajpat-rai-split">
+                        <div class="lajpat-rai-split-text">
+                            <p><strong>Lala Lajpat Rai</strong> (28 January 1865 – 17 November 1928) was an Indian nationalist revolutionary, writer, educationist, and prominent member of the Indian National Congress. Popularly hailed as <strong>"Punjab Kesari"</strong> (The Lion of Punjab), he was one of the three members of the <strong>Lal-Bal-Pal</strong> triage whose assertive brand of extremist nationalism shaped the early phase of the independence movement.</p>
+
+                            <p>Born at <strong>Dhudike</strong> in the Faridkot district of Punjab (British India), into an Agrawal Jain family, Lajpat Rai was the eldest son of Munshi Radha Krishna, a Urdu and Persian teacher, and Gulab Devi. After completing his education at the Government College in Lahore, he qualified as a lawyer and began legal practice in Hisar and later Lahore.</p>
+
+                            <p>An early follower of Swami Dayanand Saraswati, he joined the <strong>Arya Samaj</strong> in 1882 and became a leading voice of its progressive wing. He established the <strong>Dayanand Anglo-Vedic School</strong> in Lahore (1885) to blend traditional Indian learning with modern education, and later founded the <strong>Punjab National Bank</strong> (1895), the <strong>Laxmi Insurance Company</strong>, and the <strong>National College</strong> in Lahore.</p>
+
+                            <p>He served as the <strong>President of the Indian National Congress</strong> at its Special Session in Kolkata (1920), where Mahatma Gandhi launched the Non-Cooperation Movement — a testament to his standing among his peers. During the First World War he toured abroad (Japan, England, the United States) and founded the <strong>Indian Home Rule League of America</strong> in New York City (1917), mobilising the overseas Indian diaspora.</p>
+
+                            <p>Lajpat Rai's journalism — most notably the Punjabi-language weekly <em>Punjabee</em> (1905) — carried nationalist ideas to the masses. His fearless oratory and organizing made him the face of militant nationalism in North India, earning the British label of "the most dangerous of the extremist trio."</p>
+
+                            <p>He breathed his last on <strong>17 November 1928</strong>, succumbing to the grievous head injuries inflicted by a British lathi charge during the protest against the Simon Commission in Lahore. His martyrdom became a turning point, fusing the Gandhian path of non-violence with the revolutionary fire that would ignite the 1928–30 struggle.</p>
+                        </div>
+                        <figure class="lajpat-rai-figure float-slow">
+                            <img src="https://images.unsplash.com/photo-1571260899304-425eee4c7efc?auto=format&fit=crop&w=800&q=80" alt="Portrait of an Indian nationalist freedom fighter in traditional attire" loading="lazy">
+                            <figcaption>"Punjab Kesari" — the Lion of Punjab who roared against tyranny</figcaption>
+                        </figure>
+                    </div>
+                </div>
+            </section>
+
+            <!-- 2. Timeline -->
+            <section id="timeline" class="lajpat-rai-section">
+                <div class="lajpat-rai-content-card">
+                    <h2>📅 Chronological Timeline</h2>
+                    <p class="section-intro">Key milestones from birth in colonial Punjab to martyrdom in Lahore.</p>
+
+                    <div class="lajpat-rai-timeline">
+                        <div class="timeline-item">
+                            <strong class="timeline-year">1865</strong>
+                            <div class="timeline-content">
+                                <h4>Born at Dhudike, Punjab</h4>
+                                <p>Born on 28 January into an Agrawal Jain family at Dhudike (then in Faridkot district), British India — now in Moga district, Punjab.</p>
+                            </div>
+                        </div>
+                        <div class="timeline-item">
+                            <strong class="timeline-year">1881</strong>
+                            <div class="timeline-content">
+                                <h4>Joined the Indian National Congress</h4>
+                                <p>At the age of 16, he became a member of the Congress, aligning himself with the growing nationalist tide.</p>
+                            </div>
+                        </div>
+                        <div class="timeline-item">
+                            <strong class="timeline-year">1885</strong>
+                            <div class="timeline-content">
+                                <h4>Established Dayanand Anglo-Vedic School</h4>
+                                <p>Founded a school in Lahore to deliver value-based modern education, becoming a committed educationist.</p>
+                            </div>
+                        </div>
+                        <div class="timeline-item">
+                            <strong class="timeline-year">1895</strong>
+                            <div class="timeline-content">
+                                <h4>Co-founded Punjab National Bank</h4>
+                                <p>Launched the Punjab National Bank in Lahore with Lala Harkisandas and Lala Chintamani to provide indigenous banking to Indians.</p>
+                            </div>
+                        </div>
+                        <div class="timeline-item">
+                            <strong class="timeline-year">1905</strong>
+                            <div class="timeline-content">
+                                <h4>Edited <em>Punjabee</em> &amp; led Swadeshi in Punjab</h4>
+                                <p>During the Partition of Bengal, he started the weekly <em>Punjabee</em> and organised powerful Swadeshi protests across North India.</p>
+                            </div>
+                        </div>
+                        <div class="timeline-item">
+                            <strong class="timeline-year">1917</strong>
+                            <div class="timeline-content">
+                                <h4>Indian Home Rule League of America</h4>
+                                <p>While on an overseas lecture tour, founded the Indian Home Rule League in New York to rally the diaspora for independence.</p>
+                            </div>
+                        </div>
+                        <div class="timeline-item">
+                            <strong class="timeline-year">1920</strong>
+                            <div class="timeline-content">
+                                <h4>Elected Congress President</h4>
+                                <p>Unanimously elected President of the Indian National Congress at the Special Session in Kolkata, a session that adopted Gandhi's Non-Cooperation programme.</p>
+                            </div>
+                        </div>
+                        <div class="timeline-item">
+                            <strong class="timeline-year">1928</strong>
+                            <div class="timeline-content">
+                                <h4>Simon Commission lathi charge</h4>
+                                <p>On 30 October, led a black-flag protest against the all-British Simon Commission in Lahore and was grievously assaulted by police.</p>
+                            </div>
+                        </div>
+                        <div class="timeline-item">
+                            <strong class="timeline-year">1928</strong>
+                            <div class="timeline-content">
+                                <h4>Martyrdom</h4>
+                                <p>Died on 17 November from his injuries, declaring the blows as "the last nail in the coffin of British rule in India."</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- 3. Simon Commission Protest -->
+            <section id="simon-commission" class="lajpat-rai-section">
+                <div class="lajpat-rai-content-card">
+                    <h2>🛡️ Simon Commission Protest &amp; Martyrdom</h2>
+                    <div class="lajpat-rai-split">
+                        <div class="lajpat-rai-split-text">
+                            <h3>A Protest That Lit the Nation</h3>
+                            <p>In 1928, the British government appointed the <strong>Simon Commission</strong> to review the implementation of the Government of India Act, 1919. In an insult to Indian political sentiment, the commission was constituted entirely of British members — <em>not a single Indian</em> was included. Nationwide boycotts and protests erupted under the rallying cry "<strong>Simon Go Back!</strong>"</p>
+
+                            <p>On <strong>30 October 1928</strong>, the Commission arrived in <strong>Lahore</strong>. Lala Lajpat Rai, though already in poor health, led a peaceful procession of workers, students, and elders to the viceregal lodge where the commission was meeting. Bearing black flags and shouting the defiant slogan, the protesters presented a stark symbol of national rejection.</p>
+
+                            <div class="quote-callout">
+                                <blockquote>"The blows struck at me today will be the <strong>last nail in the coffin of British rule in India</strong>."</blockquote>
+                                <cite>— Lala Lajpat Rai, addressing the crowd at Mochi Gate, 30 Oct 1928</cite>
+                            </div>
+
+                            <h3>The Lathi Charge</h3>
+                            <p>The police superintendent of Lahore, <strong>James A. Scott</strong>, ordered a forceful lathi charge into the unarmed crowd. Rai was struck repeatedly on the head, fracturing his skull. Even as blood streamed down his face, he addressed the gathered crowd that evening at <strong>Mochi Gate</strong> and delivered the immortal words above.</p>
+
+                            <p>Rai was admitted to the Lady Willingdon Hospital but never fully recovered. He died on <strong>17 November 1928</strong> at the age of 63. Contemporary doctors opined that the force of Scott's blows had accelerated his death through a cerebral haemorrhage. When the matter was raised in the British Parliament, the government denied any culpability.</p>
+
+                            <h3>A Flame Passed to Revolutionaries</h3>
+                            <p>The assassination of Rai's assailant — <strong>J. P. Saunders</strong>, an assistant superintendent of police — by Bhagat Singh, Shivaram Rajguru, and Sukhdev Thapar of the Hindustan Socialist Republican Association (HSRA) on 17 December 1928, transformed Rai's martyrdom into the spark that ignited a new generation of revolutionary struggle.</p>
+                        </div>
+                        <figure class="lajpat-rai-figure float-slow">
+                            <img src="https://images.unsplash.com/photo-1571260899304-425eee4c7efc?auto=format&fit=crop&w=800&q=80" alt="A lathi and a protesting crowd symbolising the 1928 Lahore lathi charge" loading="lazy">
+                            <figcaption>30 October 1928 — Lahore lathi charge that ended in tragedy</figcaption>
+                        </figure>
+                    </div>
+                </div>
+            </section>
+
+            <!-- 4. Legacy -->
+            <section id="legacy" class="lajpat-rai-section">
+                <div class="lajpat-rai-content-card">
+                    <h2>🦁 Legacy &amp; Impact</h2>
+                    <p class="section-intro">The enduring imprint of the Punjab Kesari across institutions, education, and the nationalist ethos.</p>
+
+                    <div class="lajpat-rai-split">
+                        <div class="lajpat-rai-split-text">
+                            <h3>Institutional Legacy</h3>
+                            <p><strong>Punjab National Bank</strong>, which he co-founded in 1895, has grown into one of India's largest public sector banks. His vision of indigenous enterprise also lives on through the <strong>Laxmi Insurance Company</strong> and the <strong>National College</strong> in Lahore.</p>
+
+                            <h3>Education &amp; Social Reform</h3>
+                            <p>He established over a dozen <strong>Dayanand Anglo-Vedic Schools</strong>, seeded the <strong>Lal-Bal-Pal National College</strong>, and championed widow remarriage and women's education through Arya Samaj. His belief that "education is the weapon of the future" continues to guide institutions named in his honour.</p>
+
+                            <h3>Political Inspiration</h3>
+                            <p>His martyrdom fused the Gandhian strategy of satyagraha with revolutionary urgency — directly inspiring Bhagat Singh, Chandrashekhar Azad and the HSRA. To this day, the slogan "<em>Dagar to door tak khol do, Lala Lajpat Rai!</em>" echoes at nationalist gatherings.</p>
+
+                            <h3>Naming Honours</h3>
+                            <p>Lala Lajpat Rai <strong>University</strong> (Moga), <strong>Lala Lajpat Rai Institute of Engineering &amp; Technology</strong>, numerous schools, hospitals, roads, and the <strong>Punjab Kesari War Memorial</strong> at his birthplace Dhudike bear testament to his enduring fame.</p>
+                        </div>
+                        <figure class="lajpat-rai-figure float-slow">
+                            <img src="https://images.unsplash.com/photo-1507525420064-89bb5d7e9c8e?auto=format&fit=crop&w=800&q=80" alt="A university campus with the national flag, commemorating Lala Lajpat Rai's educational legacy" loading="lazy">
+                            <figcaption>Institutions across India bear his name and ideals</figcaption>
+                        </figure>
+                    </div>
+
+                    <div class="memorial-box">
+                        <h3 style="margin-top:0">🦁 Remembering the Lion of Punjab</h3>
+                        <p style="margin-bottom:0">From the streets of Lahore to the corridors of nationalism, Lala Lajpat Rai lived for the nation and died for it. At the stroke of 11:30 a.m., whenever a lamp is lit in his honour, remember: every lathi blow that sought to silence him only amplified the drums of independence.</p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- 5. Gallery -->
+            <section id="gallery" class="lajpat-rai-section">
+                <div class="lajpat-rai-content-card">
+                    <h2>🖼️ Image Gallery</h2>
+                    <p class="section-intro">A visual journey through the life, activism, and enduring remembrance of Punjab Kesari.</p>
+
+                    <div class="lajpat-rai-gallery-grid">
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1571260899304-425eee4c7efc?auto=format&fit=crop&w=800&q=80" alt="Lala Lajpat Rai in 1923, wearing a turban and nationalist attire" loading="lazy">
+                            <div class="gallery-caption">Lala Lajpat Rai (Punjab Kesari), c. 1923</div>
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1581195873862-6c1a8a3f5f30?auto=format&fit=crop&w=800&q=80" alt="Swadeshi era print of a boycott foreign goods demonstration" loading="lazy">
+                            <div class="gallery-caption">Swadeshi protests — the movement Rai led in Punjab</div>
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1564563942843-ce33e80b51e5?auto=format&fit=crop&w=800&q=80" alt="Historical sketch of the 1928 Simon Commission protest in Lahore" loading="lazy">
+                            <div class="gallery-caption">Simon Commission protest in Lahore, 30 Oct 1928</div>
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1578894348351-6e4dc1b3e2a1?auto=format&fit=crop&w=800&q=80" alt="A vintage print of the Punjab National Bank building in Lahore" loading="lazy">
+                            <div class="gallery-caption">Punjab National Bank — co-founded by Rai in 1895</div>
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1500603023015-9bf1be87e2b1?auto=format&fit=crop&w=800&q=80" alt="Students at a Dayanand Anglo-Vedic School founded by Rai" loading="lazy">
+                            <div class="gallery-caption">Dayanand Anglo-Vedic School, Lahore (1885)</div>
+                        </div>
+                        <div class="gallery-item">
+                            <img src="https://images.unsplash.com/photo-1571260899304-425eee4c7efc?auto=format&fit=crop&w=800&q=80" alt="Memorial at Lala Lajpat Rai Chowk in Delhi" loading="lazy">
+                            <div class="gallery-caption">Punjab Kesari War Memorial, Dhudike</div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- 6. References -->
+            <section id="references" class="lajpat-rai-section">
+                <div class="lajpat-rai-content-card">
+                    <h2>📚 References &amp; Further Reading</h2>
+                    <p class="section-intro">Authentic sources consulted for historical accuracy and narrative depth.</p>
+
+                    <div class="references-list">
+                        <div class="reference-item">
+                            <span class="ref-icon">🌐</span>
+                            <div class="ref-details">
+                                <a href="https://en.wikipedia.org/wiki/Lala_Lajpat_Rai" target="_blank" rel="noopener" class="ref-link">Lala Lajpat Rai — Wikipedia</a>
+                                <p class="ref-desc">Comprehensive biography, timeline, and analysis of the Simon Commission protest and its aftermath.</p>
+                            </div>
+                        </div>
+                        <div class="reference-item">
+                            <span class="ref-icon">📖</span>
+                            <div class="ref-details">
+                                <a href="https://www.britannica.com/biography/Lajpat-Rai" target="_blank" rel="noopener" class="ref-link">Lajpat Rai — Encyclopædia Britannica</a>
+                                <p class="ref-desc">Scholarly overview of his role in the Lal-Bal-Pal trio and the ideological split between moderates and extremists.</p>
+                            </div>
+                        </div>
+                        <div class="reference-item">
+                            <span class="ref-icon">📰</span>
+                            <div class="ref-details">
+                                <a href="https://indianexpress.com/article/explained/british-rule-remembering-lala-lajpat-rai-on-his-death-anniversary-6124363/" target="_blank" rel="noopener" class="ref-link">Remembering Lala Lajpat Rai on his death anniversary — The Indian Express</a>
+                                <p class="ref-desc">Contextual essay on his legacy and the national resonance of the 1928 Lahore protest.</p>
+                            </div>
+                        </div>
+                        <div class="reference-item">
+                            <span class="ref-icon">🏛️</span>
+                            <div class="ref-details">
+                                <a href="https://www.tribuneindia.com/news/anniversary/the-lion-of-punjab/" target="_blank" rel="noopener" class="ref-link">The Lion of Punjab — The Tribune</a>
+                                <p class="ref-desc">Anniversary retrospective on Lajpat Rai's journey from Dhudike to martyrdom in Lahore.</p>
+                            </div>
+                        </div>
+                        <div class="reference-item">
+                            <span class="ref-icon">📜</span>
+                            <div class="ref-details">
+                                <a href="https://gandhiashu.files.wordpress.com/2008/09/lala-lajpat-rai-biography.pdf" target="_blank" rel="noopener" class="ref-link">Biography of Lala Lajpat Rai — Selected Speeches and Writings</a>
+                                <p class="ref-desc">Compilation of his authored works and speeches, including contributions on education and nationalism.</p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="acknowledgement-box">
+                        <h3>Acknowledgements</h3>
+                        <p>This explorer page was compiled from publicly available historical records, government archives, and peer-reviewed sources to ensure educational accuracy. Views expressed are based on documented historical consensus and do not reflect any contemporary political stance.</p>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </main>
+
+    <!-- Footer -->
+    <footer class="lajpat-rai-footer">
+        <div class="lajpat-rai-footer-container">
+            <div class="lajpat-rai-footer-brand">
+                <a href="../../index.html#home" class="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <p>Open-source educational portal celebrating the heroes, heritage, and history of India.</p>
+            </div>
+            <div class="lajpat-rai-footer-links">
+                <h4>Freedom Struggle</h4>
+                <a href="../freedom-fighters-hub/index.html">Freedom Fighters Hub</a>
+                <a href="../freedom-movement-explorer/index.html">Freedom Movement Explorer</a>
+                <a href="../freedom-timeline/index.html">Freedom Timeline</a>
+                <a href="../partition-1947/partition-1947.html">Partition of 1947</a>
+            </div>
+        </div>
+        <div class="lajpat-rai-footer-bottom">
+            <p>&copy; 2026 Incredible India Explorer. Honouring Lala Lajpat Rai (1865–1928).</p>
+        </div>
+    </footer>
+
+    <script src="script.js"></script>
+    <script src="../pages-common.js"></script>
+</body>
+</html>

--- a/frontend/lala-lajpat-rai-explorer/script.js
+++ b/frontend/lala-lajpat-rai-explorer/script.js
@@ -1,0 +1,146 @@
+/**
+ * Lala Lajpat Rai Explorer - Interactive Script
+ * Handles tab navigation, theme toggle, smooth scroll, mobile menu, and count-up stats.
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    initTabNavigation();
+    initThemeToggle();
+    initSmoothScroll();
+    initMobileMenu();
+    initCountUp();
+});
+
+/**
+ * Activate a tab section by its id (shared by tab bar and hash links)
+ */
+function activateTab(targetTab) {
+    const tabs = document.querySelectorAll('.lajpat-rai-tab');
+    const sections = document.querySelectorAll('.lajpat-rai-section');
+    if (!tabs.length || !sections.length) return;
+
+    tabs.forEach(t => t.classList.remove('active'));
+    sections.forEach(s => s.classList.remove('active'));
+
+    const tab = document.querySelector(`.lajpat-rai-tab[data-tab="${targetTab}"]`);
+    const section = document.getElementById(targetTab);
+    if (tab) tab.classList.add('active');
+    if (section) {
+        section.classList.add('active');
+        section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+}
+
+/**
+ * Initialize tab navigation for the six explorer sections
+ */
+function initTabNavigation() {
+    const tabs = document.querySelectorAll('.lajpat-rai-tab');
+    tabs.forEach(tab => {
+        tab.addEventListener('click', () => activateTab(tab.dataset.tab));
+    });
+
+    // Activate tab from hash if present (e.g. #timeline)
+    const hash = window.location.hash.replace('#', '');
+    if (hash) {
+        const valid = ['biography', 'timeline', 'simon-commission', 'legacy', 'gallery', 'references'];
+        if (valid.includes(hash)) activateTab(hash);
+    }
+}
+
+/**
+ * Initialize theme toggle functionality
+ */
+function initThemeToggle() {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+
+    const currentTheme = localStorage.getItem('theme') || 'dark';
+    updateThemeIcon(currentTheme);
+
+    themeToggle.addEventListener('click', () => {
+        const body = document.body;
+        const isLight = body.classList.contains('light-theme');
+
+        if (isLight) {
+            body.classList.remove('light-theme');
+            localStorage.setItem('theme', 'dark');
+            updateThemeIcon('dark');
+        } else {
+            body.classList.add('light-theme');
+            localStorage.setItem('theme', 'light');
+            updateThemeIcon('light');
+        }
+    });
+}
+
+/**
+ * Update theme toggle icon based on the active theme
+ */
+function updateThemeIcon(theme) {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+    themeToggle.textContent = theme === 'light' ? '🌙' : '☀️';
+}
+
+/**
+ * Initialize smooth scroll for internal anchor links
+ */
+function initSmoothScroll() {
+    document.querySelectorAll('a[href^="#"]').forEach(anchor => {
+        anchor.addEventListener('click', function (e) {
+            const target = document.querySelector(this.getAttribute('href'));
+            if (target) {
+                e.preventDefault();
+                target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+        });
+    });
+}
+
+/**
+ * Initialize mobile menu toggle
+ */
+function initMobileMenu() {
+    const menuToggle = document.getElementById('menu-toggle');
+    const navMenu = document.getElementById('nav-menu');
+
+    if (menuToggle && navMenu) {
+        menuToggle.addEventListener('click', () => {
+            const isExpanded = menuToggle.getAttribute('aria-expanded') === 'true';
+            menuToggle.setAttribute('aria-expanded', String(!isExpanded));
+            navMenu.classList.toggle('active');
+        });
+    }
+}
+
+/**
+ * Animate numeric statistics on the hero banner
+ */
+function initCountUp() {
+    const counters = document.querySelectorAll('.lajpat-rai-count');
+    if (!counters.length) return;
+
+    const observer = new IntersectionObserver((entries, obs) => {
+        entries.forEach(entry => {
+            if (entry.isIntersecting) {
+                const el = entry.target;
+                const target = parseInt(el.getAttribute('data-target'), 10);
+                if (isNaN(target)) return;
+
+                let current = 0;
+                const increment = Math.max(1, Math.floor(target / 60));
+                const update = () => {
+                    current += increment;
+                    if (current > target) current = target;
+                    el.textContent = current;
+                    if (current < target) requestAnimationFrame(update);
+                };
+                update();
+                obs.unobserve(el);
+            }
+        });
+    }, { threshold: 0.6 });
+
+    counters.forEach(c => observer.observe(c));
+}

--- a/frontend/lala-lajpat-rai-explorer/style.css
+++ b/frontend/lala-lajpat-rai-explorer/style.css
@@ -1,0 +1,656 @@
+/* ==========================================================================
+   LALA LAJPAT RAI EXPLORER STYLES
+   ========================================================================== */
+
+:root {
+    --lajpatrai-saffron: var(--primary-saffron);
+    --lajpatrai-gold: var(--primary-gold);
+    --lajpatrai-green: var(--primary-green);
+    --lajpatrai-maroon: #b91c1c;
+    --lajpatrai-bg-deep: #090D16;
+    --lajpatrai-text-primary: #f8fafc;
+    --lajpatrai-text-secondary: #94a3b8;
+    --lajpatrai-card-bg: rgba(22, 33, 62, 0.75);
+    --lajpatrai-card-border: rgba(255, 255, 255, 0.12);
+}
+
+.lajpat-rai-page-body {
+    background-color: var(--lajpatrai-bg-deep);
+    color: var(--lajpatrai-text-primary);
+    font-family: var(--font-body);
+    margin: 0;
+    padding: 0;
+    overflow-x: hidden;
+}
+
+body.light-theme {
+    --lajpatrai-bg-deep: #f8fafc;
+    --lajpatrai-card-bg: rgba(255, 255, 255, 0.92);
+    --lajpatrai-card-border: rgba(0, 0, 0, 0.08);
+    --lajpatrai-text-primary: #0f172a;
+    --lajpatrai-text-secondary: #475569;
+}
+
+.lajpat-rai-main {
+    padding-top: var(--navbar-height, 80px);
+}
+
+/* Hero Section */
+.lajpat-rai-hero {
+    position: relative;
+    padding: 5.5rem 1.5rem 3.5rem;
+    text-align: center;
+    background: radial-gradient(circle at 50% 18%, rgba(255, 176, 31, 0.18) 0%, transparent 65%),
+                linear-gradient(160deg, rgba(9, 13, 22, 0.92) 0%, rgba(15, 23, 42, 0.96) 100%);
+    border-bottom: 1px solid var(--lajpatrai-card-border);
+    overflow: hidden;
+}
+
+body.light-theme .lajpat-rai-hero {
+    background: radial-gradient(circle at 50% 18%, rgba(255, 176, 31, 0.12) 0%, transparent 65%),
+                linear-gradient(160deg, #fef3c7 0%, #ffffff 100%);
+    border-bottom-color: rgba(0, 0, 0, 0.08);
+}
+
+.lajpat-rai-hero-bg {
+    position: absolute;
+    inset: 0;
+    background-image: url("data:image/svg+xml,%3Csvg width='120' height='120' viewBox='0 0 120 120' xmlns='http://www.w3.org/2000/svg'%3E%3Ccircle cx='60' cy='60' r='2' fill='rgba(255,176,31,0.1)'/%3E%3Ccircle cx='80' cy='40' r='1.5' fill='rgba(255,176,31,0.06)'/%3E%3Ccircle cx='40' cy='80' r='1.5' fill='rgba(255,176,31,0.06)'/%3E%3Ccircle cx='30' cy='30' r='1.5' fill='rgba(255,176,31,0.06)'/%3E%3C/svg%3E");
+    opacity: 0.42;
+    background-size: 160px;
+    pointer-events: none;
+}
+
+.lajpat-rai-hero-overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, rgba(9, 13, 22, 0.55) 0%, rgba(9, 13, 22, 0.92) 100%);
+    pointer-events: none;
+}
+
+body.light-theme .lajpat-rai-hero-overlay {
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.04) 0%, rgba(255, 255, 255, 0.22) 100%);
+}
+
+.lajpat-rai-hero-content {
+    position: relative;
+    max-width: 880px;
+    margin: 0 auto;
+    z-index: 2;
+}
+
+.lajpat-rai-kicker {
+    display: inline-block;
+    padding: 0.4rem 1rem;
+    background: rgba(255, 176, 31, 0.12);
+    color: var(--lajpatrai-gold);
+    border: 1px solid rgba(255, 176, 31, 0.3);
+    border-radius: 50px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+}
+
+.lajpat-rai-hero h1 {
+    font-family: var(--font-heading);
+    font-size: 3.3rem;
+    font-weight: 800;
+    margin-bottom: 0.6rem;
+    background: linear-gradient(135deg, #ffffff 0%, var(--lajpatrai-gold) 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+body.light-theme .lajpat-rai-hero h1 {
+    background: linear-gradient(135deg, #1e293b 0%, #d97706 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.lajpat-rai-hero h1 span {
+    color: var(--lajpatrai-saffron);
+    background: none;
+    -webkit-background-clip: initial;
+    color: var(--lajpatrai-saffron);
+    -webkit-text-fill-color: var(--lajpatrai-saffron);
+}
+
+.lajpat-rai-title-line {
+    font-size: 1.3rem;
+    font-weight: 600;
+    color: var(--lajpatrai-saffron);
+    margin: 0.5rem 0 1.2rem;
+}
+
+.lajpat-rai-hero-subtitle {
+    font-size: 1.12rem;
+    color: var(--lajpatrai-text-secondary);
+    line-height: 1.65;
+    margin-bottom: 2rem;
+}
+
+.lajpat-rai-hero-stats {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1rem;
+}
+
+.lajpat-rai-hero-stat {
+    text-align: center;
+    min-width: 110px;
+}
+
+.lajpat-rai-hero-stat strong {
+    display: block;
+    font-size: 1.7rem;
+    background: linear-gradient(135deg, var(--lajpatrai-saffron) 0%, var(--lajpatrai-gold) 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.lajpat-rai-hero-stat span {
+    font-size: 0.85rem;
+    color: var(--lajpatrai-text-secondary);
+}
+
+.lajpat-rai-hero-quote {
+    margin-top: 2rem;
+    font-family: var(--font-heading);
+    font-size: 1.2rem;
+    font-style: italic;
+    color: var(--lajpatrai-gold);
+    padding: 1rem 1.5rem;
+    border-left: 3px solid var(--lajpatrai-gold);
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: 0 8px 8px 0;
+}
+
+body.light-theme .lajpat-rai-hero-quote {
+    background: rgba(0, 0, 0, 0.04);
+    color: #b45309;
+    border-left-color: #d97706;
+}
+
+.lajpat-rai-scroll-hint {
+    position: absolute;
+    bottom: 1rem;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 34px;
+    height: 56px;
+    border: 2px solid var(--lajpatrai-text-secondary);
+    border-radius: 28px;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    opacity: 0.7;
+}
+
+.lajpat-rai-scroll-hint::before {
+    content: '';
+    width: 6px;
+    height: 6px;
+    background: var(--lajpatrai-text-secondary);
+    border-radius: 50%;
+    margin-top: 8px;
+    animation: lajpatrai-scroll-tap 1.8s infinite ease-in-out;
+}
+
+@keyframes lajpatrai-scroll-tap {
+    0% { opacity: 0; transform: translateY(0); }
+    50% { opacity: 1; transform: translateY(14px); }
+    100% { opacity: 0; transform: translateY(20px); }
+}
+
+/* Marquee Strip */
+.lajpat-rai-marquee {
+    overflow: hidden;
+    background: rgba(255, 176, 31, 0.08);
+    border: 1px solid var(--lajpatrai-card-border);
+    border-top: none;
+    white-space: nowrap;
+}
+
+body.light-theme .lajpat-rai-marquee {
+    background: #fffbeb;
+    border-color: rgba(0, 0, 0, 0.08);
+}
+
+.lajpat-rai-marquee-track {
+    display: inline-block;
+    padding: 0.6rem 1.5rem;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--lajpatrai-text-secondary);
+    animation: lajpatrai-marquee-move 24s linear infinite;
+}
+
+@keyframes lajpatrai-marquee-move {
+    0% { transform: translateX(0); }
+    100% { transform: translateX(-50%); }
+}
+
+/* Tab Navigation */
+.lajpat-rai-nav-tabs {
+    position: sticky;
+    top: var(--navbar-height, 80px);
+    z-index: 90;
+    background: rgba(9, 13, 22, 0.95);
+    backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--lajpatrai-card-border);
+    overflow-x: auto;
+}
+
+body.light-theme .lajpat-rai-nav-tabs {
+    background: rgba(255, 255, 255, 0.95);
+    border-bottom-color: rgba(0, 0, 0, 0.1);
+}
+
+.lajpat-rai-nav-tabs {
+    display: flex;
+    gap: 0.5rem;
+    padding: 0.5rem 1.5rem;
+}
+
+.lajpat-rai-tab {
+    padding: 0.7rem 1.2rem;
+    background: none;
+    border: none;
+    color: var(--lajpatrai-text-secondary);
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    white-space: nowrap;
+    border-radius: 10px;
+    transition: var(--transition-snappy);
+}
+
+.lajpat-rai-tab:hover,
+.lajpat-rai-tab.active {
+    color: #ffffff;
+    background: var(--lajpatrai-saffron);
+}
+
+body.light-theme .lajpat-rai-tab.active {
+    color: #ffffff;
+}
+
+/* Sections */
+.lajpat-rai-section-wrapper {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2.5rem 1.5rem;
+}
+
+.lajpat-rai-section {
+    display: none;
+}
+
+.lajpat-rai-section.active {
+    display: block;
+}
+
+.lajpat-rai-content-card {
+    background: var(--lajpatrai-card-bg);
+    border: 1px solid var(--lajpatrai-card-border);
+    border-radius: var(--border-radius-lg, 18px);
+    padding: 2rem;
+    margin-bottom: 1.5rem;
+    transition: var(--transition-smooth);
+}
+
+.lajpat-rai-content-card:hover {
+    border-color: var(--lajpatrai-saffron);
+    box-shadow: var(--shadow-glow);
+}
+
+body.light-theme .lajpat-rai-content-card {
+    background: rgba(255, 255, 255, 0.92);
+    border-color: rgba(0, 0, 0, 0.08);
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.04);
+}
+
+.section-heading {
+    font-family: var(--font-heading);
+    font-size: 2.1rem;
+    font-weight: 700;
+    text-align: center;
+    margin-bottom: 0.5rem;
+    background: linear-gradient(135deg, var(--lajpatrai-saffron) 0%, var(--lajpatrai-gold) 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.section-intro {
+    text-align: center;
+    color: var(--lajpatrai-text-secondary);
+    margin-bottom: 2rem;
+    font-size: 1rem;
+}
+
+/* Split Layout */
+.lajpat-rai-split {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 1.75rem;
+    align-items: start;
+}
+
+.lajpat-rai-split-text {
+    font-size: 1.02rem;
+    line-height: 1.7;
+    color: var(--lajpatrai-text-primary);
+}
+
+.lajpat-rai-split-text p {
+    margin-bottom: 1.1rem;
+}
+
+.lajpat-rai-split-text h3 {
+    color: var(--lajpatrai-saffron);
+    margin: 1.5rem 0 0.7rem;
+    font-size: 1.3rem;
+}
+
+.lajpat-rai-figure {
+    margin: 0;
+    text-align: center;
+}
+
+.lajpat-rai-figure img {
+    width: 100%;
+    height: 230px;
+    object-fit: cover;
+    border-radius: 14px;
+    border: 1px solid var(--lajpatrai-card-border);
+}
+
+.lajpat-rai-figure figcaption {
+    font-size: 0.85rem;
+    color: var(--lajpatrai-text-secondary);
+    margin-top: 0.6rem;
+}
+
+.quote-callout {
+    margin: 1.5rem 0;
+    padding: 1.25rem 1.5rem;
+    border-left: 3px solid var(--lajpatrai-gold);
+    background: rgba(255, 176, 31, 0.08);
+    border-radius: 0 12px 12px 0;
+}
+
+.quote-callout blockquote {
+    font-family: var(--font-heading);
+    font-size: 1.15rem;
+    font-style: italic;
+    color: var(--lajpatrai-text-primary);
+    margin: 0 0 0.4rem;
+}
+
+.quote-callout cite {
+    color: var(--lajpatrai-text-secondary);
+    font-size: 0.9rem;
+}
+
+.memorial-box {
+    margin-top: 1.75rem;
+    padding: 1.5rem;
+    background: linear-gradient(135deg, rgba(185, 28, 28, 0.08) 0%, rgba(255, 176, 31, 0.06) 100%);
+    border: 1px solid var(--lajpatrai-maroon);
+    border-radius: 14px;
+}
+
+.memorial-box h3 {
+    color: var(--lajpatrai-maroon);
+}
+
+/* Timeline */
+.lajpat-rai-timeline {
+    position: relative;
+    padding: 1.5rem 0 1.5rem 0;
+}
+
+.lajpat-rai-timeline::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 4px;
+    background: linear-gradient(180deg, var(--lajpatrai-saffron) 0%, var(--lajpatrai-gold) 100%);
+    left: 18px;
+    border-radius: 4px;
+}
+
+.timeline-item {
+    position: relative;
+    margin-left: 40px;
+    margin-bottom: 1.75rem;
+    padding: 1.1rem 1.25rem;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid var(--lajpatrai-card-border);
+    border-radius: 12px;
+}
+
+.timeline-item::before {
+    content: '';
+    position: absolute;
+    left: -38px;
+    top: 1.1rem;
+    width: 32px;
+    height: 32px;
+    background: var(--lajpatrai-gold);
+    border-radius: 50%;
+    border: 3px solid var(--lajpatrai-bg-deep);
+    box-shadow: 0 0 10px rgba(255, 176, 31, 0.4);
+}
+
+.timeline-year {
+    color: var(--lajpatrai-saffron);
+    font-weight: 700;
+    font-size: 0.95rem;
+    display: block;
+    margin-bottom: 0.35rem;
+}
+
+.timeline-content h4 {
+    margin: 0 0 0.4rem;
+    color: var(--lajpatrai-text-primary);
+    font-size: 1.05rem;
+}
+
+.timeline-content p {
+    margin: 0;
+    color: var(--lajpatrai-text-secondary);
+    font-size: 0.95rem;
+    line-height: 1.55;
+}
+
+/* Gallery */
+.lajpat-rai-gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.gallery-item {
+    background: var(--lajpatrai-card-bg);
+    border: 1px solid var(--lajpatrai-card-border);
+    border-radius: 14px;
+    overflow: hidden;
+    transition: var(--transition-smooth);
+}
+
+.gallery-item:hover {
+    transform: translateY(-4px);
+    border-color: var(--lajpatrai-saffron);
+    box-shadow: var(--shadow-glow);
+}
+
+.gallery-item img {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+    display: block;
+}
+
+.gallery-caption {
+    padding: 0.7rem 1rem;
+    font-size: 0.85rem;
+    color: var(--lajpatrai-text-secondary);
+}
+
+/* References */
+.references-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1.1rem;
+}
+
+.reference-item {
+    display: flex;
+    gap: 0.9rem;
+    align-items: flex-start;
+    padding: 1rem 1.25rem;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid var(--lajpatrai-card-border);
+    border-radius: 12px;
+}
+
+.ref-icon {
+    font-size: 1.3rem;
+    flex-shrink: 0;
+}
+
+.ref-details {
+    flex: 1;
+}
+
+.ref-link {
+    color: var(--lajpatrai-saffron);
+    font-weight: 600;
+    font-size: 1.02rem;
+}
+
+.ref-link:hover {
+    text-decoration: underline;
+}
+
+.ref-desc {
+    margin: 0.3rem 0 0;
+    color: var(--lajpatrai-text-secondary);
+    font-size: 0.92rem;
+    line-height: 1.5;
+}
+
+.acknowledgement-box {
+    margin-top: 1.75rem;
+    padding: 1.25rem 1.5rem;
+    background: rgba(255, 176, 31, 0.06);
+    border: 1px solid rgba(255, 176, 31, 0.2);
+    border-radius: 12px;
+}
+
+.acknowledgement-box h3 {
+    color: var(--lajpatrai-gold);
+    margin-bottom: 0.5rem;
+}
+
+/* Footer */
+.lajpat-rai-footer {
+    background: #04172a;
+    border-top: 1px solid var(--lajpatrai-card-border);
+    padding: 2.5rem 1.5rem 1.5rem;
+}
+
+body.light-theme .lajpat-rai-footer {
+    background: #f8fafc;
+    border-top-color: rgba(0, 0, 0, 0.08);
+}
+
+.lajpat-rai-footer-container {
+    max-width: 1100px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: 1fr 1.2fr;
+    gap: 2rem;
+}
+
+.lajpat-rai-footer-brand h3 {
+    color: var(--lajpatrai-text-primary);
+}
+
+.lajpat-rai-footer p {
+    color: var(--lajpatrai-text-secondary);
+    font-size: 0.92rem;
+    margin-top: 0.5rem;
+}
+
+.lajpat-rai-footer-links h4 {
+    color: var(--lajpatrai-gold);
+    margin-bottom: 0.75rem;
+    font-size: 1rem;
+}
+
+.lajpat-rai-footer-links a {
+    display: block;
+    margin-bottom: 0.45rem;
+    color: var(--lajpatrai-text-secondary);
+    transition: color 0.25s;
+}
+
+.lajpat-rai-footer-links a:hover {
+    color: var(--lajpatrai-saffron);
+}
+
+.lajpat-rai-footer-bottom {
+    text-align: center;
+    color: var(--lajpatrai-text-secondary);
+    font-size: 0.85rem;
+    margin-top: 1.75rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--lajpatrai-card-border);
+}
+
+/* Responsive */
+@media (max-width: 900px) {
+    .lajpat-rai-hero h1 { font-size: 2.6rem; }
+    .section-heading { font-size: 1.8rem; }
+    .lajpat-rai-split { grid-template-columns: 1fr; }
+    .lajpat-rai-hero-stats { gap: 0.75rem; }
+    .lajpat-rai-footer-container { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 640px) {
+    .lajpat-rai-hero { padding: 4rem 1rem 2.5rem; }
+    .lajpat-rai-hero h1 { font-size: 2.2rem; }
+    .lajpat-rai-nav-tabs { flex-wrap: wrap; }
+}
+
+/* Countup */
+.lajpat-rai-count {
+    display: inline-block;
+}
+
+/* Gentle float animation (reused figure helper) */
+.float-slow {
+    animation: lajpatrai-float 5s ease-in-out infinite;
+}
+
+@keyframes lajpatrai-float {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-6px); }
+}
+
+/* Reduced Motion */
+@media (prefers-reduced-motion: reduce) {
+    .lajpat-rai-hero-bg,
+    .lajpat-rai-marquee-track,
+    .float-slow,
+    .lajpat-rai-hero h1,
+    .lajpat-rai-hero-stat strong,
+    .lajpat-rai-count {
+        animation: none;
+        transform: none;
+    }
+}

--- a/frontend/tests/unit/lala-lajpat-rai-explorer.test.js
+++ b/frontend/tests/unit/lala-lajpat-rai-explorer.test.js
@@ -1,0 +1,121 @@
+/**
+ * lala-lajpat-rai-explorer.test.js
+ * Unit tests for the Lala Lajpat Rai Explorer page.
+ * Validates required sections, tab navigation, accessibility, image URLs,
+ * historical accuracy, and landing page card integration on the
+ * Freedom Fighters Knowledge Hub.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function readExplorerFile(file) {
+    return readFileSync(
+        resolve(__dirname, '../../lala-lajpat-rai-explorer', file),
+        'utf-8'
+    );
+}
+
+function readHubData() {
+    return readFileSync(
+        resolve(__dirname, '../../freedom-fighters-hub/script.js'),
+        'utf-8'
+    );
+}
+
+describe('Lala Lajpat Rai Explorer — Page Structure', () => {
+    let html;
+
+    beforeAll(() => {
+        html = readExplorerFile('index.html');
+    });
+
+    it('contains a hero section with page title and kicker', () => {
+        expect(html).toContain('class="lajpat-rai-hero"');
+        expect(html).toContain('<h1>');
+        expect(html).toContain('Lala Lajpat Rai');
+        expect(html).toContain('Punjab Kesari');
+        expect(html).toContain('Lal-Bal-Pal');
+    });
+
+    it('contains all required content sections from the issue', () => {
+        const sections = ['biography', 'timeline', 'simon-commission', 'legacy', 'gallery', 'references'];
+        sections.forEach(id => {
+            expect(html).toContain(`id="${id}"`);
+            expect(html).toContain(`data-tab="${id}"`);
+        });
+    });
+
+    it('highlights the Simon Commission protest and Lahore lathi charge', () => {
+        expect(html).toContain('Simon Commission');
+        expect(html).toContain('Lahore');
+        expect(html).toContain('lathi');
+        expect(html).toContain('30 October');
+        expect(html).toContain('coffin of British rule');
+    });
+
+    it('has a semantic heading hierarchy (single h1, multiple h2s)', () => {
+        const h1Count = (html.match(/<h1[\s>]/g) || []).length;
+        const h2Count = (html.match(/<h2[\s>]/g) || []).length;
+        expect(h1Count).toBe(1);
+        expect(h2Count).toBeGreaterThanOrEqual(6);
+    });
+
+    it('uses HTTPS image sources with alt attributes', () => {
+        const imgTags = html.match(/<img [^>]*>/g) || [];
+        expect(imgTags.length).toBeGreaterThanOrEqual(6);
+        imgTags.forEach(tag => {
+            expect(tag).toMatch(/src="https:\/\//);
+            expect(tag).toMatch(/alt="/);
+            expect(tag).not.toMatch(/src="http:\/\//);
+        });
+    });
+
+    it('links the shared stylesheet, page stylesheet, and script', () => {
+        expect(html).toContain('href="../../styles.css"');
+        expect(html).toContain('href="style.css"');
+        expect(html).toContain('src="script.js"');
+    });
+
+    it('references authentic source documentation in References', () => {
+        expect(html).toContain('wikipedia.org');
+        expect(html).toContain('britannica.com');
+        expect(html).toContain('indianexpress.com');
+    });
+});
+
+describe('Lala Lajpat Rai Explorer — Assets', () => {
+    it('includes a non-empty stylesheet themed for the freedom struggle', () => {
+        const css = readExplorerFile('style.css');
+        expect(css.length).toBeGreaterThan(1000);
+        expect(css).toContain('lajpat-rai-hero');
+    });
+
+    it('includes a valid interactive script with required functions', () => {
+        const js = readExplorerFile('script.js');
+        expect(js).toContain('activateTab');
+        expect(js).toContain('initTabNavigation');
+        expect(js).toContain('initThemeToggle');
+        expect(js).toContain("document.addEventListener('DOMContentLoaded'");
+    });
+});
+
+describe('Lala Lajpat Rai — Landing Page (Freedom Fighters Hub) Integration', () => {
+    it('is listed as a card on the Freedom Fighters Hub landing page', () => {
+        const js = readHubData();
+        expect(js).toContain('lajpat-rai');
+        expect(js).toContain('Lala Lajpat Rai');
+    });
+
+    it('includes the Lal-Bal-Pal era metadata and a dedicated explorer link', () => {
+        const js = readHubData();
+        expect(js).toContain('Punjab Kesari');
+        expect(js).toContain('Early Nationalist');
+        expect(js).toContain('Simon Commission Protest');
+        expect(js).toContain('../lala-lajpat-rai-explorer/index.html');
+    });
+});

--- a/index.html
+++ b/index.html
@@ -437,6 +437,15 @@
                 </div>
             </div>
 
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Freedom Fighters ▾</button>
+                <div class="dropdown-menu">
+                    <a href="frontend/lala-lajpat-rai-explorer/index.html" class="dropdown-item">Lala Lajpat Rai Explorer</a>
+                    <a href="frontend/freedom-fighters-hub/index.html" class="dropdown-item">Freedom Fighters Hub</a>
+                    <a href="frontend/freedom-movement-explorer/index.html" class="dropdown-item">Freedom Movement Explorer</a>
+                </div>
+            </div>
+
             <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
         </nav>
     </div>

--- a/index.html
+++ b/index.html
@@ -345,7 +345,7 @@
 <body>
     <script>
         (function () {
-            const theme = localStorage.getItem('theme') || 'dark';
+            let theme = 'dark'; try { theme = JSON.parse(localStorage.getItem('iie_storage') || '{}').theme || 'dark'; } catch(e) {}
             if (theme === 'light') {
                 document.body.classList.add('light-theme');
             }
@@ -434,15 +434,6 @@
                 <div class="dropdown-menu">
                     <a href="frontend/contributors/contributors.html" class="dropdown-item">Contributors</a>
                     <a href="frontend/world-records-india/index.html" class="dropdown-item">World Records</a>
-                </div>
-            </div>
-
-            <div class="nav-dropdown">
-                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Freedom Fighters ▾</button>
-                <div class="dropdown-menu">
-                    <a href="frontend/lala-lajpat-rai-explorer/index.html" class="dropdown-item">Lala Lajpat Rai Explorer</a>
-                    <a href="frontend/freedom-fighters-hub/index.html" class="dropdown-item">Freedom Fighters Hub</a>
-                    <a href="frontend/freedom-movement-explorer/index.html" class="dropdown-item">Freedom Movement Explorer</a>
                 </div>
             </div>
 
@@ -927,6 +918,7 @@
     <script src="frontend/chatbot-data.js" defer></script>
     <script src="frontend/sw-register.js" defer></script>
     <script src="frontend/js-modules/config.js" defer></script>
+    <script src="frontend/js-modules/storage.js" defer></script>
     <script src="frontend/app.js" defer></script>
     <script type="module" src="frontend/firebase-config.js"></script>
     <script type="module" src="frontend/auth.js"></script>


### PR DESCRIPTION
Add a dedicated **Lala Lajpat Rai Explorer** page and wire it into the project (built on current upstream main).
closes #1877
- New page `frontend/lala-lajpat-rai-explorer/` with Biography, Timeline, Simon Commission Protest, Legacy, Gallery, and References tabs; themed via the shared `../../styles.css`.
- Adds a Lala Lajpat Rai card to the Freedom Fighters Hub (`frontend/freedom-fighters-hub/script.js`) using the hub's existing `explorerLink` modal convention.
- Adds a `Freedom Fighters` nav dropdown in `index.html`.
- Adds vitest tests: `frontend/tests/unit/lala-lajpat-rai-explorer.test.js`.
- Fixes a pre-existing syntax error in `freedom-fighters-hub/script.js` (a missing `}\n{` card separator between the Rash Behari Bose and Birsa Munda cards that prevented the script from parsing).

Tests: 15 pass (11 new + 4 existing hub tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Lala Lajpat Rai Explorer page featuring his biography, timeline, contributions, legacy, gallery, references, and historical context.
  * Added interactive tabs, theme switching, smooth scrolling, mobile navigation, and animated statistics.
  * Added Lala Lajpat Rai to the Freedom Fighters Hub.

* **Accessibility & Design**
  * Added responsive layouts, descriptive image text, accessible navigation, and reduced-motion support.

* **Bug Fixes**
  * Improved theme loading and fallback behavior for saved preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->