### PR TITLE
feat/added chaturanga explorer

### DIFF
--- a/frontend/Chaturanga/chaturanga-data.js
+++ b/frontend/Chaturanga/chaturanga-data.js
@@ -1,0 +1,161 @@
+/**
+ * Chaturanga Explorer Dataset
+ * The Ancient Indian Game That Became Chess
+ */
+
+export const CHATURANGA_DATA = {
+    id: 'chaturanga-explorer',
+    name: 'Chaturanga Explorer',
+    subtitle: 'The Four Divisions of an Ancient Army, Reborn as a Board Game',
+    origin: 'Gupta Empire, India',
+    firstRecorded: 'c. 6th–7th Century CE',
+    etymology: 'Sanskrit "chatur" (four) + "anga" (limbs/divisions)',
+
+    stats: [
+        { label: 'First Recorded', value: 'c. 6th Century CE', icon: '📜' },
+        { label: 'Board Size', value: '8 × 8 Squares', icon: '♟️' },
+        { label: 'Pieces per Player', value: '16', icon: '👑' },
+        { label: 'Knight\'s Move Unchanged For', value: '~1,500 Years', icon: '♞' }
+    ],
+
+    history: {
+        title: 'A Battlefield Shrunk to a Board',
+        content: 'Chaturanga takes its name from Sanskrit "chatur" (four) and "anga" (limbs, or divisions), referring to the four divisions of a classical Indian army: infantry, cavalry, elephants, and chariots. Most historians place its emergence in the Gupta Empire, around the 6th century CE, though the game\'s exact date and inventor remain debated among scholars. The earliest unambiguous literary mention appears in the Harshacharita, a 7th-century biography of Emperor Harsha written by the court poet Banabhatta, where Chaturanga is listed among the pastimes of Indian aristocracy. Some scholars point to even earlier evidence: excavations at Lothal, a port city of the Indus Valley Civilisation in Gujarat, uncovered game pieces resembling chessmen dating to roughly 2450 BCE, though whether these belonged to Chaturanga itself or an unrelated predecessor game is still an open question. Unlike a checkered chessboard, early Chaturanga was played on a plain, uncheckered 8×8 grid called an ashtapada, a board shape likely borrowed from an older race game.'
+    },
+
+    timeline: [
+        { year: 'c. 2450 BCE', title: 'Possible Earliest Evidence', desc: 'Game pieces resembling chessmen discovered at Lothal, an Indus Valley Civilisation port city in Gujarat — their exact link to Chaturanga remains debated.' },
+        { year: 'c. 6th Century CE', title: 'Chaturanga Emerges', desc: 'Most historians date the game\'s development to the Gupta Empire, played on an uncheckered 8×8 ashtapada board.' },
+        { year: '7th Century CE', title: 'First Clear Literary Record', desc: 'The Harshacharita, Banabhatta\'s biography of Emperor Harsha, lists Chaturanga among courtly pastimes of the Indian aristocracy.' },
+        { year: 'c. 7th Century CE', title: 'Spreads to Persia as Chatrang', desc: 'Chaturanga reaches Persia and becomes "Chatrang" (later "Shatranj"), beginning its journey west along trade routes.', image: 'https://commons.wikimedia.org/wiki/Special:FilePath/Persianmss14thCambassadorfromIndiabroughtchesstoPersianCourt.jpg', imageCaption: 'A Persian manuscript illustration of an Indian ambassador introducing chess to the Persian court.' },
+        { year: 'c. 760 CE', title: 'Oldest Surviving Pieces', desc: 'Ivory chess pieces in Indian artistic style are buried at Afrasiab, near Samarkand — among the oldest chess pieces ever found, supporting the theory of Indian origin and eastward transmission.' },
+        { year: '12th Century CE', title: 'Manasollasa Describes the Game', desc: 'The Chalukya king Someshvara III\'s encyclopedic text Manasollasa provides some of the most detailed surviving descriptions of the game\'s rules in India.' },
+        { year: '15th Century CE', title: 'The Queen and Bishop Transform', desc: 'In Europe, the weak vizier piece becomes the far more powerful Queen, and the pawn gains its two-square opening move, bringing the game close to its modern form.' },
+        { year: '1497 CE', title: 'First Chess Manual Published', desc: 'Luis Ramírez de Lucena\'s "Repetición de Amores y Arte de Ajedrez" becomes one of the earliest published books systematically teaching chess strategy.' }
+    ],
+
+    ancientVsModern: {
+        title: 'What Changed, and What Never Did',
+        rows: [
+            { aspect: 'Board', ancient: 'Plain, uncheckered 8×8 grid (ashtapada)', modern: 'Checkered 8×8 board with alternating light and dark squares' },
+            { aspect: 'Players', ancient: 'Some early variants were four-player; the two-player form became standard', modern: 'Always two players' },
+            { aspect: 'Minister / Queen', ancient: 'Mantri moved only one square diagonally — one of the weakest pieces', modern: 'Queen moves any distance in any direction — the most powerful piece' },
+            { aspect: 'Elephant / Bishop', ancient: 'Gaja jumped exactly two squares diagonally', modern: 'Bishop moves any distance diagonally' },
+            { aspect: 'Pawn', ancient: 'Padati moved one square at a time, no opening double-step', modern: 'Pawn may move two squares on its first move' },
+            { aspect: 'King', ancient: 'Raja moved one square in any direction', modern: 'King moves one square in any direction — unchanged' },
+            { aspect: 'Knight', ancient: 'Ashva moved in an L-shape, jumping over other pieces', modern: 'Knight moves identically — unchanged for roughly 1,500 years' },
+            { aspect: 'Objective', ancient: 'Capture or immobilise the opposing Raja', modern: 'Checkmate the opposing King' }
+        ]
+    },
+
+    pieceEvolution: [
+        {
+            id: 'raja',
+            ancientName: 'Raja',
+            sanskrit: 'राजा — "King"',
+            modernName: 'King',
+            symbol: '♔',
+            movement: 'One square in any direction',
+            description: 'The Raja represented the commanding monarch of the army. Its movement — one square in any direction, always avoiding capture — has stayed completely unchanged from Chaturanga through to the modern King.'
+        },
+        {
+            id: 'mantri',
+            ancientName: 'Mantri',
+            sanskrit: 'मंत्री — "Minister"',
+            modernName: 'Queen',
+            symbol: '♕',
+            movement: 'Ancient: one square diagonally only. Modern: any distance, any direction.',
+            description: 'The Mantri was originally one of the weakest pieces on the board, advising the king but barely able to move. Its transformation into the all-powerful Queen during the game\'s spread through Europe is the single biggest rule change in chess history.'
+        },
+        {
+            id: 'gaja',
+            ancientName: 'Gaja',
+            sanskrit: 'गज — "Elephant"',
+            modernName: 'Bishop',
+            symbol: '♗',
+            movement: 'Ancient: exactly two squares diagonally, jumping the square between. Modern: any distance diagonally.',
+            description: 'War elephants were central to classical Indian armies, and the Gaja\'s design often featured a howdah, the carriage mounted on an elephant\'s back. As the game moved through Persia and Europe, the diagonal-jumping elephant was reimagined as the long-range Bishop.'
+        },
+        {
+            id: 'ashva',
+            ancientName: 'Ashva',
+            sanskrit: 'अश्व — "Horse"',
+            modernName: 'Knight',
+            symbol: '♘',
+            movement: 'L-shaped jump: two squares in one direction, then one square perpendicular',
+            description: 'The Ashva represented cavalry, and its distinctive L-shaped leap is often cited as the most elegant surviving piece of the original Indian design — a movement pattern that has not changed in roughly 1,500 years.'
+        },
+        {
+            id: 'ratha',
+            ancientName: 'Ratha',
+            sanskrit: 'रथ — "Chariot"',
+            modernName: 'Rook',
+            symbol: '♖',
+            movement: 'Any distance in a straight line, horizontally or vertically',
+            description: 'War chariots gave the Ratha its long, straight-line power on the board. The word "rook" itself is believed to descend from the Persian "rukh," which in turn traces back to this original chariot piece.'
+        },
+        {
+            id: 'padati',
+            ancientName: 'Padati',
+            sanskrit: 'पदाति — "Foot Soldier"',
+            modernName: 'Pawn',
+            symbol: '♙',
+            movement: 'Ancient: one square forward only. Modern: one square forward, or two on its first move.',
+            description: 'Eight Padati represented the common infantry, moving slowly across the board and, upon reaching the far side, promoting to more powerful pieces — a rule that survives in modern chess pawn promotion.'
+        }
+    ],
+
+    heroImage: {
+        url: 'https://commons.wikimedia.org/wiki/Special:FilePath/Chaturanga_Chess_Set.jpg',
+        caption: 'An antique Indian chess set carved from sandalwood, in the Chaturanga tradition.'
+    },
+
+    historyImage: {
+        url: 'https://commons.wikimedia.org/wiki/Special:FilePath/Radha-Krishna_chess.jpg',
+        caption: 'A traditional Indian painting depicting Radha and Krishna playing Chaturanga.'
+    },
+
+    gallery: [
+        { title: 'Chaturaji: The Four-Player Variant', url: 'https://commons.wikimedia.org/wiki/Special:FilePath/Chaturaji_Chess_Arrangement.jpg', caption: 'An antique Mughal Indian chess set arranged for Chaturaji, the four-player form of Chaturanga.' },
+        { title: 'Ornate Ivory Chess Piece, Punjab Hills', url: 'https://commons.wikimedia.org/wiki/Special:FilePath/Chess%20piece%2C%20Punjab%20Hills%2C%20India%2C%20late%201770s%20to%20early%201800s%20AD%2C%20ivory%2C%20gilt%20and%20polychrome%20-%20Dallas%20Museum%20of%20Art%20-%20DSC04965.jpg', caption: 'A gilt and polychrome ivory chess piece from the Punjab Hills, India, late 1770s–early 1800s AD.' },
+        { title: 'Jeu d\'Échecs Indien (1876)', url: 'https://commons.wikimedia.org/wiki/Special:FilePath/Picou,_Henri_Pierre_-_Jeu_d%27Echecs_Indien_-_1876.jpg', caption: 'A 19th-century European painting, "The Indian Chess Game," by Henri Pierre Picou, reflecting the game\'s enduring association with India.' },
+        { title: 'Manuscript: Chess Reaches the Persian Court', url: 'https://commons.wikimedia.org/wiki/Special:FilePath/Persianmss14thCambassadorfromIndiabroughtchesstoPersianCourt.jpg', caption: 'A 14th-century Persian manuscript illustration depicting an ambassador from India bringing chess to the Persian court.' }
+    ],
+
+    modernInfluence: {
+        title: 'One Ancestor, Many Descendants',
+        content: 'Chaturanga did not just become Western chess. As it travelled along trade and pilgrimage routes, it split into a whole family of related games: Shatranj in Persia and the Arab world, Xiangqi in China, Janggi in Korea, and Shogi in Japan, each adapting the original four-division army concept to local culture and strategy. Chess.com and other modern platforms still trace the lineage explicitly back to Chaturanga in their own histories of the game, and the recognisable shapes of the rook, knight, and bishop remain a direct, physical link to India\'s ancient infantry, cavalry, elephant corps, and chariot divisions, preserved in a hobby played by hundreds of millions of people today.'
+    },
+
+    references: [
+        { title: 'Chaturanga Game', source: 'World Chess', url: 'https://worldchess.com/chess-terms/chaturanga-game' },
+        { title: 'The History and Evolution of Chess: From Chaturanga to the Digital Age', source: 'Chess.com', url: 'https://www.chess.com/blog/77CyrusTheGreat77/the-history-and-evolution-of-chess-from-chaturanga-to-the-digital-age-introduction' },
+        { title: 'How a 7th-Century War Game Transformed Into a Symbol of Intelligence', source: 'TheCollector', url: 'https://www.thecollector.com/history-of-chess-war-game-intelligence/' },
+        { title: 'The Complete History of Chess: From Chaturanga to Modern Masters', source: 'Ancient Games', url: 'https://ancientgames.org/chess-from-chaturanga-to-grandmasters/' },
+        { title: 'Chess in India', source: 'Wikipedia', url: 'https://en.wikipedia.org/wiki/Chess_in_India' }
+    ],
+
+    facts: [
+        'The knight\'s L-shaped move has stayed exactly the same for roughly 1,500 years, from Chaturanga to modern chess.',
+        'The original Mantri (Minister) could move only one square diagonally — it became the all-powerful Queen only centuries later, in Europe.',
+        'Some of the oldest surviving chess pieces, dated to around 760 CE, were found not in India but at Afrasiab near Samarkand, carved in Indian artistic style.',
+        'Chaturanga is considered the common ancestor not just of Western chess, but of Chinese Xiangqi, Japanese Shogi, and Korean Janggi.'
+    ],
+
+    /**
+     * Simplified back-rank order used for the interactive board.
+     * Historically, minister/king placement varied by side and by regional
+     * variant — this layout mirrors the standard modern chess back rank so
+     * ancient and modern positions can be compared square-for-square.
+     */
+    boardBackRank: ['ratha', 'ashva', 'gaja', 'mantri', 'raja', 'gaja', 'ashva', 'ratha'],
+    modernBackRank: ['rook', 'knight', 'bishop', 'queen', 'king', 'bishop', 'knight', 'rook'],
+    modernPieceMap: {
+        ratha: { name: 'Rook', symbol: '♖' },
+        ashva: { name: 'Knight', symbol: '♘' },
+        gaja: { name: 'Bishop', symbol: '♗' },
+        mantri: { name: 'Queen', symbol: '♕' },
+        raja: { name: 'King', symbol: '♔' },
+        padati: { name: 'Pawn', symbol: '♙' }
+    }
+};

