### PR TITLE
feat: Create Karkota Dynasty Explorer (#1525)

### DIFF
--- a/frontend/history/dynasties/data.js
+++ b/frontend/history/dynasties/data.js
@@ -354,13 +354,45 @@ art: "Dated silver drachm coinage with royal portraiture, Brahmi epigraphy, Juna
       "Continued support for Nalanda University as a major center of Buddhist learning",
       "Diplomatic exchanges with Tang China, including missions that shaped early Sino-Indian relations"
     ],
-    art: "Sanskrit court literature and drama, copper-plate epigraphy, continued patronage of Buddhist monastic art at Nalanda",
+art: "Sanskrit court literature and drama, copper-plate epigraphy, continued patronage of Buddhist monastic art at Nalanda",
     era: "ancient",
     color: "#8e44ad",
     mapPosition: { top: "26%", left: "52%" },
     link: "pushyabhuti/index.html"
   },
-        {
+  {
+    id: "karkota",
+    name: "Karkota Dynasty",
+    period: "c. 625–855 CE",
+    startYear: 625,
+    endYear: 855,
+    capital: "Srinagar, later Parihasapura (founded by Lalitaditya)",
+    founders: "Durlabhavardhana",
+    notableRulers: [
+      { name: "Durlabhavardhana", reign: "c. 625–662 CE", achievement: "Founded the Karkota dynasty after marrying Princess Anangalekha; built the Durlabhasvamin Vishnu shrine at Srinagar" },
+      { name: "Lalitaditya Muktapida", reign: "c. 724–760 CE", achievement: "Greatest Karkota ruler; led extensive military campaigns, built the Martand Sun Temple, and founded the new capital of Parihasapura" },
+      { name: "Jayapida", reign: "8th century CE", achievement: "Grandson of Lalitaditya; patronized Buddhist viharas and founded the town of Jayapura" }
+    ],
+    territory: "The Kashmir valley and, under Lalitaditya, campaigns extending into parts of northern India and Central Asia",
+    peakExtent: "Kashmir and neighbouring Himalayan and Gangetic-plain regions under Lalitaditya Muktapida, though the full extent described in the Rajatarangini is considered partly legendary",
+    governance: "A centralized Kashmiri monarchy that consolidated power after the decline of the earlier Gonanda dynasty, maintaining diplomatic ties with Tang China and Central Asian powers",
+    military: "Campaigns associated with Lalitaditya Muktapida across northern India and against Tibetan and Arab incursions in the northwest, described in Kalhana's Rajatarangini",
+    decline: "Weakened through the 9th century by invasions, internal instability, and economic strain; rule ended in 855 CE when Avantivarman ascended the throne and founded the Utpala dynasty",
+    contributions: [
+      "The Martand Sun Temple — the oldest known Sun temple in India, blending Gupta and local Kashmiri architectural styles with its distinctive trefoil arches",
+      "Founding of Parihasapura, a new capital showcasing Karkota-era urban planning and monumental architecture",
+      "Religious harmony — Karkota rulers were Vaishnavas who built numerous Vishnu shrines while also patronizing Buddhist viharas and stupas",
+      "Kalhana's Rajatarangini, composed in the 12th century, remains the principal chronicle of Kashmiri history and preserves the Karkota period's legacy",
+      "Diplomatic and cultural contact with Tang-dynasty China and Central Asia under Lalitaditya Muktapida",
+      "Development of a distinct Kashmiri architectural idiom, drawing on post-Gupta trends from Sarnath and Nalanda"
+    ],
+    art: "Martand Sun Temple, trefoil-arch Kashmiri temple architecture, Parihasapura monuments, Buddhist viharas and stupas",
+    era: "medieval",
+    color: "#e91e63",
+    mapPosition: { top: "8%", left: "50%" },
+    link: "karkota/index.html"
+  },
+          {
     id: "kushan",
     name: "Kushan Empire",
     period: "c. 30–375 CE",
@@ -539,8 +571,13 @@ export const timelineEvents = [
   { year: 606, event: "Harshavardhana becomes king after his brother Rajyavardhana is killed by Shashanka of Gauda", dynasty: "pushyabhuti" },
   { year: 619, event: "Chalukya king Pulakesin II defeats Harshavardhana at the Narmada River, halting his southward expansion", dynasty: "pushyabhuti" },
   { year: 643, event: "Harsha holds the Kannauj assembly in honour of the Chinese pilgrim Xuanzang", dynasty: "pushyabhuti" },
-  { year: 647, event: "Harshavardhana dies without an heir, and the Pushyabhuti dynasty rapidly disintegrates", dynasty: "pushyabhuti" },
-  { year: 105, event: "Vima Kadphises conquers Gandhara and expands Kushan trade with Rome", dynasty: "kushan" },
+{ year: 647, event: "Harshavardhana dies without an heir, and the Pushyabhuti dynasty rapidly disintegrates", dynasty: "pushyabhuti" },
+  { year: 625, event: "Durlabhavardhana founds the Karkota dynasty in Kashmir", dynasty: "karkota" },
+  { year: 724, event: "Lalitaditya Muktapida becomes king, beginning the dynasty's most celebrated reign", dynasty: "karkota" },
+  { year: 750, event: "Lalitaditya commissions the Martand Sun Temple and founds the new capital of Parihasapura", dynasty: "karkota" },
+  { year: 760, event: "Death of Lalitaditya Muktapida; Kashmir's imperial influence begins to wane after his reign", dynasty: "karkota" },
+  { year: 855, event: "Avantivarman ascends the throne and founds the Utpala dynasty, ending Karkota rule", dynasty: "karkota" },
+    { year: 105, event: "Vima Kadphises conquers Gandhara and expands Kushan trade with Rome", dynasty: "kushan" },
   { year: 127, event: "Kanishka I ascends the throne; the Kushan Empire reaches its greatest extent", dynasty: "kushan" },
   { year: 150, event: "Huvishka succeeds Kanishka, continuing patronage of Buddhism and Zoroastrianism", dynasty: "kushan" },
   { year: 230, event: "Death of Vasudeva I, the last powerful Kushan ruler, marks the start of decline", dynasty: "kushan" },

--- a/frontend/history/dynasties/karkota/index.html
+++ b/frontend/history/dynasties/karkota/index.html
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Karkota Dynasty Explorer - Discover the Karkota Dynasty (c. 625-855 CE), which established Kashmir as a powerful kingdom under Lalitaditya Muktapida and built the Martand Sun Temple.">
+    <title>Karkota Dynasty Explorer | Incredible India Explorer</title>
+    <link rel="icon" href="data:,">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:wght@500;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="../../../styles.css">
+    <link rel="stylesheet" href="style.css">
+
+    <meta property="og:title" content="Karkota Dynasty Explorer | Incredible India Explorer">
+    <meta property="og:description" content="The Karkota Dynasty — Lalitaditya Muktapida, the Martand Sun Temple, and the rise of Kashmir.">
+    <meta property="og:type" content="website">
+    <meta property="og:locale" content="en_IN">
+</head>
+
+<body class="kk-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../../index.html#home" class="nav-link">Home</a>
+                <a href="../index.html" class="nav-link">Indian Dynasties</a>
+                <a href="index.html" class="nav-link active" style="color: #e91e63">Karkota Dynasty</a>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+            </nav>
+        </div>
+    </header>
+
+    <main class="kk-main">
+        <!-- Hero Banner -->
+        <section class="kk-hero">
+            <span class="kk-kicker">🏔️ Kashmir's Imperial Golden Age</span>
+            <h1>Karkota Dynasty Explorer</h1>
+            <p>The <strong>Karkota Dynasty</strong> ruled Kashmir from around 625 to 855 CE, transforming the valley from an isolated Himalayan region into a powerful and culturally vibrant kingdom. Under its greatest ruler, <strong>Lalitaditya Muktapida</strong>, Kashmir became a major power of the subcontinent, remembered above all for the magnificent <strong>Martand Sun Temple</strong>.</p>
+
+            <div class="kk-hero-stats">
+                <div class="kk-hero-stat">
+                    <strong>c. 625–855 CE</strong>
+                    <span>Dynasty Period</span>
+                </div>
+                <div class="kk-hero-stat">
+                    <strong>Parihasapura</strong>
+                    <span>New Capital</span>
+                </div>
+                <div class="kk-hero-stat">
+                    <strong>84</strong>
+                    <span>Shrines at Martand</span>
+                </div>
+                <div class="kk-hero-stat">
+                    <strong>Rajatarangini</strong>
+                    <span>Chief Chronicle</span>
+                </div>
+            </div>
+        </section>
+
+        <!-- Navigation Tabs -->
+        <div class="kk-nav-tabs">
+            <button class="kk-tab active" data-tab="overview">📜 Historical Overview</button>
+            <button class="kk-tab" data-tab="timeline">🕰️ Timeline</button>
+            <button class="kk-tab" data-tab="rulers">👑 Major Rulers</button>
+            <button class="kk-tab" data-tab="architecture">🏛️ Architectural Achievements</button>
+            <button class="kk-tab" data-tab="gallery">🖼️ Gallery</button>
+            <button class="kk-tab" data-tab="references">📚 References</button>
+        </div>
+
+        <!-- Historical Overview -->
+        <section id="overview" class="kk-section active">
+            <div class="kk-content-card">
+                <h2>📜 Historical Overview</h2>
+                <div class="kk-content">
+                    <p>The <strong>Karkota Dynasty</strong> emerged in Kashmir around 625 CE, in the aftermath of the declining Gonanda dynasty that had ruled the valley since ancient times. Its founder, <strong>Durlabhavardhana</strong>, was originally a feudatory under the last Gonanda ruler; he rose to the throne after marrying Princess Anangalekha, establishing a new ruling line that would dominate Kashmir for over two centuries.</p>
+                    <p>The dynasty's early rulers steadily consolidated power, building temples and shrines and introducing architectural styles drawn from post-Gupta centres such as Sarnath and Nalanda. The Karkotas reached their zenith under <strong>Lalitaditya Muktapida</strong>, whose reign from around 724 to 760 CE is described in glowing, if partly legendary, terms by the 12th-century chronicler Kalhana in his <em>Rajatarangini</em>. Lalitaditya is credited with extensive military campaigns across northern India and Central Asia, diplomatic contact with Tang China, and the construction of the celebrated <strong>Martand Sun Temple</strong>.</p>
+                    <p>After Lalitaditya's death, later Karkota rulers — including his grandson Jayapida — continued to patronize religion and the arts, but the dynasty's power gradually waned through the 9th century amid invasions, internal instability, and economic strain. Karkota rule finally ended in 855 CE, when <strong>Avantivarman</strong> ascended the throne and founded the succeeding Utpala dynasty — but the cultural and architectural foundations the Karkotas had laid endured, cementing Kashmir's lasting reputation as a centre of art, learning, and philosophy.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Timeline -->
+        <section id="timeline" class="kk-section">
+            <div class="kk-content-card">
+                <h2>🕰️ Timeline</h2>
+                <div class="kk-content">
+                    <div class="kk-timeline">
+                        <div class="kk-timeline-item">
+                            <span class="kk-timeline-year">c. 625 CE</span>
+                            <p>Durlabhavardhana founds the Karkota dynasty in Kashmir after marrying Princess Anangalekha.</p>
+                        </div>
+                        <div class="kk-timeline-item">
+                            <span class="kk-timeline-year">c. 724 CE</span>
+                            <p>Lalitaditya Muktapida becomes king, beginning the dynasty's most celebrated and expansive reign.</p>
+                        </div>
+                        <div class="kk-timeline-item">
+                            <span class="kk-timeline-year">c. 750 CE</span>
+                            <p>Lalitaditya commissions the Martand Sun Temple and founds the new capital of Parihasapura.</p>
+                        </div>
+                        <div class="kk-timeline-item">
+                            <span class="kk-timeline-year">c. 760 CE</span>
+                            <p>Death of Lalitaditya Muktapida; Kashmir's imperial influence gradually begins to wane after his reign.</p>
+                        </div>
+                        <div class="kk-timeline-item">
+                            <span class="kk-timeline-year">855 CE</span>
+                            <p>Avantivarman ascends the throne and founds the Utpala dynasty, bringing Karkota rule to an end.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Major Rulers -->
+        <section id="rulers" class="kk-section">
+            <div class="kk-content-card">
+                <h2>👑 Major Rulers</h2>
+                <div class="kk-content">
+                    <div class="ruler-list">
+                        <div class="ruler-item">
+                            <h3>Durlabhavardhana <span class="ruler-reign">(c. 625–662 CE)</span></h3>
+                            <p>Founder of the Karkota dynasty. He built the Durlabhasvamin Vishnu shrine at Srinagar and introduced post-Gupta architectural influences from Sarnath and Nalanda into Kashmir.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Durlabhaka (Pratapaditya II) <span class="ruler-reign">(early 8th century CE)</span></h3>
+                            <p>Established the city of Pratapapura and the Malhanasvamin shrine, continuing the dynasty's tradition of temple patronage.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Lalitaditya Muktapida <span class="ruler-reign">(c. 724–760 CE)</span></h3>
+                            <p>The dynasty's greatest ruler. Credited by Kalhana's Rajatarangini with sweeping military campaigns and diplomatic ties to Tang China, he built the Martand Sun Temple and founded the new capital of Parihasapura.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Jayapida <span class="ruler-reign">(8th century CE)</span></h3>
+                            <p>Grandson of Lalitaditya. He patronized Buddhist viharas, commissioned Buddha statues, and founded the town of Jayapura.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Architectural Achievements -->
+        <section id="architecture" class="kk-section">
+            <div class="kk-content-card">
+                <h2>🏛️ Architectural Achievements</h2>
+                <div class="kk-content">
+                    <p>The Karkota period represents the zenith of early Kashmiri architecture, blending Gupta-era influences with a distinct local idiom that would define the region's temple-building for centuries.</p>
+                    <ul class="kk-list">
+                        <li><strong>Martand Sun Temple:</strong> Built by Lalitaditya Muktapida and dedicated to the sun god Surya, this limestone complex is the oldest known Sun temple in India — a rectangular courtyard enclosing 84 subsidiary shrines around a central pillared hall</li>
+                        <li><strong>The trefoil arch:</strong> A defining feature of Kashmiri Brahminical temple architecture, prominently used at Martand and other Karkota-era shrines</li>
+                        <li><strong>Parihasapura:</strong> Lalitaditya's purpose-built capital, showcasing sophisticated urban planning alongside temples, stupas, and viharas</li>
+                        <li><strong>Durlabhasvamin shrine:</strong> An early Vishnu temple at Srinagar built by dynasty founder Durlabhavardhana, reflecting the introduction of post-Gupta architectural trends into Kashmir</li>
+                        <li><strong>Buddhist monuments:</strong> Viharas, stupas, and chaityas built alongside Vaishnava shrines, reflecting the religious harmony that characterized Karkota patronage</li>
+                        <li><strong>Jayapura:</strong> A further new town founded by Jayapida, continuing the dynasty's tradition of monumental urban and religious construction</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <!-- Gallery -->
+        <section id="gallery" class="kk-section">
+            <div class="kk-content-card">
+                <h2>🖼️ Gallery</h2>
+                <div class="kk-content">
+                    <p>A visual look at the Karkota dynasty's temples, capitals, and cultural legacy.</p>
+                    <div class="gallery-grid">
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🛕</div>
+                            <h3>Martand Sun Temple</h3>
+                            <p>The grand limestone complex dedicated to Surya, built by Lalitaditya Muktapida.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🏛️</div>
+                            <h3>Parihasapura Ruins</h3>
+                            <p>The remains of Lalitaditya's purpose-built capital, with its temples and stupas.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">📜</div>
+                            <h3>Rajatarangini</h3>
+                            <p>Kalhana's 12th-century chronicle, the primary source on Karkota-era Kashmir.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🗿</div>
+                            <h3>Buddhist Viharas</h3>
+                            <p>Monastic structures patronized by Karkota rulers alongside their Vishnu shrines.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">⛰️</div>
+                            <h3>The Kashmir Valley</h3>
+                            <p>The Himalayan heartland that the Karkotas transformed into a major cultural centre.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🗺️</div>
+                            <h3>Karkota Influence</h3>
+                            <p>The dynasty's reach across Kashmir and into parts of northern India under Lalitaditya.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- References -->
+        <section id="references" class="kk-section">
+            <div class="kk-content-card">
+                <h2>📚 References</h2>
+                <div class="kk-content">
+                    <ul class="kk-list kk-references">
+                        <li>Wikipedia — Karkota dynasty. <a href="https://en.wikipedia.org/wiki/Karkota_dynasty" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>Wikipedia — Lalitaditya Muktapida. <a href="https://en.wikipedia.org/wiki/Lalitaditya_Muktapida" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>Wikipedia — Martand Sun Temple. <a href="https://en.wikipedia.org/wiki/Martand_Sun_Temple" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>GKToday — Karkota Dynasty overview. <a href="https://www.gktoday.in/karkota-dynasty/" target="_blank" rel="noopener noreferrer">gktoday.in</a></li>
+                        <li>Bharatpedia — Karkota Dynasty. <a href="https://en.bharatpedia.org/wiki/Karkota_Dynasty" target="_blank" rel="noopener noreferrer">en.bharatpedia.org</a></li>
+                        <li>Kalhana. <em>Rajatarangini</em> (12th century CE), trans. M. A. Stein.</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="kk-footer">
+        <p>Part of <a href="../../../index.html" style="color: #FF9933;">Incredible India Explorer</a> · <a href="../index.html" style="color: #e91e63;">Indian Dynasties Explorer</a></p>
+    </footer>
+
+    <script type="module" src="script.js"></script>
+</body>
+</html>

--- a/frontend/history/dynasties/karkota/script.js
+++ b/frontend/history/dynasties/karkota/script.js
@@ -1,0 +1,92 @@
+/**
+ * Karkota Dynasty Explorer - Interactive Script
+ * Handles tab navigation, smooth scrolling, theme toggle, and mobile menu
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    initTabNavigation();
+    initThemeToggle();
+    initMobileMenu();
+});
+
+/**
+ * Initialize tab navigation for different sections
+ */
+function initTabNavigation() {
+    const tabs = document.querySelectorAll('.kk-tab');
+    const sections = document.querySelectorAll('.kk-section');
+
+    tabs.forEach(tab => {
+        tab.addEventListener('click', () => {
+            const targetTab = tab.dataset.tab;
+
+            tabs.forEach(t => t.classList.remove('active'));
+            sections.forEach(s => s.classList.remove('active'));
+
+            tab.classList.add('active');
+            const targetSection = document.getElementById(targetTab);
+            if (targetSection) {
+                targetSection.classList.add('active');
+                targetSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+        });
+    });
+}
+
+/**
+ * Initialize theme toggle functionality
+ */
+function initThemeToggle() {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+
+    const currentTheme = localStorage.getItem('theme') || 'dark';
+    updateThemeIcon(currentTheme);
+
+    themeToggle.addEventListener('click', () => {
+        const body = document.body;
+        const isLight = body.classList.contains('light-theme');
+
+        if (isLight) {
+            body.classList.remove('light-theme');
+            localStorage.setItem('theme', 'dark');
+            updateThemeIcon('dark');
+        } else {
+            body.classList.add('light-theme');
+            localStorage.setItem('theme', 'light');
+            updateThemeIcon('light');
+        }
+    });
+}
+
+/**
+ * Update theme toggle icon
+ */
+function updateThemeIcon(theme) {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+    themeToggle.textContent = theme === 'light' ? '🌙' : '☀️';
+}
+
+/**
+ * Initialize mobile menu toggle
+ */
+function initMobileMenu() {
+    const menuToggle = document.getElementById('menu-toggle');
+    const navMenu = document.getElementById('nav-menu');
+
+    if (menuToggle && navMenu) {
+        menuToggle.addEventListener('click', () => {
+            const isExpanded = menuToggle.getAttribute('aria-expanded') === 'true';
+            menuToggle.setAttribute('aria-expanded', !isExpanded);
+            navMenu.classList.toggle('active');
+        });
+
+        document.addEventListener('click', (e) => {
+            if (!menuToggle.contains(e.target) && !navMenu.contains(e.target)) {
+                navMenu.classList.remove('active');
+                menuToggle.setAttribute('aria-expanded', 'false');
+            }
+        });
+    }
+}

--- a/frontend/history/dynasties/karkota/style.css
+++ b/frontend/history/dynasties/karkota/style.css
@@ -1,0 +1,341 @@
+/* ==========================================================================
+   Karkota Dynasty Explorer Styling
+   Kashmir's imperial golden age (c. 625-855 CE)
+   ========================================================================== */
+
+.kk-page-body {
+    background-color: var(--bg-primary, #0B0F19);
+    color: var(--text-primary, #E2E8F0);
+    font-family: 'Outfit', system-ui, -apple-system, sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+}
+
+.kk-main {
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: 80px 20px 60px;
+}
+
+/* --- Hero Banner --- */
+.kk-hero {
+    text-align: center;
+    padding: 48px 24px;
+    background: linear-gradient(135deg, rgba(11, 15, 25, 0.95) 0%, rgba(42, 10, 26, 0.85) 100%);
+    border: 1px solid rgba(233, 30, 99, 0.35);
+    border-radius: 16px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+    margin-bottom: 32px;
+    position: relative;
+    overflow: hidden;
+}
+
+.kk-hero::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: linear-gradient(90deg, #FF9933 0%, #D4AF37 50%, #e91e63 100%);
+}
+
+.kk-kicker {
+    display: inline-block;
+    padding: 6px 16px;
+    background: rgba(233, 30, 99, 0.18);
+    color: #f47ea6;
+    border: 1px solid rgba(233, 30, 99, 0.4);
+    border-radius: 20px;
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 16px;
+}
+
+.kk-hero h1 {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 2.6rem;
+    font-weight: 700;
+    color: var(--text-heading, #F8FAFC);
+    margin: 0 0 12px;
+}
+
+.kk-hero p {
+    font-size: 1.1rem;
+    color: var(--text-secondary, #94A3B8);
+    max-width: 850px;
+    margin: 0 auto 24px;
+}
+
+.kk-hero-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 16px;
+    margin-top: 24px;
+}
+
+.kk-hero-stat {
+    background: rgba(15, 23, 42, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    padding: 16px;
+    text-align: center;
+}
+
+.kk-hero-stat strong {
+    display: block;
+    font-size: 1.3rem;
+    color: #FF9933;
+    font-family: 'Playfair Display', Georgia, serif;
+}
+
+.kk-hero-stat span {
+    font-size: 0.8rem;
+    color: var(--text-secondary, #94A3B8);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+/* --- Navigation Tabs --- */
+.kk-nav-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: center;
+    margin-bottom: 32px;
+    padding: 12px;
+    background: rgba(15, 23, 42, 0.5);
+    border-radius: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.kk-tab {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: var(--text-secondary, #94A3B8);
+    padding: 8px 16px;
+    border-radius: 20px;
+    font-size: 0.88rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.25s ease;
+    white-space: nowrap;
+}
+
+.kk-tab:hover {
+    border-color: rgba(233, 30, 99, 0.5);
+    color: #f47ea6;
+}
+
+.kk-tab.active {
+    background: linear-gradient(135deg, #e91e63, #a3143f);
+    border-color: #e91e63;
+    color: #fff;
+}
+
+.kk-tab:focus-visible {
+    outline: 2px solid #FF9933;
+    outline-offset: 2px;
+}
+
+/* --- Content Sections --- */
+.kk-section {
+    display: none;
+    animation: fadeIn 0.4s ease;
+}
+
+.kk-section.active {
+    display: block;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.kk-content-card {
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 16px;
+    padding: 32px;
+}
+
+.kk-content-card h2 {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 1.8rem;
+    color: var(--text-heading, #F8FAFC);
+    margin: 0 0 20px;
+}
+
+.kk-content h3 {
+    color: #f47ea6;
+    font-size: 1.1rem;
+    margin: 0 0 6px;
+}
+
+.kk-content p {
+    color: var(--text-secondary, #CBD5E1);
+    margin: 0 0 14px;
+}
+
+.kk-list {
+    color: var(--text-secondary, #CBD5E1);
+    padding-left: 20px;
+    margin: 0 0 14px;
+}
+
+.kk-list li {
+    margin-bottom: 8px;
+}
+
+.kk-references a {
+    color: #f47ea6;
+    text-decoration: none;
+}
+
+.kk-references a:hover {
+    text-decoration: underline;
+}
+
+/* --- Timeline --- */
+.kk-timeline {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    border-left: 2px solid rgba(233, 30, 99, 0.5);
+    padding-left: 20px;
+    margin-top: 8px;
+}
+
+.kk-timeline-item {
+    position: relative;
+}
+
+.kk-timeline-item::before {
+    content: '';
+    position: absolute;
+    left: -26px;
+    top: 4px;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: #e91e63;
+}
+
+.kk-timeline-year {
+    display: block;
+    font-weight: 700;
+    color: #FF9933;
+    font-family: 'Playfair Display', Georgia, serif;
+    margin-bottom: 4px;
+}
+
+.kk-timeline-item p {
+    margin: 0;
+}
+
+/* --- Rulers --- */
+.ruler-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 16px;
+}
+
+.ruler-item {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 12px;
+    padding: 18px;
+}
+
+.ruler-reign {
+    font-size: 0.85rem;
+    color: var(--text-secondary, #94A3B8);
+    font-weight: 400;
+}
+
+/* --- Gallery --- */
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+    margin-top: 16px;
+}
+
+.gallery-item {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 12px;
+    padding: 20px;
+    text-align: center;
+    transition: transform 0.25s ease;
+}
+
+.gallery-item:hover {
+    transform: translateY(-4px);
+    border-color: rgba(233, 30, 99, 0.5);
+}
+
+.gallery-placeholder {
+    font-size: 2.6rem;
+    margin-bottom: 10px;
+}
+
+.gallery-item h3 {
+    margin: 0 0 6px;
+}
+
+.gallery-item p {
+    font-size: 0.9rem;
+    margin: 0;
+}
+
+/* --- Footer --- */
+.kk-footer {
+    text-align: center;
+    padding: 30px 20px;
+    color: var(--text-secondary, #94A3B8);
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* --- Responsive --- */
+@media (max-width: 768px) {
+    .kk-hero h1 {
+        font-size: 2rem;
+    }
+
+    .kk-content-card {
+        padding: 20px;
+    }
+
+    .kk-nav-tabs {
+        justify-content: flex-start;
+        overflow-x: auto;
+        flex-wrap: nowrap;
+    }
+
+    .kk-timeline {
+        padding-left: 16px;
+    }
+}
+
+/* --- Light Theme Overrides --- */
+body.light-theme.kk-page-body {
+    background-color: #F8FAFC;
+    color: #0F172A;
+}
+
+body.light-theme .kk-content-card,
+body.light-theme .kk-hero {
+    background: rgba(255, 255, 255, 0.85);
+    border-color: rgba(0, 0, 0, 0.08);
+}
+
+body.light-theme .kk-content p,
+body.light-theme .kk-list,
+body.light-theme .ruler-reign {
+    color: #334155;
+}


### PR DESCRIPTION
## What this PR does

Adds a dedicated explorer page for the Karkota Dynasty, which
established Kashmir as a powerful kingdom (c. 625-855 CE), reaching
its zenith under Lalitaditya Muktapida, and integrates it into the
existing Indian Dynasties Explorer landing page.

### New files
- history/dynasties/karkota/index.html
- history/dynasties/karkota/style.css
- history/dynasties/karkota/script.js

### Modified files
- history/dynasties/data.js — added a Karkota Dynasty entry to the
  dynasties array and five events to the timelineEvents array

### Note for reviewers
This builds on the already-data-driven Indian Dynasties Explorer
landing page (history/dynasties/), including the "View Full Explorer"
card-link mechanism added in earlier dynasty PRs — no changes to
DynastyCard.js or styles.css were needed this time. Adding the
Karkota Dynasty to data.js automatically surfaces it in the card
grid (under "Medieval"), the map (positioned at the far north for
Kashmir), the timeline, and the site-wide Contributions view.

### Sections covered on the dedicated page
Historical Overview, Timeline, Major Rulers, Architectural
Achievements, Gallery, and References — content is based on
Wikipedia, GKToday, and standard early-medieval Indian history
references, linked in the References tab.

### Testing
- Verified navigation from the landing page card to the Karkota
  Dynasty page via the "View Full Explorer" link
- Checked script.js for syntax errors (node --check)
- Confirmed the new entries render correctly in the landing page's
  Timeline, Map, and Contributions tabs
- Confirmed responsive layout at mobile and desktop breakpoints

Closes #1525

@Eshajha19 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Karkota Dynasty Explorer page with historical metadata, rulers, territory, governance, decline, cultural contributions, architecture, artwork, timeline, gallery, and references.
  * Added five timeline events covering the dynasty’s founding, Lalitaditya’s reign, major construction projects, succession changes, and decline.
  * Added interactive tabs, smooth navigation, theme switching, and responsive mobile menus.
  * Added responsive layouts, light-theme support, animations, and accessibility-focused interaction states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->