### PR TITLE
feat: add Congress Radio Explorer page

### DIFF
--- a/frontend/assets/congress_radio_arrest.svg
+++ b/frontend/assets/congress_radio_arrest.svg
@@ -1,0 +1,23 @@
+<svg viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="t4 d4">
+  <title id="t4">The raid at Parekh Wadi</title>
+  <desc id="d4">A doorway with a torch beam cutting through darkness, symbolising the night of the final raid.</desc>
+  <rect width="400" height="300" fill="#0f1012"/>
+  <!-- room wall -->
+  <rect x="0" y="0" width="400" height="300" fill="#17181b"/>
+  <!-- doorway -->
+  <rect x="150" y="40" width="100" height="220" fill="#0a0a0b" stroke="#33353a" stroke-width="4"/>
+  <!-- torch beam -->
+  <polygon points="200,150 40,20 40,90" fill="#e6c65c" opacity="0.18"/>
+  <polygon points="200,150 40,20 40,90" fill="none" stroke="#e6c65c" stroke-width="1" opacity="0.4"/>
+  <!-- silhouettes at door: officers -->
+  <ellipse cx="175" cy="170" rx="10" ry="12" fill="#2a2b30"/>
+  <rect x="165" y="180" width="20" height="55" fill="#2a2b30"/>
+  <ellipse cx="222" cy="170" rx="10" ry="12" fill="#2a2b30"/>
+  <rect x="212" y="180" width="20" height="55" fill="#2a2b30"/>
+  <!-- overturned transmitter equipment on floor -->
+  <rect x="270" y="230" width="60" height="26" rx="4" fill="#3a2f1e" stroke="#c9a227" stroke-width="1.5" transform="rotate(-8 300 243)"/>
+  <line x1="330" y1="235" x2="360" y2="200" stroke="#c9a227" stroke-width="2"/>
+  <!-- window glow, night outside -->
+  <rect x="20" y="200" width="70" height="60" fill="#1c1d21" stroke="#33353a" stroke-width="2"/>
+  <circle cx="55" cy="215" r="4" fill="#d9c9a3" opacity="0.5"/>
+</svg>

--- a/frontend/assets/congress_radio_hero.svg
+++ b/frontend/assets/congress_radio_hero.svg
@@ -1,0 +1,34 @@
+<svg viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="t1 d1">
+  <title id="t1">Congress Radio secret transmitter</title>
+  <desc id="d1">A wood-panelled transmitter set with dials and an aerial, lit by a single bulb.</desc>
+  <rect width="400" height="300" fill="#17181b"/>
+  <rect x="0" y="0" width="400" height="300" fill="url(#g1)"/>
+  <defs>
+    <radialGradient id="g1" cx="50%" cy="30%" r="70%">
+      <stop offset="0%" stop-color="#2a2416"/>
+      <stop offset="100%" stop-color="#17181b"/>
+    </radialGradient>
+  </defs>
+  <!-- table -->
+  <rect x="40" y="210" width="320" height="14" fill="#3a2f1e"/>
+  <rect x="60" y="224" width="12" height="50" fill="#2a2216"/>
+  <rect x="328" y="224" width="12" height="50" fill="#2a2216"/>
+  <!-- transmitter box -->
+  <rect x="110" y="120" width="180" height="90" rx="6" fill="#4a3c22" stroke="#c9a227" stroke-width="2"/>
+  <rect x="128" y="140" width="50" height="50" rx="4" fill="#0f1012" stroke="#c9a227" stroke-width="1.5"/>
+  <circle cx="153" cy="165" r="14" fill="none" stroke="#e6c65c" stroke-width="2"/>
+  <line x1="153" y1="165" x2="160" y2="155" stroke="#e6c65c" stroke-width="2"/>
+  <circle cx="220" cy="150" r="10" fill="#0f1012" stroke="#c9a227" stroke-width="1.5"/>
+  <circle cx="250" cy="150" r="10" fill="#0f1012" stroke="#c9a227" stroke-width="1.5"/>
+  <rect x="200" y="170" width="70" height="16" rx="3" fill="#0f1012" stroke="#c9a227"/>
+  <!-- aerial -->
+  <line x1="260" y1="120" x2="300" y2="30" stroke="#c9a227" stroke-width="3"/>
+  <circle cx="300" cy="30" r="5" fill="#e6c65c"/>
+  <!-- signal waves -->
+  <path d="M310,30 Q330,20 320,50" stroke="#6fae8f" stroke-width="2" fill="none" opacity="0.7"/>
+  <path d="M320,25 Q350,10 335,55" stroke="#6fae8f" stroke-width="2" fill="none" opacity="0.5"/>
+  <path d="M330,20 Q370,0 350,60" stroke="#6fae8f" stroke-width="2" fill="none" opacity="0.3"/>
+  <!-- bulb -->
+  <circle cx="140" cy="100" r="10" fill="#e6c65c" opacity="0.9"/>
+  <line x1="140" y1="90" x2="140" y2="60" stroke="#c9a227" stroke-width="2"/>
+</svg>