--- a/frontend/Chaturanga/index.html
+++ b/frontend/Chaturanga/index.html
@@ -1,0 +1,270 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    document.body.classList.add('light-theme');
+                }
+            })();
+        </script>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Explore Chaturanga, the ancient Indian game that evolved into modern chess — its history, timeline, ancient vs modern comparison, piece evolution, and an interactive board."
+        />
+        <title>Chaturanga Explorer | Incredible India</title>
+
+        <!-- Google Fonts -->
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+            rel="stylesheet"
+        />
+
+        <!-- Stylesheets -->
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="style.css" />
+
+        <!-- Open Graph -->
+        <meta property="og:title" content="Chaturanga Explorer | Incredible India" />
+        <meta
+            property="og:description"
+            content="Interactive showcase of Chaturanga — historical overview, timeline, ancient vs modern chess comparison, piece evolution, an interactive board, and references."
+        />
+        <meta property="og:type" content="website" />
+    </head>
+
+    <body class="chaturanga-main">
+        <!-- Site Navbar -->
+        <header class="navbar scrolled" id="navbar">
+            <div class="nav-container">
+                <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </button>
+                <nav class="nav-menu" id="nav-menu">
+                    <a href="../../index.html#home" class="nav-link">Home</a>
+                    <a href="../traditional-games/index.html" class="nav-link">Traditional Games</a>
+                    <a href="index.html" class="nav-link active" style="color: var(--saffron)">Chaturanga</a>
+                    <button
+                        id="theme-toggle"
+                        class="btn-theme-toggle"
+                        aria-label="Toggle Dark/Light Mode"
+                        title="Toggle Light Mode"
+                    >
+                        ☀️
+                    </button>
+                </nav>
+            </div>
+        </header>
+
+        <main>
+            <!-- Hero Section -->
+            <section class="chaturanga-hero">
+                <div class="section-container">
+                    <div class="hero-badges-row">
+                        <span class="hero-pill pill-origin">📜 Gupta Empire, c. 6th Century CE</span>
+                        <span class="hero-pill pill-board">♟️ 8×8 Ashtapada Board</span>
+                        <span class="hero-pill pill-legacy">♞ Ancestor of Modern Chess</span>
+                    </div>
+                    <h1>Chaturanga <span>Explorer</span></h1>
+                    <p class="hero-subtitle">
+                        Discover the ancient Indian war-game of four divisions — infantry, cavalry, elephants, and
+                        chariots — that travelled the world's trade routes and, over a thousand years, became the
+                        game of chess we know today.
+                    </p>
+
+                    <!-- Quick Stats Bar -->
+                    <div id="stats-grid" class="stats-grid">
+                        <!-- Populated dynamically -->
+                    </div>
+
+                    <!-- Hero Image -->
+                    <figure class="hero-image-wrap" id="hero-image-wrap">
+                        <!-- Populated dynamically -->
+                    </figure>
+                </div>
+            </section>
+
+            <!-- History Section -->
+            <section class="history-section" id="history">
+                <div class="section-container">
+                    <div class="history-layout">
+                        <div class="info-card">
+                            <span class="section-tag">FOUR DIVISIONS OF AN ARMY</span>
+                            <h2 id="history-title"></h2>
+                            <p id="history-content"></p>
+                        </div>
+                        <figure class="history-image-wrap" id="history-image-wrap">
+                            <!-- Populated dynamically -->
+                        </figure>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Timeline Section -->
+            <section class="timeline-section" id="timeline">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-tag">FROM LOTHAL TO THE FIRST CHESS BOOK</span>
+                        <h2>Timeline</h2>
+                        <p>How a South Asian war game became a global sport of the mind.</p>
+                    </div>
+                    <div class="timeline-list" id="timeline-list">
+                        <!-- Populated dynamically -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Ancient vs Modern Comparison Section -->
+            <section class="compare-section" id="ancient-vs-modern">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-tag">WHAT CHANGED, WHAT DIDN'T</span>
+                        <h2 id="compare-title"></h2>
+                    </div>
+                    <div class="compare-table-wrap">
+                        <table class="compare-table" id="compare-table">
+                            <thead>
+                                <tr>
+                                    <th>Aspect</th>
+                                    <th>Chaturanga</th>
+                                    <th>Modern Chess</th>
+                                </tr>
+                            </thead>
+                            <tbody id="compare-tbody">
+                                <!-- Populated dynamically -->
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Piece Evolution Section -->
+            <section class="pieces-section" id="piece-evolution">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-tag">SIX PIECES, ONE LINEAGE</span>
+                        <h2>Piece Evolution</h2>
+                        <p>Every modern chess piece traces back to a rank in a classical Indian army.</p>
+                    </div>
+                    <div class="pieces-grid" id="pieces-grid">
+                        <!-- Populated dynamically -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Interactive Board Section -->
+            <section class="board-section" id="interactive-board">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-tag">TRY IT YOURSELF</span>
+                        <h2>Interactive Board Visualization</h2>
+                        <p>Toggle between the ancient and modern back rank, then click any piece to learn how it moves.</p>
+                    </div>
+
+                    <div class="board-toggle-row">
+                        <button class="board-toggle-btn active" id="toggle-ancient" data-mode="ancient">
+                            Chaturanga (Ancient)
+                        </button>
+                        <button class="board-toggle-btn" id="toggle-modern" data-mode="modern">
+                            Modern Chess
+                        </button>
+                    </div>
+
+                    <div class="board-layout">
+                        <div class="chess-board" id="chess-board" role="grid" aria-label="Interactive chess board">
+                            <!-- Populated dynamically -->
+                        </div>
+                        <div class="board-detail" id="board-detail">
+                            <p class="board-detail-hint">Click a piece on the board to see its details here.</p>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Modern Influence Section -->
+            <section class="influence-section" id="modern-influence">
+                <div class="section-container">
+                    <div class="info-card highlight-card">
+                        <span class="section-tag">ONE ANCESTOR, MANY GAMES</span>
+                        <h2 id="influence-title"></h2>
+                        <p id="influence-content"></p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Photo Gallery Section -->
+            <section class="gallery-section" id="gallery">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-tag">MEDIA SHOTS</span>
+                        <h2>Image Gallery</h2>
+                        <p>Antique sets, paintings, and manuscripts tracing Chaturanga's journey.</p>
+                    </div>
+                    <div class="gallery-grid" id="gallery-grid">
+                        <!-- Populated dynamically -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- References Section -->
+            <section class="references-section" id="references">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-tag">FURTHER READING</span>
+                        <h2>References</h2>
+                    </div>
+                    <div class="references-list" id="references-list">
+                        <!-- Populated dynamically -->
+                    </div>
+                </div>
+            </section>
+
+            <!-- Interesting Facts Section -->
+            <section class="facts-section" id="facts">
+                <div class="section-container">
+                    <div class="section-header">
+                        <span class="section-tag">TRIVIA</span>
+                        <h2>Interesting Facts</h2>
+                    </div>
+                    <div class="facts-grid" id="facts-grid">
+                        <!-- Populated dynamically -->
+                    </div>
+                </div>
+            </section>
+        </main>
+
+        <!-- Footer -->
+        <footer class="footer">
+            <div class="section-container">
+                <div class="footer-content">
+                    <div class="footer-logo">
+                        <h3>Incredible India Explorer</h3>
+                        <p>Celebrating India's scientific, cultural, and strategic heritage.</p>
+                    </div>
+                    <div class="footer-links">
+                        <a href="../../index.html#home">Home</a>
+                        <a href="../traditional-games/index.html">Traditional Games</a>
+                    </div>
+                </div>
+                <div class="footer-bottom">
+                    <p>&copy; 2026 Incredible India Explorer. Open Source Educational Platform.</p>
+                </div>
+            </div>
+        </footer>
+
+        <!-- Scripts -->
+        <script type="module" src="script.js"></script>
+    </body>
+</html>

