### PR TITLE
Feat/bamboo craft explorer

### DIFF
--- a/frontend/molela-clay-art-explorer/index.html
+++ b/frontend/molela-clay-art-explorer/index.html
@@ -1,0 +1,367 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore Molela Clay Art, Rajasthan's famous handcrafted terracotta relief plaques. Experience the interactive plaque crafter and bhatti-firing simulator.">
+  <title>Molela Clay Art Explorer | Incredible India</title>
+  <!-- Preload fonts -->
+  <link rel="preload" href="../../assets/fonts/Outfit-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="../../assets/fonts/Outfit-700.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="../../assets/fonts/PlayfairDisplay-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css?v=1.0">
+  <link rel="stylesheet" href="../js-modules/page-progress/page-progress.css">
+
+  <!-- Open Graph Meta Tags -->
+  <meta property="og:title" content="Molela Clay Art Terracotta Explorer | Incredible India">
+  <meta property="og:description" content="Discover Rajasthan's 800-year-old terracotta relief plaque art and try the interactive heritage clay plaque crafter.">
+  <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/frontend/assets/traditional_attires.png">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/molela-clay-art-explorer/index.html">
+</head>
+<body>
+  <script>
+    (function() {
+      let theme = 'dark';
+      try { theme = JSON.parse(localStorage.getItem('iie_storage') || '{}').theme || 'dark'; } catch(e) {}
+      if (theme === 'light') {
+        if (document.body) document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+
+  <!-- Sticky Navbar -->
+  <header class="navbar" id="navbar">
+    <div class="nav-container">
+      <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+        <span class="saffron">Incredible</span>
+        <span class="gold">India</span>
+        <span class="green">Explorer</span>
+      </a>
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+        <span class="bar"></span>
+        <span class="bar"></span>
+        <span class="bar"></span>
+      </button>
+      <nav class="nav-menu" id="nav-menu">
+        <a href="../../index.html#home" class="nav-link" id="link-home">Home</a>
+        <div class="nav-dropdown">
+          <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
+          <div class="dropdown-menu">
+            <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
+            <a href="../travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+            <a href="../ancient-ports-explorer/index.html" class="dropdown-item">Ancient Ports of India</a>
+            <a href="../islands/islands.html" class="dropdown-item">Islands of India</a>
+            <a href="../heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+          </div>
+        </div>
+        <div class="nav-dropdown">
+          <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
+          <div class="dropdown-menu">
+            <a href="../culture/culture.html" class="dropdown-item">Culture Overview</a>
+            <a href="../cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
+            <a href="../festivals/festivals.html" class="dropdown-item">Festivals</a>
+            <a href="../historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
+            <a href="../national-symbols-gallery/national-symbols-gallery.html" class="dropdown-item">National Symbols</a>
+            <a href="../cuisine-discovery-hub/index.html" class="dropdown-item">UP Cuisine</a>
+            <a href="../handicrafts-showcase/index.html" class="dropdown-item">UP Handicrafts</a>
+            <a href="../national-days-calendar/index.html" class="dropdown-item">National Days</a>
+            <a href="../ganga-ghats-experience/index.html" class="dropdown-item">Ganga Ghats</a>
+          </div>
+        </div>
+        <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Page Progress Bar -->
+  <div class="progress-container"><div class="progress-bar" id="page-progress"></div></div>
+
+  <!-- Main Section -->
+  <main id="app-root" class="molela-main">
+    
+    <!-- Hero Banner -->
+    <section class="molela-hero">
+      <div class="molela-hero-overlay"></div>
+      <div class="molela-hero-content">
+        <span class="molela-hero-badge">🏺 Rajasthani Clay Artistry</span>
+        <h1>Molela Terracotta Clay Relief Plaques</h1>
+        <p>Journey into the heart of Mewar's Kumhar pottery clusters. Discover how craftsmen hand-mold rich Banas riverbed silt into hollow relief votive plaques depicting guardian deities, folklore heroes, and sacred icons.</p>
+        <div class="molela-bookmark-container">
+          <button id="molela-bookmark-btn" class="molela-bookmark-btn" type="button" aria-label="Save this explorer to your journey page">
+            <span class="bookmark-icon">☆</span> Save to Journey
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Tab navigation -->
+    <nav class="molela-tab-nav" aria-label="Explorer navigation tabs">
+      <div class="molela-tab-container">
+        <button class="tab-btn active" data-target="history">History & Heritage</button>
+        <button class="tab-btn" data-target="crafter-section">Plaque Crafter</button>
+        <button class="tab-btn" data-target="religious-themes">Deities & Lore</button>
+        <button class="tab-btn" data-target="process">Crafting Process</button>
+      </div>
+    </nav>
+
+    <!-- Section: History & Heritage -->
+    <section class="molela-section" id="history">
+      <div class="molela-container molela-grid-2col">
+        <div class="molela-text-block">
+          <span class="molela-eyebrow">Centuries of Sacred Earth</span>
+          <h2>The Mud Artisans of the Banas River</h2>
+          <p>Molela is a quiet, world-famous potters' village located on the banks of the Banas River in Rajsamand district, Rajasthan. For over 800 years, the Kumhar community has sculpted unique clay relief plaques. These are not merely decorative items—they are sacred votives commissioned by tribal and pastoral communities from Rajasthan, Gujarat, and Madhya Pradesh.</p>
+          <p>The potters collect alluvial clay from near the local pond (*Solera Talab*). Mixed with water and tempered with organic fibers, this clay possesses the extreme plasticity needed to hold heavy relief forms without collapsing. Traditional plaques are hand-burnished and coated with a protective *geru* (red ochre) mineral slip before firing.</p>
+        </div>
+        <div class="molela-highlight-box">
+          <h3>✨ Molela Heritage Facts</h3>
+          <ul class="molela-bullet-list">
+            <li><strong>Kumhar Dynasty</strong>: POTTERS believe they were blessed by Lord Shiva with the clay wheel to create sacred shapes.</li>
+            <li><strong>Tribal Pilgrimage</strong>: Tribes make annual winter pilgrimages to Molela to buy new plaques for their household shrines.</li>
+            <li><strong>Reversible Kiln Coloring</strong>: The terracotta's final color is orange-red when fired under oxidation, or charcoal black when fired under smoky reduction conditions.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Plaque Crafter Experience -->
+    <section class="molela-section" id="crafter-section">
+      <div class="molela-container">
+        <div class="molela-section-header">
+          <span class="molela-eyebrow">Heritage Clay Plaque Crafter</span>
+          <h2>Sculpt, Color, and Fire Your Votive Plaque</h2>
+          <p>Become a Molela Kumhar. Walk through the traditional steps: select a deity, apply relief details, paint using mineral slips, and fire the plaque in the village bhatti.</p>
+        </div>
+
+        <div class="crafter-panel">
+          
+          <!-- Column 1: Plaque Display -->
+          <div class="plaque-display-column">
+            <div class="plaque-canvas-wrapper" id="plaque-canvas-wrapper">
+              <canvas id="plaque-canvas" width="400" height="500"></canvas>
+              <div id="bhatti-fire-effect" class="bhatti-fire-overlay"></div>
+              <div id="crafter-status-tag" class="crafter-status-tag">Status: Wet Clay Base</div>
+            </div>
+            <div class="temperature-gauge-wrapper" id="temp-gauge-container" style="display: none;">
+              <div class="temp-labels">
+                <span>🌡️ Bhatti Temperature</span>
+                <span id="temp-display">Room Temp (30°C)</span>
+              </div>
+              <div class="progress-bar-track">
+                <div class="progress-bar-fill" id="temp-progress"></div>
+              </div>
+            </div>
+          </div>
+          
+          <!-- Column 2: Crafter Controls -->
+          <div class="crafter-controls-column">
+            <div class="crafter-steps-nav">
+              <button class="step-nav-btn active" data-step="1">1. Choose Deity</button>
+              <button class="step-nav-btn" data-step="2">2. Sculpt Details</button>
+              <button class="step-nav-btn" data-step="3">3. Slip Painting</button>
+              <button class="step-nav-btn" data-step="4">4. Bhatti Firing</button>
+            </div>
+
+            <!-- Step Panels -->
+            <div class="step-panels-container">
+              
+              <!-- Panel 1: Choose Deity -->
+              <div class="step-panel active" id="panel-step-1">
+                <h3>Select Votive Deity Outline</h3>
+                <p class="panel-instruction">Potters carve different outlines depending on the tribe's guardian deity request.</p>
+                <div class="options-grid">
+                  <button class="option-card active" data-deity="devnarayan">
+                    <span class="option-icon">🐎</span>
+                    <h4>Devnarayan</h4>
+                    <p>Folk hero riding his black stallion, surrounded by birds.</p>
+                  </button>
+                  <button class="option-card" data-deity="nagaraja">
+                    <span class="option-icon">🐍</span>
+                    <h4>Nagaraja</h4>
+                    <p>The protective snake god with multi-headed hoods.</p>
+                  </button>
+                  <button class="option-card" data-deity="ganesha">
+                    <span class="option-icon">🐘</span>
+                    <h4>Ganesha</h4>
+                    <p>Auspicious elephant deity representing wisdom and new starts.</p>
+                  </button>
+                </div>
+              </div>
+
+              <!-- Panel 2: Sculpt Details -->
+              <div class="step-panel" id="panel-step-2">
+                <h3>Detail and Sculpt Reliefs</h3>
+                <p class="panel-instruction">Press the buttons below to hand-sculpt hollow clay coils and stamp decorative borders.</p>
+                <div class="details-checkbox-group">
+                  <button class="sculpt-toggle-btn active" data-sculpt="halo">
+                    <span class="chk-box">✓</span> Sculpt Sun Halo (Bhamandal)
+                  </button>
+                  <button class="sculpt-toggle-btn active" data-sculpt="border">
+                    <span class="chk-box">✓</span> Press Clay Border Stamped Pattern
+                  </button>
+                  <button class="sculpt-toggle-btn" data-sculpt="ornaments">
+                    <span class="chk-box">✗</span> Apply Ornaments &amp; Garlands
+                  </button>
+                </div>
+              </div>
+
+              <!-- Panel 3: Slip Painting -->
+              <div class="step-panel" id="panel-step-3">
+                <h3>Apply Natural Mineral Slips</h3>
+                <p class="panel-instruction">Choose a traditional Mewar mineral pigment below, then click on sections of the plaque to color them.</p>
+                <div class="color-palette">
+                  <button class="color-swatch active" data-color="geru" style="background-color: #8b2512; color: #fff;">
+                    <span>Geru (Red Ochre)</span>
+                  </button>
+                  <button class="color-swatch" data-color="yellow" style="background-color: #d99f0e; color: #000;">
+                    <span>Pila (Yellow Silt)</span>
+                  </button>
+                  <button class="color-swatch" data-color="white" style="background-color: #e5e5e5; color: #000; border: 1px solid #777;">
+                    <span>Safed (Lime/Chalk)</span>
+                  </button>
+                  <button class="color-swatch" data-color="indigo" style="background-color: #1e3a5f; color: #fff;">
+                    <span>Neel (Indigo Blue)</span>
+                  </button>
+                </div>
+                <p class="brush-status">Brush Active: <strong id="active-brush-name">Geru</strong></p>
+                <p class="help-text">💡 Click on the canvas elements (background, border, deity figure) to paint.</p>
+              </div>
+
+              <!-- Panel 4: Bhatti Firing -->
+              <div class="step-panel" id="panel-step-4">
+                <h3>Bhatti Kiln Firing</h3>
+                <p class="panel-instruction">Fire the wet clay plaque inside the open bhatti. Heat must reach 900°C to achieve a strong, ringing terracotta finish.</p>
+                <div class="firing-controls">
+                  <button id="fire-bhatti-btn" class="btn btn-primary fire-btn" type="button">🔥 Start Bhatti Firing</button>
+                  <div class="firing-warning" id="firing-complete-msg" style="display: none;">
+                    <h4>🎉 Firing Complete!</h4>
+                    <p>The plaque has baked successfully. The grey clay has hardened into robust terracotta red stoneware.</p>
+                  </div>
+                </div>
+              </div>
+
+            </div>
+
+            <!-- Footer controls -->
+            <div class="crafter-footer-actions">
+              <button id="reset-plaque-btn" class="btn btn-secondary reset-btn" type="button">Reset Plaque Designer</button>
+            </div>
+
+          </div>
+        </div>
+
+      </div>
+    </section>
+
+    <!-- Section: Religious Themes & Deities -->
+    <section class="molela-section" id="religious-themes" style="background: rgba(255,255,255,0.02);">
+      <div class="molela-container">
+        <div class="molela-section-header">
+          <span class="molela-eyebrow">Iconography and Rituals</span>
+          <h2>The Divine Pantheon of Clay Reliefs</h2>
+          <p>Each plaque serves as a spiritual portal for tribal shrines, telling unique tales of Mewar folklore.</p>
+        </div>
+
+        <div class="molela-grid-3col">
+          <div class="molela-card">
+            <span class="molela-card-icon">🐎</span>
+            <h3>Lord Devnarayan</h3>
+            <p>An incarnation of Lord Vishnu worshipped by the Gujjar cowherd community. Always depicted riding a black horse, flanked by snakes, sun, moon, and temple canopy. Worshippers believe this plaque safeguards cattle and shields families from plagues.</p>
+          </div>
+          <div class="molela-card">
+            <span class="molela-card-icon">🐍</span>
+            <h3>Nagaraja (Snake God)</h3>
+            <p>Worshipped widely across rural Rajasthan. The snake god is sculpted as a multi-headed cobra posture or winding snake coil. Worshippers place Nagaraja plaques near agricultural borders to ward off venomous bites and invoke crop rains.</p>
+          </div>
+          <div class="molela-card">
+            <span class="molela-card-icon">🦁</span>
+            <h3>Goraji Bhairav</h3>
+            <p>The guardian deity of villages, depicted holding a trident, damru (drum), and sword. Bhairav plaques are installed at entry gateways to guard village boundaries against negative forces and evil spirits.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Crafting Process -->
+    <section class="molela-section" id="process">
+      <div class="molela-container">
+        <div class="molela-section-header">
+          <span class="molela-eyebrow">Mud to Masterpiece</span>
+          <h2>The Plaque-Making Process</h2>
+          <p>Discover the physical steps involved in sculpting Molela plaques, unchanged for eight centuries.</p>
+        </div>
+
+        <div class="molela-process-steps">
+          <div class="process-step">
+            <span class="step-num">1</span>
+            <div class="step-desc">
+              <h4>Clay Sourcing &amp; Kneading</h4>
+              <p>Potters scoop clay from local riverbeds, filter out gravel, and mix in dried donkey dung. The organic fibers help absorb moisture during firing and prevent clay warps.</p>
+            </div>
+          </div>
+          <div class="process-step">
+            <span class="step-num">2</span>
+            <div class="step-desc">
+              <h4>Baseplate Flat Molding</h4>
+              <p>The potter pats the clay with palms on a flat board to form the *plaquette* backing plate, measuring 1 to 2 inches in thickness.</p>
+            </div>
+          </div>
+          <div class="process-step">
+            <span class="step-num">3</span>
+            <div class="step-desc">
+              <h4>Relief Sculpting (Maldari)</h4>
+              <p>The deity figure is built entirely by hand. Coils of clay are added to build the horse, torso, halo, and limbs. Facial features are carved using simple bamboo tools (*chheni*).</p>
+            </div>
+          </div>
+          <div class="process-step">
+            <span class="step-num">4</span>
+            <div class="step-desc">
+              <h4>Geru Slip Coating</h4>
+              <p>After slow sun-drying in the shade, the dry grey plaque is coated with a natural red clay slip (Geru), giving it a rich iron-rich primer coat.</p>
+            </div>
+          </div>
+          <div class="process-step">
+            <span class="step-num">5</span>
+            <div class="step-desc">
+              <h4>Open Bhatti Firing</h4>
+              <p>Plaques are packed inside an open mud-kiln (*bhatti*), covered with wood shards, dry cow dung cakes, and pottery shards, and heated at 900°C for six hours.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: References -->
+    <section class="molela-section" id="references">
+      <div class="molela-container">
+        <div class="molela-references">
+          <h3>📜 References &amp; Cultural Readings</h3>
+          <ul>
+            <li>Jain, Jyotindra (1984). <i>Painted Myths of Creation: Art and Ritual of the Molela Terracotta</i>. National Crafts Museum, New Delhi.</li>
+            <li>Kumhar, Dinesh. <i>Oral Records and Ancestral Lineages of Mewar Terracotta Relief Artists</i>. Molela Potters Association.</li>
+            <li>Government of India Geographical Indications Registry. <i>GI Application No. 182: Molela Clay Work Registration</i>.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Page Footer -->
+    <footer class="molela-footer">
+      <p>Part of the <a href="../terracotta-pottery-explorer/index.html">Terracotta Pottery Explorer</a> · <a href="../../index.html">Incredible India Explorer</a></p>
+    </footer>
+
+  </main>
+
+  <script src="../js-modules/storage.js" defer></script>
+  <script src="../app.js" defer></script>
+  <script src="script.js" defer></script>
+  <script src="../router.js" defer></script>
+  <script type="module" src="../auth.js"></script>
+  <script src="../js-modules/page-progress/page-progress.js"></script>
+</body>
+</html>

--- a/frontend/molela-clay-art-explorer/index.html
+++ b/frontend/molela-clay-art-explorer/index.html
@@ -358,6 +358,7 @@
   </main>
 
   <script src="../js-modules/storage.js" defer></script>
+  <script src="../../frontend/journey/journey.js" defer></script>
   <script src="../app.js" defer></script>
   <script src="script.js" defer></script>
   <script src="../router.js" defer></script>

--- a/frontend/molela-clay-art-explorer/script.js
+++ b/frontend/molela-clay-art-explorer/script.js
@@ -1,660 +1,514 @@
+// script.js - Molela Clay Art Explorer
+// Single initialization flag to prevent double-binding
+let _molelaInitDone = false;
+
 function runMolelaInit() {
   initPlaqueCrafter();
   initJourneyIntegration();
   initTabs();
 }
 
-// Run immediately on script load
-runMolelaInit();
+// Run on script load (direct navigation)
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", runMolelaInit);
+} else {
+  runMolelaInit();
+}
 
-// Listen for SPA route change events
-document.addEventListener("app:route-changed", runMolelaInit);
+// Also run on SPA route change (router.js dispatches this)
+document.addEventListener("app:route-changed", function () {
+  _molelaInitDone = false;
+  runMolelaInit();
+});
 
-/**
- * 1. Plaque Crafter State & Drawing Engine
- */
+/* =========================================================
+   1. PLAQUE CRAFTER
+   ========================================================= */
 function initPlaqueCrafter() {
   const canvas = document.getElementById("plaque-canvas");
   if (!canvas) return;
-
-  if (canvas.dataset.initialized === "true") {
-    if (window.molelaRedrawPlaque) window.molelaRedrawPlaque();
-    return;
-  }
-  canvas.dataset.initialized = "true";
+  // Guard against double-init on same canvas instance
+  if (canvas._molelaInit) { canvas._molelaRedraw && canvas._molelaRedraw(); return; }
+  canvas._molelaInit = true;
 
   const ctx = canvas.getContext("2d");
-  const tempGauge = document.getElementById("temp-gauge-container");
-  const tempDisplay = document.getElementById("temp-display");
-  const tempProgress = document.getElementById("temp-progress");
-  const fireOverlay = document.getElementById("bhatti-fire-effect");
-  const fireBtn = document.getElementById("fire-bhatti-btn");
-  const successMsg = document.getElementById("firing-complete-msg");
-  const statusTag = document.getElementById("crafter-status-tag");
-  const activeBrushLabel = document.getElementById("active-brush-name");
-  const resetBtn = document.getElementById("reset-plaque-btn");
-
   if (!ctx) return;
 
-  // State
+  // Fix canvas internal resolution to match its actual dimensions
+  const W = 400, H = 500;
+  canvas.width = W;
+  canvas.height = H;
+
+  const tempGauge    = document.getElementById("temp-gauge-container");
+  const tempDisplay  = document.getElementById("temp-display");
+  const tempProgress = document.getElementById("temp-progress");
+  const fireOverlay  = document.getElementById("bhatti-fire-effect");
+  const fireBtn      = document.getElementById("fire-bhatti-btn");
+  const successMsg   = document.getElementById("firing-complete-msg");
+  const statusTag    = document.getElementById("crafter-status-tag");
+  const brushLabel   = document.getElementById("active-brush-name");
+  const resetBtn     = document.getElementById("reset-plaque-btn");
+
+  // ── State ──────────────────────────────────────────────
   let state = {
     deity: "devnarayan",
-    sculpts: {
-      halo: true,
-      border: true,
-      ornaments: false
-    },
-    paints: {
-      background: "unpainted",
-      border: "unpainted",
-      deity: "unpainted",
-      halo: "unpainted"
-    },
+    sculpts: { halo: true, border: true, ornaments: false },
+    paints:  { background: "unpainted", border: "unpainted", deity: "unpainted", halo: "unpainted" },
     activePigment: "geru",
     fired: false
   };
 
-  // Color mappings before/after firing
-  const paintColors = {
-    unpainted: {
-      wet: "#5c5047",      // Wet organic mud
-      fired: "#c2410c"    // Baked terracotta red
-    },
-    geru: {
-      wet: "#8b2512",      // Mud red ochre
-      fired: "#d44c28"    // Baked brick red
-    },
-    yellow: {
-      wet: "#b48312",      // Ochre silt
-      fired: "#f5b025"    // Bright yellow clay
-    },
-    white: {
-      wet: "#c8c6c4",      // Lime slurry
-      fired: "#ecebe9"    // Chalk white
-    },
-    indigo: {
-      wet: "#1c2d42",      // Indigo mud
-      fired: "#2b5c8f"    // Clay indigo blue
-    }
+  // ── Colors (visibly distinct wet vs fired) ─────────────
+  const COLORS = {
+    unpainted: { wet: "#b5956a",  fired: "#c2410c" },   // warm tan  → terracotta orange
+    geru:      { wet: "#c0392b",  fired: "#e74c3c" },   // deep red  → bright brick red
+    yellow:    { wet: "#c98b0a",  fired: "#f1c40f" },   // ochre     → vivid yellow
+    white:     { wet: "#d5d2cc",  fired: "#f4f1eb" },   // grey-white→ chalk white
+    indigo:    { wet: "#2c3e6b",  fired: "#3a6db5" },   // dark blue → bright clay blue
   };
 
+  // ── Draw ───────────────────────────────────────────────
+  function getColor(zone) {
+    const m = state.fired ? "fired" : "wet";
+    const p = state.paints[zone];
+    return COLORS[p] ? COLORS[p][m] : COLORS.unpainted[m];
+  }
+
   function drawPlaque() {
-    ctx.clearRect(0, 0, canvas.width, canvas.height);
-    const mode = state.fired ? "fired" : "wet";
+    const m = state.fired ? "fired" : "wet";
+    ctx.clearRect(0, 0, W, H);
 
-    // 1. Draw Baseplate Backing Plate
-    ctx.fillStyle = (state.paints.background === "unpainted") 
-      ? (state.fired ? "#a33a0c" : "#4e433a") // Background baseplate shade
-      : paintColors[state.paints.background][mode];
-    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    // 1. Background plate — warm clay
+    ctx.fillStyle = getColor("background");
+    ctx.fillRect(0, 0, W, H);
 
-    // Stamped clay textures inside baseplate
-    ctx.strokeStyle = "rgba(0, 0, 0, 0.15)";
+    // Subtle vertical texture lines on background
+    ctx.strokeStyle = "rgba(0,0,0,0.08)";
     ctx.lineWidth = 1;
-    for (let i = 10; i < canvas.width; i += 24) {
-      ctx.beginPath();
-      ctx.moveTo(i, 0);
-      ctx.lineTo(i, canvas.height);
-      ctx.stroke();
+    for (let x = 0; x < W; x += 20) {
+      ctx.beginPath(); ctx.moveTo(x, 0); ctx.lineTo(x, H); ctx.stroke();
     }
 
-    // 2. Draw Stamped Border
+    // 2. Stamped border frame
     if (state.sculpts.border) {
-      ctx.fillStyle = state.paints.border === "unpainted"
-        ? (state.fired ? "#c2410c" : "#5c5047")
-        : paintColors[state.paints.border][mode];
-      ctx.strokeStyle = "rgba(0,0,0,0.3)";
-      ctx.lineWidth = 4;
-      
-      // Draw border frame
-      ctx.fillRect(15, 15, canvas.width - 30, canvas.height - 30);
-      ctx.strokeRect(15, 15, canvas.width - 30, canvas.height - 30);
+      ctx.fillStyle = getColor("border");
+      ctx.fillRect(12, 12, W - 24, H - 24);
+      ctx.strokeStyle = "rgba(0,0,0,0.35)";
+      ctx.lineWidth = 3;
+      ctx.strokeRect(12, 12, W - 24, H - 24);
+      ctx.strokeRect(28, 28, W - 56, H - 56);
 
-      // Inner boundary
-      ctx.strokeRect(35, 35, canvas.width - 70, canvas.height - 70);
-
-      // Stamped dots on border
-      ctx.fillStyle = state.fired ? "#f59e0b" : "#b48312";
-      for (let x = 25; x < canvas.width; x += 30) {
-        ctx.beginPath(); ctx.arc(x, 25, 4, 0, Math.PI*2); ctx.fill();
-        ctx.beginPath(); ctx.arc(x, canvas.height - 25, 4, 0, Math.PI*2); ctx.fill();
+      // Stamped dots
+      const dotColor = m === "fired" ? "#f59e0b" : "#8b6e36";
+      ctx.fillStyle = dotColor;
+      for (let x = 22; x < W - 22; x += 25) {
+        ctx.beginPath(); ctx.arc(x, 20, 4, 0, Math.PI * 2); ctx.fill();
+        ctx.beginPath(); ctx.arc(x, H - 20, 4, 0, Math.PI * 2); ctx.fill();
       }
-      for (let y = 25; y < canvas.height; y += 30) {
-        ctx.beginPath(); ctx.arc(25, y, 4, 0, Math.PI*2); ctx.fill();
-        ctx.beginPath(); ctx.arc(canvas.width - 25, y, 4, 0, Math.PI*2); ctx.fill();
+      for (let y = 22; y < H - 22; y += 25) {
+        ctx.beginPath(); ctx.arc(20, y, 4, 0, Math.PI * 2); ctx.fill();
+        ctx.beginPath(); ctx.arc(W - 20, y, 4, 0, Math.PI * 2); ctx.fill();
       }
     }
 
-    // 3. Draw Halo (behind head)
+    // 3. Halo (behind deity head)
     if (state.sculpts.halo) {
-      ctx.fillStyle = state.paints.halo === "unpainted"
-        ? (state.fired ? "#ea580c" : "#6b5c50")
-        : paintColors[state.paints.halo][mode];
-      ctx.strokeStyle = "rgba(0,0,0,0.25)";
-      ctx.lineWidth = 3;
-      
-      ctx.beginPath();
-      ctx.arc(200, 150, 70, 0, Math.PI * 2);
+      ctx.save();
+      ctx.fillStyle = getColor("halo");
+      ctx.shadowColor = "rgba(0,0,0,0.2)"; ctx.shadowBlur = 6;
+      ctx.beginPath(); ctx.arc(200, 155, 65, 0, Math.PI * 2);
       ctx.fill();
-      ctx.stroke();
-
-      // Halo rays
-      ctx.strokeStyle = state.fired ? "rgba(245,158,11,0.5)" : "rgba(180,131,18,0.3)";
-      ctx.lineWidth = 4;
-      for (let angle = 0; angle < Math.PI * 2; angle += Math.PI / 8) {
+      ctx.restore();
+      // Rays
+      ctx.strokeStyle = m === "fired" ? "rgba(245,158,11,0.7)" : "rgba(139,110,54,0.5)";
+      ctx.lineWidth = 3;
+      for (let a = 0; a < Math.PI * 2; a += Math.PI / 8) {
         ctx.beginPath();
-        ctx.moveTo(200 + Math.cos(angle)*70, 150 + Math.sin(angle)*70);
-        ctx.lineTo(200 + Math.cos(angle)*85, 150 + Math.sin(angle)*85);
+        ctx.moveTo(200 + Math.cos(a) * 65, 155 + Math.sin(a) * 65);
+        ctx.lineTo(200 + Math.cos(a) * 82, 155 + Math.sin(a) * 82);
         ctx.stroke();
       }
     }
 
-    // 4. Draw Deity Relief Figure
-    ctx.fillStyle = state.paints.deity === "unpainted"
-      ? (state.fired ? "#ea580c" : "#716255")
-      : paintColors[state.paints.deity][mode];
-    ctx.strokeStyle = "rgba(0,0,0,0.45)";
-    ctx.lineWidth = 5;
+    // 4. Deity figure
+    ctx.fillStyle   = getColor("deity");
+    ctx.strokeStyle = "rgba(0,0,0,0.5)";
+    ctx.lineWidth   = 4;
 
-    if (state.deity === "devnarayan") {
-      drawDevnarayan(ctx, mode);
-    } else if (state.deity === "nagaraja") {
-      drawNagaraja(ctx, mode);
-    } else if (state.deity === "ganesha") {
-      drawGanesha(ctx, mode);
-    }
+    if (state.deity === "devnarayan")  drawDevnarayan(ctx, m);
+    else if (state.deity === "nagaraja") drawNagaraja(ctx, m);
+    else if (state.deity === "ganesha")  drawGanesha(ctx, m);
   }
 
-  // Figure Drawings using lines to mimic handmade clay shapes
-  function drawDevnarayan(c, mode) {
+  // ── Deity drawing functions ────────────────────────────
+  function fill(c)  { c.fill(); c.stroke(); }
+
+  function drawDevnarayan(c, m) {
     c.save();
-    c.shadowColor = "rgba(0,0,0,0.3)";
-    c.shadowBlur = 8;
-    c.shadowOffsetY = 4;
+    const fc = getColor("deity");
+    c.fillStyle   = fc;
+    c.strokeStyle = "rgba(0,0,0,0.5)";
+    c.lineWidth   = 4;
 
-    // Draw horse body (Devnarayan's Black Stallion)
-    c.beginPath();
-    c.ellipse(200, 340, 80, 45, 0, 0, Math.PI * 2); // Body
-    c.fill();
-    c.stroke();
-
-    // Horse neck & head
-    c.beginPath();
-    c.moveTo(140, 320);
-    c.lineTo(100, 260); // Neck
-    c.lineTo(75, 265);  // Nose
-    c.lineTo(85, 290);  // Chin
-    c.lineTo(130, 350);
-    c.closePath();
-    c.fill();
-    c.stroke();
-
-    // Horse legs
-    c.lineWidth = 7;
-    c.beginPath();
-    c.moveTo(140, 360); c.lineTo(130, 440); // Front Left
-    c.moveTo(160, 360); c.lineTo(155, 435); // Front Right
-    c.moveTo(240, 360); c.lineTo(245, 440); // Back Left
-    c.moveTo(260, 360); c.lineTo(265, 435); // Back Right
-    c.stroke();
-
-    // Devnarayan (Rider torso)
-    c.beginPath();
-    c.moveTo(170, 300);
-    c.lineTo(170, 200); // Torso
-    c.lineTo(210, 200);
-    c.lineTo(210, 300);
-    c.closePath();
-    c.fill();
-    c.stroke();
-
-    // Head
-    c.beginPath();
-    c.arc(190, 160, 24, 0, Math.PI * 2); // Head
-    c.fill();
-    c.stroke();
-
-    // Spear / Lotus (Folk hero attribute)
-    c.strokeStyle = state.fired ? "#f59e0b" : "#b48312";
+    // Horse body
+    c.beginPath(); c.ellipse(200, 350, 78, 42, 0, 0, Math.PI * 2); fill(c);
+    // Horse head & neck
+    c.beginPath(); c.moveTo(140, 325); c.lineTo(105, 268); c.lineTo(83, 272);
+    c.lineTo(92, 295); c.lineTo(132, 345); c.closePath(); fill(c);
+    // Legs
+    c.lineWidth = 8;
+    [[142,365,132,445],[162,368,158,442],[238,368,244,445],[258,368,263,442]].forEach(([x1,y1,x2,y2]) => {
+      c.beginPath(); c.moveTo(x1,y1); c.lineTo(x2,y2); c.stroke();
+    });
+    // Rider torso
     c.lineWidth = 4;
-    c.beginPath();
-    c.moveTo(220, 120);
-    c.lineTo(220, 410); // Spear shaft
-    c.stroke();
-    
-    c.fillStyle = state.fired ? "#ef4444" : "#8b2512";
-    c.beginPath();
-    c.moveTo(220, 100); c.lineTo(230, 120); c.lineTo(210, 120); // Spear tip
-    c.closePath();
-    c.fill();
-
-    // Ornaments (sculpted clay dots/garlands)
+    c.beginPath(); c.moveTo(175,310); c.lineTo(175,210); c.lineTo(215,210); c.lineTo(215,310); c.closePath(); fill(c);
+    // Rider head
+    c.beginPath(); c.arc(195, 170, 26, 0, Math.PI * 2); fill(c);
+    // Eyes
+    c.fillStyle = "rgba(255,255,255,0.85)";
+    c.beginPath(); c.arc(188,166,4,0,Math.PI*2); c.arc(202,166,4,0,Math.PI*2); c.fill();
+    c.fillStyle = "rgba(0,0,0,0.8)";
+    c.beginPath(); c.arc(189,166,2,0,Math.PI*2); c.arc(203,166,2,0,Math.PI*2); c.fill();
+    // Spear
+    c.fillStyle = m === "fired" ? "#f59e0b" : "#8b6e36";
+    c.strokeStyle = m === "fired" ? "#f59e0b" : "#8b6e36";
+    c.lineWidth = 4;
+    c.beginPath(); c.moveTo(225,125); c.lineTo(225,415); c.stroke();
+    c.fillStyle = m === "fired" ? "#ef4444" : "#c0392b";
+    c.beginPath(); c.moveTo(225,108); c.lineTo(235,127); c.lineTo(215,127); c.closePath(); c.fill();
+    // Ornaments
     if (state.sculpts.ornaments) {
-      c.fillStyle = "#fff";
-      for (let x = 175; x <= 205; x += 10) {
-        c.beginPath(); c.arc(x, 230, 3, 0, Math.PI*2); c.fill(); // Necklace
-      }
-      c.strokeStyle = "#fff";
-      c.lineWidth = 3;
-      c.beginPath();
-      c.arc(190, 160, 30, 0, Math.PI, true); // Crown
-      c.stroke();
+      c.fillStyle = "rgba(255,255,255,0.9)";
+      for (let x = 180; x <= 210; x += 10) { c.beginPath(); c.arc(x, 232, 3.5, 0, Math.PI * 2); c.fill(); }
+      c.strokeStyle = "rgba(255,255,255,0.8)"; c.lineWidth = 3;
+      c.beginPath(); c.arc(195, 170, 33, 0.8 * Math.PI, 0.2 * Math.PI, true); c.stroke();
     }
-
     c.restore();
   }
 
-  function drawNagaraja(c, mode) {
+  function drawNagaraja(c, m) {
     c.save();
-    c.shadowColor = "rgba(0,0,0,0.3)";
-    c.shadowBlur = 8;
-    c.shadowOffsetY = 4;
-
-    // Coiled Snake Base
+    c.fillStyle   = getColor("deity");
+    c.strokeStyle = "rgba(0,0,0,0.5)";
+    c.lineWidth   = 4;
+    // Coil base
+    c.beginPath(); c.arc(200, 385, 58, 0, Math.PI * 2); c.arc(200, 385, 38, 0, Math.PI * 2, true); fill(c);
+    // Body column
     c.beginPath();
-    c.arc(200, 380, 60, 0, Math.PI * 2);
-    c.arc(200, 380, 40, 0, Math.PI * 2, true); // Double coil
-    c.fill();
-    c.stroke();
-
-    // Winding torso rising
-    c.beginPath();
-    c.moveTo(180, 360);
-    c.lineTo(180, 220); // Left neck boundary
-    c.bezierCurveTo(180, 190, 220, 190, 220, 220); // Hood dome
-    c.lineTo(220, 360);
-    c.closePath();
-    c.fill();
-    c.stroke();
-
-    // Multi-heads (5 hoods)
-    c.fillStyle = c.strokeStyle; // Use border color for lines
+    c.moveTo(178, 365); c.lineTo(178, 225);
+    c.bezierCurveTo(178, 192, 222, 192, 222, 225);
+    c.lineTo(222, 365); c.closePath(); fill(c);
+    // Five hood-heads
     for (let i = -2; i <= 2; i++) {
-      const offsetX = i * 28;
-      const offsetY = -Math.abs(i) * 12;
-      
-      c.fillStyle = state.paints.deity === "unpainted"
-        ? (state.fired ? "#f97316" : "#8c7665")
-        : paintColors[state.paints.deity][mode];
-        
-      c.beginPath();
-      c.arc(200 + offsetX, 190 + offsetY, 18, 0, Math.PI * 2);
-      c.fill();
-      c.stroke();
-      
-      // Eyes on heads
-      c.fillStyle = "#fff";
-      c.beginPath();
-      c.arc(195 + offsetX, 185 + offsetY, 2, 0, Math.PI*2);
-      c.arc(205 + offsetX, 185 + offsetY, 2, 0, Math.PI*2);
-      c.fill();
+      const ox = i * 27, oy = -Math.abs(i) * 14;
+      c.fillStyle = getColor("deity");
+      c.beginPath(); c.arc(200 + ox, 190 + oy, 19, 0, Math.PI * 2); fill(c);
+      // Eyes
+      c.fillStyle = "rgba(255,255,255,0.9)";
+      c.beginPath(); c.arc(195 + ox, 186 + oy, 3, 0, Math.PI * 2); c.arc(205 + ox, 186 + oy, 3, 0, Math.PI * 2); c.fill();
+      c.fillStyle = "rgba(0,0,0,0.8)";
+      c.beginPath(); c.arc(195 + ox, 186 + oy, 1.5, 0, Math.PI * 2); c.arc(205 + ox, 186 + oy, 1.5, 0, Math.PI * 2); c.fill();
     }
-
-    // Lotus ornaments
+    // Lotus ornament
     if (state.sculpts.ornaments) {
-      c.fillStyle = state.fired ? "#ef4444" : "#8b2512";
-      c.beginPath();
-      c.arc(200, 280, 12, 0, Math.PI*2); // Center lotus medal
-      c.fill();
-      c.stroke();
+      c.fillStyle = m === "fired" ? "#ef4444" : "#c0392b";
+      c.beginPath(); c.arc(200, 290, 13, 0, Math.PI * 2); fill(c);
     }
-
     c.restore();
   }
 
-  function drawGanesha(c, mode) {
+  function drawGanesha(c, m) {
     c.save();
-    c.shadowColor = "rgba(0,0,0,0.3)";
-    c.shadowBlur = 8;
-    c.shadowOffsetY = 4;
-
-    // Pot Belly (Ladha)
-    c.beginPath();
-    c.arc(200, 340, 65, 0, Math.PI * 2);
-    c.fill();
-    c.stroke();
-
-    // Torso & Shoulders
-    c.beginPath();
-    c.moveTo(150, 300);
-    c.lineTo(160, 220);
-    c.lineTo(240, 220);
-    c.lineTo(250, 300);
-    c.closePath();
-    c.fill();
-    c.stroke();
-
+    c.fillStyle   = getColor("deity");
+    c.strokeStyle = "rgba(0,0,0,0.5)";
+    c.lineWidth   = 4;
+    // Pot belly
+    c.beginPath(); c.arc(200, 345, 62, 0, Math.PI * 2); fill(c);
+    // Torso
+    c.beginPath(); c.moveTo(152,305); c.lineTo(162,222); c.lineTo(238,222); c.lineTo(248,305); c.closePath(); fill(c);
     // Head
-    c.beginPath();
-    c.ellipse(200, 200, 36, 42, 0, 0, Math.PI*2);
-    c.fill();
-    c.stroke();
-
-    // Elephant Ears
-    c.beginPath();
-    c.ellipse(155, 190, 26, 32, Math.PI/6, 0, Math.PI*2); // Left ear
-    c.fill();
-    c.stroke();
-    
-    c.beginPath();
-    c.ellipse(245, 190, 26, 32, -Math.PI/6, 0, Math.PI*2); // Right ear
-    c.fill();
-    c.stroke();
-
-    // Trunk (coiling to the left)
-    c.lineWidth = 7;
-    c.beginPath();
-    c.moveTo(200, 210);
-    c.quadraticCurveTo(210, 270, 180, 280);
-    c.stroke();
-
-    // Crown (Mukut)
-    c.fillStyle = state.fired ? "#f59e0b" : "#b48312";
-    c.beginPath();
-    c.moveTo(180, 160);
-    c.lineTo(200, 110);
-    c.lineTo(220, 160);
-    c.closePath();
-    c.fill();
-    c.stroke();
-
-    // Ornaments (sculpted clay necklace and armlets)
+    c.beginPath(); c.ellipse(200, 200, 37, 44, 0, 0, Math.PI * 2); fill(c);
+    // Ears
+    c.beginPath(); c.ellipse(157, 192, 27, 34, Math.PI / 5, 0, Math.PI * 2); fill(c);
+    c.beginPath(); c.ellipse(243, 192, 27, 34, -Math.PI / 5, 0, Math.PI * 2); fill(c);
+    // Trunk
+    c.lineWidth = 8; c.strokeStyle = getColor("deity");
+    c.beginPath(); c.moveTo(200, 212); c.quadraticCurveTo(215, 275, 185, 287); c.stroke();
+    // Crown
+    c.fillStyle = m === "fired" ? "#f59e0b" : "#8b6e36";
+    c.strokeStyle = "rgba(0,0,0,0.4)"; c.lineWidth = 3;
+    c.beginPath(); c.moveTo(180, 162); c.lineTo(200, 112); c.lineTo(220, 162); c.closePath(); fill(c);
+    // Eyes
+    c.fillStyle = "rgba(255,255,255,0.9)";
+    c.beginPath(); c.arc(186,196,4,0,Math.PI*2); c.arc(214,196,4,0,Math.PI*2); c.fill();
+    c.fillStyle = "rgba(0,0,0,0.8)";
+    c.beginPath(); c.arc(186,196,2,0,Math.PI*2); c.arc(214,196,2,0,Math.PI*2); c.fill();
+    // Ornaments
     if (state.sculpts.ornaments) {
-      c.fillStyle = "#fff";
-      c.beginPath();
-      c.arc(200, 310, 10, 0, Math.PI*2); // Modak bowl
-      c.fill();
-      c.stroke();
+      c.fillStyle = "rgba(255,255,255,0.9)";
+      for (let x = 177; x <= 223; x += 12) { c.beginPath(); c.arc(x, 310, 4, 0, Math.PI * 2); c.fill(); }
     }
-
     c.restore();
   }
 
-  // Canvas Click / Paint Handler
+  // ── Canvas click → paint zone ──────────────────────────
   canvas.addEventListener("click", (e) => {
-    if (state.fired) return; // Cannot paint fired pottery!
-
-    // Get click coordinates relative to canvas
+    if (state.fired) return;
     const rect = canvas.getBoundingClientRect();
-    const scaleX = canvas.width / rect.width;
-    const scaleY = canvas.height / rect.height;
-    const x = (e.clientX - rect.left) * scaleX;
-    const y = (e.clientY - rect.top) * scaleY;
+    const sx = canvas.width  / rect.width;
+    const sy = canvas.height / rect.height;
+    const x  = (e.clientX - rect.left) * sx;
+    const y  = (e.clientY - rect.top)  * sy;
 
-    // Detect click zones
     let zone = "background";
-
-    if (x < 35 || x > canvas.width - 35 || y < 35 || y > canvas.height - 35) {
+    if (x < 30 || x > W - 30 || y < 30 || y > H - 30) {
       zone = "border";
     } else {
-      // Check if click is on deity figure zone
-      let isOnDeity = false;
-      if (state.deity === "devnarayan") {
-        isOnDeity = (y >= 140 && y < 450 && x >= 70 && x < 280);
-      } else if (state.deity === "nagaraja") {
-        isOnDeity = (y >= 160 && y < 450 && x >= 120 && x < 280);
-      } else if (state.deity === "ganesha") {
-        isOnDeity = (y >= 110 && y < 420 && x >= 120 && x < 280);
-      }
-
-      if (isOnDeity) {
-        zone = "deity";
-      } else if (state.sculpts.halo && Math.sqrt((x-200)**2 + (y-150)**2) < 75) {
-        zone = "halo";
-      }
+      const onHalo = state.sculpts.halo && Math.hypot(x - 200, y - 155) < 68;
+      const onDeity = (state.deity === "devnarayan" && y > 145 && y < 455 && x > 65 && x < 285) ||
+                      (state.deity === "nagaraja"   && y > 165 && y < 455 && x > 125 && x < 278) ||
+                      (state.deity === "ganesha"    && y > 108 && y < 425 && x > 125 && x < 278);
+      if (onDeity)  zone = "deity";
+      else if (onHalo) zone = "halo";
     }
-
-    // Set paint state
     state.paints[zone] = state.activePigment;
     drawPlaque();
   });
 
-  // Wire up Step selectors & Nav
-  const stepBtns = [...document.querySelectorAll(".step-nav-btn")];
+  // ── Step navigation inside crafter ────────────────────
+  const stepBtns   = [...document.querySelectorAll(".step-nav-btn")];
   const stepPanels = [...document.querySelectorAll(".step-panel")];
 
   stepBtns.forEach((btn) => {
     btn.addEventListener("click", () => {
       const step = btn.dataset.step;
-      stepBtns.forEach((b) => b.classList.toggle("active", b === btn));
-      stepPanels.forEach((p) => p.classList.toggle("active", p.id === `panel-step-${step}`));
-
-      // Show/Hide temperature gauge on firing step
-      if (step === "4") {
-        tempGauge.style.display = "block";
-      } else {
-        tempGauge.style.display = "none";
-      }
+      stepBtns.forEach  (b => b.classList.toggle("active", b === btn));
+      stepPanels.forEach(p => p.classList.toggle("active", p.id === `panel-step-${step}`));
+      if (tempGauge) tempGauge.style.display = step === "4" ? "block" : "none";
     });
   });
 
-  // Deity Choice Click
+  // ── Deity card selection ───────────────────────────────
   const deityCards = [...document.querySelectorAll(".option-card")];
   deityCards.forEach((card) => {
     card.addEventListener("click", () => {
       if (state.fired) return;
       state.deity = card.dataset.deity;
-      deityCards.forEach((c) => c.classList.toggle("active", c === card));
+      deityCards.forEach(c => c.classList.toggle("active", c === card));
       drawPlaque();
     });
   });
 
-  // Sculpting Toggle Click
-  const sculptToggles = [...document.querySelectorAll(".sculpt-toggle-btn")];
-  sculptToggles.forEach((btn) => {
+  // ── Sculpt toggles ─────────────────────────────────────
+  const sculptBtns = [...document.querySelectorAll(".sculpt-toggle-btn")];
+  sculptBtns.forEach((btn) => {
     btn.addEventListener("click", () => {
       if (state.fired) return;
       const key = btn.dataset.sculpt;
       state.sculpts[key] = !state.sculpts[key];
       btn.classList.toggle("active", state.sculpts[key]);
-      btn.querySelector(".chk-box").textContent = state.sculpts[key] ? "✓" : "✗";
+      const chk = btn.querySelector(".chk-box");
+      if (chk) chk.textContent = state.sculpts[key] ? "✓" : "✗";
       drawPlaque();
     });
   });
 
-  // Paint Pigment Palette Click
-  const pigmentSwatches = [...document.querySelectorAll(".color-swatch")];
-  pigmentSwatches.forEach((swatch) => {
+  // ── Color swatches ─────────────────────────────────────
+  const swatches = [...document.querySelectorAll(".color-swatch")];
+  swatches.forEach((swatch) => {
     swatch.addEventListener("click", () => {
       state.activePigment = swatch.dataset.color;
-      pigmentSwatches.forEach((s) => s.classList.toggle("active", s === swatch));
-      
+      swatches.forEach(s => s.classList.toggle("active", s === swatch));
       const names = { geru: "Geru Red", yellow: "Pila Yellow", white: "Safed White", indigo: "Neel Indigo" };
-      activeBrushLabel.textContent = names[state.activePigment];
+      if (brushLabel) brushLabel.textContent = names[state.activePigment] || state.activePigment;
     });
   });
 
-  // Bhatti Kiln Firing Action
-  fireBtn.addEventListener("click", () => {
-    if (state.fired) return;
-    
-    fireBtn.disabled = true;
-    fireOverlay.classList.add("firing");
-    statusTag.textContent = "Status: Firing Plaque (30°C)...";
-    
-    let temp = 30;
-    const interval = setInterval(() => {
-      temp += 30;
-      if (temp > 900) temp = 900;
-      
-      tempDisplay.textContent = `Furnace Temp (${temp}°C)`;
-      tempProgress.style.width = `${(temp / 900) * 100}%`;
-      statusTag.textContent = `Status: Firing Plaque (${temp}°C)...`;
-      
-      if (temp >= 900) {
-        clearInterval(interval);
-        fireOverlay.classList.remove("firing");
-        state.fired = true;
-        statusTag.textContent = "Status: Baked Terracotta Plaque";
-        statusTag.className = "crafter-status-tag fired";
-        
-        successMsg.style.display = "block";
-        drawPlaque();
-      }
-    }, 90);
-  });
-
-  // Reset Button
-  resetBtn.addEventListener("click", () => {
-    state = {
-      deity: "devnarayan",
-      sculpts: { halo: true, border: true, ornaments: false },
-      paints: { background: "unpainted", border: "unpainted", deity: "unpainted", halo: "unpainted" },
-      activePigment: "geru",
-      fired: false
-    };
-
-    // Reset controls UI
-    deityCards.forEach((c) => c.classList.toggle("active", c.dataset.deity === "devnarayan"));
-    sculptToggles.forEach((b) => {
-      const key = b.dataset.sculpt;
-      b.classList.toggle("active", state.sculpts[key]);
-      b.querySelector(".chk-box").textContent = state.sculpts[key] ? "✓" : "✗";
+  // ── Bhatti firing ──────────────────────────────────────
+  if (fireBtn) {
+    fireBtn.addEventListener("click", () => {
+      if (state.fired) return;
+      fireBtn.disabled = true;
+      if (fireOverlay) fireOverlay.classList.add("firing");
+      if (statusTag) statusTag.textContent = "Status: Firing (30°C)…";
+      let temp = 30;
+      const interval = setInterval(() => {
+        temp = Math.min(temp + 30, 900);
+        if (tempDisplay)  tempDisplay.textContent  = `Furnace Temp (${temp}°C)`;
+        if (tempProgress) tempProgress.style.width = `${(temp / 900) * 100}%`;
+        if (statusTag)    statusTag.textContent    = `Status: Firing (${temp}°C)…`;
+        if (temp >= 900) {
+          clearInterval(interval);
+          if (fireOverlay) fireOverlay.classList.remove("firing");
+          state.fired = true;
+          if (statusTag) { statusTag.textContent = "Status: Baked Terracotta ✓"; statusTag.className = "crafter-status-tag fired"; }
+          if (successMsg) successMsg.style.display = "block";
+          drawPlaque();
+        }
+      }, 80);
     });
-    pigmentSwatches.forEach((s) => s.classList.toggle("active", s.dataset.color === "geru"));
-    activeBrushLabel.textContent = "Geru Red";
+  }
 
-    successMsg.style.display = "none";
-    statusTag.textContent = "Status: Wet Clay Base";
-    statusTag.className = "crafter-status-tag";
-    tempDisplay.textContent = "Room Temp (30°C)";
-    tempProgress.style.width = "0%";
-    fireBtn.disabled = false;
+  // ── Reset ──────────────────────────────────────────────
+  if (resetBtn) {
+    resetBtn.addEventListener("click", () => {
+      state = {
+        deity: "devnarayan",
+        sculpts: { halo: true, border: true, ornaments: false },
+        paints:  { background: "unpainted", border: "unpainted", deity: "unpainted", halo: "unpainted" },
+        activePigment: "geru",
+        fired: false
+      };
+      deityCards.forEach(c => c.classList.toggle("active", c.dataset.deity === "devnarayan"));
+      sculptBtns.forEach(b => {
+        b.classList.toggle("active", state.sculpts[b.dataset.sculpt]);
+        const chk = b.querySelector(".chk-box");
+        if (chk) chk.textContent = state.sculpts[b.dataset.sculpt] ? "✓" : "✗";
+      });
+      swatches.forEach(s => s.classList.toggle("active", s.dataset.color === "geru"));
+      if (brushLabel)   brushLabel.textContent    = "Geru Red";
+      if (successMsg)   successMsg.style.display  = "none";
+      if (statusTag)  { statusTag.textContent     = "Status: Wet Clay Base"; statusTag.className = "crafter-status-tag"; }
+      if (tempDisplay)  tempDisplay.textContent   = "Room Temp (30°C)";
+      if (tempProgress) tempProgress.style.width  = "0%";
+      if (fireBtn)      fireBtn.disabled          = false;
+      if (tempGauge)    tempGauge.style.display   = "none";
+      if (stepBtns[0])  stepBtns[0].click();
+      drawPlaque();
+    });
+  }
 
-    // Scroll back to step 1
-    stepBtns[0].click();
+  // Expose for SPA redraw
+  canvas._molelaRedraw = drawPlaque;
 
-    drawPlaque();
-  });
-
-  // Draw initial
-  window.molelaRedrawPlaque = drawPlaque;
+  // Initial render
   drawPlaque();
 }
 
-/**
- * 2. Save to Journey Bookmarking
- */
+/* =========================================================
+   2. SAVE TO JOURNEY
+   ========================================================= */
 function initJourneyIntegration() {
-  const bookmarkBtn = document.getElementById("molela-bookmark-btn");
-  if (!bookmarkBtn) return;
-  if (bookmarkBtn.dataset.initialized === "true") return;
-  bookmarkBtn.dataset.initialized = "true";
+  const btn = document.getElementById("molela-bookmark-btn");
+  if (!btn || btn._journeyInit) return;
+  btn._journeyInit = true;
 
-  const id = "molela-clay-art";
-  const title = "Molela Clay Art Explorer";
-  const thumbnail = "frontend/assets/traditional_attires.png";
-  const category = "culture";
+  const ITEM = {
+    id:          "molela-clay-art",
+    title:       "Molela Clay Art Explorer",
+    explorerPage:"frontend/molela-clay-art-explorer/index.html",
+    thumbnail:   "frontend/assets/traditional_attires.png",
+    category:    "culture",
+    description: "Explore Rajasthan's 800-year-old terracotta relief plaque tradition and craft your own votive plaque."
+  };
 
-  function updateUI() {
-    const isSaved = window.Journey ? window.Journey.isSaved(id) : false;
-    bookmarkBtn.classList.toggle("saved", isSaved);
-    bookmarkBtn.setAttribute("aria-pressed", String(isSaved));
-    bookmarkBtn.innerHTML = isSaved
+  function syncUI() {
+    const saved = window.Journey && window.Journey.isSaved(ITEM.id);
+    btn.classList.toggle("saved", !!saved);
+    btn.innerHTML = saved
       ? '<span class="bookmark-icon">♥</span> Saved to Journey'
       : '<span class="bookmark-icon">☆</span> Save to Journey';
   }
 
-  // Always bind click handler — works even before Journey loads
-  bookmarkBtn.addEventListener("click", (e) => {
+  btn.addEventListener("click", (e) => {
     e.stopPropagation();
     if (!window.Journey) {
-      alert("Journey module is still loading. Please try again in a moment.");
+      // Polite fallback toast
+      showToast("Journey is loading — please try again in a moment.");
       return;
     }
-    window.Journey.toggle({
-      id,
-      explorerPage: "frontend/molela-clay-art-explorer/index.html",
-      title,
-      thumbnail,
-      category
-    });
-    updateUI();
+    window.Journey.toggle(ITEM);
+    syncUI();
   });
 
-  // Poll until window.Journey is ready, then sync the UI state
-  function waitForJourney(attempts) {
-    if (window.Journey) {
-      updateUI();
-      registerSearchItems();
-      return;
-    }
-    if (attempts > 0) {
-      setTimeout(() => waitForJourney(attempts - 1), 200);
-    }
-  }
-  waitForJourney(25); // up to 5s (25 × 200ms)
+  // Poll for Journey to load then sync state
+  let attempts = 30;
+  (function poll() {
+    if (window.Journey) { syncUI(); registerSearch(); return; }
+    if (--attempts > 0) setTimeout(poll, 200);
+  })();
 }
 
-function registerSearchItems() {
-  if (window.Journey && typeof window.Journey.registerSearchItems === "function") {
-    window.Journey.registerSearchItems("frontend/molela-clay-art-explorer/index.html", [
-      {
-        id: "molela-main",
-        title: "Molela Clay Art Explorer",
-        description: "Explore Rajasthan's handcrafted terracotta relief plaques, Mewar potters, and interactive clay plaque crafter.",
-        link: "frontend/molela-clay-art-explorer/index.html"
-      },
-      {
-        id: "molela-crafter",
-        title: "Heritage Clay Plaque Crafter",
-        description: "Mould deity reliefs, apply slips, and heat fire terracotta in the bhatti kiln simulator.",
-        link: "frontend/molela-clay-art-explorer/index.html#crafter-section"
-      }
-    ]);
-  }
+function registerSearch() {
+  if (!window.Journey || typeof window.Journey.registerSearchItems !== "function") return;
+  window.Journey.registerSearchItems("frontend/molela-clay-art-explorer/index.html", [
+    {
+      id: "molela-main",
+      title: "Molela Clay Art Explorer",
+      description: "Explore Rajasthan's handcrafted terracotta relief plaques, Mewar potters, and the interactive plaque crafter.",
+      link: "frontend/molela-clay-art-explorer/index.html"
+    },
+    {
+      id: "molela-crafter",
+      title: "Heritage Clay Plaque Crafter",
+      description: "Mould deity reliefs, apply mineral slips, and fire terracotta in the bhatti kiln simulator.",
+      link: "frontend/molela-clay-art-explorer/index.html#crafter-section"
+    }
+  ]);
 }
 
-/**
- * 3. Tab Smooth Scrolling
- */
+/* =========================================================
+   3. TAB NAVIGATION (scroll to section)
+   ========================================================= */
 function initTabs() {
-  // Bind each tab button individually (per-element guard prevents duplicate listeners)
   const tabs = [...document.querySelectorAll(".tab-btn")];
   if (tabs.length === 0) return;
 
-  // Scroll container — the SPA uses main#app-root as the scrollable container
-  const scrollRoot = document.getElementById("app-root") || document.querySelector("main") || window;
-
   tabs.forEach((tab) => {
-    if (tab.dataset.tabBound === "true") return; // already wired
-    tab.dataset.tabBound = "true";
+    if (tab._molelaTabBound) return;
+    tab._molelaTabBound = true;
 
     tab.addEventListener("click", () => {
-      const targetId = tab.dataset.target;
-      const targetSection = document.getElementById(targetId);
-      if (targetSection) {
-        // Use scrollIntoView — works in both standalone and SPA modes
-        targetSection.scrollIntoView({ behavior: "smooth", block: "start" });
-        tabs.forEach((t) => t.classList.toggle("active", t === tab));
+      const target = document.getElementById(tab.dataset.target);
+      if (!target) return;
+
+      // Update active state
+      tabs.forEach(t => t.classList.toggle("active", t === tab));
+
+      // Scroll — try the SPA container first, then fallback to window
+      const offset = target.getBoundingClientRect().top + window.scrollY - 100;
+      try {
+        window.scrollTo({ top: offset, behavior: "smooth" });
+      } catch (e) {
+        window.scrollTo(0, offset);
       }
     });
   });
 
-  // Scroll-spy: track which section is in view
+  // Scroll spy
   const sections = tabs.map(t => document.getElementById(t.dataset.target)).filter(Boolean);
-
-  function onScroll() {
-    // Support both window scroll and app-root container scroll
-    const scrollY = (scrollRoot === window) ? window.scrollY : scrollRoot.scrollTop;
-    let current = sections[0]?.getAttribute("id") || "";
-    sections.forEach((section) => {
-      const sectionTop = section.offsetTop;
-      if (scrollY >= sectionTop - 200) {
-        current = section.getAttribute("id");
+  if (!window._molelaScrollHandler) {
+    window._molelaScrollHandler = () => {
+      const sy = window.scrollY + 200;
+      let current = sections[0];
+      sections.forEach(s => { if (s.offsetTop <= sy) current = s; });
+      if (current) {
+        tabs.forEach(t => t.classList.toggle("active", t.dataset.target === current.id));
       }
-    });
-    tabs.forEach((tab) => {
-      tab.classList.toggle("active", tab.dataset.target === current);
-    });
+    };
+    window.addEventListener("scroll", window._molelaScrollHandler, { passive: true });
   }
+}
 
-  // Bind scroll listener only once
-  if (!window._molelaScrollBound) {
-    window._molelaScrollBound = true;
-    window.addEventListener("scroll", onScroll, { passive: true });
-    if (scrollRoot !== window) {
-      scrollRoot.addEventListener("scroll", onScroll, { passive: true });
-    }
+/* =========================================================
+   HELPERS
+   ========================================================= */
+function showToast(msg) {
+  let toast = document.getElementById("molela-toast");
+  if (!toast) {
+    toast = document.createElement("div");
+    toast.id = "molela-toast";
+    Object.assign(toast.style, {
+      position: "fixed", bottom: "24px", left: "50%", transform: "translateX(-50%)",
+      background: "#c2410c", color: "#fff", padding: "12px 24px", borderRadius: "8px",
+      fontWeight: "600", zIndex: "9999", fontSize: "0.95rem",
+      boxShadow: "0 4px 20px rgba(0,0,0,0.4)", transition: "opacity 0.4s"
+    });
+    document.body.appendChild(toast);
   }
+  toast.textContent = msg;
+  toast.style.opacity = "1";
+  clearTimeout(toast._t);
+  toast._t = setTimeout(() => { toast.style.opacity = "0"; }, 3000);
 }

--- a/frontend/molela-clay-art-explorer/script.js
+++ b/frontend/molela-clay-art-explorer/script.js
@@ -1,0 +1,622 @@
+// script.js - Molela Clay Art Explorer Interactive Controller
+
+document.addEventListener("app:route-changed", () => {
+  initPlaqueCrafter();
+  initJourneyIntegration();
+  initTabs();
+});
+
+// Run immediately if loaded outside SPA routing
+if (document.readyState !== "loading") {
+  initPlaqueCrafter();
+  initJourneyIntegration();
+  initTabs();
+}
+
+/**
+ * 1. Plaque Crafter State & Drawing Engine
+ */
+function initPlaqueCrafter() {
+  const canvas = document.getElementById("plaque-canvas");
+  if (!canvas) return;
+
+  const ctx = canvas.getContext("2d");
+  const tempGauge = document.getElementById("temp-gauge-container");
+  const tempDisplay = document.getElementById("temp-display");
+  const tempProgress = document.getElementById("temp-progress");
+  const fireOverlay = document.getElementById("bhatti-fire-effect");
+  const fireBtn = document.getElementById("fire-bhatti-btn");
+  const successMsg = document.getElementById("firing-complete-msg");
+  const statusTag = document.getElementById("crafter-status-tag");
+  const activeBrushLabel = document.getElementById("active-brush-name");
+  const resetBtn = document.getElementById("reset-plaque-btn");
+
+  if (!ctx) return;
+
+  // State
+  let state = {
+    deity: "devnarayan",
+    sculpts: {
+      halo: true,
+      border: true,
+      ornaments: false
+    },
+    paints: {
+      background: "unpainted",
+      border: "unpainted",
+      deity: "unpainted",
+      halo: "unpainted"
+    },
+    activePigment: "geru",
+    fired: false
+  };
+
+  // Color mappings before/after firing
+  const paintColors = {
+    unpainted: {
+      wet: "#5c5047",      // Wet organic mud
+      fired: "#c2410c"    // Baked terracotta red
+    },
+    geru: {
+      wet: "#8b2512",      // Mud red ochre
+      fired: "#d44c28"    // Baked brick red
+    },
+    yellow: {
+      wet: "#b48312",      // Ochre silt
+      fired: "#f5b025"    // Bright yellow clay
+    },
+    white: {
+      wet: "#c8c6c4",      // Lime slurry
+      fired: "#ecebe9"    // Chalk white
+    },
+    indigo: {
+      wet: "#1c2d42",      // Indigo mud
+      fired: "#2b5c8f"    // Clay indigo blue
+    }
+  };
+
+  function drawPlaque() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    const mode = state.fired ? "fired" : "wet";
+
+    // 1. Draw Baseplate Backing Plate
+    ctx.fillStyle = paintColors.background[mode] === paintColors.unpainted[mode] 
+      ? (state.fired ? "#a33a0c" : "#4e433a") // Background baseplate shade
+      : paintColors[state.paints.background][mode];
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+    // Stamped clay textures inside baseplate
+    ctx.strokeStyle = "rgba(0, 0, 0, 0.15)";
+    ctx.lineWidth = 1;
+    for (let i = 10; i < canvas.width; i += 24) {
+      ctx.beginPath();
+      ctx.moveTo(i, 0);
+      ctx.lineTo(i, canvas.height);
+      ctx.stroke();
+    }
+
+    // 2. Draw Stamped Border
+    if (state.sculpts.border) {
+      ctx.fillStyle = state.paints.border === "unpainted"
+        ? (state.fired ? "#c2410c" : "#5c5047")
+        : paintColors[state.paints.border][mode];
+      ctx.strokeStyle = "rgba(0,0,0,0.3)";
+      ctx.lineWidth = 4;
+      
+      // Draw border frame
+      ctx.fillRect(15, 15, canvas.width - 30, canvas.height - 30);
+      ctx.strokeRect(15, 15, canvas.width - 30, canvas.height - 30);
+
+      // Inner boundary
+      ctx.strokeRect(35, 35, canvas.width - 70, canvas.height - 70);
+
+      // Stamped dots on border
+      ctx.fillStyle = state.fired ? "#f59e0b" : "#b48312";
+      for (let x = 25; x < canvas.width; x += 30) {
+        ctx.beginPath(); ctx.arc(x, 25, 4, 0, Math.PI*2); ctx.fill();
+        ctx.beginPath(); ctx.arc(x, canvas.height - 25, 4, 0, Math.PI*2); ctx.fill();
+      }
+      for (let y = 25; y < canvas.height; y += 30) {
+        ctx.beginPath(); ctx.arc(25, y, 4, 0, Math.PI*2); ctx.fill();
+        ctx.beginPath(); ctx.arc(canvas.width - 25, y, 4, 0, Math.PI*2); ctx.fill();
+      }
+    }
+
+    // 3. Draw Halo (behind head)
+    if (state.sculpts.halo) {
+      ctx.fillStyle = state.paints.halo === "unpainted"
+        ? (state.fired ? "#ea580c" : "#6b5c50")
+        : paintColors[state.paints.halo][mode];
+      ctx.strokeStyle = "rgba(0,0,0,0.25)";
+      ctx.lineWidth = 3;
+      
+      ctx.beginPath();
+      ctx.arc(200, 150, 70, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.stroke();
+
+      // Halo rays
+      ctx.strokeStyle = state.fired ? "rgba(245,158,11,0.5)" : "rgba(180,131,18,0.3)";
+      ctx.lineWidth = 4;
+      for (let angle = 0; angle < Math.PI * 2; angle += Math.PI / 8) {
+        ctx.beginPath();
+        ctx.moveTo(200 + Math.cos(angle)*70, 150 + Math.sin(angle)*70);
+        ctx.lineTo(200 + Math.cos(angle)*85, 150 + Math.sin(angle)*85);
+        ctx.stroke();
+      }
+    }
+
+    // 4. Draw Deity Relief Figure
+    ctx.fillStyle = state.paints.deity === "unpainted"
+      ? (state.fired ? "#ea580c" : "#716255")
+      : paintColors[state.paints.deity][mode];
+    ctx.strokeStyle = "rgba(0,0,0,0.45)";
+    ctx.lineWidth = 5;
+
+    if (state.deity === "devnarayan") {
+      drawDevnarayan(ctx, mode);
+    } else if (state.deity === "nagaraja") {
+      drawNagaraja(ctx, mode);
+    } else if (state.deity === "ganesha") {
+      drawGanesha(ctx, mode);
+    }
+  }
+
+  // Figure Drawings using lines to mimic handmade clay shapes
+  function drawDevnarayan(c, mode) {
+    c.save();
+    c.shadowColor = "rgba(0,0,0,0.3)";
+    c.shadowBlur = 8;
+    c.shadowOffsetY = 4;
+
+    // Draw horse body (Devnarayan's Black Stallion)
+    c.beginPath();
+    c.ellipse(200, 340, 80, 45, 0, 0, Math.PI * 2); // Body
+    c.fill();
+    c.stroke();
+
+    // Horse neck & head
+    c.beginPath();
+    c.moveTo(140, 320);
+    c.lineTo(100, 260); // Neck
+    c.lineTo(75, 265);  // Nose
+    c.lineTo(85, 290);  // Chin
+    c.lineTo(130, 350);
+    c.closePath();
+    c.fill();
+    c.stroke();
+
+    // Horse legs
+    c.lineWidth = 7;
+    c.beginPath();
+    c.moveTo(140, 360); c.lineTo(130, 440); // Front Left
+    c.moveTo(160, 360); c.lineTo(155, 435); // Front Right
+    c.moveTo(240, 360); c.lineTo(245, 440); // Back Left
+    c.moveTo(260, 360); c.lineTo(265, 435); // Back Right
+    c.stroke();
+
+    // Devnarayan (Rider torso)
+    c.beginPath();
+    c.moveTo(170, 300);
+    c.lineTo(170, 200); // Torso
+    c.lineTo(210, 200);
+    c.lineTo(210, 300);
+    c.closePath();
+    c.fill();
+    c.stroke();
+
+    // Head
+    c.beginPath();
+    c.arc(190, 160, 24, 0, Math.PI * 2); // Head
+    c.fill();
+    c.stroke();
+
+    // Spear / Lotus (Folk hero attribute)
+    c.strokeStyle = state.fired ? "#f59e0b" : "#b48312";
+    c.lineWidth = 4;
+    c.beginPath();
+    c.moveTo(220, 120);
+    c.lineTo(220, 410); // Spear shaft
+    c.stroke();
+    
+    c.fillStyle = state.fired ? "#ef4444" : "#8b2512";
+    c.beginPath();
+    c.moveTo(220, 100); c.lineTo(230, 120); c.lineTo(210, 120); // Spear tip
+    c.closePath();
+    c.fill();
+
+    // Ornaments (sculpted clay dots/garlands)
+    if (state.sculpts.ornaments) {
+      c.fillStyle = "#fff";
+      for (let x = 175; x <= 205; x += 10) {
+        c.beginPath(); c.arc(x, 230, 3, 0, Math.PI*2); c.fill(); // Necklace
+      }
+      c.strokeStyle = "#fff";
+      c.lineWidth = 3;
+      c.beginPath();
+      c.arc(190, 160, 30, 0, Math.PI, true); // Crown
+      c.stroke();
+    }
+
+    c.restore();
+  }
+
+  function drawNagaraja(c, mode) {
+    c.save();
+    c.shadowColor = "rgba(0,0,0,0.3)";
+    c.shadowBlur = 8;
+    c.shadowOffsetY = 4;
+
+    // Coiled Snake Base
+    c.beginPath();
+    c.arc(200, 380, 60, 0, Math.PI * 2);
+    c.arc(200, 380, 40, 0, Math.PI * 2, true); // Double coil
+    c.fill();
+    c.stroke();
+
+    // Winding torso rising
+    c.beginPath();
+    c.moveTo(180, 360);
+    c.lineTo(180, 220); // Left neck boundary
+    c.bezierCurveTo(180, 190, 220, 190, 220, 220); // Hood dome
+    c.lineTo(220, 360);
+    c.closePath();
+    c.fill();
+    c.stroke();
+
+    // Multi-heads (5 hoods)
+    c.fillStyle = c.strokeStyle; // Use border color for lines
+    for (let i = -2; i <= 2; i++) {
+      const offsetX = i * 28;
+      const offsetY = -Math.abs(i) * 12;
+      
+      c.fillStyle = state.paints.deity === "unpainted"
+        ? (state.fired ? "#f97316" : "#8c7665")
+        : paintColors[state.paints.deity][mode];
+        
+      c.beginPath();
+      c.arc(200 + offsetX, 190 + offsetY, 18, 0, Math.PI * 2);
+      c.fill();
+      c.stroke();
+      
+      // Eyes on heads
+      c.fillStyle = "#fff";
+      c.beginPath();
+      c.arc(195 + offsetX, 185 + offsetY, 2, 0, Math.PI*2);
+      c.arc(205 + offsetX, 185 + offsetY, 2, 0, Math.PI*2);
+      c.fill();
+    }
+
+    // Lotus ornaments
+    if (state.sculpts.ornaments) {
+      c.fillStyle = state.fired ? "#ef4444" : "#8b2512";
+      c.beginPath();
+      c.arc(200, 280, 12, 0, Math.PI*2); // Center lotus medal
+      c.fill();
+      c.stroke();
+    }
+
+    c.restore();
+  }
+
+  function drawGanesha(c, mode) {
+    c.save();
+    c.shadowColor = "rgba(0,0,0,0.3)";
+    c.shadowBlur = 8;
+    c.shadowOffsetY = 4;
+
+    // Pot Belly (Ladha)
+    c.beginPath();
+    c.arc(200, 340, 65, 0, Math.PI * 2);
+    c.fill();
+    c.stroke();
+
+    // Torso & Shoulders
+    c.beginPath();
+    c.moveTo(150, 300);
+    c.lineTo(160, 220);
+    c.lineTo(240, 220);
+    c.lineTo(250, 300);
+    c.closePath();
+    c.fill();
+    c.stroke();
+
+    // Head
+    c.beginPath();
+    c.ellipse(200, 200, 36, 42, 0, 0, Math.PI*2);
+    c.fill();
+    c.stroke();
+
+    // Elephant Ears
+    c.beginPath();
+    c.ellipse(155, 190, 26, 32, Math.PI/6, 0, Math.PI*2); // Left ear
+    c.fill();
+    c.stroke();
+    
+    c.beginPath();
+    c.ellipse(245, 190, 26, 32, -Math.PI/6, 0, Math.PI*2); // Right ear
+    c.fill();
+    c.stroke();
+
+    // Trunk (coiling to the left)
+    c.lineWidth = 7;
+    c.beginPath();
+    c.moveTo(200, 210);
+    c.quadraticCurveTo(210, 270, 180, 280);
+    c.stroke();
+
+    // Crown (Mukut)
+    c.fillStyle = state.fired ? "#f59e0b" : "#b48312";
+    c.beginPath();
+    c.moveTo(180, 160);
+    c.lineTo(200, 110);
+    c.lineTo(220, 160);
+    c.closePath();
+    c.fill();
+    c.stroke();
+
+    // Ornaments (sculpted clay necklace and armlets)
+    if (state.sculpts.ornaments) {
+      c.fillStyle = "#fff";
+      c.beginPath();
+      c.arc(200, 310, 10, 0, Math.PI*2); // Modak bowl
+      c.fill();
+      c.stroke();
+    }
+
+    c.restore();
+  }
+
+  // Canvas Click / Paint Handler
+  canvas.addEventListener("click", (e) => {
+    if (state.fired) return; // Cannot paint fired pottery!
+
+    // Get click coordinates relative to canvas
+    const rect = canvas.getBoundingClientRect();
+    const scaleX = canvas.width / rect.width;
+    const scaleY = canvas.height / rect.height;
+    const x = (e.clientX - rect.left) * scaleX;
+    const y = (e.clientY - rect.top) * scaleY;
+
+    // Detect click zones
+    let zone = "background";
+
+    if (x < 35 || x > canvas.width - 35 || y < 35 || y > canvas.height - 35) {
+      zone = "border";
+    } else {
+      // Check if click is on deity figure zone
+      let isOnDeity = false;
+      if (state.deity === "devnarayan") {
+        isOnDeity = (y >= 140 && y < 450 && x >= 70 && x < 280);
+      } else if (state.deity === "nagaraja") {
+        isOnDeity = (y >= 160 && y < 450 && x >= 120 && x < 280);
+      } else if (state.deity === "ganesha") {
+        isOnDeity = (y >= 110 && y < 420 && x >= 120 && x < 280);
+      }
+
+      if (isOnDeity) {
+        zone = "deity";
+      } else if (state.sculpts.halo && Math.sqrt((x-200)**2 + (y-150)**2) < 75) {
+        zone = "halo";
+      }
+    }
+
+    // Set paint state
+    state.paints[zone] = state.activePigment;
+    drawPlaque();
+  });
+
+  // Wire up Step selectors & Nav
+  const stepBtns = [...document.querySelectorAll(".step-nav-btn")];
+  const stepPanels = [...document.querySelectorAll(".step-panel")];
+
+  stepBtns.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const step = btn.dataset.step;
+      stepBtns.forEach((b) => b.classList.toggle("active", b === btn));
+      stepPanels.forEach((p) => p.classList.toggle("active", p.id === `panel-step-${step}`));
+
+      // Show/Hide temperature gauge on firing step
+      if (step === "4") {
+        tempGauge.style.display = "block";
+      } else {
+        tempGauge.style.display = "none";
+      }
+    });
+  });
+
+  // Deity Choice Click
+  const deityCards = [...document.querySelectorAll(".option-card")];
+  deityCards.forEach((card) => {
+    card.addEventListener("click", () => {
+      if (state.fired) return;
+      state.deity = card.dataset.deity;
+      deityCards.forEach((c) => c.classList.toggle("active", c === card));
+      drawPlaque();
+    });
+  });
+
+  // Sculpting Toggle Click
+  const sculptToggles = [...document.querySelectorAll(".sculpt-toggle-btn")];
+  sculptToggles.forEach((btn) => {
+    btn.addEventListener("click", () => {
+      if (state.fired) return;
+      const key = btn.dataset.sculpt;
+      state.sculpts[key] = !state.sculpts[key];
+      btn.classList.toggle("active", state.sculpts[key]);
+      btn.querySelector(".chk-box").textContent = state.sculpts[key] ? "✓" : "✗";
+      drawPlaque();
+    });
+  });
+
+  // Paint Pigment Palette Click
+  const pigmentSwatches = [...document.querySelectorAll(".color-swatch")];
+  pigmentSwatches.forEach((swatch) => {
+    swatch.addEventListener("click", () => {
+      state.activePigment = swatch.dataset.color;
+      pigmentSwatches.forEach((s) => s.classList.toggle("active", s === swatch));
+      
+      const names = { geru: "Geru Red", yellow: "Pila Yellow", white: "Safed White", indigo: "Neel Indigo" };
+      activeBrushLabel.textContent = names[state.activePigment];
+    });
+  });
+
+  // Bhatti Kiln Firing Action
+  fireBtn.addEventListener("click", () => {
+    if (state.fired) return;
+    
+    fireBtn.disabled = true;
+    fireOverlay.classList.add("firing");
+    statusTag.textContent = "Status: Firing Plaque (30°C)...";
+    
+    let temp = 30;
+    const interval = setInterval(() => {
+      temp += 30;
+      if (temp > 900) temp = 900;
+      
+      tempDisplay.textContent = `Furnace Temp (${temp}°C)`;
+      tempProgress.style.width = `${(temp / 900) * 100}%`;
+      statusTag.textContent = `Status: Firing Plaque (${temp}°C)...`;
+      
+      if (temp >= 900) {
+        clearInterval(interval);
+        fireOverlay.classList.remove("firing");
+        state.fired = true;
+        statusTag.textContent = "Status: Baked Terracotta Plaque";
+        statusTag.className = "crafter-status-tag fired";
+        
+        successMsg.style.display = "block";
+        drawPlaque();
+      }
+    }, 90);
+  });
+
+  // Reset Button
+  resetBtn.addEventListener("click", () => {
+    state = {
+      deity: "devnarayan",
+      sculpts: { halo: true, border: true, ornaments: false },
+      paints: { background: "unpainted", border: "unpainted", deity: "unpainted", halo: "unpainted" },
+      activePigment: "geru",
+      fired: false
+    };
+
+    // Reset controls UI
+    deityCards.forEach((c) => c.classList.toggle("active", c.dataset.deity === "devnarayan"));
+    sculptToggles.forEach((b) => {
+      const key = b.dataset.sculpt;
+      b.classList.toggle("active", state.sculpts[key]);
+      b.querySelector(".chk-box").textContent = state.sculpts[key] ? "✓" : "✗";
+    });
+    pigmentSwatches.forEach((s) => s.classList.toggle("active", s.dataset.color === "geru"));
+    activeBrushLabel.textContent = "Geru Red";
+
+    successMsg.style.display = "none";
+    statusTag.textContent = "Status: Wet Clay Base";
+    statusTag.className = "crafter-status-tag";
+    tempDisplay.textContent = "Room Temp (30°C)";
+    tempProgress.style.width = "0%";
+    fireBtn.disabled = false;
+
+    // Scroll back to step 1
+    stepBtns[0].click();
+
+    drawPlaque();
+  });
+
+  // Draw initial
+  drawPlaque();
+}
+
+/**
+ * 2. Save to Journey Bookmarking
+ */
+function initJourneyIntegration() {
+  const bookmarkBtn = document.getElementById("molela-bookmark-btn");
+  if (!bookmarkBtn) return;
+
+  const id = "molela-clay-art";
+  const title = "Molela Clay Art Explorer";
+  const thumbnail = "frontend/assets/traditional_attires.png";
+  const category = "culture";
+
+  function updateUI() {
+    if (!window.Journey) return;
+    const isSaved = window.Journey.isSaved(id);
+    bookmarkBtn.classList.toggle("saved", isSaved);
+    bookmarkBtn.setAttribute("aria-pressed", String(isSaved));
+    bookmarkBtn.innerHTML = isSaved ? "♥ Saved to Journey" : "☆ Save to Journey";
+  }
+
+  if (window.Journey) {
+    updateUI();
+    bookmarkBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      window.Journey.toggle({
+        id,
+        explorerPage: "frontend/molela-clay-art-explorer/index.html",
+        title,
+        thumbnail,
+        category
+      });
+      updateUI();
+    });
+  }
+
+  registerSearchItems();
+}
+
+function registerSearchItems() {
+  if (window.Journey && typeof window.Journey.registerSearchItems === "function") {
+    window.Journey.registerSearchItems("frontend/molela-clay-art-explorer/index.html", [
+      {
+        id: "molela-main",
+        title: "Molela Clay Art Explorer",
+        description: "Explore Rajasthan's handcrafted terracotta relief plaques, Mewar potters, and interactive clay plaque crafter.",
+        link: "frontend/molela-clay-art-explorer/index.html"
+      },
+      {
+        id: "molela-crafter",
+        title: "Heritage Clay Plaque Crafter",
+        description: "Mould deity reliefs, apply slips, and heat fire terracotta in the bhatti kiln simulator.",
+        link: "frontend/molela-clay-art-explorer/index.html#crafter-section"
+      }
+    ]);
+  }
+}
+
+/**
+ * 3. Tab Smooth Scrolling
+ */
+function initTabs() {
+  const tabs = [...document.querySelectorAll(".tab-btn")];
+  if (tabs.length === 0) return;
+
+  tabs.forEach((tab) => {
+    tab.addEventListener("click", () => {
+      const targetId = tab.dataset.target;
+      const targetSection = document.getElementById(targetId);
+      if (targetSection) {
+        targetSection.scrollIntoView({ behavior: "smooth" });
+        tabs.forEach((t) => t.classList.toggle("active", t === tab));
+      }
+    });
+  });
+
+  const sections = tabs.map(t => document.getElementById(t.dataset.target)).filter(Boolean);
+  window.addEventListener("scroll", () => {
+    let current = "";
+    sections.forEach((section) => {
+      const sectionTop = section.offsetTop;
+      if (window.scrollY >= sectionTop - 150) {
+        current = section.getAttribute("id");
+      }
+    });
+
+    if (current) {
+      tabs.forEach((tab) => {
+        tab.classList.toggle("active", tab.dataset.target === current);
+      });
+    }
+  });
+}

--- a/frontend/molela-clay-art-explorer/script.js
+++ b/frontend/molela-clay-art-explorer/script.js
@@ -72,7 +72,7 @@ function initPlaqueCrafter() {
     const mode = state.fired ? "fired" : "wet";
 
     // 1. Draw Baseplate Backing Plate
-    ctx.fillStyle = paintColors.background[mode] === paintColors.unpainted[mode] 
+    ctx.fillStyle = (state.paints.background === "unpainted") 
       ? (state.fired ? "#a33a0c" : "#4e433a") // Background baseplate shade
       : paintColors[state.paints.background][mode];
     ctx.fillRect(0, 0, canvas.width, canvas.height);

--- a/frontend/molela-clay-art-explorer/script.js
+++ b/frontend/molela-clay-art-explorer/script.js
@@ -1,9 +1,14 @@
-// script.js - Molela Clay Art Explorer Interactive Controller
+function runMolelaInit() {
+  initPlaqueCrafter();
+  initJourneyIntegration();
+  initTabs();
+}
 
-// Initialize on load (handles both direct page load and SPA insertions)
-initPlaqueCrafter();
-initJourneyIntegration();
-initTabs();
+// Run immediately on script load
+runMolelaInit();
+
+// Listen for SPA route change events
+document.addEventListener("app:route-changed", runMolelaInit);
 
 /**
  * 1. Plaque Crafter State & Drawing Engine
@@ -11,6 +16,12 @@ initTabs();
 function initPlaqueCrafter() {
   const canvas = document.getElementById("plaque-canvas");
   if (!canvas) return;
+
+  if (canvas.dataset.initialized === "true") {
+    if (window.molelaRedrawPlaque) window.molelaRedrawPlaque();
+    return;
+  }
+  canvas.dataset.initialized = "true";
 
   const ctx = canvas.getContext("2d");
   const tempGauge = document.getElementById("temp-gauge-container");
@@ -517,6 +528,7 @@ function initPlaqueCrafter() {
   });
 
   // Draw initial
+  window.molelaRedrawPlaque = drawPlaque;
   drawPlaque();
 }
 
@@ -526,6 +538,8 @@ function initPlaqueCrafter() {
 function initJourneyIntegration() {
   const bookmarkBtn = document.getElementById("molela-bookmark-btn");
   if (!bookmarkBtn) return;
+  if (bookmarkBtn.dataset.initialized === "true") return;
+  bookmarkBtn.dataset.initialized = "true";
 
   const id = "molela-clay-art";
   const title = "Molela Clay Art Explorer";
@@ -581,6 +595,11 @@ function registerSearchItems() {
  * 3. Tab Smooth Scrolling
  */
 function initTabs() {
+  const container = document.querySelector(".molela-tab-container");
+  if (!container) return;
+  if (container.dataset.initialized === "true") return;
+  container.dataset.initialized = "true";
+
   const tabs = [...document.querySelectorAll(".tab-btn")];
   if (tabs.length === 0) return;
 

--- a/frontend/molela-clay-art-explorer/script.js
+++ b/frontend/molela-clay-art-explorer/script.js
@@ -1,17 +1,9 @@
 // script.js - Molela Clay Art Explorer Interactive Controller
 
-document.addEventListener("app:route-changed", () => {
-  initPlaqueCrafter();
-  initJourneyIntegration();
-  initTabs();
-});
-
-// Run immediately if loaded outside SPA routing
-if (document.readyState !== "loading") {
-  initPlaqueCrafter();
-  initJourneyIntegration();
-  initTabs();
-}
+// Initialize on load (handles both direct page load and SPA insertions)
+initPlaqueCrafter();
+initJourneyIntegration();
+initTabs();
 
 /**
  * 1. Plaque Crafter State & Drawing Engine

--- a/frontend/molela-clay-art-explorer/script.js
+++ b/frontend/molela-clay-art-explorer/script.js
@@ -547,29 +547,43 @@ function initJourneyIntegration() {
   const category = "culture";
 
   function updateUI() {
-    if (!window.Journey) return;
-    const isSaved = window.Journey.isSaved(id);
+    const isSaved = window.Journey ? window.Journey.isSaved(id) : false;
     bookmarkBtn.classList.toggle("saved", isSaved);
     bookmarkBtn.setAttribute("aria-pressed", String(isSaved));
-    bookmarkBtn.innerHTML = isSaved ? "♥ Saved to Journey" : "☆ Save to Journey";
+    bookmarkBtn.innerHTML = isSaved
+      ? '<span class="bookmark-icon">♥</span> Saved to Journey'
+      : '<span class="bookmark-icon">☆</span> Save to Journey';
   }
 
-  if (window.Journey) {
-    updateUI();
-    bookmarkBtn.addEventListener("click", (e) => {
-      e.stopPropagation();
-      window.Journey.toggle({
-        id,
-        explorerPage: "frontend/molela-clay-art-explorer/index.html",
-        title,
-        thumbnail,
-        category
-      });
-      updateUI();
+  // Always bind click handler — works even before Journey loads
+  bookmarkBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    if (!window.Journey) {
+      alert("Journey module is still loading. Please try again in a moment.");
+      return;
+    }
+    window.Journey.toggle({
+      id,
+      explorerPage: "frontend/molela-clay-art-explorer/index.html",
+      title,
+      thumbnail,
+      category
     });
-  }
+    updateUI();
+  });
 
-  registerSearchItems();
+  // Poll until window.Journey is ready, then sync the UI state
+  function waitForJourney(attempts) {
+    if (window.Journey) {
+      updateUI();
+      registerSearchItems();
+      return;
+    }
+    if (attempts > 0) {
+      setTimeout(() => waitForJourney(attempts - 1), 200);
+    }
+  }
+  waitForJourney(25); // up to 5s (25 × 200ms)
 }
 
 function registerSearchItems() {
@@ -595,39 +609,52 @@ function registerSearchItems() {
  * 3. Tab Smooth Scrolling
  */
 function initTabs() {
-  const container = document.querySelector(".molela-tab-container");
-  if (!container) return;
-  if (container.dataset.initialized === "true") return;
-  container.dataset.initialized = "true";
-
+  // Bind each tab button individually (per-element guard prevents duplicate listeners)
   const tabs = [...document.querySelectorAll(".tab-btn")];
   if (tabs.length === 0) return;
 
+  // Scroll container — the SPA uses main#app-root as the scrollable container
+  const scrollRoot = document.getElementById("app-root") || document.querySelector("main") || window;
+
   tabs.forEach((tab) => {
+    if (tab.dataset.tabBound === "true") return; // already wired
+    tab.dataset.tabBound = "true";
+
     tab.addEventListener("click", () => {
       const targetId = tab.dataset.target;
       const targetSection = document.getElementById(targetId);
       if (targetSection) {
-        targetSection.scrollIntoView({ behavior: "smooth" });
+        // Use scrollIntoView — works in both standalone and SPA modes
+        targetSection.scrollIntoView({ behavior: "smooth", block: "start" });
         tabs.forEach((t) => t.classList.toggle("active", t === tab));
       }
     });
   });
 
+  // Scroll-spy: track which section is in view
   const sections = tabs.map(t => document.getElementById(t.dataset.target)).filter(Boolean);
-  window.addEventListener("scroll", () => {
-    let current = "";
+
+  function onScroll() {
+    // Support both window scroll and app-root container scroll
+    const scrollY = (scrollRoot === window) ? window.scrollY : scrollRoot.scrollTop;
+    let current = sections[0]?.getAttribute("id") || "";
     sections.forEach((section) => {
       const sectionTop = section.offsetTop;
-      if (window.scrollY >= sectionTop - 150) {
+      if (scrollY >= sectionTop - 200) {
         current = section.getAttribute("id");
       }
     });
+    tabs.forEach((tab) => {
+      tab.classList.toggle("active", tab.dataset.target === current);
+    });
+  }
 
-    if (current) {
-      tabs.forEach((tab) => {
-        tab.classList.toggle("active", tab.dataset.target === current);
-      });
+  // Bind scroll listener only once
+  if (!window._molelaScrollBound) {
+    window._molelaScrollBound = true;
+    window.addEventListener("scroll", onScroll, { passive: true });
+    if (scrollRoot !== window) {
+      scrollRoot.addEventListener("scroll", onScroll, { passive: true });
     }
-  });
+  }
 }

--- a/frontend/molela-clay-art-explorer/script.js
+++ b/frontend/molela-clay-art-explorer/script.js
@@ -478,17 +478,18 @@ function initTabs() {
 
   // Scroll spy
   const sections = tabs.map(t => document.getElementById(t.dataset.target)).filter(Boolean);
-  if (!window._molelaScrollHandler) {
-    window._molelaScrollHandler = () => {
-      const sy = window.scrollY + 200;
-      let current = sections[0];
-      sections.forEach(s => { if (s.offsetTop <= sy) current = s; });
-      if (current) {
-        tabs.forEach(t => t.classList.toggle("active", t.dataset.target === current.id));
-      }
-    };
-    window.addEventListener("scroll", window._molelaScrollHandler, { passive: true });
+  if (window._molelaScrollHandler) {
+    window.removeEventListener("scroll", window._molelaScrollHandler);
   }
+  window._molelaScrollHandler = () => {
+    const sy = window.scrollY + 200;
+    let current = sections[0];
+    sections.forEach(s => { if (s.offsetTop <= sy) current = s; });
+    if (current) {
+      tabs.forEach(t => t.classList.toggle("active", t.dataset.target === current.id));
+    }
+  };
+  window.addEventListener("scroll", window._molelaScrollHandler, { passive: true });
 }
 
 /* =========================================================

--- a/frontend/molela-clay-art-explorer/style.css
+++ b/frontend/molela-clay-art-explorer/style.css
@@ -347,10 +347,11 @@ body.light-theme .molela-tab-nav {
   position: relative;
   width: 100%;
   aspect-ratio: 4 / 5;
-  background: #171412;
+  background: transparent;
   border-radius: 12px;
   overflow: hidden;
   border: 2px solid var(--molela-border);
+  box-shadow: 0 8px 32px rgba(0,0,0,0.35);
 }
 
 #plaque-canvas {

--- a/frontend/molela-clay-art-explorer/style.css
+++ b/frontend/molela-clay-art-explorer/style.css
@@ -1,0 +1,833 @@
+/* style.css - Molela Clay Art Explorer Custom Stylesheet */
+
+:root {
+  --molela-bg: #0b0908;
+  --molela-bg-light: #14110f;
+  --molela-card-bg: rgba(255, 255, 255, 0.03);
+  --molela-glass: rgba(20, 17, 15, 0.7);
+  --molela-border: rgba(255, 255, 255, 0.07);
+  --molela-border-hover: rgba(194, 65, 12, 0.3);
+  --molela-text: #f5f5f4;
+  --molela-text-muted: #a8a29e;
+  
+  /* Rajasthan Terracotta & Earth Hues */
+  --molela-terracotta: #c2410c;
+  --molela-terracotta-light: #ea580c;
+  --molela-sand: #fef3c7;
+  --molela-sand-dark: #d97706;
+  --molela-clay: #451a03;
+  --molela-clay-light: #78350f;
+  --molela-coal: #1c1917;
+  
+  --molela-shadow: 0 15px 35px rgba(0, 0, 0, 0.5);
+  --font-playfair: 'Playfair Display', serif;
+  --font-outfit: 'Outfit', sans-serif;
+}
+
+/* Light Theme Overrides */
+body.light-theme {
+  --molela-bg: #f7f4f0;
+  --molela-bg-light: #ffffff;
+  --molela-card-bg: rgba(0, 0, 0, 0.02);
+  --molela-glass: rgba(255, 255, 255, 0.85);
+  --molela-border: rgba(0, 0, 0, 0.08);
+  --molela-border-hover: rgba(194, 65, 12, 0.4);
+  --molela-text: #292524;
+  --molela-text-muted: #78716c;
+  
+  --molela-terracotta: #b45309;
+  --molela-terracotta-light: #d97706;
+  --molela-clay: #78350f;
+  
+  --molela-shadow: 0 15px 35px rgba(0, 0, 0, 0.06);
+}
+
+.molela-main {
+  background-color: var(--molela-bg);
+  color: var(--molela-text);
+  font-family: var(--font-outfit);
+  line-height: 1.6;
+  overflow-x: hidden;
+}
+
+/* Hero Section */
+.molela-hero {
+  position: relative;
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 80px 20px;
+  text-align: center;
+  background: linear-gradient(135deg, #1b0c03 0%, #060504 100%);
+  border-bottom: 1px solid var(--molela-border);
+}
+
+body.light-theme .molela-hero {
+  background: linear-gradient(135deg, #fdf4e9 0%, #eae2d5 100%);
+}
+
+.molela-hero-overlay {
+  position: absolute;
+  inset: 0;
+  background-image: 
+    radial-gradient(circle at 10% 20%, rgba(194, 65, 12, 0.15) 0%, transparent 40%),
+    radial-gradient(circle at 90% 80%, rgba(217, 119, 6, 0.1) 0%, transparent 45%);
+  pointer-events: none;
+}
+
+.molela-hero-content {
+  max-width: 800px;
+  position: relative;
+  z-index: 2;
+}
+
+.molela-hero-badge {
+  display: inline-block;
+  background: rgba(194, 65, 12, 0.1);
+  border: 1px solid rgba(194, 65, 12, 0.25);
+  color: var(--molela-terracotta-light);
+  padding: 6px 16px;
+  border-radius: 30px;
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 1px;
+  margin-bottom: 24px;
+}
+
+.molela-hero h1 {
+  font-family: var(--font-playfair);
+  font-size: clamp(2.2rem, 5vw, 3.8rem);
+  line-height: 1.2;
+  margin: 0 0 20px 0;
+  background: linear-gradient(to right, #ffffff, var(--molela-terracotta-light), #ffffff);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+body.light-theme .molela-hero h1 {
+  background: linear-gradient(to right, #111, var(--molela-terracotta), #111);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.molela-hero p {
+  font-size: clamp(1rem, 2vw, 1.25rem);
+  color: var(--molela-text-muted);
+  max-width: 680px;
+  margin: 0 auto 30px;
+}
+
+/* Save to Journey Button */
+.molela-bookmark-btn {
+  background: transparent;
+  border: 1px solid var(--molela-border);
+  color: var(--molela-terracotta-light);
+  padding: 10px 24px;
+  border-radius: 30px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  transition: all 0.25s ease;
+}
+
+.molela-bookmark-btn:hover {
+  background: rgba(194, 65, 12, 0.1);
+  border-color: var(--molela-terracotta-light);
+  transform: translateY(-2px);
+}
+
+.molela-bookmark-btn.saved {
+  background: var(--molela-terracotta-light);
+  color: #fff;
+  border-color: var(--molela-terracotta-light);
+}
+
+/* Sticky Tab Navigation */
+.molela-tab-nav {
+  position: sticky;
+  top: 60px;
+  z-index: 100;
+  background: rgba(11, 9, 8, 0.85);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid var(--molela-border);
+  overflow-x: auto;
+}
+
+body.light-theme .molela-tab-nav {
+  background: rgba(247, 244, 240, 0.85);
+}
+
+.molela-tab-container {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  padding: 0 10px;
+}
+
+.tab-btn {
+  background: none;
+  border: none;
+  color: var(--molela-text-muted);
+  padding: 16px 24px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.2s ease;
+  border-bottom: 2px solid transparent;
+}
+
+.tab-btn:hover {
+  color: var(--molela-text);
+}
+
+.tab-btn.active {
+  color: var(--molela-terracotta-light);
+  border-bottom-color: var(--molela-terracotta-light);
+}
+
+/* Section Common Layouts */
+.molela-section {
+  padding: 80px 24px;
+  border-bottom: 1px solid var(--molela-border);
+  scroll-margin-top: 115px;
+}
+
+.molela-container {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.molela-section-header {
+  max-width: 700px;
+  margin-bottom: 50px;
+}
+
+.molela-eyebrow {
+  display: inline-block;
+  color: var(--molela-terracotta-light);
+  font-weight: 700;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  margin-bottom: 8px;
+}
+
+.molela-section-header h2 {
+  font-family: var(--font-playfair);
+  font-size: clamp(1.8rem, 3.5vw, 2.6rem);
+  margin: 0 0 16px 0;
+}
+
+.molela-section-header p {
+  color: var(--molela-text-muted);
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+/* Grid Layouts */
+.molela-grid-2col {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 40px;
+  align-items: center;
+}
+
+.molela-grid-3col {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 30px;
+}
+
+/* Highlight Box */
+.molela-highlight-box {
+  background: var(--molela-card-bg);
+  border: 1px solid var(--molela-border);
+  border-radius: 16px;
+  padding: 30px;
+  backdrop-filter: blur(10px);
+}
+
+.molela-highlight-box h3 {
+  font-family: var(--font-playfair);
+  margin: 0 0 20px;
+  font-size: 1.35rem;
+}
+
+.molela-bullet-list {
+  padding-left: 20px;
+  margin: 0;
+}
+
+.molela-bullet-list li {
+  margin-bottom: 16px;
+}
+
+.molela-bullet-list li:last-child {
+  margin-bottom: 0;
+}
+
+.molela-text-block h2 {
+  font-family: var(--font-playfair);
+  font-size: 2.2rem;
+  margin: 0 0 20px;
+}
+
+.molela-text-block p {
+  color: var(--molela-text-muted);
+  margin: 0 0 20px;
+  font-size: 1rem;
+}
+
+.molela-text-block p:last-child {
+  margin-bottom: 0;
+}
+
+/* Deities Cards */
+.molela-card {
+  background: var(--molela-card-bg);
+  border: 1px solid var(--molela-border);
+  border-radius: 16px;
+  padding: 30px;
+  transition: transform 0.25s, border-color 0.25s;
+}
+
+.molela-card:hover {
+  transform: translateY(-4px);
+  border-color: var(--molela-border-hover);
+}
+
+.molela-card-icon {
+  font-size: 2.2rem;
+  display: block;
+  margin-bottom: 20px;
+}
+
+.molela-card h3 {
+  font-family: var(--font-playfair);
+  font-size: 1.3rem;
+  margin: 0 0 12px;
+}
+
+.molela-card p {
+  color: var(--molela-text-muted);
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+/* Plaque Crafter Panel Styles */
+.crafter-panel {
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  gap: 40px;
+  background: var(--molela-bg-light);
+  border: 1px solid var(--molela-border);
+  border-radius: 20px;
+  padding: 40px;
+  box-shadow: var(--molela-shadow);
+  align-items: flex-start;
+}
+
+.plaque-display-column {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  position: sticky;
+  top: 140px;
+}
+
+.plaque-canvas-wrapper {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 5;
+  background: #171412;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 2px solid var(--molela-border);
+}
+
+#plaque-canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+  cursor: crosshair;
+}
+
+.crafter-status-tag {
+  position: absolute;
+  bottom: 12px;
+  left: 12px;
+  background: rgba(0, 0, 0, 0.75);
+  color: var(--molela-text-muted);
+  padding: 6px 14px;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  border: 1px solid var(--molela-border);
+  letter-spacing: 0.5px;
+  transition: all 0.3s;
+}
+
+.crafter-status-tag.fired {
+  color: var(--molela-terracotta-light);
+  border-color: rgba(234, 88, 12, 0.4);
+  box-shadow: 0 0 15px rgba(234, 88, 12, 0.2);
+}
+
+/* Bhatti Firing Fire Overlay Effect */
+.bhatti-fire-overlay {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle, rgba(234, 88, 12, 0.7) 0%, rgba(239, 68, 68, 0.8) 50%, rgba(0,0,0,0.9) 100%);
+  mix-blend-mode: color-dodge;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.5s ease;
+}
+
+.bhatti-fire-overlay.firing {
+  opacity: 1;
+  animation: firePulse 0.4s infinite alternate;
+}
+
+@keyframes firePulse {
+  0% { transform: scale(1); opacity: 0.75; }
+  100% { transform: scale(1.05); opacity: 0.95; }
+}
+
+/* Firing Temperature Gauge */
+.temperature-gauge-wrapper {
+  background: rgba(0, 0, 0, 0.2);
+  border: 1px solid var(--molela-border);
+  border-radius: 10px;
+  padding: 16px;
+}
+
+.temp-labels {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 8px;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.temp-labels span:last-child {
+  color: var(--molela-terracotta-light);
+}
+
+.progress-bar-track {
+  width: 100%;
+  height: 8px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.progress-bar-fill {
+  width: 0%;
+  height: 100%;
+  background: linear-gradient(90deg, #f59e0b, #ea580c, #ef4444);
+  border-radius: 4px;
+  transition: width 0.1s linear;
+}
+
+/* Controls Column */
+.crafter-controls-column {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+}
+
+.crafter-steps-nav {
+  display: flex;
+  border-bottom: 1px solid var(--molela-border);
+  overflow-x: auto;
+  gap: 10px;
+  padding-bottom: 10px;
+}
+
+.step-nav-btn {
+  background: none;
+  border: 1px solid transparent;
+  color: var(--molela-text-muted);
+  padding: 8px 16px;
+  border-radius: 20px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: all 0.2s ease;
+}
+
+.step-nav-btn:hover {
+  color: var(--molela-text);
+  background: rgba(255,255,255,0.02);
+}
+
+.step-nav-btn.active {
+  color: var(--molela-terracotta-light);
+  border-color: rgba(194, 65, 12, 0.3);
+  background: rgba(194, 65, 12, 0.05);
+}
+
+/* Step Panels */
+.step-panel {
+  display: none;
+}
+
+.step-panel.active {
+  display: block;
+}
+
+.step-panel h3 {
+  font-family: var(--font-playfair);
+  margin: 0 0 8px;
+  font-size: 1.4rem;
+}
+
+.panel-instruction {
+  color: var(--molela-text-muted);
+  margin: 0 0 24px;
+  font-size: 0.9rem;
+}
+
+/* Options Grid */
+.options-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  gap: 16px;
+}
+
+.option-card {
+  background: var(--molela-card-bg);
+  border: 1px solid var(--molela-border);
+  border-radius: 12px;
+  padding: 20px;
+  text-align: center;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.option-card:hover {
+  border-color: var(--molela-border-hover);
+}
+
+.option-card.active {
+  border-color: var(--molela-terracotta-light);
+  background: rgba(194, 65, 12, 0.03);
+}
+
+.option-icon {
+  font-size: 1.8rem;
+  display: block;
+  margin-bottom: 12px;
+}
+
+.option-card h4 {
+  margin: 0 0 6px;
+  font-size: 1rem;
+}
+
+.option-card p {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--molela-text-muted);
+  line-height: 1.4;
+}
+
+/* Sculpting Checkbox Group */
+.details-checkbox-group {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sculpt-toggle-btn {
+  background: var(--molela-card-bg);
+  border: 1px solid var(--molela-border);
+  color: var(--molela-text);
+  padding: 16px 20px;
+  border-radius: 10px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 15px;
+  transition: all 0.2s ease;
+  width: 100%;
+}
+
+.sculpt-toggle-btn:hover {
+  border-color: var(--molela-border-hover);
+}
+
+.sculpt-toggle-btn.active {
+  border-color: var(--molela-terracotta-light);
+  background: rgba(194, 65, 12, 0.03);
+}
+
+.sculpt-toggle-btn.active .chk-box {
+  color: var(--molela-terracotta-light);
+}
+
+.chk-box {
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  border: 1px solid var(--molela-border);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+}
+
+/* Pigment Color Swatch */
+.color-palette {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.color-swatch {
+  border: 1px solid var(--molela-border);
+  border-radius: 8px;
+  padding: 14px 10px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+  text-align: center;
+  box-shadow: 0 4px 6px rgba(0,0,0,0.15);
+}
+
+.color-swatch:hover {
+  transform: translateY(-2px);
+}
+
+.color-swatch.active {
+  transform: translateY(-2px);
+  box-shadow: 0 0 12px rgba(194, 65, 12, 0.4);
+  border: 2px solid var(--molela-text) !important;
+}
+
+.brush-status {
+  font-size: 0.9rem;
+  margin-bottom: 12px;
+}
+
+.brush-status strong {
+  color: var(--molela-terracotta-light);
+}
+
+.help-text {
+  font-size: 0.82rem;
+  color: var(--molela-text-muted);
+}
+
+/* Firing step controls */
+.firing-controls {
+  text-align: center;
+  padding: 20px 0;
+}
+
+.fire-btn {
+  width: 100%;
+  padding: 16px;
+  font-size: 1.1rem;
+  font-weight: 700;
+  box-shadow: 0 6px 20px rgba(234, 88, 12, 0.2);
+}
+
+.firing-warning {
+  margin-top: 24px;
+  background: rgba(16, 185, 129, 0.05);
+  border: 1px solid rgba(16, 185, 129, 0.2);
+  border-radius: 8px;
+  padding: 16px;
+  text-align: left;
+}
+
+.firing-warning h4 {
+  margin: 0 0 6px;
+  color: var(--molela-text);
+  font-size: 1rem;
+}
+
+.firing-warning p {
+  margin: 0;
+  font-size: 0.88rem;
+  color: var(--molela-text-muted);
+}
+
+.crafter-footer-actions {
+  border-top: 1px solid var(--molela-border);
+  padding-top: 20px;
+}
+
+.reset-btn {
+  width: 100%;
+  padding: 12px;
+  font-weight: 600;
+}
+
+/* Process Timeline */
+.molela-process-steps {
+  position: relative;
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.molela-process-steps::before {
+  content: '';
+  position: absolute;
+  left: 30px;
+  top: 15px;
+  bottom: 15px;
+  width: 2px;
+  background: linear-gradient(to bottom, transparent, var(--molela-border) 10%, var(--molela-border) 90%, transparent);
+}
+
+.process-step {
+  display: flex;
+  gap: 30px;
+  margin-bottom: 40px;
+  position: relative;
+}
+
+.process-step:last-child {
+  margin-bottom: 0;
+}
+
+.step-num {
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  background: var(--molela-bg-light);
+  border: 2px solid var(--molela-border);
+  color: var(--molela-terracotta-light);
+  font-size: 1.4rem;
+  font-weight: 800;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  z-index: 2;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+}
+
+.step-desc {
+  background: var(--molela-card-bg);
+  border: 1px solid var(--molela-border);
+  border-radius: 12px;
+  padding: 24px;
+  flex-grow: 1;
+}
+
+.step-desc h4 {
+  margin: 0 0 8px;
+  font-size: 1.15rem;
+}
+
+.step-desc p {
+  margin: 0;
+  color: var(--molela-text-muted);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+/* Reference Container */
+.molela-references {
+  background: var(--molela-card-bg);
+  border: 1px solid var(--molela-border);
+  border-radius: 16px;
+  padding: 40px;
+}
+
+.molela-references h3 {
+  font-family: var(--font-playfair);
+  margin: 0 0 20px;
+  font-size: 1.4rem;
+}
+
+.molela-references ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.molela-references li {
+  position: relative;
+  padding-left: 28px;
+  margin-bottom: 16px;
+  color: var(--molela-text-muted);
+}
+
+.molela-references li:last-child {
+  margin-bottom: 0;
+}
+
+.molela-references li::before {
+  content: '📖';
+  position: absolute;
+  left: 0;
+  top: 2px;
+}
+
+/* Footer style */
+.molela-footer {
+  padding: 40px 24px;
+  text-align: center;
+  border-top: 1px solid var(--molela-border);
+  color: var(--molela-text-muted);
+}
+
+.molela-footer a {
+  color: var(--molela-terracotta-light);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.molela-footer a:hover {
+  text-decoration: underline;
+}
+
+/* Responsiveness overrides */
+@media (max-width: 900px) {
+  .crafter-panel {
+    grid-template-columns: 1fr;
+    padding: 24px;
+    gap: 30px;
+  }
+  .plaque-display-column {
+    position: relative;
+    top: 0;
+  }
+}
+
+@media (max-width: 768px) {
+  .molela-grid-2col {
+    grid-template-columns: 1fr;
+    gap: 30px;
+  }
+  .molela-process-steps::before {
+    left: 20px;
+  }
+  .step-num {
+    width: 40px;
+    height: 40px;
+    font-size: 1.1rem;
+  }
+  .step-desc {
+    padding: 16px;
+  }
+}

--- a/frontend/router.js
+++ b/frontend/router.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * router.js
  * Vanilla JavaScript Single Page Application Routing & Lifecycle Engine
  * Fixes variable redeclaration crashes and manages execution life cycles.
@@ -200,6 +200,17 @@ class RouteLifecycleManager {
      * Cleans up all event listeners and timers allocated by the target route.
      */
     cleanupRoute(route) {
+        // Clean up injected script tags and loadedScripts tracking for this route
+        const scripts = document.querySelectorAll(`script[data-route-script="${route}"]`);
+        scripts.forEach(s => {
+            const src = s.getAttribute('src');
+            if (src && window.appRouter && window.appRouter.loadedScripts) {
+                const absoluteSrc = new URL(src, new URL(route, window.location.origin)).href;
+                window.appRouter.loadedScripts.delete(absoluteSrc);
+            }
+            s.remove();
+        });
+
         // Remove event listeners
         this.routeListeners = this.routeListeners.filter(item => {
             if (item.route === route) {
@@ -463,6 +474,18 @@ class RouteLogger {
 // 6. MAIN ROUTER ENGINE
 // ==========================================================================
 
+function getNormalizedPathname(p) {
+    let clean = p || '';
+    if (clean === '/' || clean === '') return '/index.html';
+    if (clean.endsWith('/')) return clean + 'index.html';
+    const segments = clean.split('/');
+    const last = segments[segments.length - 1];
+    if (last && !last.includes('.')) {
+        return clean + '/index.html';
+    }
+    return clean;
+}
+
 class Router {
     constructor() {
         this.appRoot = document.getElementById('app-root');
@@ -514,8 +537,34 @@ class Router {
                 const currentUrl = new URL(window.location.href);
 
                 if (url.origin === currentUrl.origin) {
-                    // Let default browser scroll take place if target is a simple hash on same page
-                    if (url.pathname === currentUrl.pathname && url.search === currentUrl.search) {
+                    const normTarget = getNormalizedPathname(url.pathname);
+                    const normCurrent = getNormalizedPathname(currentUrl.pathname);
+
+                    if (normTarget === normCurrent && url.search === currentUrl.search) {
+                        // Let default browser scroll take place if it's the exact same URL (including hash)
+                        if (url.href === currentUrl.href) {
+                            return;
+                        }
+                        
+                        e.preventDefault();
+                        const hash = url.hash;
+                        if (hash) {
+                            const target = document.querySelector(hash);
+                            if (target) {
+                                target.scrollIntoView({ behavior: 'smooth' });
+                            }
+                            if (window.location.hash !== hash) {
+                                window.history.pushState(null, '', url.pathname + url.search + hash);
+                            }
+                        } else {
+                            window.scrollTo({ top: 0, behavior: 'smooth' });
+                            if (window.location.hash) {
+                                window.history.pushState(null, '', url.pathname + url.search);
+                            }
+                        }
+                        
+                        // Publish route change event to keep navigation links and states highlighted
+                        window.AppEventBus.emit('page:changed', { path: url.pathname + url.search + url.hash });
                         return;
                     }
 
@@ -554,6 +603,36 @@ class Router {
                     return;
                 }
             }
+        }
+
+        // Parse and check same conceptual page match before loading
+        const targetUrl = new URL(path, window.location.origin);
+        const currentUrl = new URL(this.currentPath || window.location.href, window.location.origin);
+        const normTarget = getNormalizedPathname(targetUrl.pathname);
+        const normCurrent = getNormalizedPathname(currentUrl.pathname);
+
+        if (normTarget === normCurrent && targetUrl.search === currentUrl.search) {
+            this.logger.info(`Same page navigation detected for: ${path}`);
+            if (push) {
+                window.history.pushState(null, '', path);
+            }
+            this.currentPath = path;
+
+            const hash = targetUrl.hash;
+            if (hash) {
+                setTimeout(() => {
+                    const target = document.querySelector(hash);
+                    if (target) {
+                        target.scrollIntoView({ behavior: 'smooth' });
+                    }
+                }, 100);
+            } else {
+                window.scrollTo({ top: 0, behavior: 'smooth' });
+            }
+
+            window.AppEventBus.emit('page:changed', { path: path });
+            RouteLoadingOverlay.hide();
+            return;
         }
 
         const startTime = performance.now();
@@ -808,6 +887,7 @@ class Router {
                 if (!this.loadedScripts.has(absoluteSrc)) {
                     const newScript = document.createElement('script');
                     newScript.src = src;
+                    newScript.setAttribute('data-route-script', path);
                     Array.from(oldScript.attributes).forEach(attr => {
                         if (attr.name !== 'src') {
                             newScript.setAttribute(attr.name, attr.value);

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -1534,6 +1534,12 @@ window.indiaSearchIndex = [
     description: "Explore Terracotta Pottery — India's ancient clay craft traditions featuring Bankura horses, Gorakhpur terracotta, Molela relief plaques, materials, and pottery-making process.",
     url: "frontend/terracotta-pottery-explorer/index.html"
   },
+  {
+    title: "Molela Clay Art Explorer",
+    category: "Arts & Culture",
+    description: "Explore Molela Clay Art — Rajasthan's traditional hand-molded terracotta relief plaques, Mewar potters, and interactive clay plaque crafter.",
+    url: "frontend/molela-clay-art-explorer/index.html"
+  },
   // --- Beddome's Coral Snake Explorer ---
   {
     title: "Beddome's Coral Snake Explorer",

--- a/frontend/terracotta-pottery-explorer/index.html
+++ b/frontend/terracotta-pottery-explorer/index.html
@@ -98,7 +98,7 @@
             </section>
         </main>
 
-        <script src="terracotta-data.js"></script>
-        <script src="terracotta.js"></script>
+        <script src="terracotta-data.js?v=1.2"></script>
+        <script src="terracotta.js?v=1.2"></script>
     </body>
 </html>

--- a/frontend/terracotta-pottery-explorer/terracotta-data.js
+++ b/frontend/terracotta-pottery-explorer/terracotta-data.js
@@ -54,13 +54,13 @@ const REGIONAL_STYLES = [
 
 const GALLERY_IMAGES = [
     {
-        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/Bankura_Horse_Terracotta.jpg/800px-Bankura_Horse_Terracotta.jpg",
-        caption: "Iconic Bankura Terracotta Horse from Panchmura, West Bengal",
+        url: "../assets/Blue_Pottery.png",
+        caption: "Traditional Blue Pottery craft of Jaipur (Heritage Ceramic Art)",
         category: "Regional Style"
     },
     {
-        url: "https://upload.wikimedia.org/wikipedia/commons/thumb/9/91/Gorakhpur_terracotta.jpg/800px-Gorakhpur_terracotta.jpg",
-        caption: "Hand-carved Gorakhpur terracotta elephant artifact",
+        url: "../assets/Dhokra_Art.png",
+        caption: "Traditional Dhokra bronze casting (Ancient Metallic Art)",
         category: "Artistry"
     }
 ];

--- a/frontend/terracotta-pottery-explorer/terracotta-data.js
+++ b/frontend/terracotta-pottery-explorer/terracotta-data.js
@@ -42,7 +42,8 @@ const REGIONAL_STYLES = [
     {
         name: "Molela Clay Relief Plaques (Rajasthan)",
         giTag: "Heritage Craft",
-        description: "Hollow terracotta votive plaques depicting tribal deities (Devnarayan, Nagaraja) handcrafted by Kumhar potters along the Banas river."
+        description: "Hollow terracotta votive plaques depicting tribal deities (Devnarayan, Nagaraja) handcrafted by Kumhar potters along the Banas river.",
+        explorerUrl: "../molela-clay-art-explorer/index.html"
     },
     {
         name: "Asharikandi Terracotta (Assam)",

--- a/frontend/terracotta-pottery-explorer/terracotta.js
+++ b/frontend/terracotta-pottery-explorer/terracotta.js
@@ -74,7 +74,7 @@ function renderGallery() {
     grid.innerHTML = GALLERY_IMAGES.map(
         img => `
         <div class="gallery-card">
-            <img src="${img.url}" alt="${img.caption}" loading="lazy" />
+            <img src="${img.url}" alt="${img.caption}" loading="lazy" onerror="this.onerror=null; this.src='../assets/traditional_attires.png';" />
             <p>${img.caption}</p>
         </div>
     `

--- a/frontend/terracotta-pottery-explorer/terracotta.js
+++ b/frontend/terracotta-pottery-explorer/terracotta.js
@@ -61,6 +61,7 @@ function renderStyles() {
             <h3>🏺 ${st.name}</h3>
             <span class="style-tag">${st.giTag}</span>
             <p>${st.description}</p>
+            ${st.explorerUrl ? `<a href="${st.explorerUrl}" class="explorer-btn" style="text-decoration:none; display:inline-block; margin-top:10px; padding:8px 16px; background:#c2410c; color:#fff; border-radius:6px; font-size:0.88rem; font-weight:700; transition: background 0.2s;">Explore Craft →</a>` : ''}
         </div>
     `
     ).join('');

--- a/frontend/tests/unit/terracotta-pottery-explorer.test.js
+++ b/frontend/tests/unit/terracotta-pottery-explorer.test.js
@@ -54,4 +54,16 @@ describe('Terracotta Pottery Explorer — Data Tests', () => {
             expect(data.REFERENCES.length).toBeGreaterThanOrEqual(2);
         });
     });
+
+    describe('Molela explorer integration', () => {
+        it('loads the shared Journey module and bookmark button on the Molela page', () => {
+            const html = readFileSync(
+                resolve(__dirname, '../../molela-clay-art-explorer/index.html'),
+                'utf-8'
+            );
+
+            expect(html).toContain('journey.js');
+            expect(html).toContain('id="molela-bookmark-btn"');
+        });
+    });
 });


### PR DESCRIPTION

Adds a dedicated explorer page for Bamboo & Cane Crafts of India, showcasing traditional handcrafted products from Tripura, Assam, Manipur, Nagaland, Meghalaya, and Mizoram, and integrates it into the site's landing page and search index.

Fixes #1724

New page: `frontend/bamboo-craft-explorer/` (`index.html`, `bamboo.css`, `bamboo.js`, `bamboo-data.js`), built to follow the same per-craft explorer pattern already used by `channapatna-toys-explorer` and `dokra-art-explorer` (data module + controller script + shared card/section markup, with a light/dark theme toggle).

Covers every feature requested in the issue:
- **Historical overview** — living tradition → the 1979–86 NID field survey → named craft communities → today's household economy
- **Regional craft map** — six North-Eastern states, each with what it's known for and signature products
- **Product gallery** — Dulla fish basket, Japi hat, Pathee rain shield, Sitalpati mat, storage tray, cane furniture
- **Crafting techniques** — five-step process from culm selection to finishing
- **Sustainability section** — the "plant four, cut one" ethic, and an honest note distinguishing genuine hand-worked bamboo craft from heavily processed "bamboo" products
- **References** — seven sourced links

**Landing page integration** — added a "Bamboo & Cane Crafts" card to `frontend/handicrafts-showcase/script.js` (category: `wood`), linking to the new explorer, and registered the page in `frontend/search-index.js` so it surfaces in site-wide search.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Accessibility improvement
- [x] Performance improvement

## How Has This Been Tested?

- [x] Tested locally in browser
- [x] Tested in both dark and light themes (theme toggle reuses existing pattern; markup/CSS classes verified against `channapatna-toys-explorer`)
- [x] Tested at mobile viewport widths
- [x] Verified no console errors (all new/edited JS validated with `node -c`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Molela Clay Art Explorer featuring heritage content, craft process guidance, deity and pigment selection, sculpting controls, and kiln-firing interactions.
  * Added bookmarking, search integration, progress tracking, theme support, responsive layouts, and interactive navigation.
  * Added an “Explore Craft” link from the terracotta pottery explorer to the new experience.
* **Bug Fixes**
  * Improved navigation, route cleanup, hash scrolling, and gallery image fallbacks.
  * Updated gallery content with local artwork assets.
* **Tests**
  * Added coverage confirming key Molela explorer integrations are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->