--- a/frontend/assets/congress_radio_transmitter.svg
+++ b/frontend/assets/congress_radio_transmitter.svg
@@ -1,0 +1,31 @@
+<svg viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="t2 d2">
+  <title id="t2">Radio signal over nighttime Bombay</title>
+  <desc id="d2">Concentric signal waves radiating over a skyline of rooftops under a night sky.</desc>
+  <rect width="400" height="300" fill="#121316"/>
+  <!-- stars -->
+  <circle cx="40" cy="30" r="1.4" fill="#d9c9a3"/>
+  <circle cx="90" cy="55" r="1" fill="#d9c9a3"/>
+  <circle cx="150" cy="20" r="1.2" fill="#d9c9a3"/>
+  <circle cx="330" cy="40" r="1.4" fill="#d9c9a3"/>
+  <circle cx="360" cy="70" r="1" fill="#d9c9a3"/>
+  <circle cx="270" cy="25" r="1" fill="#d9c9a3"/>
+  <!-- concentric waves -->
+  <circle cx="200" cy="120" r="30" fill="none" stroke="#6fae8f" stroke-width="2" opacity="0.8"/>
+  <circle cx="200" cy="120" r="55" fill="none" stroke="#6fae8f" stroke-width="2" opacity="0.55"/>
+  <circle cx="200" cy="120" r="80" fill="none" stroke="#6fae8f" stroke-width="2" opacity="0.35"/>
+  <circle cx="200" cy="120" r="105" fill="none" stroke="#6fae8f" stroke-width="2" opacity="0.18"/>
+  <!-- rooftop skyline -->
+  <rect x="0" y="220" width="60" height="80" fill="#1f2125"/>
+  <rect x="55" y="190" width="45" height="110" fill="#26282c"/>
+  <rect x="95" y="230" width="55" height="70" fill="#1f2125"/>
+  <rect x="145" y="200" width="40" height="100" fill="#26282c"/>
+  <rect x="180" y="240" width="60" height="60" fill="#1f2125"/>
+  <rect x="235" y="180" width="35" height="120" fill="#26282c"/>
+  <rect x="265" y="225" width="50" height="75" fill="#1f2125"/>
+  <rect x="310" y="205" width="45" height="95" fill="#26282c"/>
+  <rect x="350" y="235" width="50" height="65" fill="#1f2125"/>
+  <!-- aerial mast on rooftop -->
+  <line x1="200" y1="180" x2="200" y2="120" stroke="#c9a227" stroke-width="3"/>
+  <circle cx="200" cy="118" r="5" fill="#e6c65c"/>
+  <rect x="180" y="180" width="40" height="40" fill="#2a2b30" stroke="#33353a"/>
+</svg>

--- a/frontend/assets/congress_radio_usha_mehta.svg
+++ b/frontend/assets/congress_radio_usha_mehta.svg
@@ -1,0 +1,29 @@
+<svg viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="t3 d3">
+  <title id="t3">Usha Mehta broadcasting</title>
+  <desc id="d3">A stylised silhouette of a young woman in a sari speaking into a period microphone.</desc>
+  <rect width="400" height="300" fill="#1c1d21"/>
+  <rect width="400" height="300" fill="url(#g3)"/>
+  <defs>
+    <radialGradient id="g3" cx="50%" cy="35%" r="65%">
+      <stop offset="0%" stop-color="#2c2515"/>
+      <stop offset="100%" stop-color="#1c1d21"/>
+    </radialGradient>
+  </defs>
+  <!-- desk -->
+  <rect x="60" y="240" width="280" height="12" fill="#3a2f1e"/>
+  <!-- figure silhouette -->
+  <ellipse cx="200" cy="140" rx="34" ry="40" fill="#d9c9a3"/>
+  <path d="M155,240 C150,180 170,150 200,150 C230,150 250,180 245,240 Z" fill="#d9c9a3"/>
+  <!-- sari drape accent -->
+  <path d="M175,160 C168,200 175,235 185,240 L195,235 C185,200 185,175 190,160 Z" fill="#c9a227" opacity="0.85"/>
+  <!-- hair bun -->
+  <circle cx="200" cy="104" r="10" fill="#0f1012"/>
+  <path d="M168,130 C168,105 232,105 232,130 C232,110 168,110 168,130Z" fill="#0f1012"/>
+  <!-- microphone -->
+  <rect x="196" y="150" width="8" height="90" fill="#0f1012"/>
+  <rect x="180" y="130" width="40" height="26" rx="10" fill="#3a2f1e" stroke="#c9a227" stroke-width="2"/>
+  <line x1="150" y1="250" x2="250" y2="250" stroke="#33353a" stroke-width="4"/>
+  <!-- sound waves from mic -->
+  <path d="M225,140 Q245,140 245,120" stroke="#6fae8f" stroke-width="2" fill="none" opacity="0.7"/>
+  <path d="M232,145 Q262,145 262,110" stroke="#6fae8f" stroke-width="2" fill="none" opacity="0.4"/>
+</svg>