--- a/frontend/Chaturanga/script.js
+++ b/frontend/Chaturanga/script.js
@@ -1,0 +1,296 @@
+import { CHATURANGA_DATA } from './chaturanga-data.js';
+
+let currentMode = 'ancient';
+
+document.addEventListener('DOMContentLoaded', () => {
+    initTheme();
+    initNavbar();
+    renderStats();
+    renderHeroImage();
+    renderHistory();
+    renderTimeline();
+    renderComparisonTable();
+    renderPieceEvolution();
+    initBoardToggle();
+    renderBoard(currentMode);
+    renderModernInfluence();
+    renderGallery();
+    renderReferences();
+    renderFacts();
+});
+
+function initTheme() {
+    const themeToggleBtn = document.getElementById('theme-toggle');
+    if (!themeToggleBtn) return;
+
+    themeToggleBtn.addEventListener('click', () => {
+        document.body.classList.toggle('light-theme');
+        const isLight = document.body.classList.contains('light-theme');
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        themeToggleBtn.textContent = isLight ? '🌙' : '☀️';
+    });
+}
+
+function initNavbar() {
+    const menuToggle = document.getElementById('menu-toggle');
+    const navMenu = document.getElementById('nav-menu');
+    if (!menuToggle || !navMenu) return;
+
+    menuToggle.addEventListener('click', () => {
+        const isExpanded = menuToggle.getAttribute('aria-expanded') === 'true';
+        menuToggle.setAttribute('aria-expanded', !isExpanded);
+        navMenu.classList.toggle('active');
+    });
+}
+
+function renderStats() {
+    const container = document.getElementById('stats-grid');
+    if (!container || !CHATURANGA_DATA.stats) return;
+
+    container.innerHTML = CHATURANGA_DATA.stats
+        .map(
+            (stat) => `
+        <div class="stat-card">
+            <span class="stat-icon">${stat.icon}</span>
+            <div class="stat-value">${stat.value}</div>
+            <div class="stat-label">${stat.label}</div>
+        </div>
+    `
+        )
+        .join('');
+}
+
+function renderHeroImage() {
+    const wrap = document.getElementById('hero-image-wrap');
+    if (!wrap || !CHATURANGA_DATA.heroImage) return;
+
+    wrap.innerHTML = `
+        <img src="${CHATURANGA_DATA.heroImage.url}" alt="${CHATURANGA_DATA.heroImage.caption}" loading="lazy" />
+        <figcaption>${CHATURANGA_DATA.heroImage.caption}</figcaption>
+    `;
+}
+
+function renderHistory() {
+    const title = document.getElementById('history-title');
+    const content = document.getElementById('history-content');
+    const imageWrap = document.getElementById('history-image-wrap');
+
+    if (title) title.textContent = CHATURANGA_DATA.history.title;
+    if (content) content.textContent = CHATURANGA_DATA.history.content;
+
+    if (imageWrap && CHATURANGA_DATA.historyImage) {
+        imageWrap.innerHTML = `
+            <img src="${CHATURANGA_DATA.historyImage.url}" alt="${CHATURANGA_DATA.historyImage.caption}" loading="lazy" />
+            <figcaption>${CHATURANGA_DATA.historyImage.caption}</figcaption>
+        `;
+    }
+}
+
+function renderTimeline() {
+    const container = document.getElementById('timeline-list');
+    if (!container || !CHATURANGA_DATA.timeline) return;
+
+    container.innerHTML = CHATURANGA_DATA.timeline
+        .map(
+            (event) => `
+        <div class="timeline-item">
+            <div class="timeline-year">${event.year}</div>
+            <div class="timeline-body">
+                <h4>${event.title}</h4>
+                <p>${event.desc}</p>
+                ${
+                    event.image
+                        ? `<figure class="timeline-image-wrap">
+                        <img src="${event.image}" alt="${event.imageCaption || event.title}" loading="lazy" />
+                        <figcaption>${event.imageCaption || ''}</figcaption>
+                    </figure>`
+                        : ''
+                }
+            </div>
+        </div>
+    `
+        )
+        .join('');
+}
+
+function renderComparisonTable() {
+    const title = document.getElementById('compare-title');
+    const tbody = document.getElementById('compare-tbody');
+
+    if (title) title.textContent = CHATURANGA_DATA.ancientVsModern.title;
+
+    if (tbody && CHATURANGA_DATA.ancientVsModern.rows) {
+        tbody.innerHTML = CHATURANGA_DATA.ancientVsModern.rows
+            .map(
+                (row) => `
+            <tr>
+                <td class="aspect-cell">${row.aspect}</td>
+                <td>${row.ancient}</td>
+                <td>${row.modern}</td>
+            </tr>
+        `
+            )
+            .join('');
+    }
+}
+
+function renderPieceEvolution() {
+    const container = document.getElementById('pieces-grid');
+    if (!container || !CHATURANGA_DATA.pieceEvolution) return;
+
+    container.innerHTML = CHATURANGA_DATA.pieceEvolution
+        .map(
+            (piece) => `
+        <div class="piece-card">
+            <div class="piece-symbol">${piece.symbol}</div>
+            <h4>${piece.ancientName} → ${piece.modernName}</h4>
+            <span class="piece-sanskrit">${piece.sanskrit}</span>
+            <p class="piece-movement"><strong>Movement:</strong> ${piece.movement}</p>
+            <p class="piece-description">${piece.description}</p>
+        </div>
+    `
+        )
+        .join('');
+}
+
+function initBoardToggle() {
+    const ancientBtn = document.getElementById('toggle-ancient');
+    const modernBtn = document.getElementById('toggle-modern');
+    if (!ancientBtn || !modernBtn) return;
+
+    ancientBtn.addEventListener('click', () => setBoardMode('ancient', ancientBtn, modernBtn));
+    modernBtn.addEventListener('click', () => setBoardMode('modern', modernBtn, ancientBtn));
+}
+
+function setBoardMode(mode, activeBtn, inactiveBtn) {
+    currentMode = mode;
+    activeBtn.classList.add('active');
+    inactiveBtn.classList.remove('active');
+    renderBoard(mode);
+    resetBoardDetail();
+}
+
+function renderBoard(mode) {
+    const board = document.getElementById('chess-board');
+    if (!board) return;
+
+    const backRank = CHATURANGA_DATA.boardBackRank;
+    board.innerHTML = '';
+
+    for (let row = 0; row < 8; row++) {
+        for (let col = 0; col < 8; col++) {
+            const square = document.createElement('div');
+            const isLight = (row + col) % 2 === 0;
+            square.className = `chess-square ${isLight ? 'square-light' : 'square-dark'}`;
+
+            const { pieceId, side } = getPieceAt(row, col, backRank);
+
+            if (pieceId) {
+                const piece = CHATURANGA_DATA.pieceEvolution.find((p) => p.id === pieceId);
+                const symbol = mode === 'modern' ? getModernSymbol(pieceId) : piece.symbol;
+
+                const pieceBtn = document.createElement('button');
+                pieceBtn.type = 'button';
+                pieceBtn.className = `chess-piece piece-${side}`;
+                pieceBtn.textContent = symbol;
+                pieceBtn.setAttribute(
+                    'aria-label',
+                    `${side === 'white' ? 'White' : 'Black'} ${mode === 'modern' ? piece.modernName : piece.ancientName}`
+                );
+                pieceBtn.addEventListener('click', () => showPieceDetail(pieceId, mode));
+                square.appendChild(pieceBtn);
+            }
+
+            board.appendChild(square);
+        }
+    }
+}
+
+function getPieceAt(row, col, backRank) {
+    if (row === 0) return { pieceId: backRank[col], side: 'black' };
+    if (row === 1) return { pieceId: 'padati', side: 'black' };
+    if (row === 6) return { pieceId: 'padati', side: 'white' };
+    if (row === 7) return { pieceId: backRank[col], side: 'white' };
+    return { pieceId: null, side: null };
+}
+
+function getModernSymbol(pieceId) {
+    const modernInfo = CHATURANGA_DATA.modernPieceMap[pieceId];
+    return modernInfo ? modernInfo.symbol : '';
+}
+
+function showPieceDetail(pieceId, mode) {
+    const detailContainer = document.getElementById('board-detail');
+    if (!detailContainer) return;
+
+    const piece = CHATURANGA_DATA.pieceEvolution.find((p) => p.id === pieceId);
+    if (!piece) return;
+
+    const displayName = mode === 'modern' ? piece.modernName : `${piece.ancientName} (${piece.sanskrit})`;
+    const displaySymbol = mode === 'modern' ? getModernSymbol(pieceId) : piece.symbol;
+
+    detailContainer.innerHTML = `
+        <div class="board-detail-symbol">${displaySymbol}</div>
+        <h3>${displayName}</h3>
+        ${mode === 'ancient' ? `<p class="board-detail-modern-note">Becomes the modern <strong>${piece.modernName}</strong></p>` : ''}
+        <p class="board-detail-movement"><strong>Movement:</strong> ${piece.movement}</p>
+        <p class="board-detail-description">${piece.description}</p>
+    `;
+}
+
+function resetBoardDetail() {
+    const detailContainer = document.getElementById('board-detail');
+    if (!detailContainer) return;
+    detailContainer.innerHTML = '<p class="board-detail-hint">Click a piece on the board to see its details here.</p>';
+}
+
+function renderModernInfluence() {
+    const title = document.getElementById('influence-title');
+    const content = document.getElementById('influence-content');
+    if (title) title.textContent = CHATURANGA_DATA.modernInfluence.title;
+    if (content) content.textContent = CHATURANGA_DATA.modernInfluence.content;
+}
+
+function renderGallery() {
+    const container = document.getElementById('gallery-grid');
+    if (!container || !CHATURANGA_DATA.gallery) return;
+
+    container.innerHTML = CHATURANGA_DATA.gallery
+        .map(
+            (g) => `
+        <div class="gallery-card">
+            <img src="${g.url}" alt="${g.title}" loading="lazy" />
+            <div class="gallery-info">
+                <h4>${g.title}</h4>
+                <p>${g.caption}</p>
+            </div>
+        </div>
+    `
+        )
+        .join('');
+}
+
+function renderReferences() {
+    const container = document.getElementById('references-list');
+    if (!container || !CHATURANGA_DATA.references) return;
+
+    container.innerHTML = CHATURANGA_DATA.references
+        .map(
+            (ref) => `
+        <a class="reference-card" href="${ref.url}" target="_blank" rel="noopener noreferrer">
+            <h4>${ref.title}</h4>
+            <span class="reference-source">${ref.source}</span>
+        </a>
+    `
+        )
+        .join('');
+}
+
+function renderFacts() {
+    const container = document.getElementById('facts-grid');
+    if (!container || !CHATURANGA_DATA.facts) return;
+
+    container.innerHTML = CHATURANGA_DATA.facts
+        .map((f) => `<div class="trivia-box">💡 ${f}</div>`)
+        .join('');
+}

