### PR TITLE
feat: add Baji Rout freedom fighter explorer

### DIFF
--- a/frontend/baji-rout-explorer/baji-data.js
+++ b/frontend/baji-rout-explorer/baji-data.js
@@ -1,0 +1,59 @@
+/**
+ * Baji Rout Explorer — Data Module
+ */
+
+const BAJI_INFO = {
+    id: "baji-rout",
+    title: "Baji Rout",
+    quickStats: [
+        { label: "Born", value: "1926, Nilakanthapur", icon: "📍" },
+        { label: "Died", value: "October 11, 1938", icon: "🕯️" },
+        { label: "Age at Martyrdom", value: "12 Years", icon: "🌟" },
+        { label: "Region", value: "Odisha (then Orissa)", icon: "🗺️" },
+        { label: "Role", value: "Boatman & Village Volunteer", icon: "🛶" },
+        { label: "Remembered As", value: "One of India's Youngest Martyrs", icon: "🇮🇳" }
+    ]
+};
+
+const HISTORY_TEXT = {
+    title: "A Boatman's Son in Colonial Odisha",
+    paragraphs: [
+        "Baji Rout was born in 1926 in the village of Nilakanthapur in the princely state of Dhenkanal, in present-day Odisha. He came from a family of boatmen and worked ferrying passengers across the local river from a young age.",
+        "In the 1930s, the princely state of Dhenkanal was the site of growing unrest as local peasants organized the Praja Mandal movement, protesting oppressive taxation and forced labor imposed by the state administration. Popular resistance grew across many villages in the region.",
+        "On the night of October 11, 1938, state police arrived at the riverbank where young Baji Rout was on duty as a boatman and volunteer, demanding he ferry them across the river to suppress protesting villagers. Baji Rout refused to cooperate with the police in their mission against his own community.",
+        "In response to his refusal, the police opened fire, and Baji Rout was fatally shot. He died that night, becoming, at twelve years old, one of the youngest known martyrs of India's freedom struggle. His death became a rallying point for the Praja Mandal movement in Dhenkanal and is remembered in Odisha as a symbol of courage and sacrifice."
+    ]
+};
+
+const TIMELINE_EVENTS = [
+    { era: "1926", title: "Born in Nilakanthapur", description: "Baji Rout was born into a boatman family in the princely state of Dhenkanal, Odisha." },
+    { era: "1930s", title: "Rise of the Praja Mandal Movement", description: "Growing unrest in Dhenkanal as villagers organized against oppressive state taxation and forced labor." },
+    { era: "October 11, 1938", title: "Refusal at the Riverbank", description: "Baji Rout, on duty as a young boatman, refused to ferry state police across the river to suppress protesting villagers." },
+    { era: "October 11, 1938", title: "Martyrdom", description: "Police opened fire on him for his refusal; Baji Rout was fatally shot at the age of twelve." },
+    { era: "Post-1938", title: "Symbol of the Movement", description: "His death galvanized the Praja Mandal movement in Dhenkanal and became remembered across Odisha as an act of courage." }
+];
+
+const STRUGGLE_POINTS = [
+    { title: "The Praja Mandal Movement", description: "A popular movement in princely states like Dhenkanal, organizing peasants against oppressive taxation, forced labor, and autocratic administration." },
+    { title: "Local Resistance in Dhenkanal", description: "Villagers across the Dhenkanal region actively resisted state policies, drawing a strong police response." },
+    { title: "An Act of Quiet Defiance", description: "Baji Rout's refusal to assist police against his own community, despite being a child, exemplified the widespread resolve of the movement." },
+    { title: "Ripple Effect", description: "His death intensified public anger and support for the Praja Mandal cause across the region." }
+];
+
+const MEMORIALS = [
+    { title: "Baji Rout Chhatrabas", description: "Student hostels and institutions named in his honor exist in parts of Odisha, commemorating his sacrifice." },
+    { title: "Statues and Memorials", description: "Memorials and statues dedicated to Baji Rout have been erected in Odisha, particularly in the Dhenkanal region." },
+    { title: "Regional Commemoration", description: "His memory is honored annually in parts of Odisha as a symbol of youthful courage in the freedom struggle." }
+];
+
+const GALLERY_QUERIES = [
+    "Dhenkanal Odisha riverbank landscape",
+    "Odisha princely state historical",
+    "Mahanadi river boats Odisha"
+];
+
+const REFERENCES = [
+    { text: "Government of Odisha — historical records on the Praja Mandal movement.", link: "#" },
+    { text: "Pati, B. — historical studies on princely state resistance movements in Odisha.", link: "#" },
+    { text: "Regional archives on the Dhenkanal Praja Mandal uprising.", link: "#" }
+];