--- a/frontend/congress-radio-explorer/index.html
+++ b/frontend/congress-radio-explorer/index.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Congress Radio — The Voice of the Underground | Incredible India Explorer</title>
+<meta name="description" content="Explore Congress Radio, the secret station that broadcast uncensored news of the Quit India Movement on 42.34 metres in 1942, led by Usha Mehta." />
+<link rel="stylesheet" href="../pages-common.css" />
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<a class="skip-link" href="#main">Skip to content</a>
+
+<header class="cr-header" id="crHeader">
+  <div class="cr-header-inner">
+    <a href="../../index.html" class="cr-brand">Incredible India Explorer</a>
+    <nav class="cr-crumb" aria-label="Breadcrumb">
+      <a href="../../index.html">Home</a>
+      <span aria-hidden="true">/</span>
+      <a href="../../index.html#culture">Culture</a>
+      <span aria-hidden="true">/</span>
+      <span aria-current="page">Congress Radio</span>
+    </nav>
+  </div>
+</header>
+
+<main id="main">
+
+  <!-- HERO -->
+  <section class="cr-hero">
+    <div class="cr-hero-static" aria-hidden="true"></div>
+    <div class="cr-hero-inner">
+      <p class="cr-eyebrow">Bombay, 1942 · 42.34 Metres</p>
+      <h1 class="cr-hero-title">
+        Congress Radio<br />
+        <span class="cr-hero-sub">Calling from Somewhere in India</span>
+      </h1>
+      <p class="cr-hero-lede">
+        For eleven weeks during the Quit India Movement, a secret transmitter moved from
+        room to room across Bombay, broadcasting the news the British press was forbidden
+        to print — until the signal finally went silent on the night of 12 November 1942.
+      </p>
+      <div class="cr-hero-actions">
+        <button class="cr-btn cr-btn-primary" id="btnListen">Tune the Dial</button>
+        <button class="cr-btn cr-btn-ghost" id="btnBookmark" aria-pressed="false">
+          <span class="cr-bookmark-icon" aria-hidden="true">☆</span>
+          <span class="cr-bookmark-label">Save to Journey</span>
+        </button>
+      </div>
+    </div>
+    <div class="cr-hero-art" aria-hidden="true"></div>
+  </section>
+
+  <!-- OVERVIEW -->
+  <section class="cr-section cr-overview" aria-labelledby="overviewHeading">
+    <div class="cr-section-inner">
+      <h2 id="overviewHeading" class="cr-heading">The Station That Would Not Be Found</h2>
+      <div class="cr-overview-grid">
+        <p class="cr-lead-text">
+          On 8 August 1942, Mahatma Gandhi gave the call to "Do or Die" at Gowalia Tank
+          Maidan. Within hours, almost the entire Congress leadership was in jail, and
+          India's freedom movement was, on paper, leaderless. What the British had not
+          counted on was a twenty-two-year-old Wilson College student named Usha Mehta,
+          who decided the movement needed a voice — even if it had to speak from hiding.
+        </p>
+        <div class="cr-stat-strip">
+          <div class="cr-stat"><span class="cr-stat-num">42.34</span><span class="cr-stat-label">metres wavelength</span></div>
+          <div class="cr-stat"><span class="cr-stat-num">88</span><span class="cr-stat-label">days on air</span></div>
+          <div class="cr-stat"><span class="cr-stat-num">5</span><span class="cr-stat-label">core organisers</span></div>
+          <div class="cr-stat"><span class="cr-stat-num">4</span><span class="cr-stat-label">years, Usha Mehta's sentence</span></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- INTERACTIVE MAP -->
+  <section class="cr-section cr-map-section" aria-labelledby="mapHeading">
+    <div class="cr-section-inner">
+      <h2 id="mapHeading" class="cr-heading">Trace the Signal</h2>
+      <p class="cr-section-intro">
+        The transmitter rarely stayed in one place for long. Select a point on the board
+        to read what happened there.
+      </p>
+
+      <div class="cr-map-wrap">
+        <div class="cr-map-board" id="mapBoard" role="group" aria-label="Congress Radio locations in Bombay">
+          <svg class="cr-map-lines" viewBox="0 0 800 480" aria-hidden="true">
+            <path d="M120,90 L260,150 L420,120 L560,200 L400,320 L620,400" />
+          </svg>
+
+          <button class="cr-pin" data-loc="gowalia" style="--x:15%; --y:19%;">
+            <span class="cr-pin-dot"></span><span class="cr-pin-label">Gowalia Tank Maidan</span>
+          </button>
+          <button class="cr-pin" data-loc="seaview" style="--x:32%; --y:31%;">
+            <span class="cr-pin-dot"></span><span class="cr-pin-label">Sea-View Building</span>
+          </button>
+          <button class="cr-pin" data-loc="chicago" style="--x:52%; --y:25%;">
+            <span class="cr-pin-dot"></span><span class="cr-pin-label">Chicago Radio</span>
+          </button>
+          <button class="cr-pin" data-loc="wilson" style="--x:70%; --y:42%;">
+            <span class="cr-pin-dot"></span><span class="cr-pin-label">Wilson College</span>
+          </button>
+          <button class="cr-pin" data-loc="hideouts" style="--x:48%; --y:66%;">
+            <span class="cr-pin-dot"></span><span class="cr-pin-label">The Moving Hideouts</span>
+          </button>
+          <button class="cr-pin" data-loc="parekh" style="--x:76%; --y:83%;">
+            <span class="cr-pin-dot"></span><span class="cr-pin-label">Parekh Wadi, Girgaon</span>
+          </button>
+        </div>
+
+        <div class="cr-detail-panel" id="detailPanel" aria-live="polite">
+          <p class="cr-detail-hint">Select a location to begin.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- PROFILES -->
+  <section class="cr-section cr-profiles-section" aria-labelledby="profilesHeading">
+    <div class="cr-section-inner">
+      <h2 id="profilesHeading" class="cr-heading">Voices Behind the Static</h2>
+      <div class="cr-profiles-grid" id="profilesGrid">
+
+        <button class="cr-profile-card" data-loc="wilson" data-person="usha">
+          <span class="cr-profile-role">Founder &amp; Hindustani Newsreader</span>
+          <span class="cr-profile-name">Usha Mehta</span>
+          <span class="cr-profile-desc">22-year-old Wilson College student who conceived and ran the station until her arrest.</span>
+        </button>
+
+        <button class="cr-profile-card" data-loc="hideouts" data-person="vithalbhai">
+          <span class="cr-profile-role">Chief Organiser</span>
+          <span class="cr-profile-name">Vithalbhai Jhaveri</span>
+          <span class="cr-profile-desc">Coordinated logistics and kept the operation one step ahead of the police.</span>
+        </button>
+
+        <button class="cr-profile-card" data-loc="hideouts" data-person="lohia">
+          <span class="cr-profile-role">English Newsreader</span>
+          <span class="cr-profile-name">Ram Manohar Lohia</span>
+          <span class="cr-profile-desc">Underground Congress leader who read English news bulletins on air.</span>
+        </button>
+
+        <button class="cr-profile-card" data-loc="parekh" data-person="chandrakant">
+          <span class="cr-profile-role">Co-organiser</span>
+          <span class="cr-profile-name">Chandrakant Jhaveri</span>
+          <span class="cr-profile-desc">Arrested alongside Usha Mehta at the station's final location in Parekh Wadi.</span>
+        </button>
+
+        <button class="cr-profile-card" data-loc="chicago" data-person="motwani">
+          <span class="cr-profile-role">Equipment Supplier</span>
+          <span class="cr-profile-name">Nanka Motwani</span>
+          <span class="cr-profile-desc">Owner of Chicago Radio, who quietly supplied the transmitter equipment.</span>
+        </button>
+
+        <button class="cr-profile-card" data-loc="seaview" data-person="printer">
+          <span class="cr-profile-role">Technical Adviser</span>
+          <span class="cr-profile-name">Nariman A. Printer</span>
+          <span class="cr-profile-desc">Helped set up the transmitter; his later cooperation with police led investigators to the final raid.</span>
+        </button>
+
+      </div>
+    </div>
+  </section>
+
+  <!-- TIMELINE -->
+  <section class="cr-section cr-timeline-section" aria-labelledby="timelineHeading">
+    <div class="cr-section-inner">
+      <h2 id="timelineHeading" class="cr-heading">Eighty-Eight Days on Air</h2>
+      <ol class="cr-timeline">
+        <li class="cr-timeline-item">
+          <span class="cr-timeline-date">8 Aug 1942</span>
+          <p>Gandhi announces Quit India at Gowalia Tank Maidan; almost the entire Congress leadership is arrested within hours.</p>
+        </li>
+        <li class="cr-timeline-item">
+          <span class="cr-timeline-date">14 Aug 1942</span>
+          <p>Usha Mehta and her collaborators begin secretly assembling a transmitter to keep the movement's voice alive.</p>
+        </li>
+        <li class="cr-timeline-item">
+          <span class="cr-timeline-date">27 Aug 1942</span>
+          <p>First broadcast goes live from Sea-View Building, Chowpatty: "This is the Congress radio calling on 42.34 meters from somewhere in India."</p>
+        </li>
+        <li class="cr-timeline-item">
+          <span class="cr-timeline-date">Aug – Nov 1942</span>
+          <p>The station broadcasts uncensored news — including the Ashti-Chimur violence and the Chittagong bomb raid — in English, Hindustani, Marathi and Gujarati, moving location almost daily.</p>
+        </li>
+        <li class="cr-timeline-item">
+          <span class="cr-timeline-date">12 Nov 1942</span>
+          <p>Police raid Room 106, Parekh Wadi, Girgaon Back Road. Usha Mehta and Chandrakant Jhaveri are arrested; the station falls silent.</p>
+        </li>
+        <li class="cr-timeline-item">
+          <span class="cr-timeline-date">Apr 1943</span>
+          <p>After five months awaiting trial, sentences are handed down. Usha Mehta receives four years' rigorous imprisonment.</p>
+        </li>
+      </ol>
+    </div>
+  </section>
+
+  <!-- GALLERY -->
+  <section class="cr-section cr-gallery-section" aria-labelledby="galleryHeading">
+    <div class="cr-section-inner">
+      <h2 id="galleryHeading" class="cr-heading">Illustrated Gallery</h2>
+      <div class="cr-gallery-grid" id="galleryGrid">
+        <button class="cr-gallery-item" data-full="../assets/congress_radio_hero.svg" data-caption="The secret transmitter, assembled from parts supplied by Chicago Radio.">
+          <img src="../assets/congress_radio_hero.svg" alt="Illustration of the Congress Radio secret transmitter" loading="lazy" />
+        </button>
+        <button class="cr-gallery-item" data-full="../assets/congress_radio_transmitter.svg" data-caption="Signal waves radiating from a rooftop aerial across nighttime Bombay.">
+          <img src="../assets/congress_radio_transmitter.svg" alt="Illustration of radio signal waves over Bombay rooftops" loading="lazy" />
+        </button>
+        <button class="cr-gallery-item" data-full="../assets/congress_radio_usha_mehta.svg" data-caption="Usha Mehta at the microphone, reading the news in Hindustani.">
+          <img src="../assets/congress_radio_usha_mehta.svg" alt="Illustration of Usha Mehta broadcasting" loading="lazy" />
+        </button>
+        <button class="cr-gallery-item" data-full="../assets/congress_radio_arrest.svg" data-caption="The raid on Parekh Wadi, Girgaon, on the night of 12 November 1942." >
+          <img src="../assets/congress_radio_arrest.svg" alt="Illustration of the police raid at Parekh Wadi" loading="lazy" />
+        </button>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<!-- GALLERY MODAL -->
+<div class="cr-modal" id="galleryModal" role="dialog" aria-modal="true" aria-labelledby="modalCaption" hidden>
+  <div class="cr-modal-backdrop" id="modalBackdrop"></div>
+  <div class="cr-modal-content">
+    <button class="cr-modal-close" id="modalClose" aria-label="Close gallery">✕</button>
+    <img class="cr-modal-img" id="modalImg" src="" alt="" />
+    <p class="cr-modal-caption" id="modalCaption"></p>
+    <div class="cr-modal-nav">
+      <button class="cr-btn cr-btn-ghost" id="modalPrev" aria-label="Previous image">← Prev</button>
+      <button class="cr-btn cr-btn-ghost" id="modalNext" aria-label="Next image">Next →</button>
+    </div>
+  </div>
+</div>
+
+<footer class="cr-footer">
+  <div class="cr-section-inner">
+    <p>Part of the Incredible India Explorer · Culture Collection</p>
+  </div>
+</footer>
+
+<script src="script.js"></script>
+</body>
+</html>

