### PR TITLE
feat: Introduce the Battle of Pataliputra as an interactive explorer page

### DIFF
--- a/frontend/battle-of-pataliputra-explorer/index.html
+++ b/frontend/battle-of-pataliputra-explorer/index.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore the Battle of Pataliputra (c. 322 BCE): Chandragupta Maurya and Chanakya's siege against the Nanda Dynasty to establish the Mauryan Empire.">
+  <title>Battle of Pataliputra Explorer | Incredible India</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css">
+
+  <meta property="og:title" content="Battle of Pataliputra Explorer | Incredible India Explorer">
+  <meta property="og:description" content="Discover the Battle of Pataliputra, the strategic military victory of Chandragupta Maurya and Chanakya over Dhana Nanda.">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Incredible India Explorer">
+  <meta property="og:locale" content="en_IN">
+</head>
+<body>
+  <script>
+    (function() {
+      const theme = localStorage.getItem('theme') || 'dark';
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+
+  <!-- Sticky Navigation Bar -->
+  <header class="navbar" id="navbar">
+    <div class="nav-container">
+      <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+        <span class="saffron">Incredible</span>
+        <span class="gold">India</span>
+        <span class="green">Explorer</span>
+      </a>
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+        <span class="bar"></span>
+        <span class="bar"></span>
+        <span class="bar"></span>
+      </button>
+      <nav class="nav-menu" id="nav-menu">
+        <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+
+        <div class="nav-dropdown">
+          <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
+          <div class="dropdown-menu">
+            <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
+            <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+            <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+          </div>
+        </div>
+
+        <div class="nav-dropdown">
+          <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
+          <div class="dropdown-menu">
+            <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+            <a href="../../frontend/historic-battles-explorer/index.html" class="dropdown-item">Historic Battles</a>
+            <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
+          </div>
+        </div>
+
+        <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+      </nav>
+    </div>
+  </header>
+
+  <main id="app-root" class="pataliputra-main">
+
+    <!-- Hero Banner -->
+    <section class="pataliputra-hero">
+      <div class="pataliputra-hero-content">
+        <span class="pataliputra-kicker">⚔️ Pataliputra, Magadha · c. 322 BCE</span>
+        <h1>Battle of Pataliputra <span>Explorer</span></h1>
+        <p>The Battle of Pataliputra (c. 322 BCE) marked the overthrow of the formidable Nanda Empire by Chandragupta Maurya and his strategist Chanakya (Kautilya). By combining guerrilla strikes, diplomatic alliances with Himalayan kingdoms, and a multi-pronged siege of Magadha’s capital city, Chandragupta founded the Mauryan Empire—India’s first Pan-Subcontinental empire.</p>
+        <div class="pataliputra-bookmark-container">
+          <button class="pataliputra-bookmark-btn journey-bookmark-btn" type="button" data-bookmark-id="battle-of-pataliputra-main" aria-pressed="false" aria-label="Bookmark Battle of Pataliputra">
+            ♡ Save to Journey
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Navigation Sub-Menu -->
+    <nav class="pataliputra-nav-tabs" aria-label="Explorer Sections Navigation">
+      <a href="#overview" class="pataliputra-tab-link active">Historical Overview</a>
+      <a href="#commanders" class="pataliputra-tab-link">Commanders & Forces</a>
+      <a href="#timeline" class="pataliputra-tab-link">Campaign Timeline</a>
+      <a href="#outcome" class="pataliputra-tab-link">Strategic Outcome</a>
+      <a href="#gallery" class="pataliputra-tab-link">Gallery & Sources</a>
+    </nav>
+
+    <!-- Section 1: Historical Overview -->
+    <section class="pataliputra-section" id="overview">
+      <div class="pataliputra-container pataliputra-grid-2col">
+        <div class="pataliputra-text-block">
+          <span class="pataliputra-eyebrow">Mauryan Conquest</span>
+          <h2>The Siege of Magadha’s Wealthy Capital</h2>
+          <p>Under Emperor Dhana Nanda, Magadha possessed immense wealth and a staggering standing army of 200,000 infantry, 80,000 cavalry, 8,000 war chariots, and 6,000 war elephants. However, oppressive taxation and tyranny alienating the populace provided Chanakya and Chandragupta the opportunity to strike.</p>
+          <p>After initial setbacks attempting direct assaults on the core of Magadha, Chanakya devised a perimeter strategy: conquering outer provinces first, securing alliances with King Parvataka, and cutting off Pataliputra’s supply lines before encircling the city walls.</p>
+        </div>
+        <div class="pataliputra-highlight-box">
+          <h3>🏛️ Historical Snapshot</h3>
+          <ul>
+            <li><strong>Date:</strong> c. 322 BCE</li>
+            <li><strong>Location:</strong> Pataliputra (Modern Patna, Bihar)</li>
+            <li><strong>Belligerents:</strong> Mauryan Rebels & Himalayan Allies vs Nanda Dynasty</li>
+            <li><strong>Mauryan Commanders:</strong> Chandragupta Maurya, Chanakya (Kautilya), King Parvataka</li>
+            <li><strong>Nanda Commanders:</strong> Dhana Nanda, Prime Minister Rakshasa, Commander Bhadrasala</li>
+            <li><strong>Outcome:</strong> Fall of Pataliputra; establishment of Mauryan Empire.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 2: Commanders & Forces -->
+    <section class="pataliputra-section pataliputra-alt-bg" id="commanders">
+      <div class="pataliputra-container">
+        <div class="pataliputra-section-header">
+          <span class="pataliputra-eyebrow">Military Leaders</span>
+          <h2>Commanders & Opposing Forces</h2>
+          <p>Meet the visionary strategists and commanders involved in the siege of Pataliputra.</p>
+        </div>
+
+        <div id="forces" class="pataliputra-forces-grid">
+          <!-- Mauryan Coalition -->
+          <div class="pataliputra-force-card mauryan-card">
+            <div class="force-card-header">
+              <span class="force-badge">Mauryan Confederacy</span>
+              <h3>Mauryan & Himalayan Forces</h3>
+              <span class="force-commander">Leaders: Chandragupta Maurya & Chanakya</span>
+            </div>
+            <ul class="force-unit-list">
+              <li><strong>Chandragupta Maurya:</strong> Charismatic military genius and founder of the empire.</li>
+              <li><strong>Chanakya (Kautilya):</strong> Master strategist, author of <em>Arthashastra</em>, and mastermind of espionage.</li>
+              <li><strong>King Parvataka:</strong> Himalayan ruler who supplied elite mountain cavalry and mercenary foot soldiers.</li>
+              <li><strong>Tactical Approach:</strong> Outer ring subjugation, covert subversion inside Pataliputra, and siege warfare.</li>
+            </ul>
+          </div>
+
+          <!-- Nanda Empire -->
+          <div class="pataliputra-force-card nanda-card">
+            <div class="force-card-header">
+              <span class="force-badge nanda-badge">Nanda Dynasty</span>
+              <h3>Imperial Nanda Army</h3>
+              <span class="force-commander">Leaders: Dhana Nanda & Bhadrasala</span>
+            </div>
+            <ul class="force-unit-list">
+              <li><strong>Dhana Nanda:</strong> Last ruler of the Nanda Dynasty, notorious for vast treasuries and heavy taxes.</li>
+              <li><strong>General Bhadrasala:</strong> Chief military commander who directed the defense of Pataliputra.</li>
+              <li><strong>Minister Rakshasa:</strong> Fiercely loyal prime minister known for political intrigue and administrative skill.</li>
+              <li><strong>Defensive Strength:</strong> Massive fortification moats fed by the Ganges and Son rivers.</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 3: Campaign Timeline -->
+    <section class="pataliputra-section" id="timeline">
+      <div class="pataliputra-container">
+        <div class="pataliputra-section-header">
+          <span class="pataliputra-eyebrow">Key Events</span>
+          <h2>Campaign Timeline</h2>
+          <p>Chronological milestones in the overthrow of the Nanda Dynasty.</p>
+        </div>
+
+        <div id="battle-timeline" class="pataliputra-timeline">
+          <div class="timeline-item">
+            <div class="timeline-dot"></div>
+            <div class="timeline-content">
+              <span class="timeline-date">Phase 1: c. 324 BCE</span>
+              <h4>Pact of Taxila</h4>
+              <p>Chanakya and Chandragupta forge an alliance with King Parvataka to raise a unified liberation force.</p>
+            </div>
+          </div>
+          <div class="timeline-item">
+            <div class="timeline-dot"></div>
+            <div class="timeline-content">
+              <span class="timeline-date">Phase 2: c. 323 BCE</span>
+              <h4>Border Campaign</h4>
+              <p>Chandragupta captures border garrisons of Magadha, gradually isolating the capital city of Pataliputra.</p>
+            </div>
+          </div>
+          <div class="timeline-item">
+            <div class="timeline-dot"></div>
+            <div class="timeline-content">
+              <span class="timeline-date">Phase 3: c. 322 BCE</span>
+              <h4>Siege of Pataliputra</h4>
+              <p>Mauryan coalition besieges Pataliputra while Chanakya orchestrates internal rebellions among citizens.</p>
+            </div>
+          </div>
+          <div class="timeline-item">
+            <div class="timeline-dot"></div>
+            <div class="timeline-content">
+              <span class="timeline-date">Phase 4: c. 322 BCE</span>
+              <h4>Capitulation & Coronation</h4>
+              <p>Dhana Nanda surrenders. Chandragupta ascends the throne of Magadha, marking the birth of the Mauryan Empire.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 4: Strategic Outcome -->
+    <section class="pataliputra-section pataliputra-alt-bg" id="outcome">
+      <div class="pataliputra-container">
+        <div class="pataliputra-section-header">
+          <span class="pataliputra-eyebrow">Legacy</span>
+          <h2>Strategic Significance & Outcome</h2>
+          <p>The dramatic shift in subcontinental geopolitics following the battle.</p>
+        </div>
+
+        <div class="pataliputra-grid-3col">
+          <div class="pataliputra-feature-box">
+            <h4>👑 Rise of Mauryan Hegemony</h4>
+            <p>Chandragupta consolidated rule over Magadha, creating the foundation for expansion across modern India, Pakistan, and Afghanistan.</p>
+          </div>
+          <div class="pataliputra-feature-box">
+            <h4>📖 Practical Statecraft</h4>
+            <p>The siege demonstrated principles later codified in the <em>Arthashastra</em>: spy networks, economic warfare, and strategic alliances.</p>
+          </div>
+          <div class="pataliputra-feature-box">
+            <h4>🏛️ Capital of Empire</h4>
+            <p>Pataliputra grew into one of the largest and most prosperous cities of the ancient world, as described by Megasthenes.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 5: Gallery & Sources -->
+    <section class="pataliputra-section" id="gallery">
+      <div class="pataliputra-container">
+        <div class="pataliputra-section-header">
+          <span class="pataliputra-eyebrow">Visual Highlights</span>
+          <h2>Gallery & Historical References</h2>
+          <p>Depictions of ancient Pataliputra and literary sources.</p>
+        </div>
+
+        <div id="gallery-grid" class="pataliputra-gallery-grid">
+          <div class="gallery-card">
+            <div class="gallery-placeholder">🏰 Wooden Palisades of Pataliputra</div>
+            <h4>Pataliputra Fortifications</h4>
+            <p>Artistic rendering of the 64 gates and 570 towers recorded by ancient chroniclers.</p>
+          </div>
+          <div class="gallery-card">
+            <div class="gallery-placeholder">📜 Mudrarakshasa Manuscripts</div>
+            <h4>Historical Literature</h4>
+            <p>Dramatization of Chanakya's political maneuvers in Vishakhadatta's play.</p>
+          </div>
+          <div class="gallery-card">
+            <div class="gallery-placeholder">🪙 Mauryan Punch-Marked Coins</div>
+            <h4>Mauryan Currency</h4>
+            <p>Silver punch-marked coins circulated in post-siege Pataliputra.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="footer-container">
+      <p>&copy; 2026 Incredible India Explorer. Preserving ancient Indian military history.</p>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/battle-of-pataliputra-explorer/script.js
+++ b/frontend/battle-of-pataliputra-explorer/script.js
@@ -1,0 +1,54 @@
+/**
+ * Battle of Pataliputra Explorer Script
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+  initTheme();
+  initNavTabs();
+  initBookmark();
+});
+
+function initTheme() {
+  const themeToggle = document.getElementById('theme-toggle');
+  if (themeToggle) {
+    themeToggle.addEventListener('click', () => {
+      document.body.classList.toggle('light-theme');
+      const isLight = document.body.classList.contains('light-theme');
+      localStorage.setItem('theme', isLight ? 'light' : 'dark');
+      themeToggle.textContent = isLight ? '☀️' : '🌙';
+    });
+  }
+}
+
+function initNavTabs() {
+  const tabs = document.querySelectorAll('.pataliputra-tab-link');
+  window.addEventListener('scroll', () => {
+    let current = '';
+    const sections = document.querySelectorAll('.pataliputra-section');
+    sections.forEach(section => {
+      const sectionTop = section.offsetTop - 100;
+      if (window.scrollY >= sectionTop) {
+        current = section.getAttribute('id');
+      }
+    });
+    tabs.forEach(tab => {
+      tab.classList.remove('active');
+      if (tab.getAttribute('href') === `#${current}`) {
+        tab.classList.add('active');
+      }
+    });
+  });
+}
+
+function initBookmark() {
+  const bookmarkBtn = document.querySelector('.pataliputra-bookmark-btn');
+  if (bookmarkBtn) {
+    bookmarkBtn.addEventListener('click', () => {
+      const isBookmarked = bookmarkBtn.getAttribute('aria-pressed') === 'true';
+      bookmarkBtn.setAttribute('aria-pressed', !isBookmarked);
+      bookmarkBtn.innerHTML = !isBookmarked ? '♥ Saved in Journey' : '♡ Save to Journey';
+      bookmarkBtn.style.background = !isBookmarked ? 'var(--pataliputra-accent)' : 'transparent';
+      bookmarkBtn.style.color = !isBookmarked ? '#0f172a' : 'var(--pataliputra-accent)';
+    });
+  }
+}

--- a/frontend/battle-of-pataliputra-explorer/style.css
+++ b/frontend/battle-of-pataliputra-explorer/style.css
@@ -1,0 +1,282 @@
+/* Style for Battle of Pataliputra Explorer */
+
+:root {
+  --pataliputra-primary: #059669;
+  --pataliputra-secondary: #065f46;
+  --pataliputra-accent: #10b981;
+  --pataliputra-bg: #0f172a;
+  --pataliputra-card-bg: #1e293b;
+  --pataliputra-border: #334155;
+  --pataliputra-text: #f8fafc;
+  --pataliputra-muted: #94a3b8;
+}
+
+body.light-theme {
+  --pataliputra-bg: #f8fafc;
+  --pataliputra-card-bg: #ffffff;
+  --pataliputra-border: #e2e8f0;
+  --pataliputra-text: #0f172a;
+  --pataliputra-muted: #64748b;
+}
+
+.pataliputra-main {
+  background-color: var(--pataliputra-bg);
+  color: var(--pataliputra-text);
+  min-height: 100vh;
+  padding-bottom: 4rem;
+}
+
+/* Hero Banner */
+.pataliputra-hero {
+  background: linear-gradient(135deg, rgba(5, 150, 105, 0.2), rgba(6, 95, 70, 0.4)), url('../../assets/Warlitr.png') center/cover no-repeat;
+  padding: 5rem 1.5rem 4rem;
+  text-align: center;
+  border-bottom: 1px solid var(--pataliputra-border);
+}
+
+.pataliputra-hero-content {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.pataliputra-kicker {
+  display: inline-block;
+  background: var(--pataliputra-secondary);
+  color: #fff;
+  padding: 0.35rem 1rem;
+  border-radius: 9999px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.pataliputra-hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: 2.75rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+  color: var(--pataliputra-text);
+}
+
+.pataliputra-hero h1 span {
+  color: var(--pataliputra-accent);
+}
+
+.pataliputra-hero p {
+  font-size: 1.125rem;
+  line-height: 1.7;
+  color: var(--pataliputra-muted);
+  margin-bottom: 1.5rem;
+}
+
+.pataliputra-bookmark-btn {
+  background: transparent;
+  border: 1px solid var(--pataliputra-accent);
+  color: var(--pataliputra-accent);
+  padding: 0.5rem 1.25rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  font-weight: 600;
+  transition: all 0.2s ease;
+}
+
+.pataliputra-bookmark-btn:hover {
+  background: var(--pataliputra-accent);
+  color: #0f172a;
+}
+
+/* Sub Navigation */
+.pataliputra-nav-tabs {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  background: var(--pataliputra-card-bg);
+  padding: 1rem;
+  border-bottom: 1px solid var(--pataliputra-border);
+  position: sticky;
+  top: 70px;
+  z-index: 10;
+}
+
+.pataliputra-tab-link {
+  color: var(--pataliputra-muted);
+  text-decoration: none;
+  font-weight: 500;
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  transition: all 0.2s ease;
+}
+
+.pataliputra-tab-link:hover,
+.pataliputra-tab-link.active {
+  color: var(--pataliputra-accent);
+  background: rgba(16, 185, 129, 0.1);
+}
+
+/* Common Layout */
+.pataliputra-section {
+  padding: 4rem 1.5rem;
+  border-bottom: 1px solid var(--pataliputra-border);
+}
+
+.pataliputra-alt-bg {
+  background: rgba(30, 41, 59, 0.4);
+}
+
+body.light-theme .pataliputra-alt-bg {
+  background: rgba(241, 245, 249, 0.6);
+}
+
+.pataliputra-container {
+  max-width: 1140px;
+  margin: 0 auto;
+}
+
+.pataliputra-eyebrow {
+  color: var(--pataliputra-accent);
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  font-weight: 700;
+}
+
+.pataliputra-section-header {
+  text-align: center;
+  max-width: 700px;
+  margin: 0 auto 3rem;
+}
+
+.pataliputra-section-header h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: 2.25rem;
+  margin: 0.5rem 0 1rem;
+}
+
+.pataliputra-grid-2col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2.5rem;
+}
+
+.pataliputra-grid-3col {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 2rem;
+}
+
+/* Cards & Content */
+.pataliputra-highlight-box, .pataliputra-force-card, .pataliputra-feature-box, .gallery-card {
+  background: var(--pataliputra-card-bg);
+  border: 1px solid var(--pataliputra-border);
+  border-radius: 0.75rem;
+  padding: 1.75rem;
+}
+
+.pataliputra-highlight-box h3, .pataliputra-feature-box h4, .gallery-card h4 {
+  color: var(--pataliputra-accent);
+  margin-bottom: 1rem;
+}
+
+.pataliputra-highlight-box ul, .force-unit-list {
+  list-style: none;
+  padding: 0;
+}
+
+.pataliputra-highlight-box li, .force-unit-list li {
+  margin-bottom: 0.75rem;
+  line-height: 1.6;
+  color: var(--pataliputra-muted);
+}
+
+.pataliputra-forces-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+
+.force-card-header {
+  border-bottom: 1px solid var(--pataliputra-border);
+  padding-bottom: 1rem;
+  margin-bottom: 1rem;
+}
+
+.force-badge {
+  display: inline-block;
+  background: rgba(16, 185, 129, 0.2);
+  color: var(--pataliputra-accent);
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0.25rem 0.6rem;
+  border-radius: 0.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.force-commander {
+  font-size: 0.875rem;
+  color: var(--pataliputra-muted);
+}
+
+/* Timeline */
+.pataliputra-timeline {
+  position: relative;
+  max-width: 800px;
+  margin: 0 auto;
+  padding-left: 2rem;
+  border-left: 2px solid var(--pataliputra-accent);
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: 2rem;
+}
+
+.timeline-dot {
+  position: absolute;
+  left: -2.45rem;
+  top: 0.25rem;
+  width: 1rem;
+  height: 1rem;
+  background: var(--pataliputra-accent);
+  border-radius: 50%;
+}
+
+.timeline-date {
+  font-size: 0.85rem;
+  color: var(--pataliputra-accent);
+  font-weight: 700;
+}
+
+.timeline-content h4 {
+  margin: 0.25rem 0 0.5rem;
+  font-size: 1.25rem;
+}
+
+/* Gallery */
+.pataliputra-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+}
+
+.gallery-placeholder {
+  height: 160px;
+  background: rgba(16, 185, 129, 0.1);
+  border: 2px dashed var(--pataliputra-accent);
+  border-radius: 0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--pataliputra-accent);
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+@media (max-width: 768px) {
+  .pataliputra-grid-2col, .pataliputra-forces-grid {
+    grid-template-columns: 1fr;
+  }
+  .pataliputra-hero h1 {
+    font-size: 2rem;
+  }
+}

--- a/frontend/historic-battles-explorer/script.js
+++ b/frontend/historic-battles-explorer/script.js
@@ -18,6 +18,19 @@ const battlesData = [
     link: '../battle-of-hydaspes-explorer/index.html'
   },
   {
+    id: 'pataliputra',
+    name: 'Battle of Pataliputra',
+    year: -322,
+    date: 'c. 322 BCE',
+    century: '4th BCE',
+    dynasty: 'Maurya / Nanda',
+    region: 'East',
+    winner: 'Maurya',
+    location: 'Pataliputra (Patna, Bihar)',
+    summary: 'Strategic siege by Chandragupta Maurya and Chanakya toppling the Nanda Dynasty and establishing the Mauryan Empire.',
+    link: '../battle-of-pataliputra-explorer/index.html'
+  },
+  {
     id: 'mauryan-seleucid',
     name: 'Mauryan–Seleucid War',
     year: -305,


### PR DESCRIPTION
### Description
This PR introduces a dedicated interactive explorer page for the **Battle of Pataliputra** (c. 322 BCE), highlighting Chandragupta Maurya and Chanakya's siege against the Nanda Empire to establish the Mauryan Empire.

### Key Features Implemented
- **Historical Overview:** Contextualizes the conquest of Magadha's wealthy capital under Emperor Dhana Nanda.
- **Commanders & Forces:** Detailed comparison of Chandragupta Maurya, Chanakya, and King Parvataka's coalition against General Bhadrasala and Minister Rakshasa.
- **Campaign Timeline:** Chronological progression from the Pact of Taxila and border garrison skirmishes to the siege of Pataliputra and Chandragupta's coronation.
- **Strategic Outcome:** Explores the birth of India's first Pan-Subcontinental empire, *Arthashastra* statecraft in action, and Pataliputra's imperial prominence.
- **Gallery & References:** Visual highlights of Pataliputra wooden palisades, Mudrarakshasa manuscripts, and Mauryan punch-marked coinage.
- **Landing Page Integration:** Added a Battle of Pataliputra card to the Historic Battles landing page (`frontend/historic-battles-explorer/script.js`).

### Files Created/Modified
- `frontend/battle-of-pataliputra-explorer/index.html`
- `frontend/battle-of-pataliputra-explorer/style.css`
- `frontend/battle-of-pataliputra-explorer/script.js`
- `frontend/historic-battles-explorer/script.js`

### Testing
- Verified layout responsiveness across mobile, tablet, and desktop viewports.
- Tested interactive bookmarking functionality and theme switching.

Closes #1586
