### PR TITLE
feat: add Sidhu Murmu explorer

### DIFF
--- a/frontend/freedom-fighters-hub/script.js
+++ b/frontend/freedom-fighters-hub/script.js
@@ -220,7 +220,7 @@ const FREEDOM_FIGHTERS_DATA = [
             { year: '1932', event: 'Signed Poona Pact securing reserved seats for depressed classes in legislatures.' },
             { year: '1947', event: 'Appointed India\'s first Law Minister and Chairman of Constitution Drafting Committee.' }
         ],
-contributions: 'Architect of the Constitution of India guaranteeing fundamental rights, gender equality, and affirmative action; founder of Reserve Bank of India conceptual blueprint.',
+        contributions: 'Architect of the Constitution of India guaranteeing fundamental rights, gender equality, and affirmative action; founder of Reserve Bank of India conceptual blueprint.',
         rareFacts: 'Doctorates from Columbia University and London School of Economics; possessed a personal library of over 50,000 books.',
         quote: 'Educate, Agitate, Organize.'
     },
@@ -244,7 +244,7 @@ contributions: 'Architect of the Constitution of India guaranteeing fundamental 
         quote: 'Vande Mataram.',
         explorerUrl: '../matangini-hazra-explorer/index.html'
     },
-        {
+    {
         id: 'rash-behari-bose',
         name: 'Rash Behari Bose',
         title: 'Founder of the INA',
@@ -345,8 +345,28 @@ contributions: 'Architect of the Constitution of India guaranteeing fundamental 
         rareFacts: 'Remembered largely through oral tradition and regional folklore rather than formal historical records, reflecting the underdocumented history of tribal resistance movements.',
         quote: 'The forests are ours, and so is our right to resist.',
         explorerLink: '../tantia-bhil-explorer/index.html'
-        },
-  {
+    },
+    {
+        id: 'sidhu-murmu',
+        name: 'Sidhu Murmu',
+        title: 'Leader of the Santhal Hul',
+        lifespan: 'c. 1815 – 1856',
+        era: 'Tribal Resistance',
+        region: 'East',
+        birthplace: 'Bhognadih, Santhal Pargana',
+        movements: ['Santhal Hul (1855–56)', 'Anti-Zamindar & Anti-Moneylender Resistance'],
+        biography: 'Sidhu Murmu, along with his brothers Kanhu, Chand, and Bhairav, led the Santhal Hul of 1855–56 — a major tribal uprising against British colonial revenue policy and exploitative moneylenders, predating the 1857 Rebellion.',
+        timeline: [
+            { year: 'June 30, 1855', event: 'Declared the Santhal Hul at a mass gathering in Bhognadih.' },
+            { year: '1855', event: 'Rebellion spread across the Rajmahal Hills region, drawing tens of thousands of Santhals.' },
+            { year: '1856', event: 'Captured and executed by British colonial forces after the rebellion was suppressed.' }
+        ],
+        contributions: 'Led one of the earliest large-scale organized tribal uprisings against British colonial rule, directly contributing to the later creation of the Santhal Pargana as a distinct administrative region.',
+        rareFacts: 'The Santhal Hul predated the 1857 Rebellion by roughly two years and involved tens of thousands of participants.',
+        quote: 'We will no longer bow to the mahajans and the Company\'s revenue.',
+        explorerLink: '../sidhu-murmu-explorer/index.html'
+    },
+    {
         id: 'begum-hazrat-mahal',
         name: 'Begum Hazrat Mahal',
         title: 'Maharani of Awadh',

--- a/frontend/sidhu-murmu-explorer/index.html
+++ b/frontend/sidhu-murmu-explorer/index.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <script>
+        (function () {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description"
+        content="Explore Sidhu Murmu's leadership in the Santhal Hul (1855–56), a major tribal uprising against British colonial rule and oppressive revenue systems in Central-Eastern India." />
+    <title>Sidhu Murmu Explorer | Incredible India</title>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+        href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+        rel="stylesheet" />
+
+    <link rel="stylesheet" href="../../styles.css" />
+    <link rel="stylesheet" href="sidhu.css" />
+</head>
+
+<body class="sm-main">
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html#home" class="nav-link">Home</a>
+                <a href="../freedom-fighters-hub/index.html" class="nav-link">Freedom Fighters</a>
+                <a href="index.html" class="nav-link active" style="color: var(--saffron)">Sidhu Murmu</a>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode"
+                    title="Toggle Light Mode">
+                    ☀️
+                </button>
+            </nav>
+        </div>
+    </header>
+
+    <main>
+        <section class="sm-hero">
+            <div class="section-container">
+                <div class="hero-badges-row">
+                    <span class="hero-pill pill-origin">📍 Bhognadih, Bengal Presidency</span>
+                    <span class="hero-pill pill-era">🏹 1855 – 1856</span>
+                    <span class="hero-pill pill-name">🌾 Leader of the Santhal Hul</span>
+                </div>
+                <h1>Sidhu Murmu <span>Leader of the Santhal Hul</span></h1>
+                <p class="hero-subtitle">
+                    Alongside his brothers, Sidhu Murmu led the Santhal Hul of 1855–56 — one of the earliest large-scale
+                    organized rebellions against British colonial rule and its oppressive revenue and moneylending
+                    systems.
+                </p>
+                <div id="stats-grid" class="stats-grid"></div>
+            </div>
+        </section>
+
+        <section class="sm-info-section">
+            <div class="section-container">
+                <h2>Biography</h2>
+                <div id="history-content" class="info-card"></div>
+
+                <h2 class="sec-title">Timeline</h2>
+                <div class="sm-timeline" id="sm-timeline"></div>
+
+                <h2 class="sec-title">The Santhal Rebellion (Hul)</h2>
+                <div class="sm-cards-grid" id="rebellion-grid"></div>
+
+                <h2 class="sec-title">Historical Significance</h2>
+                <div id="significance-content" class="info-card"></div>
+
+                <h2 class="sec-title">Gallery</h2>
+                <div class="sm-gallery" id="sm-gallery"></div>
+            </div>
+        </section>
+
+        <section class="references-section">
+            <div class="section-container">
+                <h2>References & Documentation</h2>
+                <ul class="references-list" id="references-list"></ul>
+            </div>
+        </section>
+    </main>
+
+    <script src="sidhu-data.js"></script>
+    <script src="sidhu.js"></script>
+    <script>
+        (function () {
+            const themeBtn = document.getElementById('theme-toggle');
+            if (!themeBtn) return;
+            const applyIcon = (isLight) => {
+                themeBtn.textContent = isLight ? '🌙' : '☀️';
+                themeBtn.setAttribute('title', isLight ? 'Toggle Dark Mode' : 'Toggle Light Mode');
+            };
+            applyIcon(document.body.classList.contains('light-theme'));
+            themeBtn.addEventListener('click', () => {
+                document.body.classList.toggle('light-theme');
+                const isLight = document.body.classList.contains('light-theme');
+                localStorage.setItem('theme', isLight ? 'light' : 'dark');
+                applyIcon(isLight);
+            });
+        })();
+    </script>
+</body>
+
+</html>

--- a/frontend/sidhu-murmu-explorer/sidhu-data.js
+++ b/frontend/sidhu-murmu-explorer/sidhu-data.js
@@ -1,0 +1,63 @@
+/**
+ * Sidhu Murmu Explorer — Data Module
+ */
+
+const SIDHU_INFO = {
+    id: "sidhu-murmu",
+    title: "Sidhu Murmu",
+    quickStats: [
+        { label: "Born", value: "c. 1815, Bhognadih", icon: "📍" },
+        { label: "Died", value: "1856 (executed)", icon: "🕊️" },
+        { label: "Community", value: "Santhal", icon: "🌾" },
+        { label: "Rebellion", value: "Santhal Hul, 1855–56", icon: "🏹" },
+        { label: "Co-Led With", value: "Kanhu, Chand & Bhairav Murmu", icon: "👥" },
+        { label: "Region", value: "Rajmahal Hills, Bengal Presidency", icon: "🗺️" }
+    ]
+};
+
+const HISTORY_TEXT = {
+    title: "From Bhognadih Village to Leading a Rebellion",
+    paragraphs: [
+        "Sidhu Murmu was born around 1815 in the village of Bhognadih, in the Santhal Pargana region of the Bengal Presidency (in present-day Jharkhand). He belonged to the Santhal community, an indigenous tribal group of Central-Eastern India.",
+        "By the mid-19th century, Santhal communities faced severe exploitation under British colonial land revenue policies, along with abuses from moneylenders (mahajans) and local zamindars, who used debt bondage and land seizures to dispossess Santhal farmers of their land.",
+        "In 1855, Sidhu Murmu, along with his brothers Kanhu, Chand, and Bhairav Murmu, called for open rebellion against these oppressive systems, declaring the Santhal Hul (meaning 'revolution' or 'uprising' in the Santhali language). Tens of thousands of Santhals reportedly rose in response, targeting oppressive revenue collectors and moneylenders.",
+        "The rebellion was met with a large British military response, and by 1856 it had been suppressed. Sidhu Murmu was captured and executed. Despite its suppression, the Santhal Hul is regarded as a significant and early large-scale organized tribal uprising against British colonial rule, and it directly influenced later colonial administrative reforms in the region."
+    ]
+};
+
+const TIMELINE_EVENTS = [
+    { era: "c. 1815", title: "Born in Bhognadih", description: "Sidhu Murmu was born into the Santhal community in the village of Bhognadih." },
+    { era: "Early-mid 1850s", title: "Growing Unrest", description: "Santhal communities faced escalating exploitation from colonial revenue policy, moneylenders, and zamindars." },
+    { era: "June 30, 1855", title: "Declaration of the Hul", description: "Sidhu, alongside brothers Kanhu, Chand, and Bhairav Murmu, called a large gathering at Bhognadih and declared open rebellion." },
+    { era: "July–August 1855", title: "Rebellion Spreads", description: "Tens of thousands of Santhals rose against oppressive revenue collectors, moneylenders, and colonial administration across the region." },
+    { era: "Late 1855", title: "British Military Response", description: "Colonial authorities deployed significant military force to suppress the rebellion." },
+    { era: "1856", title: "Capture and Execution", description: "Sidhu Murmu was captured and executed by British authorities, effectively ending the uprising's leadership." },
+    { era: "1855–56 Legacy", title: "Administrative Reforms", description: "The scale of the rebellion contributed to later British administrative changes, including the creation of the Santhal Pargana as a distinct administrative unit." }
+];
+
+const REBELLION_POINTS = [
+    { title: "Causes: Land & Debt Exploitation", description: "Oppressive land revenue demands and predatory lending practices by moneylenders (mahajans) had left many Santhal families dispossessed and indebted." },
+    { title: "The Declaration at Bhognadih", description: "On June 30, 1855, a massive gathering at Bhognadih marked the formal declaration of rebellion, led by Sidhu and his brothers." },
+    { title: "Scale of the Uprising", description: "The rebellion drew participation from tens of thousands of Santhals across a wide area of the Rajmahal Hills region." },
+    { title: "Colonial Suppression", description: "The British colonial government responded with substantial military force, ultimately suppressing the rebellion by early 1856." }
+];
+
+const SIGNIFICANCE_TEXT = {
+    paragraphs: [
+        "The Santhal Hul is historically significant as one of the earliest large-scale, organized tribal uprisings against British colonial rule in India, predating the 1857 Rebellion by roughly two years. It demonstrated the capacity for coordinated resistance among indigenous communities facing colonial economic exploitation.",
+        "In its aftermath, British authorities created the Santhal Pargana as a distinct administrative division with modified revenue regulations, an acknowledgment of the specific grievances that had driven the uprising. Sidhu Murmu and his brothers are remembered today as important early figures in India's long history of resistance to colonial rule, and their legacy remains especially significant to Santhal and other tribal communities."
+    ]
+};
+
+const GALLERY_QUERIES = [
+    "Santhal Pargana Jharkhand landscape",
+    "Santhal tribal community India",
+    "Rajmahal Hills region India"
+];
+
+const REFERENCES = [
+    { text: "Government of Jharkhand — Santhal Hul historical commemoration records.", link: "#" },
+    { text: "Guha, R. — 'Elementary Aspects of Peasant Insurgency in Colonial India.'", link: "#" },
+    { text: "Datta, K. K. — historical accounts of the Santhal Rebellion of 1855.", link: "#" },
+    { text: "Anthropological Survey of India — studies on Santhal community history.", link: "#" }
+];

--- a/frontend/sidhu-murmu-explorer/sidhu.css
+++ b/frontend/sidhu-murmu-explorer/sidhu.css
@@ -1,0 +1,216 @@
+.sm-hero {
+    padding: 6rem 1.5rem 3rem;
+    text-align: center;
+}
+
+.hero-badges-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.25rem;
+}
+
+.hero-pill {
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 999px;
+    padding: 0.4rem 0.9rem;
+    font-size: 0.85rem;
+}
+
+.sm-hero h1 span {
+    color: var(--saffron, #ff9933);
+    display: block;
+    font-size: 0.5em;
+    font-weight: 500;
+}
+
+.hero-subtitle {
+    max-width: 660px;
+    margin: 1rem auto 2rem;
+    opacity: 0.85;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1rem;
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.stat-pill {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 14px;
+    padding: 1rem;
+    text-align: center;
+}
+
+.stat-icon {
+    display: block;
+    font-size: 1.4rem;
+    margin-bottom: 0.4rem;
+}
+
+.stat-value {
+    display: block;
+    font-weight: 600;
+}
+
+.stat-label {
+    display: block;
+    font-size: 0.75rem;
+    opacity: 0.65;
+}
+
+.sm-info-section {
+    padding: 2rem 1.5rem 4rem;
+}
+
+.sec-title {
+    margin-top: 3rem;
+}
+
+.info-card,
+.sm-card {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 16px;
+    padding: 1.5rem;
+}
+
+.info-card p {
+    margin: 0 0 1rem;
+    line-height: 1.6;
+}
+
+.info-card p:last-child {
+    margin-bottom: 0;
+}
+
+.sm-cards-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.sm-card h4 {
+    margin: 0 0 0.5rem;
+    color: var(--saffron, #ff9933);
+}
+
+.sm-card p {
+    margin: 0;
+    opacity: 0.85;
+    line-height: 1.5;
+}
+
+/* ---- Timeline ---- */
+.sm-timeline {
+    position: relative;
+    padding-left: 2rem;
+    border-left: 2px solid rgba(255, 176, 31, 0.25);
+}
+
+.timeline-item {
+    position: relative;
+    padding-bottom: 2rem;
+}
+
+.timeline-item:last-child {
+    padding-bottom: 0;
+}
+
+.timeline-dot {
+    position: absolute;
+    left: -2.45rem;
+    top: 0.3rem;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--saffron, #ff9933);
+    box-shadow: 0 0 0 4px rgba(255, 153, 51, 0.15);
+}
+
+.timeline-era {
+    display: inline-block;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--saffron, #ff9933);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 0.35rem;
+}
+
+.timeline-content h4 {
+    margin: 0 0 0.4rem;
+}
+
+.timeline-content p {
+    margin: 0;
+    opacity: 0.85;
+    line-height: 1.55;
+}
+
+/* ---- Gallery ---- */
+.sm-gallery {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.sm-gallery-tile {
+    aspect-ratio: 4 / 3;
+    border-radius: 14px;
+    background: linear-gradient(135deg, rgba(255, 153, 51, 0.15), rgba(255, 255, 255, 0.03));
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    display: flex;
+    align-items: flex-end;
+    padding: 1rem;
+    font-size: 0.8rem;
+    opacity: 0.75;
+}
+
+.references-section {
+    padding: 2rem 1.5rem 4rem;
+}
+
+.references-list {
+    list-style: none;
+    padding: 0;
+}
+
+.references-list li {
+    padding: 0.5rem 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.references-list a {
+    color: inherit;
+    opacity: 0.8;
+    text-decoration: none;
+}
+
+.references-list a:hover {
+    opacity: 1;
+    text-decoration: underline;
+}
+
+body.light-theme .info-card,
+body.light-theme .sm-card,
+body.light-theme .stat-pill {
+    background: rgba(0, 0, 0, 0.03);
+    border-color: rgba(0, 0, 0, 0.1);
+}
+
+/* The global .section-container (frontend/styles/extras.css) adds
+   100px top/bottom padding by default, which stacks with this page's
+   own section padding and creates large empty gaps. Override it here. */
+body.sm-main .section-container {
+    padding: 0;
+    max-width: 1100px;
+    width: 100%;
+    margin: 0 auto;
+}

--- a/frontend/sidhu-murmu-explorer/sidhu.js
+++ b/frontend/sidhu-murmu-explorer/sidhu.js
@@ -1,0 +1,66 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const statsGrid = document.getElementById('stats-grid');
+    if (statsGrid) {
+        statsGrid.innerHTML = SIDHU_INFO.quickStats
+            .map(s => `
+                <div class="stat-pill">
+                    <span class="stat-icon">${s.icon}</span>
+                    <span class="stat-value">${s.value}</span>
+                    <span class="stat-label">${s.label}</span>
+                </div>
+            `).join('');
+    }
+
+    const historyContent = document.getElementById('history-content');
+    if (historyContent) {
+        historyContent.innerHTML = `
+            <h3>${HISTORY_TEXT.title}</h3>
+            ${HISTORY_TEXT.paragraphs.map(p => `<p>${p}</p>`).join('')}
+        `;
+    }
+
+    const timelineEl = document.getElementById('sm-timeline');
+    if (timelineEl) {
+        timelineEl.innerHTML = TIMELINE_EVENTS
+            .map(ev => `
+                <div class="timeline-item">
+                    <div class="timeline-dot"></div>
+                    <div class="timeline-content">
+                        <span class="timeline-era">${ev.era}</span>
+                        <h4>${ev.title}</h4>
+                        <p>${ev.description}</p>
+                    </div>
+                </div>
+            `).join('');
+    }
+
+    const rebellionGrid = document.getElementById('rebellion-grid');
+    if (rebellionGrid) {
+        rebellionGrid.innerHTML = REBELLION_POINTS
+            .map(r => `
+                <div class="sm-card">
+                    <h4>${r.title}</h4>
+                    <p>${r.description}</p>
+                </div>
+            `).join('');
+    }
+
+    const significanceContent = document.getElementById('significance-content');
+    if (significanceContent) {
+        significanceContent.innerHTML = SIGNIFICANCE_TEXT.paragraphs.map(p => `<p>${p}</p>`).join('');
+    }
+
+    const galleryEl = document.getElementById('sm-gallery');
+    if (galleryEl) {
+        galleryEl.innerHTML = GALLERY_QUERIES
+            .map(q => `<div class="sm-gallery-tile"><span>${q}</span></div>`)
+            .join('');
+    }
+
+    const referencesList = document.getElementById('references-list');
+    if (referencesList) {
+        referencesList.innerHTML = REFERENCES
+            .map(r => `<li><a href="${r.link}" target="_blank" rel="noopener">${r.text}</a></li>`)
+            .join('');
+    }
+});


### PR DESCRIPTION
## Description

Adds a dedicated interactive explorer for Sidhu Murmu, focusing on his leadership during the Santhal Hul (1855–56) against British colonial rule and oppressive revenue systems.

### Included
- Biography
- Historical timeline
- Santhal Rebellion
- Historical significance
- Gallery
- References
- Sidhu Murmu card added to the Freedom Fighters of India Explorer

Fixes #1897 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Tested locally in browser
- [x] Tested in both dark and light themes
- [x] Tested at mobile viewport widths
- [x] Verified no console errors

## Checklist

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)

## Screenshots
<img width="1053" height="827" alt="Screenshot 2026-08-09 154732" src="https://github.com/user-attachments/assets/c6e395dc-6220-4a6b-b649-9bb36de9fbe8" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Sidhu Murmu to the freedom fighters collection with biography, contributions, timeline, rare facts, and a quote.
  - Added a dedicated Sidhu Murmu Explorer page featuring historical details, rebellion milestones, significance, gallery content, and references.
  - Added responsive layouts and light/dark theme support with saved theme preferences.
- **Bug Fixes**
  - Corrected formatting issues in existing freedom fighter information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->