--- a/frontend/congress-radio-explorer/script.js
+++ b/frontend/congress-radio-explorer/script.js
@@ -1,0 +1,260 @@
+(function () {
+  "use strict";
+
+  /* ---------------------------------------------------------
+     Data: locations + associated people
+     --------------------------------------------------------- */
+  var LOCATIONS = {
+    gowalia: {
+      title: "Gowalia Tank Maidan",
+      date: "8 August 1942",
+      body: "Mahatma Gandhi delivers the \"Do or Die\" call, launching the Quit India Movement. Within hours almost the entire Congress leadership is arrested, leaving the movement without a public voice — the gap Congress Radio was built to fill.",
+      people: "Context for the entire station's founding."
+    },
+    seaview: {
+      title: "Sea-View Building, Chowpatty",
+      date: "27 August 1942",
+      body: "From a rented flat here, the station's first broadcast goes out: \"This is the Congress radio calling on 42.34 meters from somewhere in India.\" Technical adviser Nariman Printer helped set up the transmitter at this address.",
+      people: "Usha Mehta · Nariman A. Printer"
+    },
+    chicago: {
+      title: "Chicago Radio",
+      date: "August 1942",
+      body: "A radio equipment shop owned by Nanka Motwani, who quietly supplied the parts needed to assemble the transmitter — equipment that would otherwise have been impossible to source without drawing suspicion.",
+      people: "Nanka Motwani"
+    },
+    wilson: {
+      title: "Wilson College",
+      date: "1942",
+      body: "Usha Mehta was a student here when she conceived the idea for an underground radio station to carry the movement's news after its leaders were jailed.",
+      people: "Usha Mehta"
+    },
+    hideouts: {
+      title: "The Moving Hideouts",
+      date: "August – November 1942",
+      body: "To stay ahead of British Special Branch, CID, Military Intelligence, the Naval Department and the Air Force — all jointly hunting the signal — the station shifted location almost daily across Bombay, broadcasting in English, Hindustani, Marathi and Gujarati.",
+      people: "Ram Manohar Lohia · Achyutrao Patwardhan · Moinuddin Harris · Coomi Dastur · Vithalbhai Jhaveri"
+    },
+    parekh: {
+      title: "Parekh Wadi, Girgaon Back Road",
+      date: "12 November 1942",
+      body: "Room 106, fifth floor. Acting on information after Nariman Printer's cooperation with investigators, police raid the station's final location. Usha Mehta and Chandrakant Jhaveri are arrested and the broadcasts end.",
+      people: "Usha Mehta · Chandrakant Jhaveri"
+    }
+  };
+
+  var galleryData = [];
+
+  /* ---------------------------------------------------------
+     Map + detail panel
+     --------------------------------------------------------- */
+  var pins = Array.prototype.slice.call(document.querySelectorAll(".cr-pin"));
+  var profileCards = Array.prototype.slice.call(document.querySelectorAll(".cr-profile-card"));
+  var panel = document.getElementById("detailPanel");
+
+  function renderLocation(key) {
+    var data = LOCATIONS[key];
+    if (!data || !panel) return;
+
+    panel.innerHTML =
+      '<h3 class="cr-detail-title">' + escapeHTML(data.title) + '</h3>' +
+      '<span class="cr-detail-date">' + escapeHTML(data.date) + '</span>' +
+      '<p class="cr-detail-body">' + escapeHTML(data.body) + '</p>' +
+      '<div class="cr-detail-people">' + escapeHTML(data.people) + '</div>';
+
+    pins.forEach(function (p) {
+      p.setAttribute("aria-pressed", p.dataset.loc === key ? "true" : "false");
+    });
+    profileCards.forEach(function (c) {
+      c.classList.toggle("is-active", c.dataset.loc === key);
+    });
+  }
+
+  function escapeHTML(str) {
+    var div = document.createElement("div");
+    div.textContent = str;
+    return div.innerHTML;
+  }
+
+  pins.forEach(function (pin) {
+    pin.setAttribute("aria-pressed", "false");
+    pin.addEventListener("click", function () {
+      renderLocation(pin.dataset.loc);
+    });
+  });
+
+  profileCards.forEach(function (card) {
+    card.addEventListener("click", function () {
+      renderLocation(card.dataset.loc);
+      card.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    });
+  });
+
+  var btnListen = document.getElementById("btnListen");
+  if (btnListen) {
+    btnListen.addEventListener("click", function () {
+      var mapSection = document.getElementById("mapHeading");
+      if (mapSection) mapSection.scrollIntoView({ behavior: "smooth", block: "start" });
+      renderLocation("seaview");
+    });
+  }
+
+  /* ---------------------------------------------------------
+     Gallery modal with focus trap
+     --------------------------------------------------------- */
+  var galleryItems = Array.prototype.slice.call(document.querySelectorAll(".cr-gallery-item"));
+  var modal = document.getElementById("galleryModal");
+  var modalImg = document.getElementById("modalImg");
+  var modalCaption = document.getElementById("modalCaption");
+  var modalClose = document.getElementById("modalClose");
+  var modalBackdrop = document.getElementById("modalBackdrop");
+  var modalPrev = document.getElementById("modalPrev");
+  var modalNext = document.getElementById("modalNext");
+  var currentIndex = 0;
+  var lastFocused = null;
+
+  galleryItems.forEach(function (item, i) {
+    galleryData.push({
+      full: item.dataset.full,
+      caption: item.dataset.caption
+    });
+    item.addEventListener("click", function () {
+      openModal(i);
+    });
+  });
+
+  function openModal(index) {
+    if (!modal) return;
+    currentIndex = index;
+    updateModalContent();
+    lastFocused = document.activeElement;
+    modal.hidden = false;
+    document.body.style.overflow = "hidden";
+    modalClose.focus();
+    document.addEventListener("keydown", onModalKeydown);
+  }
+
+  function closeModal() {
+    if (!modal) return;
+    modal.hidden = true;
+    document.body.style.overflow = "";
+    document.removeEventListener("keydown", onModalKeydown);
+    if (lastFocused) lastFocused.focus();
+  }
+
+  function updateModalContent() {
+    var data = galleryData[currentIndex];
+    if (!data) return;
+    modalImg.src = data.full;
+    modalImg.alt = data.caption || "";
+    modalCaption.textContent = data.caption || "";
+  }
+
+  function showPrev() {
+    currentIndex = (currentIndex - 1 + galleryData.length) % galleryData.length;
+    updateModalContent();
+  }
+  function showNext() {
+    currentIndex = (currentIndex + 1) % galleryData.length;
+    updateModalContent();
+  }
+
+  function getFocusable() {
+    return Array.prototype.slice.call(
+      modal.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')
+    ).filter(function (el) { return !el.disabled && el.offsetParent !== null; });
+  }
+
+  function onModalKeydown(e) {
+    if (e.key === "Escape") {
+      closeModal();
+      return;
+    }
+    if (e.key === "ArrowLeft") { showPrev(); return; }
+    if (e.key === "ArrowRight") { showNext(); return; }
+
+    if (e.key === "Tab") {
+      var focusable = getFocusable();
+      if (focusable.length === 0) return;
+      var first = focusable[0];
+      var last = focusable[focusable.length - 1];
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+
+  if (modalClose) modalClose.addEventListener("click", closeModal);
+  if (modalBackdrop) modalBackdrop.addEventListener("click", closeModal);
+  if (modalPrev) modalPrev.addEventListener("click", showPrev);
+  if (modalNext) modalNext.addEventListener("click", showNext);
+
+  /* ---------------------------------------------------------
+     Journey bookmark
+     --------------------------------------------------------- */
+  var BOOKMARK_KEY = "journey-bookmarks";
+  var PAGE_ID = "congress-radio-explorer";
+  var btnBookmark = document.getElementById("btnBookmark");
+
+  function getBookmarks() {
+    try {
+      return JSON.parse(localStorage.getItem(BOOKMARK_KEY)) || [];
+    } catch (e) {
+      return [];
+    }
+  }
+
+  function setBookmarks(list) {
+    try {
+      localStorage.setItem(BOOKMARK_KEY, JSON.stringify(list));
+    } catch (e) { /* storage unavailable, ignore */ }
+  }
+
+  function refreshBookmarkButton() {
+    if (!btnBookmark) return;
+    var isSaved = getBookmarks().indexOf(PAGE_ID) !== -1;
+    btnBookmark.setAttribute("aria-pressed", isSaved ? "true" : "false");
+    var icon = btnBookmark.querySelector(".cr-bookmark-icon");
+    var label = btnBookmark.querySelector(".cr-bookmark-label");
+    if (icon) icon.textContent = isSaved ? "★" : "☆";
+    if (label) label.textContent = isSaved ? "Saved to Journey" : "Save to Journey";
+  }
+
+  if (btnBookmark) {
+    btnBookmark.addEventListener("click", function () {
+      var list = getBookmarks();
+      var idx = list.indexOf(PAGE_ID);
+      if (idx === -1) {
+        list.push(PAGE_ID);
+      } else {
+        list.splice(idx, 1);
+      }
+      setBookmarks(list);
+      refreshBookmarkButton();
+    });
+    refreshBookmarkButton();
+  }
+
+  /* ---------------------------------------------------------
+     Global search registration
+     (Consumed by frontend/search-index.js if present)
+     --------------------------------------------------------- */
+  window.crSearchEntries = [
+    {
+      title: "Congress Radio",
+      keywords: "congress radio underground quit india usha mehta 1942 42.34 metres secret transmitter",
+      url: "frontend/congress-radio-explorer/index.html"
+    },
+    {
+      title: "Usha Mehta",
+      keywords: "usha mehta wilson college congress radio broadcaster hindustani newsreader",
+      url: "frontend/congress-radio-explorer/index.html#profilesHeading"
+    }
+  ];
+
+})();

--- a/frontend/congress-radio-explorer/style.css
+++ b/frontend/congress-radio-explorer/style.css
@@ -1,0 +1,317 @@
+/* ==========================================================
+   Congress Radio Explorer
+   Palette: Iron / Gold / Sand — matches Cellular Jail Explorer
+   ========================================================== */
+
+:root {
+  --cr-iron: #17181b;
+  --cr-iron-soft: #1f2125;
+  --cr-iron-line: #33353a;
+  --cr-gold: #c9a227;
+  --cr-gold-bright: #e6c65c;
+  --cr-sand: #d9c9a3;
+  --cr-sand-dim: #a89a78;
+  --cr-signal: #6fae8f;
+  --cr-danger: #b5533c;
+  --cr-radius: 10px;
+  --cr-shadow: 0 12px 30px rgba(0,0,0,0.45);
+  font-family: 'Georgia', 'Iowan Old Style', serif;
+}
+
+.cr-header, .cr-hero, .cr-section, .cr-footer, .cr-modal {
+  box-sizing: border-box;
+}
+.cr-header *, .cr-hero *, .cr-section *, .cr-footer *, .cr-modal * {
+  box-sizing: border-box;
+}
+
+/* ---------- Header ---------- */
+.cr-header {
+  background: var(--cr-iron);
+  border-bottom: 1px solid var(--cr-iron-line);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+.cr-header-inner {
+  max-width: 1140px;
+  margin: 0 auto;
+  padding: 14px 24px;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+}
+.cr-brand {
+  color: var(--cr-gold-bright);
+  font-weight: 700;
+  text-decoration: none;
+  letter-spacing: 0.02em;
+}
+.cr-crumb { font-size: 0.85rem; color: var(--cr-sand-dim); }
+.cr-crumb a { color: var(--cr-sand-dim); text-decoration: none; }
+.cr-crumb a:hover { color: var(--cr-gold); }
+.cr-crumb span[aria-current] { color: var(--cr-sand); }
+
+.skip-link {
+  position: absolute; left: -9999px; top: 0;
+  background: var(--cr-gold); color: var(--cr-iron); padding: 10px 16px; z-index: 100;
+}
+.skip-link:focus { left: 16px; top: 16px; }
+
+/* ---------- Hero ---------- */
+.cr-hero {
+  position: relative;
+  background: radial-gradient(ellipse at 70% 20%, #24211a 0%, var(--cr-iron) 60%);
+  color: var(--cr-sand);
+  padding: 96px 24px 80px;
+  overflow: hidden;
+}
+.cr-hero-static {
+  position: absolute; inset: 0;
+  background-image: repeating-linear-gradient(0deg, rgba(201,162,39,0.04) 0px, rgba(201,162,39,0.04) 1px, transparent 1px, transparent 3px);
+  opacity: 0.5;
+  pointer-events: none;
+}
+.cr-hero-art {
+  position: absolute; right: -60px; bottom: -60px; width: 380px; height: 380px;
+  background: radial-gradient(circle, rgba(201,162,39,0.15) 0%, transparent 70%);
+  pointer-events: none;
+}
+.cr-hero-inner { position: relative; max-width: 760px; margin: 0 auto; text-align: center; }
+.cr-eyebrow {
+  color: var(--cr-gold);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  margin-bottom: 18px;
+  font-family: Georgia, serif;
+}
+.cr-hero-title {
+  font-size: clamp(2.2rem, 5vw, 3.6rem);
+  line-height: 1.15;
+  margin: 0 0 20px;
+  color: var(--cr-gold-bright);
+}
+.cr-hero-sub {
+  display: block;
+  font-size: 0.5em;
+  color: var(--cr-sand);
+  font-style: italic;
+  margin-top: 10px;
+  letter-spacing: 0.02em;
+}
+.cr-hero-lede {
+  font-size: 1.08rem;
+  line-height: 1.7;
+  color: var(--cr-sand-dim);
+  max-width: 620px;
+  margin: 0 auto 34px;
+}
+.cr-hero-actions { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; }
+
+.cr-btn {
+  font-family: inherit;
+  font-size: 0.95rem;
+  padding: 12px 24px;
+  border-radius: var(--cr-radius);
+  border: 1px solid var(--cr-gold);
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.15s ease, color 0.15s ease;
+  display: inline-flex; align-items: center; gap: 8px;
+}
+.cr-btn:hover { transform: translateY(-1px); }
+.cr-btn:focus-visible { outline: 3px solid var(--cr-gold-bright); outline-offset: 2px; }
+.cr-btn-primary { background: var(--cr-gold); color: var(--cr-iron); font-weight: 700; }
+.cr-btn-primary:hover { background: var(--cr-gold-bright); }
+.cr-btn-ghost { background: transparent; color: var(--cr-sand); }
+.cr-btn-ghost:hover { background: rgba(201,162,39,0.12); }
+.cr-btn-ghost[aria-pressed="true"] { background: var(--cr-gold); color: var(--cr-iron); }
+.cr-bookmark-icon { font-size: 1.05em; }
+
+/* ---------- Sections ---------- */
+.cr-section { padding: 72px 24px; background: var(--cr-iron-soft); }
+.cr-section:nth-of-type(even) { background: var(--cr-iron); }
+.cr-section-inner { max-width: 1080px; margin: 0 auto; }
+.cr-heading {
+  color: var(--cr-gold-bright);
+  font-size: clamp(1.5rem, 3vw, 2.1rem);
+  margin: 0 0 12px;
+}
+.cr-section-intro { color: var(--cr-sand-dim); max-width: 640px; margin: 0 0 36px; line-height: 1.6; }
+.cr-lead-text { color: var(--cr-sand); line-height: 1.75; font-size: 1.05rem; }
+
+.cr-stat-strip {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 18px;
+  margin-top: 28px;
+}
+.cr-stat {
+  border: 1px solid var(--cr-iron-line);
+  border-radius: var(--cr-radius);
+  padding: 18px 12px;
+  text-align: center;
+  background: rgba(201,162,39,0.03);
+}
+.cr-stat-num { display: block; color: var(--cr-gold-bright); font-size: 1.6rem; font-weight: 700; }
+.cr-stat-label { display: block; color: var(--cr-sand-dim); font-size: 0.78rem; margin-top: 4px; text-transform: uppercase; letter-spacing: 0.05em; }
+
+@media (max-width: 700px) {
+  .cr-stat-strip { grid-template-columns: repeat(2, 1fr); }
+}
+
+/* ---------- Map ---------- */
+.cr-map-wrap {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 28px;
+  align-items: start;
+}
+.cr-map-board {
+  position: relative;
+  aspect-ratio: 800 / 480;
+  background:
+    linear-gradient(160deg, #1c1d21 0%, #121316 100%);
+  border: 1px solid var(--cr-iron-line);
+  border-radius: var(--cr-radius);
+  overflow: hidden;
+}
+.cr-map-lines { position: absolute; inset: 0; width: 100%; height: 100%; }
+.cr-map-lines path {
+  fill: none;
+  stroke: var(--cr-gold);
+  stroke-width: 1;
+  stroke-dasharray: 4 6;
+  opacity: 0.35;
+}
+.cr-pin {
+  position: absolute;
+  left: var(--x); top: var(--y);
+  transform: translate(-50%, -50%);
+  background: none; border: none; cursor: pointer;
+  display: flex; flex-direction: column; align-items: center; gap: 6px;
+  color: var(--cr-sand);
+  padding: 4px;
+}
+.cr-pin-dot {
+  width: 16px; height: 16px; border-radius: 50%;
+  background: var(--cr-gold);
+  box-shadow: 0 0 0 4px rgba(201,162,39,0.18);
+  transition: transform 0.15s ease, background 0.15s ease;
+}
+.cr-pin:hover .cr-pin-dot, .cr-pin:focus-visible .cr-pin-dot { transform: scale(1.25); background: var(--cr-gold-bright); }
+.cr-pin[aria-pressed="true"] .cr-pin-dot { background: var(--cr-signal); box-shadow: 0 0 0 5px rgba(111,174,143,0.25); }
+.cr-pin-label {
+  font-size: 0.72rem;
+  white-space: nowrap;
+  background: rgba(0,0,0,0.55);
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+.cr-pin:focus-visible { outline: 2px solid var(--cr-gold-bright); outline-offset: 3px; border-radius: 6px; }
+
+.cr-detail-panel {
+  border: 1px solid var(--cr-iron-line);
+  border-radius: var(--cr-radius);
+  padding: 24px;
+  background: var(--cr-iron);
+  min-height: 260px;
+  color: var(--cr-sand);
+}
+.cr-detail-hint { color: var(--cr-sand-dim); font-style: italic; }
+.cr-detail-title { color: var(--cr-gold-bright); font-size: 1.25rem; margin: 0 0 4px; }
+.cr-detail-date { color: var(--cr-gold); font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.06em; display: block; margin-bottom: 14px; }
+.cr-detail-body { line-height: 1.7; }
+.cr-detail-people { margin-top: 16px; padding-top: 14px; border-top: 1px solid var(--cr-iron-line); font-size: 0.88rem; color: var(--cr-sand-dim); }
+
+@media (max-width: 820px) {
+  .cr-map-wrap { grid-template-columns: 1fr; }
+}
+
+/* ---------- Profiles ---------- */
+.cr-profiles-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 18px;
+}
+.cr-profile-card {
+  text-align: left;
+  background: var(--cr-iron-soft);
+  border: 1px solid var(--cr-iron-line);
+  border-radius: var(--cr-radius);
+  padding: 20px;
+  cursor: pointer;
+  color: var(--cr-sand);
+  display: flex; flex-direction: column; gap: 6px;
+  transition: border-color 0.15s ease, transform 0.15s ease;
+}
+.cr-profile-card:hover, .cr-profile-card:focus-visible {
+  border-color: var(--cr-gold);
+  transform: translateY(-2px);
+  outline: none;
+}
+.cr-profile-card.is-active { border-color: var(--cr-signal); box-shadow: 0 0 0 1px var(--cr-signal); }
+.cr-profile-role { color: var(--cr-gold); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.06em; }
+.cr-profile-name { color: var(--cr-gold-bright); font-size: 1.15rem; font-weight: 700; }
+.cr-profile-desc { color: var(--cr-sand-dim); font-size: 0.9rem; line-height: 1.5; }
+
+/* ---------- Timeline ---------- */
+.cr-timeline { list-style: none; margin: 0; padding: 0; border-left: 2px solid var(--cr-iron-line); }
+.cr-timeline-item { position: relative; padding: 0 0 32px 28px; }
+.cr-timeline-item::before {
+  content: ""; position: absolute; left: -7px; top: 4px;
+  width: 12px; height: 12px; border-radius: 50%;
+  background: var(--cr-gold); border: 2px solid var(--cr-iron-soft);
+}
+.cr-timeline-date { display: block; color: var(--cr-gold-bright); font-weight: 700; margin-bottom: 4px; }
+.cr-timeline-item p { color: var(--cr-sand); line-height: 1.65; margin: 0; max-width: 640px; }
+
+/* ---------- Gallery ---------- */
+.cr-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+}
+.cr-gallery-item {
+  border: 1px solid var(--cr-iron-line);
+  border-radius: var(--cr-radius);
+  overflow: hidden;
+  background: var(--cr-iron);
+  cursor: pointer;
+  padding: 0;
+  aspect-ratio: 4 / 3;
+}
+.cr-gallery-item img { width: 100%; height: 100%; object-fit: cover; display: block; transition: transform 0.2s ease; }
+.cr-gallery-item:hover img, .cr-gallery-item:focus-visible img { transform: scale(1.05); }
+.cr-gallery-item:focus-visible { outline: 3px solid var(--cr-gold-bright); outline-offset: -3px; }
+
+/* ---------- Modal ---------- */
+.cr-modal { position: fixed; inset: 0; z-index: 100; display: flex; align-items: center; justify-content: center; }
+.cr-modal[hidden] { display: none; }
+.cr-modal-backdrop { position: absolute; inset: 0; background: rgba(10,10,10,0.85); }
+.cr-modal-content {
+  position: relative;
+  background: var(--cr-iron-soft);
+  border: 1px solid var(--cr-iron-line);
+  border-radius: var(--cr-radius);
+  padding: 24px;
+  max-width: 640px;
+  width: 90%;
+  box-shadow: var(--cr-shadow);
+}
+.cr-modal-img { width: 100%; border-radius: 6px; margin-bottom: 14px; background: #000; }
+.cr-modal-caption { color: var(--cr-sand); font-size: 0.95rem; margin: 0 0 16px; }
+.cr-modal-close {
+  position: absolute; top: 12px; right: 12px;
+  background: none; border: none; color: var(--cr-sand); font-size: 1.2rem; cursor: pointer;
+}
+.cr-modal-close:focus-visible, .cr-modal-nav .cr-btn:focus-visible { outline: 2px solid var(--cr-gold-bright); }
+.cr-modal-nav { display: flex; justify-content: space-between; }
+
+/* ---------- Footer ---------- */
+.cr-footer { background: var(--cr-iron); border-top: 1px solid var(--cr-iron-line); padding: 28px 24px; color: var(--cr-sand-dim); font-size: 0.85rem; text-align: center; }
+
+/* ---------- Reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .cr-btn, .cr-pin-dot, .cr-profile-card, .cr-gallery-item img { transition: none; }
+}

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -656,6 +656,12 @@ window.indiaSearchIndex = [
     url: "frontend/sanjhi-art-explorer/index.html"
   },
   {
+    title: "Congress Radio Explorer",
+    category: "Culture",
+    description: "Discover Congress Radio, the secret underground station that broadcast uncensored news of the Quit India Movement on 42.34 metres in 1942, led by 22-year-old Usha Mehta.",
+    url: "frontend/congress-radio-explorer/index.html"
+  },
+  {
     title: "Gujarati Cinema (Dhollywood) Explorer",
     category: "Culture",
     description: "Discover Dhollywood, the Gujarati film industry — from Narsinh Mehta (1932), the first Gujarati talkie, to National Award-winning classics and its modern urban revival.",

--- a/index.html
+++ b/index.html
@@ -393,6 +393,7 @@
                 <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
                 <div class="dropdown-menu">
                     <a href="frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+                    <a href="frontend/congress-radio-explorer/index.html">Congress Radio Explorer</a>
                     <a href="frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
                     <a href="frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
                     <a href="frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>

--- a/index.html
+++ b/index.html
@@ -393,7 +393,6 @@
                 <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
                 <div class="dropdown-menu">
                     <a href="frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
-                    <a href="frontend/congress-radio-explorer/index.html">Congress Radio Explorer</a>
                     <a href="frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
                     <a href="frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
                     <a href="frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>


### PR DESCRIPTION
Closes #1990
## Overview
Adds a new "Congress Radio — The Voice of the Underground" page under Culture, telling the story of the secret radio station that broadcast uncensored news of the Quit India Movement on 42.34 metres in 1942, led by 22-year-old Usha Mehta, until its final raid on 12 November 1942.

## What's included
- **New page**: `frontend/congress-radio-explorer/index.html` — hero section, historical overview with key stats, an interactive location map, organiser profile cards, a day-by-day timeline, and an illustrated visual gallery
- **Styling**: `frontend/congress-radio-explorer/style.css` — iron/gold/sand theme consistent with the site's other Culture explorer pages, linked to the shared `pages-common.css`
- **Interactivity**: `frontend/congress-radio-explorer/script.js` — clickable location pins synced with a live detail panel, profile cards that cross-highlight their matching pin, gallery modal with keyboard navigation and focus trap, Journey bookmark toggle with localStorage persistence
- **4 custom SVG illustrations**: the secret transmitter, signal waves over nighttime Bombay, Usha Mehta at the microphone, and the raid at Parekh Wadi
- **Search**: registered new entry in `frontend/search-index.js` for global search discoverability

## Interactive location map
Six clickable points (Gowalia Tank Maidan, Sea-View Building, Chicago Radio, Wilson College, the Moving Hideouts, Parekh Wadi) — selecting a pin or its matching profile card updates a live detail panel with that location's history and the people connected to it.

## Testing done
- [x] Verified no functional console errors (only harmless ServiceWorker/favicon 404s shared across all pages) — confirmed via curl status checks on every asset before browser testing
- [x] Map pins and profile cards tested — detail panel updates correctly and cross-highlights for each location
- [x] Gallery modal open/close via click, keyboard (arrows + Escape), with focus trap active
- [x] Journey bookmark save/unsave toggle works and persists across refresh
- [x] `node -c` syntax check passed on script.js
- [x] Responsive layout checked on mobile widths
- [x] Global search returns results for "Congress Radio"
<img width="1440" height="852" alt="Screenshot 2026-08-09 214657" src="https://github.com/user-attachments/assets/6548c2e1-357e-43a5-b833-62c659a59d8f" />
<img width="1440" height="852" alt="Screenshot 2026-08-09 214706" src="https://github.com/user-attachments/assets/209cde15-cd61-471c-8375-a165183ef264" />
<img width="1440" height="852" alt="Screenshot 2026-08-09 214711" src="https://github.com/user-attachments/assets/b84a0dcd-8b55-42db-8d61-474761e8177a" />
