### PR TITLE
feat: Preserve Matangini Hazra's legacy through an interactive Quit India Movement explorer

### DIFF
--- a/frontend/freedom-fighters-hub/script.js
+++ b/frontend/freedom-fighters-hub/script.js
@@ -219,11 +219,31 @@ const FREEDOM_FIGHTERS_DATA = [
             { year: '1932', event: 'Signed Poona Pact securing reserved seats for depressed classes in legislatures.' },
             { year: '1947', event: 'Appointed India\'s first Law Minister and Chairman of Constitution Drafting Committee.' }
         ],
-        contributions: 'Architect of the Constitution of India guaranteeing fundamental rights, gender equality, and affirmative action; founder of Reserve Bank of India conceptual blueprint.',
+contributions: 'Architect of the Constitution of India guaranteeing fundamental rights, gender equality, and affirmative action; founder of Reserve Bank of India conceptual blueprint.',
         rareFacts: 'Doctorates from Columbia University and London School of Economics; possessed a personal library of over 50,000 books.',
         quote: 'Educate, Agitate, Organize.'
     },
     {
+        id: 'matangini-hazra',
+        name: 'Matangini Hazra',
+        title: 'Gandhi Buri',
+        lifespan: '1870 – 1942',
+        era: 'Quit India Movement',
+        region: 'East',
+        birthplace: 'Hogla, Tamluk, Bengal Presidency (now West Bengal)',
+        movements: ['Non-Cooperation Movement', 'Civil Disobedience Movement (Salt Satyagraha)', 'Quit India Movement'],
+        biography: 'Matangini Hazra was a Bengali freedom fighter from a poor peasant family who, despite having no formal education, became one of the most fearless faces of the independence movement in Midnapore, earning the affectionate title "Gandhi Buri" for her devotion to Gandhian ideals of non-violence.',
+        timeline: [
+            { year: '1930', event: 'Joined the Salt Satyagraha and Civil Disobedience Movement, courting arrest.' },
+            { year: '1933', event: 'Waved a black flag at the Governor of Bengal in Tamluk and served six months of rigorous imprisonment.' },
+            { year: '1942', event: 'Led roughly 6,000 volunteers, mostly women, toward Tamluk Police Station during the Quit India Movement and was shot dead on 29 September.' }
+        ],
+        contributions: 'Led the Vidyut Bahini volunteer corps during the Quit India Movement; became the first martyr of the movement in Midnapore, dying while holding the national flag aloft and chanting "Vande Mataram".',
+        rareFacts: 'Despite being shot multiple times, she continued walking forward with the tricolour until she fell. India Post issued a commemorative postage stamp in her honor in 2002, and a road and statue in Kolkata bear her name.',
+        quote: 'Vande Mataram.',
+        explorerUrl: '../matangini-hazra-explorer/index.html'
+    },
+        {
         id: 'rash-behari-bose',
         name: 'Rash Behari Bose',
         title: 'Founder of the INA',
@@ -392,18 +412,18 @@ if (typeof window !== 'undefined') {
                     <strong>💡 Rare Historical Fact:</strong> ${ff.rareFacts}
                 </div>
 
-                <div style="margin-top: 1.2rem; padding: 1rem; border-radius: 10px; background: rgba(0,0,0,0.3); border-left: 3px solid var(--ff-gold);">
+<div style="margin-top: 1.2rem; padding: 1rem; border-radius: 10px; background: rgba(0,0,0,0.3); border-left: 3px solid var(--ff-gold);">
                     <em style="color: var(--ff-gold); font-size: 1.05rem;">"${ff.quote}"</em>
                 </div>
 
-                ${ff.explorerLink ? `
+                ${ff.explorerUrl ? `
                 <div style="margin-top: 1.2rem; text-align: center;">
-                    <a href="${ff.explorerLink}" style="color: var(--ff-gold); font-weight: 700; text-decoration: none;">Read the Full Explorer Page &rarr;</a>
-                </div>` : ''}
+                    <a href="${ff.explorerUrl}" class="btn-explorer-link" style="display:inline-block; padding:0.75rem 1.5rem; background:linear-gradient(135deg, #d97706, #16a34a); color:#fff; font-weight:700; border-radius:999px; text-decoration:none;">Launch Dedicated Explorer ➔</a>
+                </div>
+                ` : ''}
             `;
             ffModal.classList.remove('hidden');
         }
-
         function updateView() {
             const searchVal = searchInput ? searchInput.value : '';
             const eraVal = eraFilter ? eraFilter.value : 'all';

--- a/frontend/history/dynasties/data.js
+++ b/frontend/history/dynasties/data.js
@@ -354,13 +354,45 @@ art: "Dated silver drachm coinage with royal portraiture, Brahmi epigraphy, Juna
       "Continued support for Nalanda University as a major center of Buddhist learning",
       "Diplomatic exchanges with Tang China, including missions that shaped early Sino-Indian relations"
     ],
-    art: "Sanskrit court literature and drama, copper-plate epigraphy, continued patronage of Buddhist monastic art at Nalanda",
+art: "Sanskrit court literature and drama, copper-plate epigraphy, continued patronage of Buddhist monastic art at Nalanda",
     era: "ancient",
     color: "#8e44ad",
     mapPosition: { top: "26%", left: "52%" },
     link: "pushyabhuti/index.html"
   },
-        {
+  {
+    id: "karkota",
+    name: "Karkota Dynasty",
+    period: "c. 625–855 CE",
+    startYear: 625,
+    endYear: 855,
+    capital: "Srinagar, later Parihasapura (founded by Lalitaditya)",
+    founders: "Durlabhavardhana",
+    notableRulers: [
+      { name: "Durlabhavardhana", reign: "c. 625–662 CE", achievement: "Founded the Karkota dynasty after marrying Princess Anangalekha; built the Durlabhasvamin Vishnu shrine at Srinagar" },
+      { name: "Lalitaditya Muktapida", reign: "c. 724–760 CE", achievement: "Greatest Karkota ruler; led extensive military campaigns, built the Martand Sun Temple, and founded the new capital of Parihasapura" },
+      { name: "Jayapida", reign: "8th century CE", achievement: "Grandson of Lalitaditya; patronized Buddhist viharas and founded the town of Jayapura" }
+    ],
+    territory: "The Kashmir valley and, under Lalitaditya, campaigns extending into parts of northern India and Central Asia",
+    peakExtent: "Kashmir and neighbouring Himalayan and Gangetic-plain regions under Lalitaditya Muktapida, though the full extent described in the Rajatarangini is considered partly legendary",
+    governance: "A centralized Kashmiri monarchy that consolidated power after the decline of the earlier Gonanda dynasty, maintaining diplomatic ties with Tang China and Central Asian powers",
+    military: "Campaigns associated with Lalitaditya Muktapida across northern India and against Tibetan and Arab incursions in the northwest, described in Kalhana's Rajatarangini",
+    decline: "Weakened through the 9th century by invasions, internal instability, and economic strain; rule ended in 855 CE when Avantivarman ascended the throne and founded the Utpala dynasty",
+    contributions: [
+      "The Martand Sun Temple — the oldest known Sun temple in India, blending Gupta and local Kashmiri architectural styles with its distinctive trefoil arches",
+      "Founding of Parihasapura, a new capital showcasing Karkota-era urban planning and monumental architecture",
+      "Religious harmony — Karkota rulers were Vaishnavas who built numerous Vishnu shrines while also patronizing Buddhist viharas and stupas",
+      "Kalhana's Rajatarangini, composed in the 12th century, remains the principal chronicle of Kashmiri history and preserves the Karkota period's legacy",
+      "Diplomatic and cultural contact with Tang-dynasty China and Central Asia under Lalitaditya Muktapida",
+      "Development of a distinct Kashmiri architectural idiom, drawing on post-Gupta trends from Sarnath and Nalanda"
+    ],
+    art: "Martand Sun Temple, trefoil-arch Kashmiri temple architecture, Parihasapura monuments, Buddhist viharas and stupas",
+    era: "medieval",
+    color: "#e91e63",
+    mapPosition: { top: "8%", left: "50%" },
+    link: "karkota/index.html"
+  },
+          {
     id: "kushan",
     name: "Kushan Empire",
     period: "c. 30–375 CE",
@@ -539,8 +571,13 @@ export const timelineEvents = [
   { year: 606, event: "Harshavardhana becomes king after his brother Rajyavardhana is killed by Shashanka of Gauda", dynasty: "pushyabhuti" },
   { year: 619, event: "Chalukya king Pulakesin II defeats Harshavardhana at the Narmada River, halting his southward expansion", dynasty: "pushyabhuti" },
   { year: 643, event: "Harsha holds the Kannauj assembly in honour of the Chinese pilgrim Xuanzang", dynasty: "pushyabhuti" },
-  { year: 647, event: "Harshavardhana dies without an heir, and the Pushyabhuti dynasty rapidly disintegrates", dynasty: "pushyabhuti" },
-  { year: 105, event: "Vima Kadphises conquers Gandhara and expands Kushan trade with Rome", dynasty: "kushan" },
+{ year: 647, event: "Harshavardhana dies without an heir, and the Pushyabhuti dynasty rapidly disintegrates", dynasty: "pushyabhuti" },
+  { year: 625, event: "Durlabhavardhana founds the Karkota dynasty in Kashmir", dynasty: "karkota" },
+  { year: 724, event: "Lalitaditya Muktapida becomes king, beginning the dynasty's most celebrated reign", dynasty: "karkota" },
+  { year: 750, event: "Lalitaditya commissions the Martand Sun Temple and founds the new capital of Parihasapura", dynasty: "karkota" },
+  { year: 760, event: "Death of Lalitaditya Muktapida; Kashmir's imperial influence begins to wane after his reign", dynasty: "karkota" },
+  { year: 855, event: "Avantivarman ascends the throne and founds the Utpala dynasty, ending Karkota rule", dynasty: "karkota" },
+    { year: 105, event: "Vima Kadphises conquers Gandhara and expands Kushan trade with Rome", dynasty: "kushan" },
   { year: 127, event: "Kanishka I ascends the throne; the Kushan Empire reaches its greatest extent", dynasty: "kushan" },
   { year: 150, event: "Huvishka succeeds Kanishka, continuing patronage of Buddhism and Zoroastrianism", dynasty: "kushan" },
   { year: 230, event: "Death of Vasudeva I, the last powerful Kushan ruler, marks the start of decline", dynasty: "kushan" },

--- a/frontend/history/dynasties/karkota/index.html
+++ b/frontend/history/dynasties/karkota/index.html
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Karkota Dynasty Explorer - Discover the Karkota Dynasty (c. 625-855 CE), which established Kashmir as a powerful kingdom under Lalitaditya Muktapida and built the Martand Sun Temple.">
+    <title>Karkota Dynasty Explorer | Incredible India Explorer</title>
+    <link rel="icon" href="data:,">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:wght@500;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="../../../styles.css">
+    <link rel="stylesheet" href="style.css">
+
+    <meta property="og:title" content="Karkota Dynasty Explorer | Incredible India Explorer">
+    <meta property="og:description" content="The Karkota Dynasty — Lalitaditya Muktapida, the Martand Sun Temple, and the rise of Kashmir.">
+    <meta property="og:type" content="website">
+    <meta property="og:locale" content="en_IN">
+</head>
+
+<body class="kk-page-body">
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../../index.html#home" class="nav-link">Home</a>
+                <a href="../index.html" class="nav-link">Indian Dynasties</a>
+                <a href="index.html" class="nav-link active" style="color: #e91e63">Karkota Dynasty</a>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+            </nav>
+        </div>
+    </header>
+
+    <main class="kk-main">
+        <!-- Hero Banner -->
+        <section class="kk-hero">
+            <span class="kk-kicker">🏔️ Kashmir's Imperial Golden Age</span>
+            <h1>Karkota Dynasty Explorer</h1>
+            <p>The <strong>Karkota Dynasty</strong> ruled Kashmir from around 625 to 855 CE, transforming the valley from an isolated Himalayan region into a powerful and culturally vibrant kingdom. Under its greatest ruler, <strong>Lalitaditya Muktapida</strong>, Kashmir became a major power of the subcontinent, remembered above all for the magnificent <strong>Martand Sun Temple</strong>.</p>
+
+            <div class="kk-hero-stats">
+                <div class="kk-hero-stat">
+                    <strong>c. 625–855 CE</strong>
+                    <span>Dynasty Period</span>
+                </div>
+                <div class="kk-hero-stat">
+                    <strong>Parihasapura</strong>
+                    <span>New Capital</span>
+                </div>
+                <div class="kk-hero-stat">
+                    <strong>84</strong>
+                    <span>Shrines at Martand</span>
+                </div>
+                <div class="kk-hero-stat">
+                    <strong>Rajatarangini</strong>
+                    <span>Chief Chronicle</span>
+                </div>
+            </div>
+        </section>
+
+        <!-- Navigation Tabs -->
+        <div class="kk-nav-tabs">
+            <button class="kk-tab active" data-tab="overview">📜 Historical Overview</button>
+            <button class="kk-tab" data-tab="timeline">🕰️ Timeline</button>
+            <button class="kk-tab" data-tab="rulers">👑 Major Rulers</button>
+            <button class="kk-tab" data-tab="architecture">🏛️ Architectural Achievements</button>
+            <button class="kk-tab" data-tab="gallery">🖼️ Gallery</button>
+            <button class="kk-tab" data-tab="references">📚 References</button>
+        </div>
+
+        <!-- Historical Overview -->
+        <section id="overview" class="kk-section active">
+            <div class="kk-content-card">
+                <h2>📜 Historical Overview</h2>
+                <div class="kk-content">
+                    <p>The <strong>Karkota Dynasty</strong> emerged in Kashmir around 625 CE, in the aftermath of the declining Gonanda dynasty that had ruled the valley since ancient times. Its founder, <strong>Durlabhavardhana</strong>, was originally a feudatory under the last Gonanda ruler; he rose to the throne after marrying Princess Anangalekha, establishing a new ruling line that would dominate Kashmir for over two centuries.</p>
+                    <p>The dynasty's early rulers steadily consolidated power, building temples and shrines and introducing architectural styles drawn from post-Gupta centres such as Sarnath and Nalanda. The Karkotas reached their zenith under <strong>Lalitaditya Muktapida</strong>, whose reign from around 724 to 760 CE is described in glowing, if partly legendary, terms by the 12th-century chronicler Kalhana in his <em>Rajatarangini</em>. Lalitaditya is credited with extensive military campaigns across northern India and Central Asia, diplomatic contact with Tang China, and the construction of the celebrated <strong>Martand Sun Temple</strong>.</p>
+                    <p>After Lalitaditya's death, later Karkota rulers — including his grandson Jayapida — continued to patronize religion and the arts, but the dynasty's power gradually waned through the 9th century amid invasions, internal instability, and economic strain. Karkota rule finally ended in 855 CE, when <strong>Avantivarman</strong> ascended the throne and founded the succeeding Utpala dynasty — but the cultural and architectural foundations the Karkotas had laid endured, cementing Kashmir's lasting reputation as a centre of art, learning, and philosophy.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Timeline -->
+        <section id="timeline" class="kk-section">
+            <div class="kk-content-card">
+                <h2>🕰️ Timeline</h2>
+                <div class="kk-content">
+                    <div class="kk-timeline">
+                        <div class="kk-timeline-item">
+                            <span class="kk-timeline-year">c. 625 CE</span>
+                            <p>Durlabhavardhana founds the Karkota dynasty in Kashmir after marrying Princess Anangalekha.</p>
+                        </div>
+                        <div class="kk-timeline-item">
+                            <span class="kk-timeline-year">c. 724 CE</span>
+                            <p>Lalitaditya Muktapida becomes king, beginning the dynasty's most celebrated and expansive reign.</p>
+                        </div>
+                        <div class="kk-timeline-item">
+                            <span class="kk-timeline-year">c. 750 CE</span>
+                            <p>Lalitaditya commissions the Martand Sun Temple and founds the new capital of Parihasapura.</p>
+                        </div>
+                        <div class="kk-timeline-item">
+                            <span class="kk-timeline-year">c. 760 CE</span>
+                            <p>Death of Lalitaditya Muktapida; Kashmir's imperial influence gradually begins to wane after his reign.</p>
+                        </div>
+                        <div class="kk-timeline-item">
+                            <span class="kk-timeline-year">855 CE</span>
+                            <p>Avantivarman ascends the throne and founds the Utpala dynasty, bringing Karkota rule to an end.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Major Rulers -->
+        <section id="rulers" class="kk-section">
+            <div class="kk-content-card">
+                <h2>👑 Major Rulers</h2>
+                <div class="kk-content">
+                    <div class="ruler-list">
+                        <div class="ruler-item">
+                            <h3>Durlabhavardhana <span class="ruler-reign">(c. 625–662 CE)</span></h3>
+                            <p>Founder of the Karkota dynasty. He built the Durlabhasvamin Vishnu shrine at Srinagar and introduced post-Gupta architectural influences from Sarnath and Nalanda into Kashmir.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Durlabhaka (Pratapaditya II) <span class="ruler-reign">(early 8th century CE)</span></h3>
+                            <p>Established the city of Pratapapura and the Malhanasvamin shrine, continuing the dynasty's tradition of temple patronage.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Lalitaditya Muktapida <span class="ruler-reign">(c. 724–760 CE)</span></h3>
+                            <p>The dynasty's greatest ruler. Credited by Kalhana's Rajatarangini with sweeping military campaigns and diplomatic ties to Tang China, he built the Martand Sun Temple and founded the new capital of Parihasapura.</p>
+                        </div>
+                        <div class="ruler-item">
+                            <h3>Jayapida <span class="ruler-reign">(8th century CE)</span></h3>
+                            <p>Grandson of Lalitaditya. He patronized Buddhist viharas, commissioned Buddha statues, and founded the town of Jayapura.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Architectural Achievements -->
+        <section id="architecture" class="kk-section">
+            <div class="kk-content-card">
+                <h2>🏛️ Architectural Achievements</h2>
+                <div class="kk-content">
+                    <p>The Karkota period represents the zenith of early Kashmiri architecture, blending Gupta-era influences with a distinct local idiom that would define the region's temple-building for centuries.</p>
+                    <ul class="kk-list">
+                        <li><strong>Martand Sun Temple:</strong> Built by Lalitaditya Muktapida and dedicated to the sun god Surya, this limestone complex is the oldest known Sun temple in India — a rectangular courtyard enclosing 84 subsidiary shrines around a central pillared hall</li>
+                        <li><strong>The trefoil arch:</strong> A defining feature of Kashmiri Brahminical temple architecture, prominently used at Martand and other Karkota-era shrines</li>
+                        <li><strong>Parihasapura:</strong> Lalitaditya's purpose-built capital, showcasing sophisticated urban planning alongside temples, stupas, and viharas</li>
+                        <li><strong>Durlabhasvamin shrine:</strong> An early Vishnu temple at Srinagar built by dynasty founder Durlabhavardhana, reflecting the introduction of post-Gupta architectural trends into Kashmir</li>
+                        <li><strong>Buddhist monuments:</strong> Viharas, stupas, and chaityas built alongside Vaishnava shrines, reflecting the religious harmony that characterized Karkota patronage</li>
+                        <li><strong>Jayapura:</strong> A further new town founded by Jayapida, continuing the dynasty's tradition of monumental urban and religious construction</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <!-- Gallery -->
+        <section id="gallery" class="kk-section">
+            <div class="kk-content-card">
+                <h2>🖼️ Gallery</h2>
+                <div class="kk-content">
+                    <p>A visual look at the Karkota dynasty's temples, capitals, and cultural legacy.</p>
+                    <div class="gallery-grid">
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🛕</div>
+                            <h3>Martand Sun Temple</h3>
+                            <p>The grand limestone complex dedicated to Surya, built by Lalitaditya Muktapida.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🏛️</div>
+                            <h3>Parihasapura Ruins</h3>
+                            <p>The remains of Lalitaditya's purpose-built capital, with its temples and stupas.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">📜</div>
+                            <h3>Rajatarangini</h3>
+                            <p>Kalhana's 12th-century chronicle, the primary source on Karkota-era Kashmir.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🗿</div>
+                            <h3>Buddhist Viharas</h3>
+                            <p>Monastic structures patronized by Karkota rulers alongside their Vishnu shrines.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">⛰️</div>
+                            <h3>The Kashmir Valley</h3>
+                            <p>The Himalayan heartland that the Karkotas transformed into a major cultural centre.</p>
+                        </div>
+                        <div class="gallery-item">
+                            <div class="gallery-placeholder">🗺️</div>
+                            <h3>Karkota Influence</h3>
+                            <p>The dynasty's reach across Kashmir and into parts of northern India under Lalitaditya.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- References -->
+        <section id="references" class="kk-section">
+            <div class="kk-content-card">
+                <h2>📚 References</h2>
+                <div class="kk-content">
+                    <ul class="kk-list kk-references">
+                        <li>Wikipedia — Karkota dynasty. <a href="https://en.wikipedia.org/wiki/Karkota_dynasty" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>Wikipedia — Lalitaditya Muktapida. <a href="https://en.wikipedia.org/wiki/Lalitaditya_Muktapida" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>Wikipedia — Martand Sun Temple. <a href="https://en.wikipedia.org/wiki/Martand_Sun_Temple" target="_blank" rel="noopener noreferrer">en.wikipedia.org</a></li>
+                        <li>GKToday — Karkota Dynasty overview. <a href="https://www.gktoday.in/karkota-dynasty/" target="_blank" rel="noopener noreferrer">gktoday.in</a></li>
+                        <li>Bharatpedia — Karkota Dynasty. <a href="https://en.bharatpedia.org/wiki/Karkota_Dynasty" target="_blank" rel="noopener noreferrer">en.bharatpedia.org</a></li>
+                        <li>Kalhana. <em>Rajatarangini</em> (12th century CE), trans. M. A. Stein.</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="kk-footer">
+        <p>Part of <a href="../../../index.html" style="color: #FF9933;">Incredible India Explorer</a> · <a href="../index.html" style="color: #e91e63;">Indian Dynasties Explorer</a></p>
+    </footer>
+
+    <script type="module" src="script.js"></script>
+</body>
+</html>

--- a/frontend/history/dynasties/karkota/script.js
+++ b/frontend/history/dynasties/karkota/script.js
@@ -1,0 +1,92 @@
+/**
+ * Karkota Dynasty Explorer - Interactive Script
+ * Handles tab navigation, smooth scrolling, theme toggle, and mobile menu
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    initTabNavigation();
+    initThemeToggle();
+    initMobileMenu();
+});
+
+/**
+ * Initialize tab navigation for different sections
+ */
+function initTabNavigation() {
+    const tabs = document.querySelectorAll('.kk-tab');
+    const sections = document.querySelectorAll('.kk-section');
+
+    tabs.forEach(tab => {
+        tab.addEventListener('click', () => {
+            const targetTab = tab.dataset.tab;
+
+            tabs.forEach(t => t.classList.remove('active'));
+            sections.forEach(s => s.classList.remove('active'));
+
+            tab.classList.add('active');
+            const targetSection = document.getElementById(targetTab);
+            if (targetSection) {
+                targetSection.classList.add('active');
+                targetSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+        });
+    });
+}
+
+/**
+ * Initialize theme toggle functionality
+ */
+function initThemeToggle() {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+
+    const currentTheme = localStorage.getItem('theme') || 'dark';
+    updateThemeIcon(currentTheme);
+
+    themeToggle.addEventListener('click', () => {
+        const body = document.body;
+        const isLight = body.classList.contains('light-theme');
+
+        if (isLight) {
+            body.classList.remove('light-theme');
+            localStorage.setItem('theme', 'dark');
+            updateThemeIcon('dark');
+        } else {
+            body.classList.add('light-theme');
+            localStorage.setItem('theme', 'light');
+            updateThemeIcon('light');
+        }
+    });
+}
+
+/**
+ * Update theme toggle icon
+ */
+function updateThemeIcon(theme) {
+    const themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+    themeToggle.textContent = theme === 'light' ? '🌙' : '☀️';
+}
+
+/**
+ * Initialize mobile menu toggle
+ */
+function initMobileMenu() {
+    const menuToggle = document.getElementById('menu-toggle');
+    const navMenu = document.getElementById('nav-menu');
+
+    if (menuToggle && navMenu) {
+        menuToggle.addEventListener('click', () => {
+            const isExpanded = menuToggle.getAttribute('aria-expanded') === 'true';
+            menuToggle.setAttribute('aria-expanded', !isExpanded);
+            navMenu.classList.toggle('active');
+        });
+
+        document.addEventListener('click', (e) => {
+            if (!menuToggle.contains(e.target) && !navMenu.contains(e.target)) {
+                navMenu.classList.remove('active');
+                menuToggle.setAttribute('aria-expanded', 'false');
+            }
+        });
+    }
+}

--- a/frontend/history/dynasties/karkota/style.css
+++ b/frontend/history/dynasties/karkota/style.css
@@ -1,0 +1,341 @@
+/* ==========================================================================
+   Karkota Dynasty Explorer Styling
+   Kashmir's imperial golden age (c. 625-855 CE)
+   ========================================================================== */
+
+.kk-page-body {
+    background-color: var(--bg-primary, #0B0F19);
+    color: var(--text-primary, #E2E8F0);
+    font-family: 'Outfit', system-ui, -apple-system, sans-serif;
+    line-height: 1.6;
+    margin: 0;
+    padding: 0;
+}
+
+.kk-main {
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: 80px 20px 60px;
+}
+
+/* --- Hero Banner --- */
+.kk-hero {
+    text-align: center;
+    padding: 48px 24px;
+    background: linear-gradient(135deg, rgba(11, 15, 25, 0.95) 0%, rgba(42, 10, 26, 0.85) 100%);
+    border: 1px solid rgba(233, 30, 99, 0.35);
+    border-radius: 16px;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+    margin-bottom: 32px;
+    position: relative;
+    overflow: hidden;
+}
+
+.kk-hero::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: linear-gradient(90deg, #FF9933 0%, #D4AF37 50%, #e91e63 100%);
+}
+
+.kk-kicker {
+    display: inline-block;
+    padding: 6px 16px;
+    background: rgba(233, 30, 99, 0.18);
+    color: #f47ea6;
+    border: 1px solid rgba(233, 30, 99, 0.4);
+    border-radius: 20px;
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 16px;
+}
+
+.kk-hero h1 {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 2.6rem;
+    font-weight: 700;
+    color: var(--text-heading, #F8FAFC);
+    margin: 0 0 12px;
+}
+
+.kk-hero p {
+    font-size: 1.1rem;
+    color: var(--text-secondary, #94A3B8);
+    max-width: 850px;
+    margin: 0 auto 24px;
+}
+
+.kk-hero-stats {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 16px;
+    margin-top: 24px;
+}
+
+.kk-hero-stat {
+    background: rgba(15, 23, 42, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 12px;
+    padding: 16px;
+    text-align: center;
+}
+
+.kk-hero-stat strong {
+    display: block;
+    font-size: 1.3rem;
+    color: #FF9933;
+    font-family: 'Playfair Display', Georgia, serif;
+}
+
+.kk-hero-stat span {
+    font-size: 0.8rem;
+    color: var(--text-secondary, #94A3B8);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+/* --- Navigation Tabs --- */
+.kk-nav-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: center;
+    margin-bottom: 32px;
+    padding: 12px;
+    background: rgba(15, 23, 42, 0.5);
+    border-radius: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.kk-tab {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    color: var(--text-secondary, #94A3B8);
+    padding: 8px 16px;
+    border-radius: 20px;
+    font-size: 0.88rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.25s ease;
+    white-space: nowrap;
+}
+
+.kk-tab:hover {
+    border-color: rgba(233, 30, 99, 0.5);
+    color: #f47ea6;
+}
+
+.kk-tab.active {
+    background: linear-gradient(135deg, #e91e63, #a3143f);
+    border-color: #e91e63;
+    color: #fff;
+}
+
+.kk-tab:focus-visible {
+    outline: 2px solid #FF9933;
+    outline-offset: 2px;
+}
+
+/* --- Content Sections --- */
+.kk-section {
+    display: none;
+    animation: fadeIn 0.4s ease;
+}
+
+.kk-section.active {
+    display: block;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(10px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.kk-content-card {
+    background: rgba(15, 23, 42, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 16px;
+    padding: 32px;
+}
+
+.kk-content-card h2 {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-size: 1.8rem;
+    color: var(--text-heading, #F8FAFC);
+    margin: 0 0 20px;
+}
+
+.kk-content h3 {
+    color: #f47ea6;
+    font-size: 1.1rem;
+    margin: 0 0 6px;
+}
+
+.kk-content p {
+    color: var(--text-secondary, #CBD5E1);
+    margin: 0 0 14px;
+}
+
+.kk-list {
+    color: var(--text-secondary, #CBD5E1);
+    padding-left: 20px;
+    margin: 0 0 14px;
+}
+
+.kk-list li {
+    margin-bottom: 8px;
+}
+
+.kk-references a {
+    color: #f47ea6;
+    text-decoration: none;
+}
+
+.kk-references a:hover {
+    text-decoration: underline;
+}
+
+/* --- Timeline --- */
+.kk-timeline {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    border-left: 2px solid rgba(233, 30, 99, 0.5);
+    padding-left: 20px;
+    margin-top: 8px;
+}
+
+.kk-timeline-item {
+    position: relative;
+}
+
+.kk-timeline-item::before {
+    content: '';
+    position: absolute;
+    left: -26px;
+    top: 4px;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: #e91e63;
+}
+
+.kk-timeline-year {
+    display: block;
+    font-weight: 700;
+    color: #FF9933;
+    font-family: 'Playfair Display', Georgia, serif;
+    margin-bottom: 4px;
+}
+
+.kk-timeline-item p {
+    margin: 0;
+}
+
+/* --- Rulers --- */
+.ruler-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 16px;
+}
+
+.ruler-item {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 12px;
+    padding: 18px;
+}
+
+.ruler-reign {
+    font-size: 0.85rem;
+    color: var(--text-secondary, #94A3B8);
+    font-weight: 400;
+}
+
+/* --- Gallery --- */
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+    margin-top: 16px;
+}
+
+.gallery-item {
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 12px;
+    padding: 20px;
+    text-align: center;
+    transition: transform 0.25s ease;
+}
+
+.gallery-item:hover {
+    transform: translateY(-4px);
+    border-color: rgba(233, 30, 99, 0.5);
+}
+
+.gallery-placeholder {
+    font-size: 2.6rem;
+    margin-bottom: 10px;
+}
+
+.gallery-item h3 {
+    margin: 0 0 6px;
+}
+
+.gallery-item p {
+    font-size: 0.9rem;
+    margin: 0;
+}
+
+/* --- Footer --- */
+.kk-footer {
+    text-align: center;
+    padding: 30px 20px;
+    color: var(--text-secondary, #94A3B8);
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* --- Responsive --- */
+@media (max-width: 768px) {
+    .kk-hero h1 {
+        font-size: 2rem;
+    }
+
+    .kk-content-card {
+        padding: 20px;
+    }
+
+    .kk-nav-tabs {
+        justify-content: flex-start;
+        overflow-x: auto;
+        flex-wrap: nowrap;
+    }
+
+    .kk-timeline {
+        padding-left: 16px;
+    }
+}
+
+/* --- Light Theme Overrides --- */
+body.light-theme.kk-page-body {
+    background-color: #F8FAFC;
+    color: #0F172A;
+}
+
+body.light-theme .kk-content-card,
+body.light-theme .kk-hero {
+    background: rgba(255, 255, 255, 0.85);
+    border-color: rgba(0, 0, 0, 0.08);
+}
+
+body.light-theme .kk-content p,
+body.light-theme .kk-list,
+body.light-theme .ruler-reign {
+    color: #334155;
+}

--- a/frontend/matangini-hazra-explorer/index.html
+++ b/frontend/matangini-hazra-explorer/index.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore the life of Matangini Hazra — 'Gandhi Buri' — and her fearless role in the Quit India Movement of 1942.">
+  <title>Matangini Hazra Explorer | Incredible India</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="site-header">
+    <nav class="navbar" aria-label="Main navigation">
+      <a href="../../index.html" class="nav-logo" aria-label="Go to homepage">Incredible India Explorer</a>
+      <button id="theme-toggle" class="theme-btn" aria-label="Toggle dark and light theme">🌓 Theme</button>
+    </nav>
+  </header>
+
+  <main>
+    <section class="matangini-hero" aria-labelledby="hero-title">
+      <div class="hero-content">
+        <h1 id="hero-title">Matangini Hazra Explorer</h1>
+        <p class="hero-subtitle">"Gandhi Buri" of Midnapore — a 71-year-old widow who walked into gunfire holding the tricolour, becoming the first martyr of the Quit India Movement.</p>
+        <div class="hero-badges">
+          <span class="badge">🇮🇳 Gandhi Buri</span>
+          <span class="badge">🚩 Quit India Movement</span>
+          <span class="badge">🕊️ Martyr of Midnapore</span>
+        </div>
+        <a href="#biography" class="cta-button">Start Exploring ↓</a>
+      </div>
+    </section>
+
+    <section id="biography" class="content-section" aria-labelledby="bio-title">
+      <h2 id="bio-title">Biography</h2>
+      <div class="overview-grid">
+        <div class="overview-card">
+          <h3>Early Life</h3>
+          <p>Born Matangini Maity in 1870 in Hogla village near Tamluk, Bengal, to a poor peasant family. She never received formal schooling and was widowed by age eighteen.</p>
+        </div>
+        <div class="overview-card">
+          <h3>Gandhian Influence</h3>
+          <p>Deeply inspired by Gandhian ideals of non-violence and civil disobedience, she devoted herself to social service and earned the affectionate name "Gandhi Buri" — old lady Gandhi.</p>
+        </div>
+        <div class="overview-card">
+          <h3>Path to Sacrifice</h3>
+          <p>She joined the Salt Satyagraha, protested the Chowkidari tax, and was jailed more than once — building toward her defining moment in 1942.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="timeline" class="content-section alt-bg" aria-labelledby="timeline-title">
+      <h2 id="timeline-title">Interactive Timeline</h2>
+      <p class="section-desc">Select a year to see what happened.</p>
+      <div class="timeline-interactive">
+        <div id="timeline-rail" class="timeline-rail" role="list"></div>
+        <div id="timeline-detail" class="timeline-detail" aria-live="polite">
+          <p>Select a year on the left to see details.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="quit-india" class="content-section" aria-labelledby="qi-title">
+      <h2 id="qi-title">Quit India Movement</h2>
+      <p class="section-desc">On 29 September 1942, Matangini Hazra led thousands toward the Tamluk Police Station in defiance of British rule.</p>
+      <div id="quit-india-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="legacy" class="content-section alt-bg" aria-labelledby="legacy-title">
+      <h2 id="legacy-title">Legacy</h2>
+      <ul id="legacy-list" class="facts-list" role="list"></ul>
+    </section>
+
+    <section id="gallery" class="content-section" aria-labelledby="gallery-title">
+      <h2 id="gallery-title">Gallery</h2>
+      <p class="section-desc">Illustrative moments from her story.</p>
+      <div id="gallery-grid" class="gallery-grid" role="list"></div>
+    </section>
+
+    <section id="references" class="content-section alt-bg" aria-labelledby="ref-title">
+      <h2 id="ref-title">References</h2>
+      <ul id="references-list" class="references-list" role="list"></ul>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>&copy; 2026 Incredible India Explorer. Educational purposes only.</p>
+    <a href="../../index.html">Back to Home</a>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/matangini-hazra-explorer/script.js
+++ b/frontend/matangini-hazra-explorer/script.js
@@ -1,0 +1,125 @@
+(function() {
+  'use strict';
+
+  // Theme toggle logic
+  const themeBtn = document.getElementById('theme-toggle');
+  const body = document.body;
+
+  if (localStorage.getItem('theme') === 'light') {
+    body.classList.add('light-theme');
+  }
+
+  themeBtn.addEventListener('click', () => {
+    body.classList.toggle('light-theme');
+    localStorage.setItem('theme', body.classList.contains('light-theme') ? 'light' : 'dark');
+  });
+
+  // Data
+  const timelineData = [
+    { year: '1870', desc: 'Born Matangini Maity in Hogla village near Tamluk, Bengal, to a poor peasant family with no access to formal education.' },
+    { year: '1888', desc: 'Widowed by age eighteen after her husband Trilochan Hazra passed away. She devoted herself to social service.' },
+    { year: '1905', desc: 'Became deeply inspired by the Nationalist movement and Gandhian ideals spreading through Bengal.' },
+    { year: '1930-32', desc: 'Joined the Salt Satyagraha and Civil Disobedience Movement, courting arrest for the first time.' },
+    { year: '1933', desc: 'Waved a black flag at the Governor of Bengal during his visit to Tamluk and served six months of rigorous imprisonment.' },
+    { year: 'Sep 1942', desc: 'Led roughly 6,000 volunteers, mostly women, toward the Tamluk Police Station during the Quit India Movement and was shot dead on 29 September, becoming the movement\'s first martyr in Midnapore.' }
+  ];
+
+  const quitIndiaData = [
+    { name: 'The Call to Action', emoji: '📢', desc: 'In August 1942, Congress workers in Midnapore planned to seize local police stations as part of the nationwide Quit India Movement.' },
+    { name: 'The Vidyut Bahini', emoji: '🚩', desc: 'At 72, Matangini Hazra led one of five volunteer batches formed by the local Samar Parisad (War Council) to march on Tamluk.' },
+    { name: 'The March to Tamluk', emoji: '🚶‍♀️', desc: 'She led thousands toward the Tamluk Police Station carrying the Indian tricolour, defying orders to disband.' },
+    { name: 'The Final Moment', emoji: '🕊️', desc: 'Shot multiple times by British Indian police, she continued forward chanting "Vande Mataram" until she fell, flag still in hand.' }
+  ];
+
+  const legacyData = [
+    'She became the first martyr of the Quit India Movement in Midnapore district.',
+    'A statue of Matangini Hazra stands at the Maidan in Kolkata, and another marks the spot in Tamluk where she died.',
+    'Hazra Road, a major road in south Kolkata, is named in her memory.',
+    'In 2002, India Post issued a commemorative postage stamp marking sixty years of the Quit India Movement.'
+  ];
+
+  const galleryData = [
+    { emoji: '🚩', caption: 'Leading the Vidyut Bahini toward Tamluk Police Station' },
+    { emoji: '🇮🇳', caption: 'Holding the tricolour aloft during the final march' },
+    { emoji: '🏛️', caption: 'Her statue at the Maidan, Kolkata' },
+    { emoji: '📮', caption: '2002 commemorative postage stamp in her honor' }
+  ];
+
+  const referencesData = [
+    { title: 'Matangini Hazra — Wikipedia', url: 'https://en.wikipedia.org/wiki/Matangini_Hazra' },
+    { title: 'Quit India Movement — Wikipedia', url: 'https://en.wikipedia.org/wiki/Quit_India_Movement' },
+    { title: 'Tamluk — Wikipedia', url: 'https://en.wikipedia.org/wiki/Tamluk' }
+  ];
+
+  // Render: Interactive Timeline
+  function renderTimeline() {
+    const rail = document.getElementById('timeline-rail');
+    const detail = document.getElementById('timeline-detail');
+
+    timelineData.forEach((item, index) => {
+      const btn = document.createElement('button');
+      btn.className = 'timeline-year-btn';
+      btn.setAttribute('role', 'listitem');
+      btn.textContent = item.year;
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.timeline-year-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        detail.innerHTML = `<h3>${item.year}</h3><p>${item.desc}</p>`;
+      });
+      rail.appendChild(btn);
+      if (index === timelineData.length - 1) {
+        btn.classList.add('active');
+        detail.innerHTML = `<h3>${item.year}</h3><p>${item.desc}</p>`;
+      }
+    });
+  }
+
+  function renderCards(containerId, data) {
+    const grid = document.getElementById(containerId);
+    data.forEach(item => {
+      const card = document.createElement('div');
+      card.className = 'data-card';
+      card.setAttribute('role', 'listitem');
+      card.innerHTML = `<h3>${item.emoji} ${item.name}</h3><p>${item.desc}</p>`;
+      grid.appendChild(card);
+    });
+  }
+
+  function renderLegacy() {
+    const list = document.getElementById('legacy-list');
+    legacyData.forEach(fact => {
+      const li = document.createElement('li');
+      li.textContent = fact;
+      list.appendChild(li);
+    });
+  }
+
+  function renderGallery() {
+    const grid = document.getElementById('gallery-grid');
+    galleryData.forEach(item => {
+      const div = document.createElement('div');
+      div.className = 'gallery-item';
+      div.setAttribute('role', 'listitem');
+      div.innerHTML = `<span class="gallery-emoji">${item.emoji}</span><div class="gallery-caption">${item.caption}</div>`;
+      grid.appendChild(div);
+    });
+  }
+
+  function renderReferences() {
+    const list = document.getElementById('references-list');
+    referencesData.forEach(ref => {
+      const li = document.createElement('li');
+      li.innerHTML = `<a href="${ref.url}" target="_blank" rel="noopener noreferrer">${ref.title}</a>`;
+      list.appendChild(li);
+    });
+  }
+
+  // Initialize
+  document.addEventListener('DOMContentLoaded', () => {
+    renderTimeline();
+    renderCards('quit-india-grid', quitIndiaData);
+    renderLegacy();
+    renderGallery();
+    renderReferences();
+  });
+})();

--- a/frontend/matangini-hazra-explorer/style.css
+++ b/frontend/matangini-hazra-explorer/style.css
@@ -1,0 +1,292 @@
+/* =========================================
+   Matangini Hazra Explorer Styles
+   Supports Dark (default) and Light themes
+   ========================================= */
+
+:root {
+  --bg-primary: #171012;
+  --bg-secondary: #241a1c;
+  --bg-alt: #2e2124;
+  --text-primary: #f9f5f3;
+  --text-secondary: #cdbdb8;
+  --saffron: #ff6f3c;
+  --gold: #ffb01f;
+  --green: #10b981;
+  --card-bg: #241a1c;
+  --border-color: #3a2a2d;
+  --shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+}
+
+body.light-theme {
+  --bg-primary: #fdf8f6;
+  --bg-secondary: #ffffff;
+  --bg-alt: #f6ece9;
+  --text-primary: #241a1c;
+  --text-secondary: #5c4a47;
+  --saffron: #e0611f;
+  --gold: #b8790f;
+  --green: #0f7a5c;
+  --card-bg: #ffffff;
+  --border-color: #ecdedb;
+  --shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.site-header {
+  background-color: var(--bg-secondary);
+  padding: 1rem 2rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  box-shadow: var(--shadow);
+}
+
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.nav-logo {
+  color: var(--saffron);
+  text-decoration: none;
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.theme-btn {
+  background: var(--bg-alt);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+
+.theme-btn:hover {
+  background: var(--border-color);
+}
+
+.matangini-hero {
+  background: linear-gradient(135deg, var(--bg-secondary), var(--bg-primary));
+  padding: 5rem 2rem;
+  text-align: center;
+}
+
+.hero-content {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.hero-content h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  color: var(--saffron);
+}
+
+.hero-subtitle {
+  font-size: 1.15rem;
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.hero-badges {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.badge {
+  background: var(--bg-alt);
+  border: 1px solid var(--border-color);
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+}
+
+.cta-button {
+  display: inline-block;
+  background: var(--saffron);
+  color: #fff;
+  padding: 0.75rem 1.75rem;
+  border-radius: 0.5rem;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.cta-button:hover {
+  opacity: 0.9;
+}
+
+.content-section {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 4rem 2rem;
+}
+
+.content-section h2 {
+  font-size: 1.8rem;
+  margin-bottom: 0.5rem;
+  color: var(--saffron);
+}
+
+.section-desc {
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.alt-bg {
+  background: var(--bg-secondary);
+  border-radius: 1rem;
+}
+
+.overview-grid,
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.overview-card,
+.data-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  box-shadow: var(--shadow);
+}
+
+.overview-card h3,
+.data-card h3 {
+  margin-bottom: 0.5rem;
+  color: var(--gold);
+}
+
+.data-card p,
+.overview-card p {
+  color: var(--text-secondary);
+}
+
+.timeline-interactive {
+  display: grid;
+  grid-template-columns: 1fr 2fr;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+.timeline-rail {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.timeline-year-btn {
+  text-align: left;
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.timeline-year-btn:hover,
+.timeline-year-btn.active {
+  border-color: var(--saffron);
+  color: var(--saffron);
+}
+
+.timeline-detail {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  color: var(--text-secondary);
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.gallery-item {
+  border-radius: 0.75rem;
+  border: 1px solid var(--border-color);
+  background: var(--card-bg);
+  padding: 1.5rem;
+  text-align: center;
+}
+
+.gallery-emoji {
+  font-size: 2.5rem;
+  display: block;
+  margin-bottom: 0.75rem;
+}
+
+.gallery-caption {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.facts-list,
+.references-list {
+  list-style: none;
+  margin-top: 1.5rem;
+}
+
+.facts-list li {
+  background: var(--card-bg);
+  border-left: 4px solid var(--green);
+  padding: 0.9rem 1.25rem;
+  margin-bottom: 0.75rem;
+  border-radius: 0.5rem;
+  color: var(--text-secondary);
+}
+
+.references-list li {
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.references-list a {
+  color: var(--gold);
+}
+
+.site-footer {
+  text-align: center;
+  padding: 2rem;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+}
+
+.site-footer a {
+  color: var(--saffron);
+  margin-left: 0.5rem;
+}
+
+@media (max-width: 700px) {
+  .timeline-interactive {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## What this PR does
- Adds a new, self-contained Matangini Hazra Explorer at `frontend/matangini-hazra-explorer/` with:
  - Biography section
  - Interactive timeline (click a year to view details)
  - Dedicated Quit India Movement deep-dive section
  - Legacy section (statues, postage stamp, Hazra Road)
  - Gallery of illustrative moments
  - References section
  - Light/dark theme toggle (matches existing explorer pages)
- Adds a Matangini Hazra entry to `FREEDOM_FIGHTERS_DATA` in `frontend/freedom-fighters-hub/script.js` so a card for her now appears on the Freedom Fighters of India Explorer landing page.
- Updates `showModal()` in `frontend/freedom-fighters-hub/script.js` to conditionally render a "Launch Dedicated Explorer" button when a fighter entry includes an `explorerUrl`, linking her card to the new dedicated page.

## Files changed
- `frontend/freedom-fighters-hub/script.js` (added one new data entry, added explorer-link support to the modal)

## Files added
- `frontend/matangini-hazra-explorer/index.html`
- `frontend/matangini-hazra-explorer/style.css`
- `frontend/matangini-hazra-explorer/script.js`

Closes #1885


@Eshajha19 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.