--- a/frontend/baji-rout-explorer/baji.css
+++ b/frontend/baji-rout-explorer/baji.css
@@ -1,0 +1,219 @@
+.br-hero {
+    padding: 6rem 1.5rem 3rem;
+    text-align: center;
+}
+
+.hero-badges-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.25rem;
+}
+
+.hero-pill {
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 999px;
+    padding: 0.4rem 0.9rem;
+    font-size: 0.85rem;
+}
+
+.br-hero h1 span {
+    color: var(--saffron, #ff9933);
+    display: block;
+    font-size: 0.5em;
+    font-weight: 500;
+}
+
+.hero-subtitle {
+    max-width: 660px;
+    margin: 1rem auto 2rem;
+    opacity: 0.85;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 1rem;
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.stat-pill {
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 14px;
+    padding: 1rem;
+    text-align: center;
+}
+
+.stat-icon {
+    display: block;
+    font-size: 1.4rem;
+    margin-bottom: 0.4rem;
+}
+
+.stat-value {
+    display: block;
+    font-weight: 600;
+}
+
+.stat-label {
+    display: block;
+    font-size: 0.75rem;
+    opacity: 0.65;
+}
+
+.br-info-section {
+    padding: 2rem 1.5rem 4rem;
+}
+
+.sec-title {
+    margin-top: 3rem;
+}
+
+.info-card,
+.principle-card,
+.br-card {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 16px;
+    padding: 1.5rem;
+}
+
+.info-card p {
+    margin: 0 0 1rem;
+    line-height: 1.6;
+}
+
+.info-card p:last-child {
+    margin-bottom: 0;
+}
+
+.principles-grid,
+.br-cards-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.br-card h4 {
+    margin: 0 0 0.5rem;
+    color: var(--saffron, #ff9933);
+}
+
+.br-card p {
+    margin: 0;
+    opacity: 0.85;
+    line-height: 1.5;
+}
+
+/* ---- Timeline ---- */
+.br-timeline {
+    position: relative;
+    padding-left: 2rem;
+    border-left: 2px solid rgba(255, 176, 31, 0.25);
+}
+
+.timeline-item {
+    position: relative;
+    padding-bottom: 2rem;
+}
+
+.timeline-item:last-child {
+    padding-bottom: 0;
+}
+
+.timeline-dot {
+    position: absolute;
+    left: -2.45rem;
+    top: 0.3rem;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--saffron, #ff9933);
+    box-shadow: 0 0 0 4px rgba(255, 153, 51, 0.15);
+}
+
+.timeline-era {
+    display: inline-block;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--saffron, #ff9933);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin-bottom: 0.35rem;
+}
+
+.timeline-content h4 {
+    margin: 0 0 0.4rem;
+}
+
+.timeline-content p {
+    margin: 0;
+    opacity: 0.85;
+    line-height: 1.55;
+}
+
+/* ---- Gallery ---- */
+.br-gallery {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.br-gallery-tile {
+    aspect-ratio: 4 / 3;
+    border-radius: 14px;
+    background: linear-gradient(135deg, rgba(255, 153, 51, 0.15), rgba(255, 255, 255, 0.03));
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    display: flex;
+    align-items: flex-end;
+    padding: 1rem;
+    font-size: 0.8rem;
+    opacity: 0.75;
+}
+
+.references-section {
+    padding: 2rem 1.5rem 4rem;
+}
+
+.references-list {
+    list-style: none;
+    padding: 0;
+}
+
+.references-list li {
+    padding: 0.5rem 0;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.references-list a {
+    color: inherit;
+    opacity: 0.8;
+    text-decoration: none;
+}
+
+.references-list a:hover {
+    opacity: 1;
+    text-decoration: underline;
+}
+
+body.light-theme .info-card,
+body.light-theme .principle-card,
+body.light-theme .br-card,
+body.light-theme .stat-pill {
+    background: rgba(0, 0, 0, 0.03);
+    border-color: rgba(0, 0, 0, 0.1);
+}
+
+/* The global .section-container (frontend/styles/extras.css) adds
+   100px top/bottom padding by default, which stacks with this page's
+   own section padding and creates large empty gaps. Override it here. */
+body.br-main .section-container {
+    padding: 0;
+    max-width: 1100px;
+    width: 100%;
+    margin: 0 auto;
+}

--- a/frontend/baji-rout-explorer/baji.js
+++ b/frontend/baji-rout-explorer/baji.js
@@ -1,0 +1,72 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const statsGrid = document.getElementById('stats-grid');
+    if (statsGrid) {
+        statsGrid.innerHTML = BAJI_INFO.quickStats
+            .map(s => `
+                <div class="stat-pill">
+                    <span class="stat-icon">${s.icon}</span>
+                    <span class="stat-value">${s.value}</span>
+                    <span class="stat-label">${s.label}</span>
+                </div>
+            `).join('');
+    }
+
+    const historyContent = document.getElementById('history-content');
+    if (historyContent) {
+        historyContent.innerHTML = `
+            <h3>${HISTORY_TEXT.title}</h3>
+            ${HISTORY_TEXT.paragraphs.map(p => `<p>${p}</p>`).join('')}
+        `;
+    }
+
+    const timelineEl = document.getElementById('br-timeline');
+    if (timelineEl) {
+        timelineEl.innerHTML = TIMELINE_EVENTS
+            .map(ev => `
+                <div class="timeline-item">
+                    <div class="timeline-dot"></div>
+                    <div class="timeline-content">
+                        <span class="timeline-era">${ev.era}</span>
+                        <h4>${ev.title}</h4>
+                        <p>${ev.description}</p>
+                    </div>
+                </div>
+            `).join('');
+    }
+
+    const struggleGrid = document.getElementById('struggle-grid');
+    if (struggleGrid) {
+        struggleGrid.innerHTML = STRUGGLE_POINTS
+            .map(s => `
+                <div class="br-card">
+                    <h4>${s.title}</h4>
+                    <p>${s.description}</p>
+                </div>
+            `).join('');
+    }
+
+    const memorialsGrid = document.getElementById('memorials-grid');
+    if (memorialsGrid) {
+        memorialsGrid.innerHTML = MEMORIALS
+            .map(m => `
+                <div class="principle-card">
+                    <h4>${m.title}</h4>
+                    <p>${m.description}</p>
+                </div>
+            `).join('');
+    }
+
+    const galleryEl = document.getElementById('br-gallery');
+    if (galleryEl) {
+        galleryEl.innerHTML = GALLERY_QUERIES
+            .map(q => `<div class="br-gallery-tile"><span>${q}</span></div>`)
+            .join('');
+    }
+
+    const referencesList = document.getElementById('references-list');
+    if (referencesList) {
+        referencesList.innerHTML = REFERENCES
+            .map(r => `<li><a href="${r.link}" target="_blank" rel="noopener">${r.text}</a></li>`)
+            .join('');
+    }
+});

--- a/frontend/baji-rout-explorer/index.html
+++ b/frontend/baji-rout-explorer/index.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <script>
+        (function () {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description"
+        content="Explore the story of Baji Rout, one of the youngest martyrs of India's freedom struggle from Odisha — his bravery, sacrifice, and lasting inspiration." />
+    <title>Baji Rout Explorer | Incredible India</title>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+        href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+        rel="stylesheet" />
+
+    <link rel="stylesheet" href="../../styles.css" />
+    <link rel="stylesheet" href="baji.css" />
+</head>
+
+<body class="br-main">
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html#home" class="nav-link">Home</a>
+                <a href="../freedom-fighters-hub/index.html" class="nav-link">Freedom Fighters</a>
+                <a href="index.html" class="nav-link active" style="color: var(--saffron)">Baji Rout</a>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode"
+                    title="Toggle Light Mode">
+                    ☀️
+                </button>
+            </nav>
+        </div>
+    </header>
+
+    <main>
+        <section class="br-hero">
+            <div class="section-container">
+                <div class="hero-badges-row">
+                    <span class="hero-pill pill-origin">📍 Nilakanthapur, Odisha</span>
+                    <span class="hero-pill pill-era">🕯️ 1926 – 1938</span>
+                    <span class="hero-pill pill-name">🌟 Youngest Martyr</span>
+                </div>
+                <h1>Baji Rout <span>A Young Life Given for Freedom</span></h1>
+                <p class="hero-subtitle">
+                    At just twelve years old, Baji Rout became one of the youngest martyrs of India's freedom struggle —
+                    remembered in Odisha for his courage and unwavering conviction.
+                </p>
+                <div id="stats-grid" class="stats-grid"></div>
+            </div>
+        </section>
+
+        <section class="br-info-section">
+            <div class="section-container">
+                <h2>Biography</h2>
+                <div id="history-content" class="info-card"></div>
+
+                <h2 class="sec-title">Timeline</h2>
+                <div class="br-timeline" id="br-timeline"></div>
+
+                <h2 class="sec-title">Odisha's Freedom Struggle</h2>
+                <div class="br-cards-grid" id="struggle-grid"></div>
+
+                <h2 class="sec-title">Memorials</h2>
+                <div class="principles-grid" id="memorials-grid"></div>
+
+                <h2 class="sec-title">Gallery</h2>
+                <div class="br-gallery" id="br-gallery"></div>
+            </div>
+        </section>
+
+        <section class="references-section">
+            <div class="section-container">
+                <h2>References & Documentation</h2>
+                <ul class="references-list" id="references-list"></ul>
+            </div>
+        </section>
+    </main>
+
+    <script src="baji-data.js"></script>
+    <script src="baji.js"></script>
+    <script>
+        (function () {
+            const themeBtn = document.getElementById('theme-toggle');
+            if (!themeBtn) return;
+            const applyIcon = (isLight) => {
+                themeBtn.textContent = isLight ? '🌙' : '☀️';
+                themeBtn.setAttribute('title', isLight ? 'Toggle Dark Mode' : 'Toggle Light Mode');
+            };
+            applyIcon(document.body.classList.contains('light-theme'));
+            themeBtn.addEventListener('click', () => {
+                document.body.classList.toggle('light-theme');
+                const isLight = document.body.classList.contains('light-theme');
+                localStorage.setItem('theme', isLight ? 'light' : 'dark');
+                applyIcon(isLight);
+            });
+        })();
+    </script>
+</body>
+
+</html>

--- a/frontend/freedom-fighters-hub/script.js
+++ b/frontend/freedom-fighters-hub/script.js
@@ -408,8 +408,9 @@ const FREEDOM_FIGHTERS_DATA = [
         contributions: 'His sacrifice while protecting the national flag became a rallying symbol for the Civil Disobedience Movement in the Madras Presidency and remains commemorated in Tirupur to this day.',
         rareFacts: 'A statue of Kumaran holding the national flag stands at the Tirupur bus stand, and he is remembered every year through local commemorations honouring his sacrifice.',
         quote: 'Remembered for refusing to let the national flag touch the ground even as he collapsed from a fatal police blow.',
-        explorerLink: '../tirupur-kumaran-explorer/index.html'},
-          {
+        explorerLink: '../tirupur-kumaran-explorer/index.html'
+    },
+    {
         id: 'alluri-sitarama-raju',
         name: 'Alluri Sitarama Raju',
         title: 'Manyam Veerudu (Hero of the Jungle)',
@@ -430,6 +431,26 @@ const FREEDOM_FIGHTERS_DATA = [
         rareFacts: 'The British spent over Rs 40 lakh to crush the rebellion; his birthday, 4 July, is celebrated as a state festival in Andhra Pradesh, and the Alluri Sitharama Raju district was carved out of Visakhapatnam in 2022.',
         quote: 'Jai Hind! This is but the beginning of the fight — the forest will keep the flame of Swaraj alive.',
         explorerLink: '../alluri-sitarama-raju-explorer/index.html'
+    },
+    {
+        id: 'baji-rout',
+        name: 'Baji Rout',
+        title: 'One of India\'s Youngest Martyrs',
+        lifespan: '1926 – 1938',
+        era: 'Praja Mandal Movement',
+        region: 'East',
+        birthplace: 'Nilakanthapur, Dhenkanal, Odisha',
+        movements: ['Praja Mandal Movement (Dhenkanal)'],
+        biography: 'Baji Rout was a twelve-year-old boatman from Dhenkanal, Odisha, who was fatally shot by state police in 1938 after refusing to ferry them across a river to suppress protesting villagers, becoming one of the youngest martyrs of India\'s freedom struggle.',
+        timeline: [
+            { year: '1926', event: 'Born into a boatman family in Nilakanthapur, Dhenkanal.' },
+            { year: '1930s', event: 'Growing unrest in Dhenkanal as villagers organized under the Praja Mandal movement.' },
+            { year: 'Oct 11, 1938', event: 'Refused to ferry police across the river to suppress protesters and was fatally shot.' }
+        ],
+        contributions: 'His refusal and martyrdom at age twelve became a galvanizing symbol for the Praja Mandal movement in Dhenkanal and is remembered across Odisha as an act of extraordinary courage.',
+        rareFacts: 'Remembered as one of the youngest martyrs of India\'s freedom struggle; several institutions in Odisha are named in his honor.',
+        quote: 'I will not take the police to catch my own people.',
+        explorerLink: '../baji-rout-explorer/index.html'
     }
 ];
 


### PR DESCRIPTION
## Description

Adds a dedicated explorer page for Baji Rout, highlighting his biography, timeline, role in India's freedom struggle, memorials, gallery, and lasting legacy.

The explorer is integrated into the Freedom Fighters of India Explorer through a Baji Rout card.

Fixes #1906

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?

- [ ] Tested locally in browser
- [ ] Tested in both dark and light themes
- [ ] Tested at mobile viewport widths
- [ ] Verified no console errors

## Checklist

- [ ] My code follows the coding standards of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings or errors
- [ ] I have tested responsive layout (if UI change)
- [ ] I have considered accessibility (aria labels, keyboard nav, focus)

## Screenshots 
<img width="942" height="824" alt="Screenshot 2026-08-10 110234" src="https://github.com/user-attachments/assets/bf735ef1-d117-46d8-93e6-867b507a2f06" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Baji Rout Explorer page featuring his biography, key statistics, historical narrative, timeline, struggle themes, memorials, gallery, and references.
  * Added light-theme support with a theme toggle and saved preference.
  * Added Baji Rout to the Freedom Fighters hub with biography, contributions, facts, quote, and an explorer link.
  * Added an explorer link for Tirupur Kumaran.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->