--- a/frontend/Chaturanga/style.css
+++ b/frontend/Chaturanga/style.css
@@ -1,0 +1,667 @@
+/* Chaturanga Explorer Stylesheet */
+
+:root {
+    --chat-primary: #9f1239;
+    --chat-accent: #fbbf24;
+    --chat-dark-bg: #170a10;
+    --chat-card-bg: rgba(28, 15, 20, 0.85);
+    --chat-card-border: rgba(251, 191, 36, 0.2);
+    --chat-text-main: #fdf4e3;
+    --chat-text-sub: #c2a68f;
+    --chat-square-light: #f1dfc3;
+    --chat-square-dark: #7c3a2d;
+}
+
+body.light-theme {
+    --chat-dark-bg: #fffbf0;
+    --chat-card-bg: rgba(255, 255, 255, 0.95);
+    --chat-card-border: rgba(159, 18, 57, 0.2);
+    --chat-text-main: #241016;
+    --chat-text-sub: #6b5147;
+}
+
+body.chaturanga-main {
+    background-color: var(--chat-dark-bg);
+    color: var(--chat-text-main);
+    font-family: 'Outfit', sans-serif;
+    margin: 0;
+    padding: 0;
+    overflow-x: hidden;
+}
+
+.section-container {
+    max-width: 1240px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+}
+
+/* Header Navbar */
+.navbar {
+    background: rgba(23, 10, 16, 0.9);
+    backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--chat-card-border);
+}
+body.light-theme .navbar {
+    background: rgba(255, 251, 240, 0.92);
+}
+
+/* Hero Section */
+.chaturanga-hero {
+    padding: 8rem 0 4rem;
+    background: linear-gradient(180deg, rgba(251, 191, 36, 0.14) 0%, rgba(23, 10, 16, 0) 100%);
+    text-align: center;
+}
+
+.hero-badges-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+}
+
+.hero-pill {
+    padding: 0.4rem 1rem;
+    border-radius: 9999px;
+    font-size: 0.875rem;
+    font-weight: 600;
+    background: rgba(251, 191, 36, 0.13);
+    border: 1px solid var(--chat-card-border);
+    color: #fbbf24;
+}
+
+.chaturanga-hero h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: clamp(2.5rem, 5vw, 4rem);
+    font-weight: 800;
+    margin: 0 0 1rem;
+}
+
+.chaturanga-hero h1 span {
+    background: linear-gradient(135deg, #fbbf24 0%, #9f1239 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.hero-subtitle {
+    max-width: 800px;
+    margin: 0 auto 3rem;
+    font-size: 1.15rem;
+    color: var(--chat-text-sub);
+    line-height: 1.7;
+}
+
+/* Hero & History Images */
+.hero-image-wrap {
+    margin: 3rem auto 0;
+    max-width: 720px;
+    border-radius: 1.25rem;
+    overflow: hidden;
+    border: 1px solid var(--chat-card-border);
+}
+
+.hero-image-wrap img {
+    width: 100%;
+    height: auto;
+    max-height: 420px;
+    object-fit: cover;
+    display: block;
+}
+
+.hero-image-wrap figcaption,
+.history-image-wrap figcaption,
+.timeline-image-wrap figcaption {
+    padding: 0.85rem 1.25rem;
+    font-size: 0.85rem;
+    color: var(--chat-text-sub);
+    background: var(--chat-card-bg);
+    text-align: left;
+}
+
+.history-layout {
+    display: grid;
+    grid-template-columns: 1.3fr 1fr;
+    gap: 2rem;
+    align-items: stretch;
+}
+
+.history-image-wrap {
+    margin: 0;
+    border-radius: 1.25rem;
+    overflow: hidden;
+    border: 1px solid var(--chat-card-border);
+    display: flex;
+    flex-direction: column;
+}
+
+.history-image-wrap img {
+    width: 100%;
+    height: 100%;
+    max-height: 320px;
+    object-fit: cover;
+    display: block;
+}
+
+/* Stats Grid */
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.25rem;
+    margin-top: 2rem;
+}
+
+.stat-card {
+    background: var(--chat-card-bg);
+    border: 1px solid var(--chat-card-border);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    text-align: center;
+    transition: transform 0.3s ease;
+}
+
+.stat-card:hover {
+    transform: translateY(-4px);
+    border-color: #fbbf24;
+}
+
+.stat-icon {
+    font-size: 2rem;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.stat-value {
+    font-size: 1.4rem;
+    font-weight: 800;
+    color: #fbbf24;
+    margin-bottom: 0.25rem;
+}
+
+.stat-label {
+    font-size: 0.875rem;
+    color: var(--chat-text-sub);
+}
+
+/* Section Header */
+.section-header {
+    text-align: center;
+    margin-bottom: 3rem;
+}
+
+.section-tag {
+    font-size: 0.8rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    color: #9f1239;
+    text-transform: uppercase;
+    display: block;
+    margin-bottom: 0.5rem;
+}
+body.light-theme .section-tag {
+    color: #be123c;
+}
+
+.section-header h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2.25rem;
+    margin: 0 0 0.75rem;
+}
+
+.section-header p {
+    color: var(--chat-text-sub);
+    font-size: 1.05rem;
+    max-width: 700px;
+    margin: 0 auto;
+}
+
+/* Info Cards */
+.history-section,
+.influence-section {
+    padding: 4rem 0;
+}
+
+.info-card {
+    background: var(--chat-card-bg);
+    border: 1px solid var(--chat-card-border);
+    border-radius: 1.25rem;
+    padding: 2.5rem;
+}
+
+.highlight-card {
+    background: linear-gradient(135deg, rgba(251, 191, 36, 0.1) 0%, rgba(28, 15, 20, 0.85) 100%);
+    border-color: rgba(251, 191, 36, 0.3);
+}
+
+.info-card h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 1.8rem;
+    margin: 0.5rem 0 1rem;
+    color: #fbbf24;
+}
+
+.info-card p {
+    color: var(--chat-text-sub);
+    line-height: 1.8;
+    font-size: 1.05rem;
+    margin: 0;
+}
+
+/* Timeline */
+.timeline-section {
+    padding: 4rem 0;
+}
+
+.timeline-list {
+    max-width: 780px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.timeline-item {
+    display: flex;
+    gap: 1.25rem;
+    background: var(--chat-card-bg);
+    border: 1px solid var(--chat-card-border);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    border-left: 3px solid #fbbf24;
+}
+
+.timeline-year {
+    flex-shrink: 0;
+    width: 8.5rem;
+    font-weight: 800;
+    color: #fbbf24;
+    font-size: 0.95rem;
+}
+
+.timeline-body h4 {
+    margin: 0 0 0.4rem;
+    font-size: 1.1rem;
+    color: var(--chat-text-main);
+}
+
+.timeline-body p {
+    margin: 0;
+    color: var(--chat-text-sub);
+    font-size: 0.95rem;
+    line-height: 1.6;
+}
+
+.timeline-image-wrap {
+    margin: 0.85rem 0 0;
+    border-radius: 0.75rem;
+    overflow: hidden;
+    border: 1px solid var(--chat-card-border);
+    max-width: 360px;
+}
+
+.timeline-image-wrap img {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+
+/* Ancient vs Modern Table */
+.compare-section {
+    padding: 4rem 0;
+}
+
+.compare-table-wrap {
+    overflow-x: auto;
+    border-radius: 1rem;
+    border: 1px solid var(--chat-card-border);
+}
+
+.compare-table {
+    width: 100%;
+    border-collapse: collapse;
+    background: var(--chat-card-bg);
+}
+
+.compare-table th {
+    text-align: left;
+    padding: 1rem 1.25rem;
+    background: rgba(251, 191, 36, 0.12);
+    color: #fbbf24;
+    font-size: 0.9rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.compare-table td {
+    padding: 1rem 1.25rem;
+    border-top: 1px solid var(--chat-card-border);
+    color: var(--chat-text-sub);
+    font-size: 0.95rem;
+    line-height: 1.5;
+}
+
+.aspect-cell {
+    font-weight: 700;
+    color: var(--chat-text-main);
+    white-space: nowrap;
+}
+
+/* Piece Evolution */
+.pieces-section {
+    padding: 4rem 0;
+}
+
+.pieces-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.piece-card {
+    background: var(--chat-card-bg);
+    border: 1px solid var(--chat-card-border);
+    border-radius: 1.25rem;
+    padding: 1.75rem;
+}
+
+.piece-symbol {
+    font-size: 2.5rem;
+    color: #fbbf24;
+    margin-bottom: 0.5rem;
+}
+
+.piece-card h4 {
+    margin: 0 0 0.25rem;
+    font-size: 1.15rem;
+    color: var(--chat-text-main);
+}
+
+.piece-sanskrit {
+    display: block;
+    font-size: 0.85rem;
+    color: #fbbf24;
+    margin-bottom: 0.75rem;
+}
+
+.piece-movement {
+    font-size: 0.9rem;
+    color: var(--chat-text-sub);
+    margin: 0 0 0.5rem;
+    line-height: 1.5;
+}
+
+.piece-description {
+    font-size: 0.9rem;
+    color: var(--chat-text-sub);
+    margin: 0;
+    line-height: 1.6;
+}
+
+/* Interactive Board */
+.board-section {
+    padding: 4rem 0;
+}
+
+.board-toggle-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    margin-bottom: 2rem;
+    flex-wrap: wrap;
+}
+
+.board-toggle-btn {
+    padding: 0.7rem 1.4rem;
+    border-radius: 9999px;
+    border: 1px solid var(--chat-card-border);
+    background: var(--chat-card-bg);
+    color: var(--chat-text-sub);
+    font-weight: 600;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: all 0.25s ease;
+}
+
+.board-toggle-btn:hover {
+    border-color: #fbbf24;
+    color: var(--chat-text-main);
+}
+
+.board-toggle-btn.active {
+    background: linear-gradient(135deg, #fbbf24 0%, #9f1239 100%);
+    color: #170a10;
+    border-color: transparent;
+}
+
+.board-layout {
+    display: grid;
+    grid-template-columns: minmax(280px, 520px) 1fr;
+    gap: 2rem;
+    align-items: start;
+    justify-content: center;
+}
+
+.chess-board {
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
+    grid-template-rows: repeat(8, 1fr);
+    width: 100%;
+    aspect-ratio: 1 / 1;
+    border: 3px solid var(--chat-card-border);
+    border-radius: 0.75rem;
+    overflow: hidden;
+}
+
+.chess-square {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.square-light {
+    background-color: var(--chat-square-light);
+}
+
+.square-dark {
+    background-color: var(--chat-square-dark);
+}
+
+.chess-piece {
+    background: none;
+    border: none;
+    font-size: clamp(1.25rem, 3vw, 2.25rem);
+    line-height: 1;
+    cursor: pointer;
+    padding: 0;
+    transition: transform 0.2s ease;
+}
+
+.chess-piece:hover,
+.chess-piece:focus-visible {
+    transform: scale(1.15);
+    outline: none;
+}
+
+.piece-black {
+    color: #1c1410;
+    text-shadow: 0 0 2px rgba(251, 191, 36, 0.4);
+}
+
+.piece-white {
+    color: #fdf4e3;
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+}
+
+.board-detail {
+    background: var(--chat-card-bg);
+    border: 1px solid var(--chat-card-border);
+    border-radius: 1.25rem;
+    padding: 2rem;
+    min-height: 220px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.board-detail-hint {
+    color: var(--chat-text-sub);
+    margin: 0;
+    text-align: center;
+}
+
+.board-detail-symbol {
+    font-size: 2.5rem;
+    color: #fbbf24;
+    margin-bottom: 0.5rem;
+}
+
+.board-detail h3 {
+    font-family: 'Playfair Display', serif;
+    font-size: 1.5rem;
+    margin: 0 0 0.5rem;
+    color: var(--chat-text-main);
+}
+
+.board-detail-modern-note {
+    color: #fbbf24;
+    font-size: 0.9rem;
+    margin: 0 0 0.75rem;
+}
+
+.board-detail-movement,
+.board-detail-description {
+    color: var(--chat-text-sub);
+    font-size: 0.95rem;
+    line-height: 1.6;
+    margin: 0 0 0.6rem;
+}
+
+/* Gallery */
+.gallery-section {
+    padding: 4rem 0;
+}
+
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.gallery-card {
+    background: var(--chat-card-bg);
+    border: 1px solid var(--chat-card-border);
+    border-radius: 1rem;
+    overflow: hidden;
+}
+
+.gallery-card img {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+}
+
+.gallery-info {
+    padding: 1rem;
+}
+
+.gallery-info h4 {
+    margin: 0 0 0.35rem;
+    font-size: 1rem;
+    color: var(--chat-text-main);
+}
+
+.gallery-info p {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--chat-text-sub);
+}
+
+/* References & Facts */
+.references-section,
+.facts-section {
+    padding: 4rem 0;
+}
+
+.references-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.25rem;
+}
+
+.reference-card {
+    display: block;
+    background: var(--chat-card-bg);
+    border: 1px solid var(--chat-card-border);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    text-decoration: none;
+    transition: all 0.3s ease;
+}
+
+.reference-card:hover {
+    border-color: #fbbf24;
+    transform: translateY(-2px);
+}
+
+.reference-card h4 {
+    margin: 0 0 0.5rem;
+    color: var(--chat-text-main);
+    font-size: 1.05rem;
+    line-height: 1.4;
+}
+
+.reference-source {
+    font-size: 0.85rem;
+    color: #9f1239;
+    font-weight: 600;
+}
+body.light-theme .reference-source {
+    color: #be123c;
+}
+
+.facts-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.trivia-box {
+    background: var(--chat-card-bg);
+    border: 1px solid var(--chat-card-border);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    color: var(--chat-text-sub);
+    line-height: 1.6;
+}
+
+@media (max-width: 900px) {
+    .board-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .history-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .history-image-wrap img {
+        max-height: 240px;
+    }
+}
+
+@media (max-width: 640px) {
+    .info-card {
+        padding: 1.75rem;
+    }
+
+    .chaturanga-hero {
+        padding: 7rem 0 3rem;
+    }
+
+    .timeline-item {
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+
+    .timeline-year {
+        width: auto;
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description
Adds a new educational page for Chaturanga, the ancient Indian game that evolved into modern chess. The page follows the existing explorer pattern (index.html / style.css / script.js / chaturanga-data.js) and covers a Historical Overview, an 8-event Timeline, an Ancient-vs-Modern comparison table, Piece Evolution (six pieces from Raja to Padati), an interactive click-to-inspect chess board with an ancient/modern toggle, and References.

Fixes #1800 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?
- [ ] Tested locally in browser
- [ ] Tested in both dark and light themes
- [ ] Tested at mobile viewport widths
- [ ] Verified no console errors

## Checklist
- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [ ] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)

## Screenshots (if applicable)
_Add screenshots after local verification._