### PR TITLE
feat: Explore the underground resistance networks of 1942–44

### DIFF
--- a/frontend/freedom-fighters-hub/index.html
+++ b/frontend/freedom-fighters-hub/index.html
@@ -215,6 +215,27 @@
                 </div>
             </section>
 
+            <!-- Featured Explorer: Underground Resistance Networks of 1942–44 -->
+            <section class="featured-explorer-section" aria-label="Featured underground resistance explorer">
+                <div class="section-container">
+                    <div class="featured-explorer-card">
+                        <div class="featured-explorer-content">
+                            <span class="featured-explorer-badge">Featured Movement Explorer</span>
+                            <h2>Underground Resistance Networks of the Quit India Movement (1942&ndash;44)</h2>
+                            <p>After the mass arrests of 9 August 1942, the movement went to ground. Follow the web beneath the Empire &mdash; <em>Congress Radio</em>, the illegal presses of <em>Inquilab</em> and the <em>Congress Bulletin</em>, student courier networks, and the parallel governments of Satara and Tamluk. An interactive network graph, location map, publication markers, communication routes and a month-by-month timeline.</p>
+                            <a href="../underground-resistance-explorer/index.html" class="featured-explorer-btn">
+                                Explore the Underground &rarr;
+                            </a>
+                        </div>
+                        <div class="featured-explorer-meta">
+                            <span class="featured-explorer-date">1942 &ndash; 1944</span>
+                            <span class="featured-explorer-outcome">Quit India Movement &middot; Underground Phase</span>
+                            <span class="featured-explorer-treaty">Congress Radio &middot; Azad Dastas &middot; Prati Sarkars</span>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
             <!-- Controls Section -->
             <section class="controls-section">
                 <div class="section-container">
@@ -298,6 +319,7 @@
                         <li><a href="../begum-hazrat-mahal-explorer/index.html">Begum Hazrat Mahal Explorer</a></li>
                         <li><a href="../alluri-sitarama-raju-explorer/index.html">Alluri Sitarama Raju Explorer</a></li>
                         <li><a href="../quit-india-movement-explorer/index.html">Quit India Movement Explorer</a></li>
+                        <li><a href="../underground-resistance-explorer/index.html">Underground Resistance Explorer</a></li>
                     </ul>
                 </div>
             </div>

--- a/frontend/freedom-fighters-hub/script.js
+++ b/frontend/freedom-fighters-hub/script.js
@@ -453,6 +453,7 @@ const FREEDOM_FIGHTERS_DATA = [
         contributions: 'The Bombay launch of the Quit India Movement made the demand for immediate freedom a national imperative, triggered the widest protest wave since 1857, and convinced the British that the Raj could not survive the war.',
         rareFacts: 'The slogan "Quit India" was coined by the young Bombay socialist Yusuf Meherally; the maidan was renamed August Kranti Maidan after Independence, and India Post issued a commemorative stamp for the movement in 1992.',
         quote: '"Karo Ya Maro" — "Do or Die." We shall either free India or die in the attempt; we shall not live to see the perpetuation of our slavery. — Mahatma Gandhi, Gowalia Tank Maidan, 8 August 1942',
+<<<<<<< Updated upstream
         explorerLink: '../quit-india-movement-explorer/index.html'},
           {
         id: 'baji-rout',
@@ -513,6 +514,34 @@ const FREEDOM_FIGHTERS_DATA = [
         rareFacts: 'Earned the name "Bagha Jatin" (Tiger Jatin) after a widely recounted incident demonstrating his physical courage.',
         quote: 'We shall die to awaken the nation.',
         explorerLink: '../bagha-jatin-explorer/index.html'
+=======
+        explorerLink: '../quit-india-movement-explorer/index.html'
+    },
+    {
+        id: 'underground-resistance-networks',
+        name: 'Underground Resistance Networks — 1942–44',
+        title: 'The Leaderless Years of the Quit India Movement',
+        lifespan: '9 August 1942 – 1944',
+        era: 'Gandhian Era',
+        region: 'West',
+        birthplace: 'Bombay, Delhi, Bihar, Satara, Midnapore',
+        movements: ['Quit India Movement', 'Congress Radio', 'Underground Resistance'],
+        biography: 'When "Operation Zero Hour" swept Gandhi, Nehru, Patel, Azad and the entire Congress Working Committee into prison on 9 August 1942, the movement did not stop — it went to ground. From Bombay to Bihar, from Satara to Midnapore, younger leaders built a web of secret radio stations, illegal newspapers, student couriers and regional organisers. Congress Radio broadcast from hidden Bombay rooms on 42.34 metres, Aruna Asaf Ali and Ram Manohar Lohia edited the underground Inquilab, Jayaprakash Narayan built the Azad Dastas guerrilla squads after escaping Hazaribagh jail, and the Satara Prati Sarkar and Tamluk Jatiya Sarkar ran parallel governments until the networks were hunted down one by one.',
+        timeline: [
+            { year: '9 Aug 1942', event: 'Operation Zero Hour — mass arrests of the Congress leadership; the underground is born.' },
+            { year: '27 Aug 1942', event: 'Congress Radio begins broadcasting on 42.34 metres from a hidden Bombay room.' },
+            { year: 'Sep 1942', event: 'Aruna Asaf Ali and Ram Manohar Lohia begin publishing the underground monthly Inquilab.' },
+            { year: '9 Nov 1942', event: 'Jayaprakash Narayan escapes Hazaribagh jail and builds the Azad Dasta guerrillas of Bihar.' },
+            { year: '12 Nov 1942', event: 'A police raid silences Congress Radio; Usha Mehta is arrested in the Radio Conspiracy Case.' },
+            { year: 'Dec 1942', event: 'The Tamluk Jatiya Sarkar is established in Midnapore, printing its weekly Biplabi.' },
+            { year: '1943', event: 'The Satara Prati Sarkar consolidates under Nana Patil — the longest-running parallel government.' },
+            { year: '1944', event: 'Arrests, informers and raids thin the networks; the underground phase closes as the leaders are released.' }
+        ],
+        contributions: 'The underground networks sustained the Quit India Movement through its darkest period — carrying uncensored news, preserving morale, distributing arms, and proving village by village in Satara and Tamluk that Indians could govern themselves, forging the leaders who shaped independent India.',
+        rareFacts: 'The slogan "Quit India" was coined by Yusuf Meherally, a founding figure of the underground; a reward of ₹5,000 was placed on Aruna Asaf Ali, who eluded capture for nearly four years; and the student Usha Mehta, who ran Congress Radio, was a 22-year-old Wilson College master\'s student.',
+        quote: '"This is the Congress Radio calling on 42.34 metres from somewhere in India." — Congress Radio, 27 August 1942',
+        explorerLink: '../underground-resistance-explorer/index.html'
+>>>>>>> Stashed changes
     }
 ];
 

--- a/frontend/offline.html
+++ b/frontend/offline.html
@@ -556,7 +556,8 @@
                     '/frontend/birsa-munda-explorer/': 'Birsa Munda Explorer',
                     '/frontend/begum-hazrat-mahal-explorer/': 'Begum Hazrat Mahal Explorer',
                     '/frontend/alluri-sitarama-raju-explorer/': 'Alluri Sitarama Raju Explorer',
-                    '/frontend/quit-india-movement-explorer/': 'Quit India Movement Explorer'
+                    '/frontend/quit-india-movement-explorer/': 'Quit India Movement Explorer',
+                    '/frontend/underground-resistance-explorer/': 'Underground Resistance Explorer'
                 };
 
                 caches.keys().then(function (cacheNames) {

--- a/frontend/quit-india-movement-explorer/index.html
+++ b/frontend/quit-india-movement-explorer/index.html
@@ -628,6 +628,12 @@
             <a href="../aruna-asaf-ali-explorer/index.html" class="qi-inline-link">Visit Aruna Asaf Ali Explorer <span aria-hidden="true">↗</span></a>
           </article>
           <article class="qi-feature-card reveal">
+            <span class="qi-feature-icon" aria-hidden="true">🕸️</span>
+            <h3>The Underground Resistance</h3>
+            <p>When the arrests of 9 August drove the movement into hiding, Congress Radio, illegal presses and student couriers kept it breathing — an interactive layer of the Quit India map in its own right.</p>
+            <a href="../underground-resistance-explorer/index.html" class="qi-inline-link">Explore the Underground Resistance <span aria-hidden="true">↗</span></a>
+          </article>
+          <article class="qi-feature-card reveal">
             <span class="qi-feature-icon" aria-hidden="true">🗺️</span>
             <h3>The Freedom Movement Explorer</h3>
             <p>The complete map of India's struggle — from early resistance and the Swadeshi Movement to Quit India and the INA — with the Bombay launch in its proper place.</p>

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -722,6 +722,12 @@ window.indiaSearchIndex = [
     url: "frontend/quit-india-movement-explorer/index.html"
   },
   {
+    title: "Underground Resistance Networks of 1942–44",
+    category: "Freedom Struggle",
+    description: "Explore the underground networks that kept the Quit India Movement alive after the mass arrests of 9 August 1942: Congress Radio on 42.34 metres, the illegal presses of Inquilab and the Congress Bulletin, student couriers, regional organisers, the Azad Dastas and the parallel governments of Satara and Tamluk.",
+    url: "frontend/underground-resistance-explorer/index.html"
+  },
+  {
     title: "Gujarati Cinema (Dhollywood) Explorer",
     category: "Culture",
     description: "Discover Dhollywood, the Gujarati film industry — from Narsinh Mehta (1932), the first Gujarati talkie, to National Award-winning classics and its modern urban revival.",

--- a/frontend/sw.js
+++ b/frontend/sw.js
@@ -48,7 +48,10 @@ const STATIC_ASSETS_TO_PRECACHE = [
   './quit-india-movement-explorer/index.html',
   './quit-india-movement-explorer/style.css',
   './quit-india-movement-explorer/script.js',
-  './quit-india-movement-explorer/assets/august-kranti-maidan-hd.jpg'
+  './quit-india-movement-explorer/assets/august-kranti-maidan-hd.jpg',
+  './underground-resistance-explorer/index.html',
+  './underground-resistance-explorer/style.css',
+  './underground-resistance-explorer/script.js'
 ];
 
 // Max items allowed in dynamic caches to prevent storage overflow

--- a/frontend/underground-resistance-explorer/index.html
+++ b/frontend/underground-resistance-explorer/index.html
@@ -1,0 +1,869 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore the underground resistance networks of 1942–44: how Aruna Asaf Ali, Jayaprakash Narayan, Ram Manohar Lohia, Usha Mehta and a generation of students and regional organisers kept the Quit India Movement alive after the mass arrests of 9 August 1942 — secret communication, underground publications, Congress Radio, government surveillance and the parallel governments.">
+  <title>Underground Resistance Networks of 1942–44 | Incredible India</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="../js-modules/page-progress/page-progress.css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="">
+
+  <!-- Open Graph / Social Media Tags -->
+  <meta property="og:title" content="Underground Resistance Networks of 1942–44 | Incredible India Explorer">
+  <meta property="og:description" content="An interactive explorer of the clandestine networks that kept the Quit India Movement alive after the arrests of 9 August 1942 — Congress Radio, underground publications, student couriers, regional organisers, parallel governments and the surveillance that finally broke them.">
+  <meta property="og:image" content="https://upload.wikimedia.org/wikipedia/commons/9/93/Quit_India_Movement.JPG">
+  <meta property="og:image:width" content="2487">
+  <meta property="og:image:height" content="1256">
+  <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/underground-resistance-explorer/index.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Incredible India Explorer">
+  <meta property="og:locale" content="en_IN">
+
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/underground-resistance-explorer/index.html">
+</head>
+<body>
+  <script>
+    (function() {
+      const theme = localStorage.getItem('theme') || 'dark';
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+
+  <!-- Sticky Navigation Bar -->
+  <header class="navbar" id="navbar">
+    <div class="nav-container">
+        <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+            <span class="saffron">Incredible</span>
+            <span class="gold">India</span>
+            <span class="green">Explorer</span>
+        </a>
+        <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+            <span class="bar"></span>
+            <span class="bar"></span>
+            <span class="bar"></span>
+        </button>
+        <nav class="nav-menu" id="nav-menu">
+            <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
+                    <a href="../travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                    <a href="../islands/islands.html" class="dropdown-item">Islands of India</a>
+                    <a href="../heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    <a href="../route-planner/route-planner.html" class="dropdown-item">Route Planner</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../culture/culture.html" class="dropdown-item">Culture Overview</a>
+                    <a href="../cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
+                    <a href="../festivals/festivals.html" class="dropdown-item">Festivals</a>
+                    <a href="../historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
+                    <a href="../national-symbols-gallery/national-symbols-gallery.html" class="dropdown-item">National Symbols</a>
+                    <a href="../freedom-fighters-hub/index.html" class="dropdown-item">Freedom Fighters</a>
+                    <a href="../national-days-calendar/index.html" class="dropdown-item">National Days</a>
+                    <a href="../ganga-ghats-experience/index.html" class="dropdown-item">Ganga Ghats</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Nature ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../national-parks-explorer/index.html" class="dropdown-item">National Parks</a>
+                    <a href="../wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                    <a href="../wildlife-rescue/wildlife-rescue.html" class="dropdown-item">Wildlife Rescue</a>
+                    <a href="../endemic-flora-fauna-explorer/index.html" class="dropdown-item">Endemic Flora &amp; Fauna</a>
+                    <a href="../harike-wetland/harike-wetland.html" class="dropdown-item">Harike Wetland</a>
+                    <a href="../wular-lake/wular-lake.html" class="dropdown-item">Wular Lake</a>
+                    <a href="../crowd-density/index.html" class="dropdown-item">Crowd Density Predictor</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Games ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../passport-quest/passport-quest.html" class="dropdown-item">Passport Quest</a>
+                    <a href="../culinary-game/culinary-game.html" class="dropdown-item">Culinary Challenge</a>
+                    <a href="../monsoon-game/monsoon-game.html" class="dropdown-item">Monsoon Game</a>
+                    <a href="../river-game/river-game.html" class="dropdown-item">River Explorer</a>
+                    <a href="../geo-guesser-india/index.html" class="dropdown-item">GeoGuesser</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Community ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../contributors/contributors.html" class="dropdown-item">Contributors</a>
+                    <a href="../world-records-india/index.html" class="dropdown-item">World Records</a>
+                </div>
+            </div>
+
+            <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+        </nav>
+    </div>
+  </header>
+
+  <!-- SPA Router Target Container -->
+  <main id="app-root" class="ur-main">
+
+    <!-- Hero Banner -->
+    <section class="ur-hero" id="hero" aria-label="Underground resistance networks hero">
+      <div class="ur-hero-bg" aria-hidden="true"></div>
+      <div class="ur-hero-veil" aria-hidden="true"></div>
+      <div class="ur-hero-orbs" aria-hidden="true">
+        <span class="ur-orb ur-orb-one"></span>
+        <span class="ur-orb ur-orb-two"></span>
+        <span class="ur-orb ur-orb-three"></span>
+      </div>
+      <div class="ur-hero-content">
+        <span class="ur-kicker">🇮🇳 India · August 1942 – May 1944</span>
+        <h1>Underground Resistance <span>— The Leaderless Years</span></h1>
+        <p class="ur-hero-subtitle">When the British jailed the Congress leadership overnight, the movement did not stop — it went to ground.</p>
+        <p>On the night of 8–9 August 1942, "Operation Zero Hour" swept Gandhi, Nehru, Patel, Azad and the entire Congress Working Committee into prison. The Congress was declared unlawful and its presses shut. Yet from Bombay to Bihar, from Satara to Midnapore, a web of secret radio stations, illegal newspapers, student couriers and regional organisers rose to keep the Quit India Movement breathing. For nearly two years — until the networks were hunted down, one by one — the underground carried the voice that the Empire had tried to silence.</p>
+
+        <ul class="ur-hero-badges" aria-label="Key facts about the underground resistance networks">
+          <li>🎙️ Congress Radio · 42.34 m</li>
+          <li>📰 Inquilab &amp; Congress Bulletin</li>
+          <li>🕸️ Azad Dastas of Bihar</li>
+          <li>🏛️ Satara &amp; Tamluk Prati Sarkars</li>
+          <li>👩‍🎓 Student courier networks</li>
+        </ul>
+
+        <div class="ur-hero-actions">
+          <a href="#overview" class="ur-cta-btn">Enter the Underground <span aria-hidden="true">↓</span></a>
+          <div class="ur-bookmark-container">
+            <button class="ur-bookmark-btn journey-bookmark-btn" type="button" data-bookmark-id="underground-resistance-networks" aria-pressed="false" aria-label="Bookmark the underground resistance networks of 1942–44">
+              ♡ Save to Journey
+            </button>
+          </div>
+        </div>
+      </div>
+      <a class="ur-scroll-hint" href="#overview" aria-label="Scroll down to the story of the underground resistance">
+        <span class="ur-scroll-line" aria-hidden="true"></span>
+      </a>
+    </section>
+
+    <!-- Sticky Section Navigator -->
+    <nav class="ur-section-nav" id="ur-section-nav" aria-label="Underground resistance sections">
+      <div class="ur-section-nav-inner">
+        <a href="#overview" class="ur-section-nav-link" data-nav-target="overview">Origins</a>
+        <a href="#network" class="ur-section-nav-link" data-nav-target="network">Network</a>
+        <a href="#map" class="ur-section-nav-link" data-nav-target="map">Map &amp; Routes</a>
+        <a href="#publications" class="ur-section-nav-link" data-nav-target="publications">Publications</a>
+        <a href="#communication" class="ur-section-nav-link" data-nav-target="communication">Communication</a>
+        <a href="#students" class="ur-section-nav-link" data-nav-target="students">Students</a>
+        <a href="#regional" class="ur-section-nav-link" data-nav-target="regional">Regional Organisers</a>
+        <a href="#timeline" class="ur-section-nav-link" data-nav-target="timeline">Timeline</a>
+        <a href="#participants" class="ur-section-nav-link" data-nav-target="participants">Participants</a>
+        <a href="#surveillance" class="ur-section-nav-link" data-nav-target="surveillance">Surveillance</a>
+        <a href="#significance" class="ur-section-nav-link" data-nav-target="significance">Significance</a>
+        <a href="#references" class="ur-section-nav-link" data-nav-target="references">References</a>
+      </div>
+    </nav>
+
+    <!-- Section: Origins -->
+    <section class="ur-section" id="overview">
+      <div class="ur-container">
+        <div class="ur-section-header">
+          <span class="ur-eyebrow">Why the Underground Emerged</span>
+          <h2>A Movement Without a Leadership</h2>
+          <p>How the arrest of a party became the seedbed of its most secret phase.</p>
+        </div>
+
+        <div class="ur-bio-grid">
+          <div class="ur-bio-text reveal">
+            <p><strong>Operation Zero Hour</strong> — the codename the police used for the pre-dawn sweep of <strong>9 August 1942</strong> — removed the entire public face of the Indian National Congress in one coordinated move. Gandhi, Nehru, Patel, Azad, Rajendra Prasad, Sarojini Naidu and J. B. Kripalani were pulled from Birla House and carried by special train to Aga Khan Palace, Poona. Provincial committees were rounded up, the Congress was declared an unlawful association, its offices were seized, and its presses were closed. Overnight, India's largest political organisation had no visible leadership, no newspaper, and no legal standing.</p>
+            <p>The Empire expected silence. What it got instead was <strong>an underground movement</strong>. Younger leaders and organisers — many of them Congress Socialists — concluded that if the party could no longer speak openly, it would have to speak in code, from hiding. The underground networks were born of this necessity: they were built to <strong>maintain public morale, provide a line of command and guidance, distribute arms and ammunition, and break the government's information monopoly</strong> at a moment when the censored press carried only the colonial account of events.</p>
+            <p>By late 1942 the movement's open phase had been crushed — official figures counted over a thousand killed and tens of thousands arrested. But in the shadows, networks in Bombay, Delhi, Calcutta, Bihar, Satara and Midnapore kept the demand for freedom alive until the leaders emerged from prison in 1944–45.</p>
+          </div>
+          <aside class="ur-bio-profile reveal" aria-label="The underground at a glance">
+            <div class="ur-bio-portrait" aria-hidden="true">🕸️</div>
+            <h3>The Underground, 1942–44</h3>
+            <span class="ur-bio-title">A Leaderless Movement's Nervous System</span>
+            <ul>
+              <li><strong>Trigger</strong> — Mass arrests, 9 Aug 1942</li>
+              <li><strong>Core aims</strong> — Morale, command, arms, uncensored news</li>
+              <li><strong>Voices</strong> — Congress Radio &amp; illegal presses</li>
+              <li><strong>Carriers</strong> — Students, railwaymen, couriers</li>
+              <li><strong>Strongholds</strong> — Bombay, Bihar, Satara, Midnapore</li>
+              <li><strong>End</strong> — Networks disrupted by 1943–44</li>
+            </ul>
+            <blockquote>"The movement must be carried on. Even if our voices grow faint, let them be heard from underground."</blockquote>
+          </aside>
+        </div>
+
+        <div class="ur-theme-grid">
+          <article class="ur-theme-card reveal">
+            <span class="ur-theme-icon" aria-hidden="true">🔗</span>
+            <h3>Leaderless by Design</h3>
+            <p>Gandhi had told his followers to treat themselves as free agents if the leadership were arrested. The underground turned that instruction into an organisation.</p>
+          </article>
+          <article class="ur-theme-card reveal">
+            <span class="ur-theme-icon" aria-hidden="true">🔥</span>
+            <h3>Keeping Morale Alive</h3>
+            <p>Censored news of arrests, strikes and village resistance was countered with truthful, illegal bulletins so ordinary Indians knew the struggle had not died.</p>
+          </article>
+          <article class="ur-theme-card reveal">
+            <span class="ur-theme-icon" aria-hidden="true">🪖</span>
+            <h3>A Line of Command</h3>
+            <p>With every senior face in jail, the underground gave direction: which towns to hit, which railways to cut, which slogans to spread.</p>
+          </article>
+          <article class="ur-theme-card reveal">
+            <span class="ur-theme-icon" aria-hidden="true">💣</span>
+            <h3>Arms &amp; Guidance</h3>
+            <p>In regions like Bihar and Satara, underground groups coordinated the supply of arms and ammunition and organised guerrilla units such as the Azad Dastas and the Toofan Sena.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Network Graph -->
+    <section class="ur-section" id="network">
+      <div class="ur-container">
+        <div class="ur-section-header">
+          <span class="ur-eyebrow">Interactive Network Graph</span>
+          <h2>The Web Beneath the Empire</h2>
+          <p>How the underground was wired together — people, groups, publications and the Congress Radio. Select any node to trace its connections.</p>
+        </div>
+
+        <div class="ur-network-layout">
+          <div class="ur-network-canvas reveal" role="application" aria-label="Interactive network graph of the underground resistance, showing how participants, organisations, publications and the Congress Radio were connected">
+            <div id="ur-network" class="ur-network-board"></div>
+            <div class="ur-network-legend" aria-hidden="true">
+              <span class="ur-legend-key ur-legend-person">●</span> Participant
+              <span class="ur-legend-key ur-legend-group">●</span> Organisation
+              <span class="ur-legend-key ur-legend-publication">●</span> Publication
+              <span class="ur-legend-key ur-legend-radio">●</span> Radio
+              <span class="ur-legend-key ur-legend-link">—</span> Connection
+            </div>
+          </div>
+
+          <aside class="ur-network-detail" id="ur-network-detail" aria-live="polite">
+            <span class="ur-eyebrow">Selected Node</span>
+            <h3 id="ur-network-detail-title">Aruna Asaf Ali</h3>
+            <p id="ur-network-detail-body">The heroine of 9 August 1942. With a warrant out for her arrest, she spent nearly four years underground, moving between safe houses in Delhi, Calcutta, Bombay and Allahabad while editing the underground monthly <em>Inquilab</em>.</p>
+            <div class="ur-network-detail-tags" id="ur-network-detail-tags">
+              <span class="ur-network-tag">Inquilab</span>
+              <span class="ur-network-tag">Congress Radio</span>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Map -->
+    <section class="ur-section" id="map">
+      <div class="ur-container">
+        <div class="ur-section-header">
+          <span class="ur-eyebrow">Location Map &amp; Communication Routes</span>
+          <h2>Across India, in Hiding</h2>
+          <p>Underground activity was a national grid of cities, safe houses, press rooms and parallel governments — connected by courier routes, railways and airwaves. Select a marker to read what happened there.</p>
+        </div>
+
+        <div class="ur-map-layout">
+          <div class="ur-map-canvas reveal" role="application" aria-label="Interactive map of India with underground resistance locations, underground publication markers and communication routes of 1942–44">
+            <div id="ur-india-map" class="ur-india-map"></div>
+            <div class="ur-map-legend" aria-hidden="true">
+              <span class="ur-legend-key ur-legend-hub">H</span> Underground hub
+              <span class="ur-legend-key ur-legend-underground">U</span> Activity
+              <span class="ur-legend-key ur-legend-parallel">P</span> Parallel government
+              <span class="ur-legend-key ur-legend-jail">J</span> Jail &amp; escape
+              <span class="ur-legend-key ur-legend-publication">📰</span> Publication
+              <span class="ur-legend-key ur-legend-route">━━</span> Communication route
+            </div>
+          </div>
+
+          <aside class="ur-map-detail" id="ur-map-detail" aria-live="polite">
+            <span class="ur-eyebrow">Selected Location</span>
+            <h3 id="ur-map-detail-title">Bombay</h3>
+            <p id="ur-map-detail-body">The nerve centre of the underground. Congress Radio broadcast from hidden rooms here, <em>Inquilab</em> was printed in secret, and organisers like Yusuf Meherally and Chhotubhai Puranik coordinated the city's cells.</p>
+            <div class="ur-map-detail-tag" id="ur-map-detail-tag">🎙️ Underground Hub</div>
+          </aside>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Publications -->
+    <section class="ur-section" id="publications">
+      <div class="ur-container">
+        <div class="ur-section-header">
+          <span class="ur-eyebrow">Underground Publications</span>
+          <h2>Printers That Defied the Ban</h2>
+          <p>With the Congress presses sealed and the mainstream press censored, the underground answered with a secret newsroom scattered across cities — cyclostyled in hiding, carried by students, read aloud in villages.</p>
+        </div>
+
+        <div class="ur-pub-grid">
+          <article class="ur-pub-card reveal">
+            <span class="ur-pub-icon" aria-hidden="true">📰</span>
+            <h3>Inquilab</h3>
+            <span class="ur-pub-meta">Bombay · 1942–1946</span>
+            <p>The monthly organ of the Congress underground, edited from hiding by Aruna Asaf Ali with Ram Manohar Lohia. It published news of local uprisings and police atrocities and urged the youth to keep the revolution alive. A reward of ₹5,000 was offered for Aruna's capture.</p>
+          </article>
+          <article class="ur-pub-card reveal">
+            <span class="ur-pub-icon" aria-hidden="true">📄</span>
+            <h3>Congress Bulletin</h3>
+            <span class="ur-pub-meta">Delhi · Bombay · 1942–43</span>
+            <p>The underground news bulletin of the movement, distributed illegally to keep workers and villagers informed of strikes, arrests and resistance across the country when the government press carried only the official story.</p>
+          </article>
+          <article class="ur-pub-card reveal">
+            <span class="ur-pub-icon" aria-hidden="true">📰</span>
+            <h3>Biplabi</h3>
+            <span class="ur-pub-meta">Tamluk, Midnapore · 1942–1944</span>
+            <p>The weekly paper of the Tamluk Jatiya Sarkar, the parallel government of Midnapore district. Printed while the British still claimed to control the area, it chronicled the sarkar's courts, relief work and volunteer corps.</p>
+          </article>
+          <article class="ur-pub-card reveal">
+            <span class="ur-pub-icon" aria-hidden="true">📜</span>
+            <h3>Patrikas &amp; Cyclostyled Leaflets</h3>
+            <span class="ur-pub-meta">Everywhere · 1942–44</span>
+            <p>Single-sheet "patrikas" and cyclostyled bulletins were the underground's fastest weapon — written by students, duplicated on hand-cranked machines, and passed hand-to-hand in marketplaces, mills and schools across Patna, Madras, Ahmedabad and Dharwad.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Communication -->
+    <section class="ur-section" id="communication">
+      <div class="ur-container">
+        <div class="ur-section-header">
+          <span class="ur-eyebrow">Secret Communication</span>
+          <h2>Messages That Could Not Be Traced</h2>
+          <p>How the underground talked to itself — and to a country under censorship.</p>
+        </div>
+
+        <div class="ur-comm-grid">
+          <article class="ur-comm-card reveal">
+            <span class="ur-comm-icon" aria-hidden="true">🎙️</span>
+            <h3>Coded Broadcasts</h3>
+            <p>Congress Radio broadcast short bursts — often 15–30 minutes in the evening — on 42.34 metres, changing timing and locations to evade detection. Coded phrasing and Morse code were used for messages that had to reach organisers without being read by the police.</p>
+          </article>
+          <article class="ur-comm-card reveal">
+            <span class="ur-comm-icon" aria-hidden="true">🚶</span>
+            <h3>Couriers &amp; Safe Houses</h3>
+            <p>Students, railwaymen and sympathetic pilots and drivers carried messages and supplies. Organisers moved through a chain of safe houses under disguised identities — Aruna Asaf Ali shifted between Delhi, Calcutta, Bombay and Allahabad for nearly four years.</p>
+          </article>
+          <article class="ur-comm-card reveal">
+            <span class="ur-comm-icon" aria-hidden="true">🖨️</span>
+            <h3>Cyclostyled Bulletins</h3>
+            <p>Hand-cranked duplicating machines in private homes produced the leaflets and bulletins that carried the movement's news from city to village, bypassing a press that had been shut down.</p>
+          </article>
+          <article class="ur-comm-card reveal">
+            <span class="ur-comm-icon" aria-hidden="true">🛤️</span>
+            <h3>Railways &amp; Posts</h3>
+            <p>The rail network — the same arteries the underground sabotaged — also carried its couriers. Railway workers passed intelligence, and sympathetic officials inside the police and administration leaked secrets to activists.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Students -->
+    <section class="ur-section" id="students">
+      <div class="ur-container">
+        <div class="ur-section-header">
+          <span class="ur-eyebrow">Student Networks</span>
+          <h2>The Youth Who Ran the Wires</h2>
+          <p>Students were the underground's youngest and fastest-moving nodes — walking couriers, printers of patrikas, and organisers in their own right.</p>
+        </div>
+
+        <div class="ur-grid-2col">
+          <div class="ur-text-block reveal">
+            <span class="ur-eyebrow">The College Front</span>
+            <h3>From Campus to Underground</h3>
+            <p>When the movement went underground, the students of India's colleges went with it. Schools and universities went on strike, and the same young men and women who had marched at Gowalia Tank now wrote and distributed illegal patrikas and acted as couriers between scattered cells. The most celebrated was <strong>Usha Mehta</strong>, a 22-year-old master's student at <strong>Wilson College, Bombay</strong>, who conceived and ran the Congress Radio. In Bihar, <strong>Tarkeshwari Sinha</strong> of Patna University emerged as one of the most energetic student organisers of the underground. In Delhi and Allahabad, students carried the <em>Congress Bulletin</em> and the messages of the imprisoned leadership.</p>
+          </div>
+          <div class="ur-text-block reveal">
+            <span class="ur-eyebrow">The Hidden Curriculum</span>
+            <h3>Couriers, Printers, Safekeepers</h3>
+            <p>The student role was deliberately diffuse — a face too young to be suspected, a bag of leaflets, a bicycle, a train ticket. Students safeguarded equipment, hid presses in hostels, memorised coded addresses and ran errands that senior organisers were too well-known to attempt. Their comparative anonymity, their mobility along the railway network, and their willingness to absorb risk made them the connective tissue of the underground.</p>
+          </div>
+        </div>
+
+        <div class="ur-student-grid">
+          <article class="ur-student-card reveal">
+            <span class="ur-student-avatar" aria-hidden="true">🎧</span>
+            <h3>Wilson College, Bombay</h3>
+            <p>Where Usha Mehta, a postgraduate student, conceived of a secret radio station after the arrests of 8–9 August — and where the plan for Congress Radio began to take shape.</p>
+          </article>
+          <article class="ur-student-card reveal">
+            <span class="ur-student-avatar" aria-hidden="true">📢</span>
+            <h3>Patna University</h3>
+            <p>Tarkeshwari Sinha organised student resistance and the distribution of underground literature in Bihar, working alongside the networks Jayaprakash Narayan built after his jail escape.</p>
+          </article>
+          <article class="ur-student-card reveal">
+            <span class="ur-student-avatar" aria-hidden="true">🚲</span>
+            <h3>The Courier Cadres</h3>
+            <p>Students across Bombay, Delhi, Allahabad and Calcutta acted as couriers, moving patrikas, funds and equipment between cells — the safest hands in a city under watch.</p>
+          </article>
+          <article class="ur-student-card reveal">
+            <span class="ur-student-avatar" aria-hidden="true">🖋️</span>
+            <h3>Writers of Patrikas</h3>
+            <p>Illegal newsletters were written by student editors and duplicated by hand. Their circulation kept schools, mills and villages inside the movement when the official press denied it existed.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Regional Organisers -->
+    <section class="ur-section" id="regional">
+      <div class="ur-container">
+        <div class="ur-section-header">
+          <span class="ur-eyebrow">Regional Organisers</span>
+          <h2>Many Fronts, One Underground</h2>
+          <p>The movement's underground phase was fought district by district, by organisers who knew their terrain.</p>
+        </div>
+
+        <div class="ur-region-grid">
+          <article class="ur-region-card reveal">
+            <span class="ur-region-icon" aria-hidden="true">🌾</span>
+            <h3>Bihar &amp; Nepal Border</h3>
+            <span class="ur-region-meta">Jayaprakash Narayan · Rameshwar Prasad · Tarkeshwari Sinha</span>
+            <p>After escaping Hazaribagh jail in November 1942, JP built underground guerrilla groups — the Azad Dastas — and operated from the Nepal border until his arrest in December 1943.</p>
+          </article>
+          <article class="ur-region-card reveal">
+            <span class="ur-region-icon" aria-hidden="true">🏙️</span>
+            <h3>Bombay</h3>
+            <span class="ur-region-meta">Yusuf Meherally · Chhotubhai Puranik · Usha Mehta</span>
+            <p>The city of the launch became the hub of the underground — the home of Congress Radio, the <em>Inquilab</em> press, and the organisational work of the Congress Socialists.</p>
+          </article>
+          <article class="ur-region-card reveal">
+            <span class="ur-region-icon" aria-hidden="true">🏛️</span>
+            <h3>Satara, Maharashtra</h3>
+            <span class="ur-region-meta">Nana Patil · Y. B. Chavan · Achyutrao Patwardhan</span>
+            <p>The longest-running parallel government of the movement — the Prati Sarkar of 1943–46 — ran people's courts, collected revenue and raised the Toofan Sena from hundreds of villages.</p>
+          </article>
+          <article class="ur-region-card reveal">
+            <span class="ur-region-icon" aria-hidden="true">🌊</span>
+            <h3>Midnapore, Bengal</h3>
+            <span class="ur-region-meta">Satish Chandra Samanta · Sushil Kumar Dhara · Ajoy Mukherjee</span>
+            <p>The Tamluk Jatiya Sarkar (December 1942 – September 1944) ran courts, schools and cyclone and famine relief through its volunteer corps, the Bidyut Vahini, and printed its own weekly, <em>Biplabi</em>.</p>
+          </article>
+          <article class="ur-region-card reveal">
+            <span class="ur-region-icon" aria-hidden="true">🕊️</span>
+            <h3>Delhi &amp; the United Provinces</h3>
+            <span class="ur-region-meta">Aruna Asaf Ali · Sucheta Kripalani · Chittu Pandey</span>
+            <p>Delhi and Allahabad hosted Aruna's safe houses and Sucheta Kripalani's networks of women activists. In August 1942 the town of Ballia in eastern UP briefly ran India's first parallel government under Chittu Pandey.</p>
+          </article>
+          <article class="ur-region-card reveal">
+            <span class="ur-region-icon" aria-hidden="true">🌐</span>
+            <h3>Gujarat &amp; the South</h3>
+            <span class="ur-region-meta">Ahmedabad · Baroda · Dharwad · Madras · Nagpur</span>
+            <p>Ahmedabad ran its own underground "Azad Government" ward by ward; Dharwad sustained guerrilla action into 1943; Madras and Nagpur printed and circulated patrikas that kept the southern and central provinces inside the movement.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Timeline -->
+    <section class="ur-section" id="timeline">
+      <div class="ur-container">
+        <div class="ur-section-header">
+          <span class="ur-eyebrow">The Underground Years</span>
+          <h2>1942–1944, Month by Month</h2>
+          <p>From the arrests that created the underground to the suppression that finally broke it.</p>
+        </div>
+
+        <div class="ur-timeline">
+          <div class="ur-timeline-step reveal">
+            <div class="ur-timeline-marker" aria-hidden="true"></div>
+            <div class="ur-timeline-card">
+              <span class="ur-timeline-year">8 Aug 1942</span>
+              <span class="ur-timeline-icon" aria-hidden="true">📜</span>
+              <h3>The Quit India Call</h3>
+              <p>The AICC at Gowalia Tank Maidan, Bombay, passes the Quit India resolution; Gandhi gives the "Do or Die" mantra. The stage is set for the arrest of the entire leadership.</p>
+            </div>
+          </div>
+          <div class="ur-timeline-step reveal">
+            <div class="ur-timeline-marker" aria-hidden="true"></div>
+            <div class="ur-timeline-card">
+              <span class="ur-timeline-year">9 Aug 1942</span>
+              <span class="ur-timeline-icon" aria-hidden="true">🚨</span>
+              <h3>Operation Zero Hour</h3>
+              <p>Gandhi, Nehru, Patel, Azad and the Working Committee are arrested before dawn. Aruna Asaf Ali hoists the flag at the maidan and goes underground; a warrant is issued for her arrest.</p>
+            </div>
+          </div>
+          <div class="ur-timeline-step reveal">
+            <div class="ur-timeline-marker" aria-hidden="true"></div>
+            <div class="ur-timeline-card">
+              <span class="ur-timeline-year">Aug 1942</span>
+              <span class="ur-timeline-icon" aria-hidden="true">⛔</span>
+              <h3>The Ban &amp; the First Cells</h3>
+              <p>The Congress is declared unlawful and its presses shut. Underground cells form in Bombay, Delhi and Calcutta. Ballia in UP overthrows its district administration under Chittu Pandey.</p>
+            </div>
+          </div>
+          <div class="ur-timeline-step reveal">
+            <div class="ur-timeline-marker" aria-hidden="true"></div>
+            <div class="ur-timeline-card">
+              <span class="ur-timeline-year">27 Aug 1942</span>
+              <span class="ur-timeline-icon" aria-hidden="true">🎙️</span>
+              <h3>Congress Radio Goes On Air</h3>
+              <p>Usha Mehta and her co-organisers begin broadcasting from a hidden Bombay room: "This is the Congress Radio calling on 42.34 metres from somewhere in India."</p>
+            </div>
+          </div>
+          <div class="ur-timeline-step reveal">
+            <div class="ur-timeline-marker" aria-hidden="true"></div>
+            <div class="ur-timeline-card">
+              <span class="ur-timeline-year">Sep 1942</span>
+              <span class="ur-timeline-icon" aria-hidden="true">📰</span>
+              <h3>Inquilab Begins</h3>
+              <p>Aruna Asaf Ali and Ram Manohar Lohia begin publishing <em>Inquilab</em> from hiding. Yusuf Meherally, the coiner of the "Quit India" slogan, is arrested.</p>
+            </div>
+          </div>
+          <div class="ur-timeline-step reveal">
+            <div class="ur-timeline-marker" aria-hidden="true"></div>
+            <div class="ur-timeline-card">
+              <span class="ur-timeline-year">9 Nov 1942</span>
+              <span class="ur-timeline-icon" aria-hidden="true">🗝️</span>
+              <h3>Jayaprakash Narayan Escapes</h3>
+              <p>JP breaks out of Hazaribagh Central Jail with comrades and crosses into the underground, building the Azad Dasta guerrilla units of Bihar.</p>
+            </div>
+          </div>
+          <div class="ur-timeline-step reveal">
+            <div class="ur-timeline-marker" aria-hidden="true"></div>
+            <div class="ur-timeline-card">
+              <span class="ur-timeline-year">12 Nov 1942</span>
+              <span class="ur-timeline-icon" aria-hidden="true">🔇</span>
+              <h3>The Radio Falls Silent</h3>
+              <p>Acting on information from a captured technician, police raid Congress Radio's last hideout. Usha Mehta and the operating crew are arrested; the station's broadcasts end.</p>
+            </div>
+          </div>
+          <div class="ur-timeline-step reveal">
+            <div class="ur-timeline-marker" aria-hidden="true"></div>
+            <div class="ur-timeline-card">
+              <span class="ur-timeline-year">Dec 1942</span>
+              <span class="ur-timeline-icon" aria-hidden="true">🏛️</span>
+              <h3>Tamluk Jatiya Sarkar</h3>
+              <p>Midnapore's parallel government is established. It runs courts and relief work and prints the weekly <em>Biplabi</em> until September 1944.</p>
+            </div>
+          </div>
+          <div class="ur-timeline-step reveal">
+            <div class="ur-timeline-marker" aria-hidden="true"></div>
+            <div class="ur-timeline-card">
+              <span class="ur-timeline-year">1943</span>
+              <span class="ur-timeline-icon" aria-hidden="true">🌪️</span>
+              <h3>Satara Prati Sarkar Consolidates</h3>
+              <p>By mid-1943 underground organisers led by Nana Patil and Y. B. Chavan consolidate the Prati Sarkar across hundreds of villages — the longest-running parallel government of the era. The Bengal famine suspends much eastern activity.</p>
+            </div>
+          </div>
+          <div class="ur-timeline-step reveal">
+            <div class="ur-timeline-marker" aria-hidden="true"></div>
+            <div class="ur-timeline-card">
+              <span class="ur-timeline-year">Dec 1943</span>
+              <span class="ur-timeline-icon" aria-hidden="true">⛓️</span>
+              <h3>JP Arrested Again</h3>
+              <p>Jayaprakash Narayan is captured while trying to cross into Nepal. The Bihar underground loses its most effective organiser.</p>
+            </div>
+          </div>
+          <div class="ur-timeline-step reveal">
+            <div class="ur-timeline-marker" aria-hidden="true"></div>
+            <div class="ur-timeline-card">
+              <span class="ur-timeline-year">1944</span>
+              <span class="ur-timeline-icon" aria-hidden="true">🧱</span>
+              <h3>The Networks Wind Down</h3>
+              <p>Lohia is jailed again; informers, raids and arrests have thinned the networks. Gandhi, released from Aga Khan Palace on health grounds in May 1944, calls for restraint. The underground phase closes as the war ends.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Participants -->
+    <section class="ur-section" id="participants">
+      <div class="ur-container">
+        <div class="ur-section-header">
+          <span class="ur-eyebrow">Major Participants</span>
+          <h2>The Faces of the Underground</h2>
+          <p>Select a participant to highlight them in the network graph and fly the map to the ground they worked. Each card records their connection to the underground.</p>
+        </div>
+
+        <div class="ur-participant-grid" id="ur-participant-grid">
+          <button class="ur-participant-card reveal" type="button" data-node="aruna" data-map="bombay">
+            <span class="ur-participant-avatar" aria-hidden="true">🇮🇳</span>
+            <h3>Aruna Asaf Ali</h3>
+            <span class="ur-participant-role">Underground Organiser · Editor of <em>Inquilab</em></span>
+            <p>Underground 1942–46, moving between Delhi, Calcutta, Bombay and Allahabad. A reward of ₹5,000 was offered for her capture; she evaded it all.</p>
+          </button>
+          <button class="ur-participant-card reveal" type="button" data-node="jp" data-map="patna">
+            <span class="ur-participant-avatar" aria-hidden="true">🔥</span>
+            <h3>Jayaprakash Narayan</h3>
+            <span class="ur-participant-role">Escapee · Organiser of the Azad Dastas</span>
+            <p>Escaped Hazaribagh jail (Nov 1942), built the Bihar underground and its guerrilla units from the Nepal border, and was re-arrested in December 1943.</p>
+          </button>
+          <button class="ur-participant-card reveal" type="button" data-node="lohia" data-map="delhi">
+            <span class="ur-participant-avatar" aria-hidden="true">✊</span>
+            <h3>Ram Manohar Lohia</h3>
+            <span class="ur-participant-role">Underground Coordinator · Broadcaster</span>
+            <p>Co-edited <em>Inquilab</em> and the <em>Congress Bulletin</em> with Aruna, broadcast on Congress Radio, and mobilised the underground until jailed again in 1944.</p>
+          </button>
+          <button class="ur-participant-card reveal" type="button" data-node="achyut" data-map="satara">
+            <span class="ur-participant-avatar" aria-hidden="true">🌾</span>
+            <h3>Achyutrao Patwardhan</h3>
+            <span class="ur-participant-role">Underground Organiser · Maharashtra</span>
+            <p>Worked underground in Bombay and Maharashtra, broadcasting on Congress Radio and feeding the networks that grew into the Satara Prati Sarkar.</p>
+          </button>
+          <button class="ur-participant-card reveal" type="button" data-node="usha" data-map="bombay">
+            <span class="ur-participant-avatar" aria-hidden="true">🎙️</span>
+            <h3>Usha Mehta</h3>
+            <span class="ur-participant-role">Founder of Congress Radio</span>
+            <p>The 22-year-old Wilson College student who conceived and ran the secret station. Arrested at its final location on 12 November 1942 and jailed in the Radio Conspiracy Case.</p>
+          </button>
+          <button class="ur-participant-card reveal" type="button" data-node="vithalbhai" data-map="bombay">
+            <span class="ur-participant-avatar" aria-hidden="true">🔧</span>
+            <h3>Vithalbhai Jhaveri</h3>
+            <span class="ur-participant-role">Congress Radio Co-organiser</span>
+            <p>A Congress leader who worked with Usha Mehta to find the amateur radio operators and organise the station that broadcast from Bombay between August and November 1942.</p>
+          </button>
+          <button class="ur-participant-card reveal" type="button" data-node="yusuf" data-map="bombay">
+            <span class="ur-participant-avatar" aria-hidden="true">📣</span>
+            <h3>Yusuf Meherally</h3>
+            <span class="ur-participant-role">Bombay Coordinator · Coiner of "Quit India"</span>
+            <p>The young socialist who coined the slogan "Quit India" and helped coordinate the underground in Bombay before his arrest in September 1942.</p>
+          </button>
+          <button class="ur-participant-card reveal" type="button" data-node="sucheta" data-map="allahabad">
+            <span class="ur-participant-avatar" aria-hidden="true">🕊️</span>
+            <h3>Sucheta Kripalani</h3>
+            <span class="ur-participant-role">Underground Organiser · United Provinces</span>
+            <p>Organised underground resistance and women's networks in the United Provinces while her husband J. B. Kripalani was in prison — the future first woman Chief Minister of Uttar Pradesh.</p>
+          </button>
+          <button class="ur-participant-card reveal" type="button" data-node="nana" data-map="satara">
+            <span class="ur-participant-avatar" aria-hidden="true">⚡</span>
+            <h3>Nana Patil</h3>
+            <span class="ur-participant-role">Leader of the Satara Prati Sarkar</span>
+            <p>"Krantisinh" of the longest-running parallel government (1943–46), which raised the Toofan Sena, ran people's courts and collected its own revenue across the Satara countryside.</p>
+          </button>
+          <button class="ur-participant-card reveal" type="button" data-node="biju" data-map="calcutta">
+            <span class="ur-participant-avatar" aria-hidden="true">✈️</span>
+            <h3>Biju Patnaik</h3>
+            <span class="ur-participant-role">Logistics &amp; Aviation Support</span>
+            <p>The young pilot and industrialist who used his aircraft and industrial network to move money and supplies to Jayaprakash Narayan's underground in Bihar.</p>
+          </button>
+          <button class="ur-participant-card reveal" type="button" data-node="chhotu" data-map="bombay">
+            <span class="ur-participant-avatar" aria-hidden="true">🕯️</span>
+            <h3>Chhotubhai Puranik</h3>
+            <span class="ur-participant-role">Bombay Underground Organiser</span>
+            <p>A Bombay Congress worker who organised underground cells and kept the city's networks fed with information and funds during the leaderless years.</p>
+          </button>
+          <button class="ur-participant-card reveal" type="button" data-node="tarkeshwari" data-map="patna">
+            <span class="ur-participant-avatar" aria-hidden="true">📚</span>
+            <h3>Tarkeshwari Sinha</h3>
+            <span class="ur-participant-role">Student Organiser · Bihar</span>
+            <p>A Patna University student leader who organised the student underground in Bihar and helped distribute illegal literature for JP's networks.</p>
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Surveillance & Arrests -->
+    <section class="ur-section" id="surveillance">
+      <div class="ur-container">
+        <div class="ur-section-header">
+          <span class="ur-eyebrow">Government Surveillance &amp; Arrests</span>
+          <h2>Hunting the Underground</h2>
+          <p>The Empire fought the leaderless movement with every intelligence tool it had — and, in the end, the networks were broken by betrayal as much as by force.</p>
+        </div>
+
+        <div class="ur-grid-2col">
+          <div class="ur-text-block reveal">
+            <span class="ur-eyebrow">Watching the Shadows</span>
+            <h3>Special Branch, CID &amp; Informers</h3>
+            <p>The hunt for the underground was run by the police's Special Branch and the Criminal Investigation Department (CID), with Military Intelligence, the Naval Department and the Air Force all drawn into the search for Congress Radio. The station was detected within days of its first broadcast, but operators masked their location; the CID's Special Branch only began systematically monitoring the transmissions in <strong>October 1942</strong>. The decisive weapon was the informer: when the technician <strong>Nariman Printer</strong> was captured, his cooperation led the police straight to the station's final hideout. A reward of ₹5,000 was placed on Aruna Asaf Ali, and her property was seized — yet she eluded capture for nearly four years.</p>
+          </div>
+          <div class="ur-text-block reveal">
+            <span class="ur-eyebrow">The Cost of the Hunt</span>
+            <h3>Arrests &amp; Censorship</h3>
+            <p>The Raj answered the underground with <strong>over 60,000–100,000 arrests</strong> in the first year, mass fines, public flogging, total press censorship and the seizure of presses. Arrest followed arrest: <strong>Yusuf Meherally</strong> (September 1942), <strong>Usha Mehta</strong> and the Congress Radio crew (12 November 1942), <strong>Jayaprakash Narayan</strong> (December 1943), <strong>Ram Manohar Lohia</strong> (1944), and finally the Satara organisers as the Prati Sarkar was dismantled in 1945–46.</p>
+          </div>
+        </div>
+
+        <div class="ur-disruption-grid">
+          <article class="ur-disruption-card reveal">
+            <span class="ur-disruption-icon" aria-hidden="true">🔇</span>
+            <h3>Silencing the Voice</h3>
+            <p>The raid on Congress Radio on 12 November 1942 removed the underground's loudest instrument. The trial that followed — the "Radio Conspiracy Case" — sent its organisers to prison and deterred others from broadcasting.</p>
+          </article>
+          <article class="ur-disruption-card reveal">
+            <span class="ur-disruption-icon" aria-hidden="true">🐀</span>
+            <h3>Informers Inside</h3>
+            <p>From the betrayed radio technician to the police's network of paid agents, informers were the single greatest threat. A single captured name could dismantle a city's cells.</p>
+          </article>
+          <article class="ur-disruption-card reveal">
+            <span class="ur-disruption-icon" aria-hidden="true">⚖️</span>
+            <h3>Trials &amp; Detention</h3>
+            <p>Underground workers were tried under the Defence of India Rules in special courts. Sentences of four and five years' rigorous imprisonment broke the ranks of the young organisers.</p>
+          </article>
+          <article class="ur-disruption-card reveal">
+            <span class="ur-disruption-icon" aria-hidden="true">🧱</span>
+            <h3>The Slow Erosion</h3>
+            <p>By 1944 the combination of arrests, raids and betrayal had thinned the networks. Gandhi's release in May 1944 and his counsel against further underground action brought the phase to a close.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Significance -->
+    <section class="ur-section" id="significance">
+      <div class="ur-container">
+        <div class="ur-section-header">
+          <span class="ur-eyebrow">Historical Significance</span>
+          <h2>What the Underground Left Behind</h2>
+          <p>Why the leaderless years mattered — and the generation they forged.</p>
+        </div>
+
+        <div class="ur-grid-2col">
+          <div class="ur-text-block reveal">
+            <span class="ur-eyebrow">A Movement That Refused to Die</span>
+            <h3>Keeping the Flame Alight</h3>
+            <p>The underground sustained the Quit India Movement through its darkest period, when the public leadership was behind bars and the press was censored. By carrying news of strikes, arrests and village resistance, and by demonstrating that ordinary Indians would govern themselves, the networks denied the Empire its victory by silence.</p>
+          </div>
+          <div class="ur-text-block reveal">
+            <span class="ur-eyebrow">Forging a Generation</span>
+            <h3>The Young Leaders of 1947</h3>
+            <p>The underground years trained the leaders who would shape independent India's politics. Jayaprakash Narayan, Ram Manohar Lohia, Aruna Asaf Ali and Yusuf Meherally emerged from hiding as the architects of India's socialist movements — and the parallel governments of Satara and Tamluk proved, village by village, that Indians could run their own affairs.</p>
+          </div>
+        </div>
+
+        <div class="ur-roll-call reveal">
+          <h3>🕊️ From Underground to Independence</h3>
+          <p>The underground did not win freedom by itself — but it made it impossible for the Empire to pretend the struggle was over. When the leaders were released in 1945, they returned to a country whose morale had been kept alive in cellars, safe houses and hidden printing rooms. The networks of 1942–44 fed directly into the post-war surge — the INA trials, the Royal Indian Navy mutiny of 1946 and, finally, the transfer of power in 1947. <strong>The leaderless years were the bridge between Gowalia Tank and the Gateway of India.</strong></p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: References -->
+    <section class="ur-section" id="references">
+      <div class="ur-container">
+        <div class="ur-section-header">
+          <span class="ur-eyebrow">References &amp; Further Reading</span>
+          <h2>Sources Behind the Story</h2>
+          <p>The primary records, standard histories and scholarly treatments of the underground resistance and the parallel governments.</p>
+        </div>
+
+        <div class="ur-ref-grid">
+          <article class="ur-ref-card reveal">
+            <span class="ur-ref-icon" aria-hidden="true">📖</span>
+            <div>
+              <h3>Bipan Chandra et al. (1989)</h3>
+              <p><em>India's Struggle for Independence</em>, Viking. The standard account of the Quit India Movement's underground phase and the Satara, Tamluk and Ballia parallel governments.</p>
+            </div>
+          </article>
+          <article class="ur-ref-card reveal">
+            <span class="ur-ref-icon" aria-hidden="true">📖</span>
+            <div>
+              <h3>Chopra, P. N. (ed.)</h3>
+              <p><em>Quit India Movement: British Secret Report</em>. The colonial government's own secret assessment of the underground networks, published for the movement's golden jubilee.</p>
+            </div>
+          </article>
+          <article class="ur-ref-card reveal">
+            <span class="ur-ref-icon" aria-hidden="true">📖</span>
+            <div>
+              <h3>Thakkar, Usha (2021)</h3>
+              <p><em>Congress Radio: Usha Mehta and the Underground Radio Station of 1942</em>, Viking/Penguin. The fullest account of the secret station and the Radio Conspiracy Case.</p>
+            </div>
+          </article>
+          <article class="ur-ref-card reveal">
+            <span class="ur-ref-icon" aria-hidden="true">📖</span>
+            <div>
+              <h3>Sengupta &amp; Chatterjee (1988)</h3>
+              <p><em>Secret Congress Broadcasts and Storming Railway Tracks During Quit India Movement</em>, Navrang. Documenting the radio's broadcasts and the sabotage that accompanied the underground years.</p>
+            </div>
+          </article>
+          <article class="ur-ref-card reveal">
+            <span class="ur-ref-icon" aria-hidden="true">📖</span>
+            <div>
+              <h3>Wikipedia</h3>
+              <p><em>Congress Radio</em>, <em>Aruna Asaf Ali</em>, <em>Jayaprakash Narayan</em>, <em>Ram Manohar Lohia</em>, <em>Quit India Movement</em>, <em>Parallel Governments During Quit India Movement</em>. General reference for chronology, names and the colonial record.</p>
+              <a href="https://en.wikipedia.org/wiki/Congress_Radio" target="_blank" rel="noopener">Congress Radio <span aria-hidden="true">↗</span></a>
+              <a href="https://en.wikipedia.org/wiki/Aruna_Asaf_Ali" target="_blank" rel="noopener">Aruna Asaf Ali <span aria-hidden="true">↗</span></a>
+              <a href="https://en.wikipedia.org/wiki/Quit_India_Movement" target="_blank" rel="noopener">Quit India Movement <span aria-hidden="true">↗</span></a>
+            </div>
+          </article>
+          <article class="ur-ref-card reveal">
+            <span class="ur-ref-icon" aria-hidden="true">🔗</span>
+            <div>
+              <h3>Related Explorers</h3>
+              <p>Continue the story across the collection: the <a href="../quit-india-movement-explorer/index.html">Bombay launch of Quit India</a>, the <a href="../congress-radio-explorer/index.html">Congress Radio</a>, and <a href="../aruna-asaf-ali-explorer/index.html">Aruna Asaf Ali</a>.</p>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- Footer -->
+  <footer class="footer ur-footer">
+    <div class="footer-container">
+      <div class="footer-brand">
+        <a href="../../index.html#home" class="ur-footer-logo">
+          <span class="saffron">Incredible</span>
+          <span class="gold">India</span>
+          <span class="green">Explorer</span>
+        </a>
+        <p>An interactive digital guide to the geography, food, festivals, and cultural heritage of India. Built with passion and pure vanilla web technologies.</p>
+        <p class="ur-footer-note">In honour of the men and women who kept the Quit India Movement alive from underground between 1942 and 1944.</p>
+      </div>
+
+      <div class="footer-links">
+        <h3>Freedom Struggle</h3>
+        <ul>
+          <li><a href="../freedom-fighters-hub/index.html">Freedom Fighters Hub</a></li>
+          <li><a href="../quit-india-movement-explorer/index.html">Quit India Movement</a></li>
+          <li><a href="../congress-radio-explorer/index.html">Congress Radio</a></li>
+          <li><a href="../aruna-asaf-ali-explorer/index.html">Aruna Asaf Ali</a></li>
+          <li><a href="../freedom-movement-explorer/index.html">Freedom Movement</a></li>
+          <li><a href="../freedom-timeline/index.html">Freedom Timeline</a></li>
+        </ul>
+      </div>
+
+      <div class="footer-links">
+        <h3>Quick Navigation</h3>
+        <ul>
+          <li><a href="../../index.html#home">Home</a></li>
+          <li><a href="../../index.html#map">Interactive Map</a></li>
+          <li><a href="../cuisine/cuisine.html">Cuisine</a></li>
+          <li><a href="../festivals/festivals.html">Festivals</a></li>
+          <li><a href="../culture/culture.html">Culture</a></li>
+          <li><a href="../../index.html#quiz">Quiz</a></li>
+        </ul>
+      </div>
+
+      <div class="footer-links">
+        <h3>Legal &amp; Support</h3>
+        <ul>
+          <li><a href="../about/about.html">About</a></li>
+          <li><a href="../support/support.html">Help &amp; Support</a></li>
+          <li><a href="../changelog/changelog.html">What's New</a></li>
+          <li><a href="../newsletter/newsletter.html">Newsletter</a></li>
+          <li><a href="../terms/terms.html">Terms of Service</a></li>
+          <li><a href="../privacy/privacy.html">Privacy Policy</a></li>
+        </ul>
+      </div>
+    </div>
+    <div class="footer-credits footer-credits-center">
+      <p>&copy; 2026 Incredible India Explorer · <a href="../../index.html">Home</a> · From the cellars of 1942 to the freedom of 1947 — the underground never truly went silent.</p>
+    </div>
+  </footer>
+
+  <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+
+  <!-- JS Dependencies -->
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+  <script src="../app.js" defer></script>
+  <script src="../../frontend/journey/journey.js" defer></script>
+  <script src="script.js" defer></script>
+  <script type="module" src="../firebase-config.js"></script>
+  <script type="module" src="../auth.js"></script>
+  <script src="../router.js" defer></script>
+  <script src="../js-modules/page-progress/page-progress.js"></script>
+</body>
+</html>

--- a/frontend/underground-resistance-explorer/script.js
+++ b/frontend/underground-resistance-explorer/script.js
@@ -1,0 +1,859 @@
+document.addEventListener("app:route-changed", () => {
+  const bookmarkButtons = [...document.querySelectorAll(".journey-bookmark-btn")];
+
+  const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  // --- Welcome Toast (auto-dismisses) -------------------------------
+  function showWelcomeToast() {
+    if (document.getElementById("ur-welcome-toast")) return;
+
+    const toast = document.createElement("div");
+    toast.id = "ur-welcome-toast";
+    toast.className = "ur-welcome-toast";
+    toast.setAttribute("role", "status");
+    toast.setAttribute("aria-live", "polite");
+    toast.innerHTML = "<strong>🕸️ Underground Resistance, 1942–44</strong> — After the arrests of 9 August 1942, Congress Radio, illegal presses and student couriers kept the movement alive from hiding.";
+    document.body.appendChild(toast);
+
+    requestAnimationFrame(() => toast.classList.add("is-visible"));
+
+    setTimeout(() => {
+      toast.classList.remove("is-visible");
+      toast.addEventListener("transitionend", () => toast.remove(), { once: true });
+      setTimeout(() => toast.remove(), 500);
+    }, 3200);
+  }
+
+  showWelcomeToast();
+
+  // --- Hero parallax -------------------------------------------------
+  function initParallax() {
+    const hero = document.querySelector(".ur-hero");
+    const orbs = document.querySelector(".ur-hero-orbs");
+    if (!hero || !orbs || prefersReducedMotion) return;
+
+    const applyParallax = () => {
+      const rect = hero.getBoundingClientRect();
+      if (rect.bottom < 0 || rect.top > window.innerHeight) return;
+      const offset = window.scrollY;
+      const maxShift = 70;
+      const shift = Math.min(Math.max(offset * 0.28, 0), maxShift);
+      orbs.style.transform = `translateY(${shift}px)`;
+    };
+
+    let ticking = false;
+    const onScroll = () => {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(() => {
+        applyParallax();
+        ticking = false;
+      });
+    };
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    applyParallax();
+  }
+
+  initParallax();
+
+  // --- Scroll-reveal -------------------------------------------------
+  let revealObserver = null;
+
+  function initReveal() {
+    const revealEls = [...document.querySelectorAll(".reveal")];
+
+    if (prefersReducedMotion) {
+      revealEls.forEach((el) => el.classList.add("is-visible"));
+      return;
+    }
+
+    if (revealObserver) revealObserver.disconnect();
+
+    revealObserver = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("is-visible");
+          revealObserver.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.12, rootMargin: "0px 0px -40px 0px" });
+
+    revealEls.forEach((el) => revealObserver.observe(el));
+  }
+
+  initReveal();
+
+  // --- Sticky section nav active state --------------------------------
+  let navObserver = null;
+
+  function initSectionNav() {
+    const nav = document.getElementById("ur-section-nav");
+    const navLinks = [...document.querySelectorAll(".ur-section-nav-link")];
+    const sections = navLinks
+      .map((link) => document.querySelector(link.getAttribute("href")))
+      .filter(Boolean);
+
+    if (!nav || !sections.length) return;
+
+    if (navObserver) navObserver.disconnect();
+
+    const setActive = (id) => {
+      navLinks.forEach((link) => {
+        link.classList.toggle("active", link.dataset.navTarget === id);
+      });
+    };
+
+    navObserver = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          setActive(entry.target.id);
+        }
+      });
+    }, { rootMargin: "-35% 0px -60% 0px", threshold: 0 });
+
+    sections.forEach((section) => navObserver.observe(section));
+  }
+
+  initSectionNav();
+
+  // --- Interactive Network Graph --------------------------------------
+  const NODE_COLORS = {
+    person: "#ff9933",
+    group: "#7fd68a",
+    publication: "#8ab4f8",
+    radio: "#e8846b"
+  };
+
+  const NETWORK_NODES = {
+    aruna: {
+      type: "person",
+      title: "Aruna Asaf Ali",
+      body: "The heroine of 9 August 1942. With a warrant out for her arrest, she spent nearly four years underground, moving between safe houses in Delhi, Calcutta, Bombay and Allahabad while editing the underground monthly Inquilab.",
+      tags: ["Underground Organiser", "Editor of Inquilab", "1942–46"],
+      x: 130, y: 60
+    },
+    lohia: {
+      type: "person",
+      title: "Ram Manohar Lohia",
+      body: "Co-edited Inquilab and the Congress Bulletin with Aruna, broadcast on Congress Radio, and mobilised the underground across northern India until jailed again in 1944.",
+      tags: ["Inquilab", "Congress Radio", "Coordinator"],
+      x: 130, y: 130
+    },
+    yusuf: {
+      type: "person",
+      title: "Yusuf Meherally",
+      body: "The young socialist who coined the slogan \"Quit India\" and helped coordinate the underground in Bombay before his arrest in September 1942.",
+      tags: ["Bombay", "\"Quit India\" Slogan"],
+      x: 130, y: 200
+    },
+    chhotu: {
+      type: "person",
+      title: "Chhotubhai Puranik",
+      body: "A Bombay Congress worker who organised underground cells and kept the city's networks fed with information and funds during the leaderless years.",
+      tags: ["Bombay", "Underground Cells"],
+      x: 130, y: 270
+    },
+    usha: {
+      type: "person",
+      title: "Usha Mehta",
+      body: "The 22-year-old Wilson College student who conceived and ran the Congress Radio. Arrested at its final location on 12 November 1942 and jailed in the Radio Conspiracy Case.",
+      tags: ["Congress Radio", "Student", "Arrested Nov 1942"],
+      x: 130, y: 340
+    },
+    vithalbhai: {
+      type: "person",
+      title: "Vithalbhai Jhaveri",
+      body: "A Congress leader who worked with Usha Mehta to find the amateur radio operators and organise the station that broadcast from Bombay between August and November 1942.",
+      tags: ["Congress Radio", "Co-organiser"],
+      x: 130, y: 410
+    },
+    achyut: {
+      type: "person",
+      title: "Achyutrao Patwardhan",
+      body: "Worked underground in Bombay and Maharashtra, broadcasting on Congress Radio and feeding the networks that grew into the Satara Prati Sarkar.",
+      tags: ["Congress Radio", "Satara"],
+      x: 330, y: 60
+    },
+    sucheta: {
+      type: "person",
+      title: "Sucheta Kripalani",
+      body: "Organised underground resistance and women's networks in the United Provinces while her husband J. B. Kripalani was in prison — the future first woman Chief Minister of Uttar Pradesh.",
+      tags: ["United Provinces", "Women's Networks"],
+      x: 330, y: 130
+    },
+    jp: {
+      type: "person",
+      title: "Jayaprakash Narayan",
+      body: "Escaped Hazaribagh jail on 9 November 1942 and crossed into the underground, building the Azad Dasta guerrilla units of Bihar from the Nepal border until his re-arrest in December 1943.",
+      tags: ["Escapee", "Azad Dastas", "Bihar"],
+      x: 330, y: 200
+    },
+    tarkeshwari: {
+      type: "person",
+      title: "Tarkeshwari Sinha",
+      body: "A Patna University student leader who organised the student underground in Bihar and helped distribute illegal literature for JP's networks.",
+      tags: ["Student", "Bihar", "Courier"],
+      x: 330, y: 270
+    },
+    nana: {
+      type: "person",
+      title: "Nana Patil",
+      body: "\"Krantisinh\" of the longest-running parallel government (1943–46), which raised the Toofan Sena, ran people's courts and collected its own revenue across the Satara countryside.",
+      tags: ["Satara Prati Sarkar", "Toofan Sena"],
+      x: 330, y: 340
+    },
+    biju: {
+      type: "person",
+      title: "Biju Patnaik",
+      body: "The young pilot and industrialist who used his aircraft and industrial network to move money and supplies to Jayaprakash Narayan's underground in Bihar.",
+      tags: ["Aviation", "Logistics"],
+      x: 330, y: 410
+    },
+    "congress-radio": {
+      type: "radio",
+      title: "Congress Radio",
+      body: "Broadcasting from hidden Bombay rooms from 27 August 1942, this clandestine station announced itself \"on 42.34 metres from somewhere in India\". It was silenced by a police raid on 12 November 1942.",
+      tags: ["42.34 m", "Silenced Nov 1942"],
+      x: 560, y: 70
+    },
+    inquilab: {
+      type: "publication",
+      title: "Inquilab",
+      body: "The monthly organ of the underground, edited from hiding by Aruna Asaf Ali with Ram Manohar Lohia. It published news of local uprisings and police atrocities; a reward of ₹5,000 was offered for Aruna's capture.",
+      tags: ["Bombay", "1942–46"],
+      x: 560, y: 160
+    },
+    "congress-bulletin": {
+      type: "publication",
+      title: "Congress Bulletin",
+      body: "The underground news bulletin distributed illegally to keep workers and villagers informed of strikes, arrests and resistance when the government press carried only the official story.",
+      tags: ["Delhi · Bombay", "1942–43"],
+      x: 560, y: 250
+    },
+    patrikas: {
+      type: "publication",
+      title: "Patrikas & Cyclostyled Leaflets",
+      body: "Single-sheet patrikas and cyclostyled bulletins — the underground's fastest weapon, written by students, duplicated on hand-cranked machines and passed hand-to-hand in marketplaces, mills and schools.",
+      tags: ["Everywhere", "1942–44"],
+      x: 560, y: 340
+    },
+    biplabi: {
+      type: "publication",
+      title: "Biplabi",
+      body: "The weekly paper of the Tamluk Jatiya Sarkar in Midnapore. Printed while the British still claimed to control the area, it chronicled the sarkar's courts, relief work and volunteer corps.",
+      tags: ["Tamluk", "1942–44"],
+      x: 560, y: 430
+    },
+    "student-networks": {
+      type: "group",
+      title: "Student Courier Networks",
+      body: "India's students were the underground's connective tissue — walking couriers, printers of patrikas and safekeepers of equipment whose youth and mobility defied suspicion.",
+      tags: ["Colleges", "Couriers"],
+      x: 800, y: 70
+    },
+    "azad-dastas": {
+      type: "group",
+      title: "Azad Dastas (Bihar)",
+      body: "The guerrilla squads built by Jayaprakash Narayan after his jail escape. Operating from the Nepal border, they struck at communications, government offices and collaborators.",
+      tags: ["Bihar", "1942–43"],
+      x: 800, y: 190
+    },
+    "satara-prati-sarkar": {
+      type: "group",
+      title: "Satara Prati Sarkar",
+      body: "The longest-running parallel government of the movement (1943–46) — people's courts, revenue collection and the Toofan Sena across hundreds of Maharashtra villages.",
+      tags: ["Satara", "1943–46"],
+      x: 800, y: 310
+    },
+    "tamluk-jatiya-sarkar": {
+      type: "group",
+      title: "Tamluk Jatiya Sarkar",
+      body: "Midnapore's parallel government (December 1942 – September 1944) ran courts, schools and cyclone and famine relief through its volunteer corps, the Bidyut Vahini.",
+      tags: ["Midnapore", "1942–44"],
+      x: 800, y: 430
+    }
+  };
+
+  const NETWORK_LINKS = [
+    ["aruna", "congress-radio"],
+    ["aruna", "inquilab"],
+    ["aruna", "congress-bulletin"],
+    ["aruna", "student-networks"],
+    ["lohia", "inquilab"],
+    ["lohia", "congress-bulletin"],
+    ["lohia", "congress-radio"],
+    ["yusuf", "inquilab"],
+    ["yusuf", "congress-bulletin"],
+    ["chhotu", "congress-radio"],
+    ["chhotu", "patrikas"],
+    ["usha", "congress-radio"],
+    ["usha", "student-networks"],
+    ["vithalbhai", "congress-radio"],
+    ["achyut", "congress-radio"],
+    ["achyut", "satara-prati-sarkar"],
+    ["sucheta", "congress-bulletin"],
+    ["sucheta", "patrikas"],
+    ["sucheta", "student-networks"],
+    ["jp", "azad-dastas"],
+    ["jp", "student-networks"],
+    ["tarkeshwari", "student-networks"],
+    ["tarkeshwari", "patrikas"],
+    ["tarkeshwari", "azad-dastas"],
+    ["nana", "satara-prati-sarkar"],
+    ["biju", "azad-dastas"],
+    ["tamluk-jatiya-sarkar", "biplabi"]
+  ];
+
+  const networkBoard = document.getElementById("ur-network");
+  const networkDetailTitle = document.getElementById("ur-network-detail-title");
+  const networkDetailBody = document.getElementById("ur-network-detail-body");
+  const networkDetailTags = document.getElementById("ur-network-detail-tags");
+
+  let networkNodeEls = {};
+  let networkLinkEls = [];
+
+  function renderNetwork() {
+    if (!networkBoard) return;
+    if (networkBoard.querySelector("svg")) return;
+
+    const svgNS = "http://www.w3.org/2000/svg";
+    const svg = document.createElementNS(svgNS, "svg");
+    svg.setAttribute("viewBox", "0 0 960 560");
+    svg.setAttribute("role", "img");
+    svg.setAttribute("aria-label", "Network graph of the underground resistance");
+
+    const linksLayer = document.createElementNS(svgNS, "g");
+    const nodesLayer = document.createElementNS(svgNS, "g");
+
+    NETWORK_LINKS.forEach(([a, b]) => {
+      const na = NETWORK_NODES[a];
+      const nb = NETWORK_NODES[b];
+      if (!na || !nb) return;
+      const line = document.createElementNS(svgNS, "line");
+      line.classList.add("ur-link");
+      line.setAttribute("x1", na.x);
+      line.setAttribute("y1", na.y);
+      line.setAttribute("x2", nb.x);
+      line.setAttribute("y2", nb.y);
+      linksLayer.appendChild(line);
+      networkLinkEls.push({ a, b, el: line });
+    });
+
+    Object.entries(NETWORK_NODES).forEach(([id, node]) => {
+      const g = document.createElementNS(svgNS, "g");
+      g.classList.add("ur-node");
+      g.setAttribute("data-node-id", id);
+      g.setAttribute("tabindex", "0");
+      g.setAttribute("role", "button");
+      g.setAttribute("aria-label", `Show details about ${node.title}`);
+
+      const dot = document.createElementNS(svgNS, "circle");
+      dot.classList.add("ur-node-dot");
+      dot.setAttribute("cx", node.x);
+      dot.setAttribute("cy", node.y);
+      dot.setAttribute("r", 7);
+      dot.setAttribute("fill", NODE_COLORS[node.type]);
+      dot.setAttribute("stroke", "rgba(0,0,0,0.35)");
+      dot.setAttribute("stroke-width", "1");
+
+      const label = document.createElementNS(svgNS, "text");
+      label.classList.add("ur-node-label");
+      label.textContent = node.title.length > 22 ? node.title.slice(0, 21) + "…" : node.title;
+
+      if (node.x < 480) {
+        label.setAttribute("x", node.x + 14);
+        label.setAttribute("y", node.y + 4);
+        label.setAttribute("text-anchor", "start");
+      } else if (node.x > 640) {
+        label.setAttribute("x", node.x - 14);
+        label.setAttribute("y", node.y + 4);
+        label.setAttribute("text-anchor", "end");
+      } else {
+        label.setAttribute("x", node.x);
+        label.setAttribute("y", node.y + 22);
+        label.setAttribute("text-anchor", "middle");
+      }
+
+      g.appendChild(dot);
+      g.appendChild(label);
+      nodesLayer.appendChild(g);
+      networkNodeEls[id] = g;
+
+      g.addEventListener("click", () => selectNetworkNode(id));
+      g.addEventListener("keydown", (e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          selectNetworkNode(id);
+        }
+      });
+    });
+
+    svg.appendChild(linksLayer);
+    svg.appendChild(nodesLayer);
+    networkBoard.appendChild(svg);
+  }
+
+  function showNetworkDetail(id) {
+    const node = NETWORK_NODES[id];
+    if (!node) return;
+    if (networkDetailTitle) networkDetailTitle.textContent = node.title;
+    if (networkDetailBody) networkDetailBody.textContent = node.body;
+    if (networkDetailTags) {
+      networkDetailTags.innerHTML = node.tags
+        .map((t) => `<span class="ur-network-tag">${t}</span>`)
+        .join("");
+    }
+  }
+
+  function selectNetworkNode(id) {
+    if (!NETWORK_NODES[id]) return;
+    showNetworkDetail(id);
+
+    const connected = new Set();
+    NETWORK_LINKS.forEach(([a, b]) => {
+      if (a === id) connected.add(b);
+      if (b === id) connected.add(a);
+    });
+
+    Object.entries(networkNodeEls).forEach(([nid, el]) => {
+      el.classList.remove("is-active", "is-connected", "is-dimmed");
+      if (nid === id) el.classList.add("is-active");
+      else if (connected.has(nid)) el.classList.add("is-connected");
+      else el.classList.add("is-dimmed");
+    });
+
+    networkLinkEls.forEach(({ a, b, el }) => {
+      el.classList.remove("is-connected", "is-dimmed");
+      if (a === id || b === id) el.classList.add("is-connected");
+      else el.classList.add("is-dimmed");
+    });
+
+    [...document.querySelectorAll(".ur-participant-card")].forEach((card) => {
+      card.classList.toggle("is-active", card.dataset.node === id);
+    });
+  }
+
+  renderNetwork();
+  showNetworkDetail("aruna");
+
+  // --- Interactive India Map (Leaflet) --------------------------------
+  const MAP_POINTS = {
+    bombay: {
+      title: "Bombay",
+      tag: "🎙️ Underground Hub",
+      body: "The nerve centre of the underground. Congress Radio broadcast from hidden rooms here, Inquilab was printed in secret, and organisers like Yusuf Meherally and Chhotubhai Puranik coordinated the city's cells.",
+      coords: [19.076, 72.8777],
+      category: "hub"
+    },
+    delhi: {
+      title: "Delhi",
+      tag: "🏛️ Underground Hub",
+      body: "Home of Aruna Asaf Ali's safe houses and Sucheta Kripalani's women's networks; the Congress Bulletin was distributed from here while the city was under close police watch.",
+      coords: [28.6139, 77.209],
+      category: "hub"
+    },
+    calcutta: {
+      title: "Calcutta",
+      tag: "🌐 Underground Hub",
+      body: "A key base for Aruna Asaf Ali and a printing and courier centre feeding the eastern underground, linked by rail to Patna and the Tamluk parallel government.",
+      coords: [22.5726, 88.3639],
+      category: "hub"
+    },
+    satara: {
+      title: "Satara",
+      tag: "🏛️ Parallel Government",
+      body: "The Satara Prati Sarkar (1943–46) ran people's courts, collected revenue and raised the Toofan Sena across hundreds of villages under Nana Patil — the longest-running parallel government of the movement.",
+      coords: [17.6805, 73.9911],
+      category: "parallel"
+    },
+    tamluk: {
+      title: "Tamluk, Midnapore",
+      tag: "🏛️ Parallel Government",
+      body: "The Tamluk Jatiya Sarkar (Dec 1942 – Sep 1944) ran courts, schools and cyclone and famine relief through its volunteer corps, the Bidyut Vahini, and printed its weekly, Biplabi.",
+      coords: [22.2947, 87.9203],
+      category: "parallel"
+    },
+    ballia: {
+      title: "Ballia, UP",
+      tag: "🏛️ Parallel Government",
+      body: "In August 1942 Ballia briefly overthrew its district administration under Chittu Pandey — India's first parallel government of the movement.",
+      coords: [25.7605, 84.1475],
+      category: "parallel"
+    },
+    allahabad: {
+      title: "Allahabad",
+      tag: "📍 Activity & Safe Houses",
+      body: "One of Aruna Asaf Ali's refuges; students carried the Congress Bulletin and the messages of the imprisoned leadership through its colleges.",
+      coords: [25.4358, 81.8463],
+      category: "underground"
+    },
+    patna: {
+      title: "Patna",
+      tag: "🔥 Activity",
+      body: "Centre of the Bihar underground around JP's Azad Dastas; Patna University's student organisers distributed illegal patrikas across the province.",
+      coords: [25.5941, 85.1376],
+      category: "underground"
+    },
+    ahmedabad: {
+      title: "Ahmedabad",
+      tag: "⚡ Activity",
+      body: "Ran its own underground \"Azad Government\" ward by ward, printing and circulating patrikas that kept Gujarat inside the movement.",
+      coords: [23.0225, 72.5714],
+      category: "underground"
+    },
+    dharwad: {
+      title: "Dharwad",
+      tag: "🌾 Activity",
+      body: "Sustained guerrilla action well into 1943 — one of the last southern strongholds of the underground.",
+      coords: [15.4589, 75.0078],
+      category: "underground"
+    },
+    madras: {
+      title: "Madras",
+      tag: "📍 Activity",
+      body: "Printed and circulated patrikas that kept the southern provinces inside the movement when the official press denied it existed.",
+      coords: [13.0827, 80.2707],
+      category: "underground"
+    },
+    nagpur: {
+      title: "Nagpur",
+      tag: "📍 Activity",
+      body: "A central-province centre for underground printing and distribution, linking the Bombay and eastern networks.",
+      coords: [21.1458, 79.0882],
+      category: "underground"
+    },
+    hazaribagh: {
+      title: "Hazaribagh Central Jail",
+      tag: "🗝️ Jail & Escape",
+      body: "Jayaprakash Narayan broke out of this jail on 9 November 1942 with his comrades to build the Bihar underground.",
+      coords: [23.9933, 85.3443],
+      category: "jail"
+    },
+    "aga-khan-palace": {
+      title: "Aga Khan Palace, Poona",
+      tag: "⛓️ Imprisonment",
+      body: "Gandhi, Nehru, Patel and the arrested Working Committee were interned here from 9 August 1942 until their release in 1944–45.",
+      coords: [18.5569, 73.9026],
+      category: "jail"
+    }
+  };
+
+  const PUB_POINTS = {
+    "inquilab-press": {
+      title: "Inquilab Press (Bombay)",
+      tag: "📰 Underground Publication",
+      body: "The monthly organ of the underground, edited from hiding by Aruna Asaf Ali with Ram Manohar Lohia, printed secretly in Bombay between 1942 and 1946.",
+      coords: [18.999, 72.84],
+      category: "publication"
+    },
+    "congress-bulletin-press": {
+      title: "Congress Bulletin (Delhi)",
+      tag: "📰 Underground Publication",
+      body: "The underground news bulletin was duplicated in Delhi and Bombay and distributed illegally from 1942 to 1943.",
+      coords: [28.67, 77.24],
+      category: "publication"
+    },
+    "biplabi-press": {
+      title: "Biplabi Press (Tamluk)",
+      tag: "📰 Underground Publication",
+      body: "The weekly paper of the Tamluk Jatiya Sarkar was printed here from December 1942 to September 1944 while the British still claimed control of Midnapore.",
+      coords: [22.33, 87.95],
+      category: "publication"
+    },
+    "patrikas-madras": {
+      title: "Patrika Networks (Madras)",
+      tag: "📰 Underground Publication",
+      body: "Madras-based student editors cyclostyled and distributed single-sheet patrikas that kept the southern provinces inside the movement.",
+      coords: [13.1, 80.31],
+      category: "publication"
+    }
+  };
+
+  const ROUTES = [
+    ["bombay", "delhi"],
+    ["bombay", "calcutta"],
+    ["bombay", "satara"],
+    ["bombay", "allahabad"],
+    ["delhi", "allahabad"],
+    ["delhi", "patna"],
+    ["patna", "hazaribagh"],
+    ["patna", "calcutta"],
+    ["calcutta", "tamluk"]
+  ];
+
+  const mapDetailTitle = document.getElementById("ur-map-detail-title");
+  const mapDetailBody = document.getElementById("ur-map-detail-body");
+  const mapDetailTag = document.getElementById("ur-map-detail-tag");
+  const mapContainer = document.getElementById("ur-india-map");
+
+  let indiaMap = null;
+  let indiaMarkers = {};
+
+  function showMapPoint(pointId, { flyTo = false, openPopup = false } = {}) {
+    const point = MAP_POINTS[pointId] || PUB_POINTS[pointId];
+    if (!point) return;
+
+    if (mapDetailTitle) mapDetailTitle.textContent = point.title;
+    if (mapDetailBody) mapDetailBody.textContent = point.body;
+    if (mapDetailTag) {
+      mapDetailTag.textContent = point.tag;
+      mapDetailTag.style.color = "var(--ur-gold)";
+    }
+
+    if (indiaMap && point.coords) {
+      if (flyTo) indiaMap.flyTo(point.coords, Math.max(indiaMap.getZoom(), 7), { duration: 0.9 });
+      const marker = indiaMarkers[pointId];
+      if (openPopup && marker) marker.openPopup();
+    }
+  }
+
+  function initIndiaMap() {
+    if (!mapContainer || indiaMap) return;
+    if (typeof L === "undefined") return;
+
+    indiaMap = L.map(mapContainer, {
+      center: [23.4, 80.5],
+      zoom: 5,
+      minZoom: 4,
+      scrollWheelZoom: false,
+      attributionControl: true,
+      zoomControl: false
+    });
+
+    L.control.zoom({ position: "bottomleft" }).addTo(indiaMap);
+
+    L.tileLayer("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png", {
+      maxZoom: 18,
+      attribution: "© OpenStreetMap contributors © CARTO"
+    }).addTo(indiaMap);
+
+    const letterFor = {};
+    let index = 0;
+    Object.keys(MAP_POINTS).forEach((id) => {
+      letterFor[id] = String.fromCharCode(65 + index);
+      index += 1;
+    });
+
+    Object.entries(MAP_POINTS).forEach(([id, point]) => {
+      const icon = L.divIcon({
+        className: `ur-map-marker is-${point.category}`,
+        html: `<span aria-hidden="true">${letterFor[id]}</span>`,
+        iconSize: [22, 22],
+        iconAnchor: [11, 11],
+        popupAnchor: [0, -12]
+      });
+
+      const marker = L.marker(point.coords, { icon, title: point.title, alt: point.title, keyboard: true }).addTo(indiaMap);
+      marker.bindTooltip(point.title, { direction: "top", offset: [0, -10], className: "ur-map-tooltip" });
+
+      const popupContent = document.createElement("div");
+      popupContent.innerHTML = `<p class="ur-popup-title">${point.title}</p><p class="ur-popup-desc">${point.body}</p><span class="ur-popup-tag">${point.tag}</span>`;
+      marker.bindPopup(popupContent, { className: "ur-map-popup", closeButton: true, maxWidth: 280 });
+
+      marker.on("click", () => showMapPoint(id));
+      marker.on("keydown", (e) => {
+        if (e.originalEvent.key === "Enter" || e.originalEvent.key === " ") {
+          e.originalEvent.preventDefault();
+          showMapPoint(id, { openPopup: true });
+        }
+      });
+
+      indiaMarkers[id] = marker;
+    });
+
+    Object.entries(PUB_POINTS).forEach(([id, point]) => {
+      const icon = L.divIcon({
+        className: "ur-pub-marker",
+        html: "<span aria-hidden=\"true\">📰</span>",
+        iconSize: [26, 26],
+        iconAnchor: [13, 13],
+        popupAnchor: [0, -14]
+      });
+
+      const marker = L.marker(point.coords, { icon, title: point.title, alt: point.title, keyboard: true }).addTo(indiaMap);
+      marker.bindTooltip(point.title, { direction: "top", offset: [0, -10], className: "ur-map-tooltip" });
+
+      const popupContent = document.createElement("div");
+      popupContent.innerHTML = `<p class="ur-popup-title">${point.title}</p><p class="ur-popup-desc">${point.body}</p><span class="ur-popup-tag">${point.tag}</span>`;
+      marker.bindPopup(popupContent, { className: "ur-map-popup", closeButton: true, maxWidth: 280 });
+
+      marker.on("click", () => showMapPoint(id));
+      marker.on("keydown", (e) => {
+        if (e.originalEvent.key === "Enter" || e.originalEvent.key === " ") {
+          e.originalEvent.preventDefault();
+          showMapPoint(id, { openPopup: true });
+        }
+      });
+
+      indiaMarkers[id] = marker;
+    });
+
+    ROUTES.forEach(([a, b]) => {
+      const pa = MAP_POINTS[a];
+      const pb = MAP_POINTS[b];
+      if (!pa || !pb) return;
+      L.polyline([pa.coords, pb.coords], {
+        color: "#f5c36b",
+        weight: 2,
+        dashArray: "5 5",
+        opacity: 0.7,
+        className: "ur-route",
+        interactive: false
+      }).addTo(indiaMap);
+    });
+
+    showMapPoint("bombay");
+
+    requestAnimationFrame(() => indiaMap.invalidateSize());
+    setTimeout(() => indiaMap.invalidateSize(), 400);
+
+    const canvas = mapContainer.closest(".ur-map-canvas");
+    if (canvas && "IntersectionObserver" in window) {
+      const revealObserver = new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) indiaMap.invalidateSize();
+        });
+      }, { threshold: 0.05 });
+      revealObserver.observe(canvas);
+    }
+  }
+
+  initIndiaMap();
+
+  // --- Participant cards → network + map ------------------------------
+  function initParticipantCards() {
+    const cards = [...document.querySelectorAll(".ur-participant-card")];
+
+    cards.forEach((card) => {
+      card.addEventListener("click", () => {
+        const nodeId = card.dataset.node;
+        const mapId = card.dataset.map;
+
+        if (nodeId) selectNetworkNode(nodeId);
+        if (mapId) showMapPoint(mapId, { flyTo: true, openPopup: true });
+
+        const networkSection = document.getElementById("network");
+        if (networkSection) networkSection.scrollIntoView({ behavior: "smooth", block: "start" });
+      });
+    });
+  }
+
+  initParticipantCards();
+
+  // --- Journey Integration (Bookmarks & Global Search) -------------
+  function initJourney() {
+    if (!window.Journey) return;
+
+    // 1. Bookmark functionality
+    bookmarkButtons.forEach((btn) => {
+      const id = btn.dataset.bookmarkId;
+      const title = "Underground Resistance Networks — 1942–44";
+      const thumbnail = "https://placehold.co/100/0f0c07/f5c36b?text=Underground";
+      const category = "history";
+
+      const updateBookmarkUI = () => {
+        const isSaved = window.Journey.isSaved(id);
+        btn.classList.toggle("is-saved", isSaved);
+        btn.setAttribute("aria-pressed", String(isSaved));
+        btn.innerHTML = isSaved ? "♥ Saved to Journey" : "♡ Save to Journey";
+      };
+
+      updateBookmarkUI();
+
+      btn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        window.Journey.toggle({
+          id,
+          explorerPage: "frontend/underground-resistance-explorer/index.html",
+          title,
+          thumbnail,
+          category
+        });
+        updateBookmarkUI();
+      });
+    });
+
+    // 2. Global search index registration
+    window.Journey.registerSearchItems(
+      "frontend/underground-resistance-explorer/index.html",
+      [
+        {
+          id: "underground-resistance-main",
+          title: "Underground Resistance Networks — 1942–44",
+          description: "Explore the underground networks that kept the Quit India Movement alive after the mass arrests of 9 August 1942: Congress Radio, illegal publications, student couriers, regional organisers and the parallel governments of Satara and Tamluk.",
+          link: "frontend/underground-resistance-explorer/index.html"
+        },
+        {
+          id: "underground-resistance-overview",
+          title: "A Movement Without a Leadership",
+          description: "How Operation Zero Hour — the pre-dawn arrests of 9 August 1942 — removed the Congress leadership and gave birth to the underground resistance.",
+          link: "frontend/underground-resistance-explorer/index.html#overview"
+        },
+        {
+          id: "underground-resistance-network",
+          title: "The Web Beneath the Empire",
+          description: "Interactive network graph of the underground: participants, organisations, publications and the Congress Radio and how they were wired together.",
+          link: "frontend/underground-resistance-explorer/index.html#network"
+        },
+        {
+          id: "underground-resistance-map",
+          title: "Across India, in Hiding",
+          description: "Interactive map of underground hubs, activity centres, parallel governments, jails, underground publications and the communication routes of 1942–44.",
+          link: "frontend/underground-resistance-explorer/index.html#map"
+        },
+        {
+          id: "underground-resistance-publications",
+          title: "Printers That Defied the Ban",
+          description: "The underground press: Inquilab, the Congress Bulletin, Biplabi and the cyclostyled patrikas that bypassed a censored press.",
+          link: "frontend/underground-resistance-explorer/index.html#publications"
+        },
+        {
+          id: "underground-resistance-communication",
+          title: "Messages That Could Not Be Traced",
+          description: "How the underground talked to itself — coded broadcasts on 42.34 metres, couriers, safe houses, cyclostyled bulletins and the railways.",
+          link: "frontend/underground-resistance-explorer/index.html#communication"
+        },
+        {
+          id: "underground-resistance-students",
+          title: "The Youth Who Ran the Wires",
+          description: "Student networks from Wilson College, Bombay and Patna University: Usha Mehta, Tarkeshwari Sinha and the courier cadres.",
+          link: "frontend/underground-resistance-explorer/index.html#students"
+        },
+        {
+          id: "underground-resistance-regional",
+          title: "Many Fronts, One Underground",
+          description: "Regional organisers: JP and the Azad Dastas of Bihar, Bombay's cells, the Satara Prati Sarkar, the Tamluk Jatiya Sarkar and more.",
+          link: "frontend/underground-resistance-explorer/index.html#regional"
+        },
+        {
+          id: "underground-resistance-timeline",
+          title: "1942–1944, Month by Month",
+          description: "From the arrests that created the underground to the suppression that broke it — the full chronology of the leaderless years.",
+          link: "frontend/underground-resistance-explorer/index.html#timeline"
+        },
+        {
+          id: "underground-resistance-participants",
+          title: "The Faces of the Underground",
+          description: "The major participants of the underground: Aruna Asaf Ali, Jayaprakash Narayan, Ram Manohar Lohia, Usha Mehta, Nana Patil and more.",
+          link: "frontend/underground-resistance-explorer/index.html#participants"
+        },
+        {
+          id: "underground-resistance-surveillance",
+          title: "Hunting the Underground",
+          description: "Special Branch, CID and informers: how the Empire hunted the networks, silenced Congress Radio and finally broke the resistance.",
+          link: "frontend/underground-resistance-explorer/index.html#surveillance"
+        },
+        {
+          id: "underground-resistance-significance",
+          title: "What the Underground Left Behind",
+          description: "Why the leaderless years mattered — and the generation of leaders and parallel governments they forged for independent India.",
+          link: "frontend/underground-resistance-explorer/index.html#significance"
+        }
+      ]
+    );
+  }
+
+  // Run initialization
+  initJourney();
+});

--- a/frontend/underground-resistance-explorer/style.css
+++ b/frontend/underground-resistance-explorer/style.css
@@ -1,0 +1,1396 @@
+/* ============================================================
+   Underground Resistance Explorer — Networks of 1942–44
+   Dedicated stylesheet. Prefix: ur-
+   ============================================================ */
+
+:root {
+  --ur-ember: #e05b2c;
+  --ur-saffron: #ff9933;
+  --ur-saffron-deep: #e8892f;
+  --ur-gold: #f5c36b;
+  --ur-green: #138808;
+  --ur-green-deep: #0e7a4a;
+  --ur-cream: #f7ead0;
+  --ur-ink: #180f07;
+  --ur-bg: #0d0905;
+  --ur-bg-soft: #161008;
+  --ur-card: rgba(255, 248, 235, 0.04);
+  --ur-card-solid: #1c140c;
+  --ur-border: rgba(240, 138, 59, 0.2);
+  --ur-text: #f3e7d0;
+  --ur-text-muted: rgba(243, 231, 208, 0.72);
+  --ur-text-soft: rgba(243, 231, 208, 0.55);
+  --ur-shadow: 0 18px 50px rgba(0, 0, 0, 0.45);
+}
+
+body.light-theme {
+  --ur-bg: #fff8ef;
+  --ur-bg-soft: #fff1de;
+  --ur-card: rgba(24, 15, 7, 0.03);
+  --ur-card-solid: #ffffff;
+  --ur-border: rgba(224, 91, 44, 0.25);
+  --ur-text: #2a1c0c;
+  --ur-text-muted: rgba(42, 28, 12, 0.74);
+  --ur-text-soft: rgba(42, 28, 12, 0.56);
+  --ur-shadow: 0 18px 50px rgba(90, 60, 10, 0.14);
+}
+
+.ur-main {
+  background: var(--ur-bg);
+  color: var(--ur-text);
+  overflow-x: hidden;
+}
+
+/* ---------- Welcome Toast ---------- */
+.ur-welcome-toast {
+  position: fixed;
+  top: 86px;
+  left: 50%;
+  transform: translate(-50%, -16px);
+  z-index: 1200;
+  max-width: min(92vw, 640px);
+  padding: 14px 22px;
+  border-radius: 999px;
+  background: var(--ur-card-solid);
+  border: 1px solid var(--ur-border);
+  box-shadow: var(--ur-shadow);
+  font-size: 0.92rem;
+  line-height: 1.45;
+  text-align: center;
+  color: var(--ur-text);
+  opacity: 0;
+  transition: opacity 0.4s ease, transform 0.4s ease;
+  pointer-events: none;
+}
+.ur-welcome-toast.is-visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+.ur-welcome-toast strong {
+  color: var(--ur-saffron);
+}
+
+.ur-container {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+/* ---------- Hero ---------- */
+.ur-hero {
+  position: relative;
+  min-height: 92vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 120px 24px 96px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 18% 22%, #341707 0%, transparent 60%),
+    radial-gradient(circle at 82% 78%, #14220a 0%, transparent 55%),
+    var(--ur-bg);
+}
+.ur-hero-veil {
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(180deg, rgba(13, 9, 5, 0.92) 0%, rgba(13, 9, 5, 0.62) 45%, rgba(13, 9, 5, 0.97) 100%);
+}
+.light-theme .ur-hero-veil {
+  background:
+    linear-gradient(180deg, rgba(255, 248, 239, 0.92) 0%, rgba(255, 248, 239, 0.66) 45%, rgba(255, 248, 239, 0.97) 100%);
+}
+.ur-hero-bg {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 50% 30%, rgba(13, 9, 5, 0.18) 0%, rgba(13, 9, 5, 0.6) 100%),
+    url("https://upload.wikimedia.org/wikipedia/commons/thumb/9/93/Quit_India_Movement.JPG/1920px-Quit_India_Movement.JPG") center 55% / cover no-repeat;
+  transform-origin: center;
+  animation: ur-hero-zoom 26s ease-in-out infinite alternate;
+}
+.light-theme .ur-hero-bg {
+  background:
+    radial-gradient(circle at 50% 30%, rgba(255, 248, 239, 0.1) 0%, rgba(255, 248, 239, 0.55) 100%),
+    url("https://upload.wikimedia.org/wikipedia/commons/thumb/9/93/Quit_India_Movement.JPG/1920px-Quit_India_Movement.JPG") center 55% / cover no-repeat;
+}
+@keyframes ur-hero-zoom {
+  from { transform: scale(1) translateY(0); }
+  to { transform: scale(1.08) translateY(-10px); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ur-hero-bg {
+    animation: none;
+  }
+}
+.ur-hero-orbs {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.ur-orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(70px);
+  opacity: 0.2;
+}
+.ur-orb-one {
+  width: 380px;
+  height: 380px;
+  top: 6%;
+  right: 8%;
+  background: var(--ur-ember);
+  animation: ur-drift 14s ease-in-out infinite alternate;
+}
+.ur-orb-two {
+  width: 320px;
+  height: 320px;
+  bottom: 8%;
+  left: 4%;
+  background: var(--ur-green);
+  animation: ur-drift 18s ease-in-out infinite alternate-reverse;
+}
+.ur-orb-three {
+  width: 220px;
+  height: 220px;
+  top: 40%;
+  left: 42%;
+  background: var(--ur-saffron);
+  opacity: 0.12;
+  animation: ur-drift 12s ease-in-out infinite alternate;
+}
+@keyframes ur-drift {
+  from { transform: translateY(-18px); }
+  to { transform: translateY(22px); }
+}
+.ur-hero-content {
+  position: relative;
+  z-index: 2;
+  max-width: 880px;
+  text-align: center;
+}
+.ur-kicker {
+  display: inline-block;
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ur-gold);
+  border: 1px solid var(--ur-border);
+  border-radius: 999px;
+  padding: 8px 18px;
+  margin-bottom: 22px;
+  background: rgba(0, 0, 0, 0.25);
+}
+.light-theme .ur-kicker {
+  background: rgba(255, 255, 255, 0.6);
+}
+.ur-hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2.4rem, 6vw, 4.4rem);
+  line-height: 1.06;
+  margin: 0 0 18px;
+}
+.ur-hero h1 span {
+  display: block;
+  font-style: italic;
+  background: linear-gradient(120deg, var(--ur-saffron), var(--ur-gold));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.ur-hero-subtitle {
+  font-size: clamp(1.05rem, 2.4vw, 1.4rem);
+  font-weight: 500;
+  color: var(--ur-gold);
+  margin: 0 0 14px;
+}
+.ur-hero-content > p {
+  color: var(--ur-text-muted);
+  font-size: 1.02rem;
+  line-height: 1.7;
+  max-width: 760px;
+  margin: 0 auto 26px;
+}
+.ur-hero-badges {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+  margin: 0 0 32px;
+  padding: 0;
+}
+.ur-hero-badges li {
+  font-size: 0.9rem;
+  padding: 9px 16px;
+  border-radius: 999px;
+  border: 1px solid var(--ur-border);
+  background: var(--ur-card);
+  color: var(--ur-text);
+}
+.ur-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+}
+.ur-cta-btn {
+  display: inline-block;
+  padding: 14px 30px;
+  border-radius: 999px;
+  background: linear-gradient(120deg, var(--ur-saffron), var(--ur-ember));
+  color: #2a1200;
+  font-weight: 700;
+  text-decoration: none;
+  box-shadow: 0 12px 34px rgba(224, 91, 44, 0.35);
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+.ur-cta-btn:hover {
+  transform: translateY(-3px);
+  box-shadow: 0 18px 40px rgba(224, 91, 44, 0.45);
+}
+.ur-bookmark-btn {
+  padding: 14px 24px;
+  border-radius: 999px;
+  border: 1px solid var(--ur-border);
+  background: var(--ur-card);
+  color: var(--ur-text);
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+.ur-bookmark-btn:hover {
+  transform: translateY(-3px);
+}
+.ur-bookmark-btn.is-saved {
+  background: rgba(19, 136, 8, 0.18);
+  border-color: var(--ur-green);
+}
+.ur-scroll-hint {
+  position: absolute;
+  bottom: 26px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  opacity: 0.85;
+}
+.ur-scroll-line {
+  width: 2px;
+  height: 54px;
+  background: linear-gradient(180deg, var(--ur-saffron), transparent);
+  border-radius: 2px;
+  animation: ur-scroll 1.8s ease-in-out infinite;
+}
+@keyframes ur-scroll {
+  0% { transform: scaleY(0); transform-origin: top; }
+  45% { transform: scaleY(1); transform-origin: top; }
+  55% { transform: scaleY(1); transform-origin: bottom; }
+  100% { transform: scaleY(0); transform-origin: bottom; }
+}
+
+/* ---------- Sticky Section Nav ---------- */
+.ur-section-nav {
+  position: sticky;
+  top: 0;
+  z-index: 60;
+  background: rgba(13, 9, 5, 0.9);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--ur-border);
+}
+.light-theme .ur-section-nav {
+  background: rgba(255, 248, 239, 0.92);
+}
+.ur-section-nav-inner {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 0 16px;
+  display: flex;
+  gap: 4px;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.ur-section-nav-inner::-webkit-scrollbar {
+  display: none;
+}
+.ur-section-nav-link {
+  flex: 0 0 auto;
+  padding: 14px 14px;
+  font-size: 0.86rem;
+  font-weight: 600;
+  color: var(--ur-text-muted);
+  text-decoration: none;
+  border-bottom: 2px solid transparent;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+.ur-section-nav-link:hover {
+  color: var(--ur-saffron);
+}
+.ur-section-nav-link.active {
+  color: var(--ur-saffron);
+  border-bottom-color: var(--ur-saffron);
+}
+
+/* ---------- Sections ---------- */
+.ur-section {
+  padding: 90px 0;
+}
+.ur-section:nth-child(even) {
+  background: var(--ur-bg-soft);
+}
+.ur-section-header {
+  text-align: center;
+  max-width: 800px;
+  margin: 0 auto 52px;
+}
+.ur-eyebrow {
+  display: inline-block;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ur-saffron-deep);
+  margin-bottom: 12px;
+}
+.ur-section-header h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(1.7rem, 3.6vw, 2.6rem);
+  line-height: 1.15;
+  margin: 0 0 14px;
+}
+.ur-section-header p {
+  color: var(--ur-text-muted);
+  font-size: 1.02rem;
+  line-height: 1.7;
+}
+
+/* ---------- Bio / intro blocks ---------- */
+.ur-bio-grid {
+  display: grid;
+  grid-template-columns: 1.6fr 1fr;
+  gap: 34px;
+  align-items: start;
+}
+.ur-bio-text p,
+.ur-text-block p {
+  color: var(--ur-text-muted);
+  line-height: 1.75;
+  font-size: 1rem;
+  margin: 0 0 18px;
+}
+.ur-bio-text strong,
+.ur-text-block strong {
+  color: var(--ur-gold);
+  font-weight: 700;
+}
+.ur-bio-profile {
+  background: var(--ur-card);
+  border: 1px solid var(--ur-border);
+  border-radius: 22px;
+  padding: 30px;
+  box-shadow: var(--ur-shadow);
+  position: sticky;
+  top: 120px;
+}
+.ur-bio-portrait {
+  width: 64px;
+  height: 64px;
+  display: grid;
+  place-items: center;
+  font-size: 2rem;
+  border-radius: 18px;
+  background: linear-gradient(135deg, rgba(224, 91, 44, 0.24), rgba(19, 136, 8, 0.16));
+  margin-bottom: 18px;
+}
+.ur-bio-profile h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.35rem;
+  margin: 0 0 4px;
+}
+.ur-bio-title {
+  display: block;
+  color: var(--ur-saffron-deep);
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 18px;
+}
+.ur-bio-profile ul {
+  list-style: none;
+  margin: 0 0 20px;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+.ur-bio-profile li {
+  font-size: 0.92rem;
+  color: var(--ur-text-muted);
+  line-height: 1.5;
+}
+.ur-bio-profile li strong {
+  color: var(--ur-text);
+}
+.ur-bio-profile blockquote {
+  margin: 0;
+  padding: 16px 18px;
+  border-left: 3px solid var(--ur-saffron);
+  background: rgba(255, 153, 51, 0.07);
+  border-radius: 0 14px 14px 0;
+  font-style: italic;
+  color: var(--ur-text);
+  font-size: 0.94rem;
+  line-height: 1.6;
+}
+
+/* ---------- Theme cards ---------- */
+.ur-theme-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+  margin-top: 46px;
+}
+.ur-theme-card {
+  background: var(--ur-card);
+  border: 1px solid var(--ur-border);
+  border-radius: 20px;
+  padding: 26px;
+  transition: transform 0.28s ease, border-color 0.28s ease;
+}
+.ur-theme-card:hover {
+  transform: translateY(-6px);
+  border-color: var(--ur-saffron);
+}
+.ur-theme-icon {
+  font-size: 1.9rem;
+  display: inline-block;
+  margin-bottom: 14px;
+}
+.ur-theme-card h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.15rem;
+  margin: 0 0 10px;
+}
+.ur-theme-card p {
+  color: var(--ur-text-muted);
+  font-size: 0.92rem;
+  line-height: 1.65;
+  margin: 0;
+}
+
+/* ---------- Network graph ---------- */
+.ur-network-layout {
+  display: grid;
+  grid-template-columns: 1.7fr 1fr;
+  gap: 30px;
+  align-items: start;
+}
+.ur-network-canvas {
+  background: var(--ur-card-solid);
+  border: 1px solid var(--ur-border);
+  border-radius: 24px;
+  padding: 14px;
+  box-shadow: var(--ur-shadow);
+}
+.ur-network-board {
+  width: 100%;
+  min-height: 380px;
+  border-radius: 16px;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 18% 22%, rgba(224, 91, 44, 0.14), transparent 55%),
+    radial-gradient(circle at 82% 82%, rgba(19, 136, 8, 0.14), transparent 55%),
+    radial-gradient(circle at 55% 50%, rgba(245, 195, 107, 0.05), transparent 60%),
+    #0a0704;
+}
+.ur-network-board svg {
+  display: block;
+  width: 100%;
+  height: auto;
+  min-height: 380px;
+}
+.ur-node {
+  cursor: pointer;
+  outline: none;
+}
+.ur-node-dot {
+  transition: r 0.2s ease, fill 0.2s ease, stroke 0.2s ease;
+}
+.ur-node-ring {
+  fill: none;
+  stroke: rgba(245, 195, 107, 0.4);
+  stroke-width: 1;
+  opacity: 0;
+  transition: opacity 0.2s ease, r 0.2s ease;
+}
+.ur-node:hover .ur-node-dot,
+.ur-node:focus-visible .ur-node-dot {
+  stroke: var(--ur-gold);
+  stroke-width: 2.5;
+}
+.ur-node.is-active .ur-node-dot {
+  stroke: var(--ur-gold);
+  stroke-width: 3;
+  filter: drop-shadow(0 0 6px var(--ur-gold));
+}
+.ur-node.is-active .ur-node-ring {
+  opacity: 1;
+  animation: ur-node-pulse 1.6s ease-out infinite;
+}
+@keyframes ur-node-pulse {
+  0% { opacity: 0.9; transform: none; }
+  70% { opacity: 0; transform: scale(2.6); }
+  100% { opacity: 0; transform: scale(2.6); }
+}
+.ur-node.is-connected .ur-node-dot {
+  stroke: var(--ur-gold);
+  stroke-width: 2;
+}
+.ur-node.is-dimmed .ur-node-dot {
+  opacity: 0.2;
+}
+.ur-node-label {
+  fill: var(--ur-text-soft);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  pointer-events: none;
+  paint-order: stroke;
+  stroke: var(--ur-bg);
+  stroke-width: 3px;
+  stroke-linejoin: round;
+}
+.ur-node.is-active .ur-node-label,
+.ur-node.is-connected .ur-node-label {
+  fill: var(--ur-text);
+}
+.ur-node.is-dimmed .ur-node-label {
+  opacity: 0.25;
+}
+.ur-link {
+  fill: none;
+  stroke: rgba(245, 195, 107, 0.22);
+  stroke-width: 1.5;
+  transition: stroke 0.2s ease, stroke-width 0.2s ease, opacity 0.2s ease;
+}
+.ur-link.is-connected {
+  stroke: var(--ur-saffron);
+  stroke-width: 2.4;
+  filter: drop-shadow(0 0 4px rgba(255, 153, 51, 0.45));
+}
+.ur-link.is-dimmed {
+  opacity: 0.1;
+}
+.ur-network-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  padding: 14px 6px 2px;
+  font-size: 0.8rem;
+  color: var(--ur-text-muted);
+  align-items: center;
+}
+.ur-legend-key {
+  display: inline-block;
+  margin-right: 4px;
+  font-weight: 700;
+}
+.ur-legend-person { color: var(--ur-saffron); }
+.ur-legend-group { color: #7fd68a; }
+.ur-legend-publication { color: #8ab4f8; }
+.ur-legend-radio { color: #e8846b; }
+.ur-legend-link { color: var(--ur-gold); }
+
+.ur-network-detail {
+  background: var(--ur-card-solid);
+  border: 1px solid var(--ur-border);
+  border-radius: 22px;
+  padding: 30px;
+  box-shadow: var(--ur-shadow);
+  position: sticky;
+  top: 120px;
+  min-height: 220px;
+}
+.ur-network-detail h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.4rem;
+  margin: 0 0 12px;
+}
+.ur-network-detail p {
+  color: var(--ur-text-muted);
+  line-height: 1.7;
+  font-size: 0.95rem;
+  margin: 0 0 18px;
+}
+.ur-network-detail-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.ur-network-tag {
+  display: inline-block;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--ur-gold);
+  border: 1px solid var(--ur-border);
+  border-radius: 999px;
+  padding: 6px 12px;
+}
+
+/* ---------- Map ---------- */
+.ur-map-layout {
+  display: grid;
+  grid-template-columns: 1.7fr 1fr;
+  gap: 30px;
+  align-items: start;
+}
+.ur-map-canvas {
+  background: var(--ur-card-solid);
+  border: 1px solid var(--ur-border);
+  border-radius: 24px;
+  padding: 14px;
+  box-shadow: var(--ur-shadow);
+}
+.ur-india-map {
+  width: 100%;
+  height: 560px;
+  border-radius: 16px;
+  overflow: hidden;
+  background: #0d1b26;
+  z-index: 1;
+}
+.ur-india-map .leaflet-container {
+  font-family: 'Outfit', sans-serif;
+  background: #0d1b26;
+}
+.ur-india-map .leaflet-control-attribution {
+  background: rgba(0, 0, 0, 0.55);
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 10px;
+}
+.ur-india-map .leaflet-control-attribution a {
+  color: rgba(255, 255, 255, 0.75);
+}
+.ur-map-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  padding: 14px 6px 2px;
+  font-size: 0.8rem;
+  color: var(--ur-text-muted);
+  align-items: center;
+}
+.ur-map-legend .ur-legend-key {
+  display: inline-grid;
+  place-items: center;
+  min-width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  font-size: 0.66rem;
+  font-weight: 700;
+  color: #2a1200;
+}
+.ur-map-legend .ur-legend-hub { background: var(--ur-saffron); }
+.ur-map-legend .ur-legend-underground { background: var(--ur-green); color: #fff; }
+.ur-map-legend .ur-legend-parallel { background: #7fd68a; color: #0a2a12; }
+.ur-map-legend .ur-legend-jail { background: #e8846b; color: #2a1200; }
+.ur-map-legend .ur-legend-publication { background: #8ab4f8; color: #081a3a; }
+.ur-map-legend .ur-legend-route {
+  background: transparent;
+  font-size: 0.8rem;
+  letter-spacing: 0.12em;
+  color: var(--ur-gold);
+}
+
+.ur-map-detail {
+  background: var(--ur-card-solid);
+  border: 1px solid var(--ur-border);
+  border-radius: 22px;
+  padding: 30px;
+  box-shadow: var(--ur-shadow);
+  position: sticky;
+  top: 120px;
+  min-height: 220px;
+}
+.ur-map-detail h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.4rem;
+  margin: 0 0 12px;
+}
+.ur-map-detail p {
+  color: var(--ur-text-muted);
+  line-height: 1.7;
+  font-size: 0.95rem;
+  margin: 0 0 18px;
+}
+.ur-map-detail-tag {
+  display: inline-block;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ur-gold);
+  border: 1px solid var(--ur-border);
+  border-radius: 999px;
+  padding: 7px 14px;
+}
+
+/* Leaflet marker styles */
+.ur-map-marker {
+  display: inline-block;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  border: 2px solid #2a1200;
+  background: var(--ur-saffron);
+  color: #2a1200;
+  font-weight: 800;
+  font-size: 11px;
+  line-height: 18px;
+  text-align: center;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.55);
+}
+.ur-map-marker.is-hub {
+  background: var(--ur-saffron);
+}
+.ur-map-marker.is-underground {
+  background: var(--ur-green);
+  color: #fff;
+  border-color: #0a3d1a;
+}
+.ur-map-marker.is-parallel {
+  background: #7fd68a;
+  color: #0a2a12;
+  border-color: #0e5c2a;
+}
+.ur-map-marker.is-jail {
+  background: #e8846b;
+}
+.ur-pub-marker {
+  width: 26px;
+  height: 26px;
+  border-radius: 8px;
+  background: #8ab4f8;
+  color: #081a3a;
+  border: 2px solid #dce7ff;
+  font-size: 13px;
+  line-height: 22px;
+  text-align: center;
+  font-weight: 800;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.55);
+}
+.ur-route {
+  stroke: var(--ur-gold);
+  stroke-width: 2;
+  stroke-dasharray: 5 5;
+  opacity: 0.7;
+}
+.ur-map-tooltip {
+  background: var(--ur-card-solid);
+  border: 1px solid var(--ur-border);
+  border-radius: 10px;
+  color: var(--ur-text);
+  font-family: 'Outfit', sans-serif;
+  font-size: 0.85rem;
+  box-shadow: var(--ur-shadow);
+}
+.ur-map-tooltip::before {
+  display: none;
+}
+.ur-map-popup .leaflet-popup-content-wrapper {
+  background: var(--ur-card-solid);
+  color: var(--ur-text);
+  border: 1px solid var(--ur-border);
+  border-radius: 14px;
+  box-shadow: var(--ur-shadow);
+  font-family: 'Outfit', sans-serif;
+}
+.ur-map-popup .leaflet-popup-tip {
+  background: var(--ur-card-solid);
+  border: 1px solid var(--ur-border);
+}
+.ur-map-popup .leaflet-popup-content {
+  margin: 14px 16px;
+  line-height: 1.5;
+}
+.ur-map-popup .ur-popup-title {
+  font-family: 'Playfair Display', serif;
+  font-size: 1rem;
+  font-weight: 700;
+  margin: 0 0 6px;
+  color: var(--ur-gold);
+}
+.ur-map-popup .ur-popup-desc {
+  font-size: 0.86rem;
+  color: var(--ur-text-muted);
+}
+.ur-map-popup .ur-popup-tag {
+  display: inline-block;
+  margin-top: 8px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ur-gold);
+}
+
+/* ---------- Publications ---------- */
+.ur-pub-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px;
+}
+.ur-pub-card {
+  background: var(--ur-card);
+  border: 1px solid var(--ur-border);
+  border-radius: 20px;
+  padding: 28px;
+  transition: transform 0.28s ease, border-color 0.28s ease;
+}
+.ur-pub-card:hover {
+  transform: translateY(-6px);
+  border-color: var(--ur-saffron);
+}
+.ur-pub-icon {
+  font-size: 1.9rem;
+  display: inline-block;
+  margin-bottom: 12px;
+}
+.ur-pub-card h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.25rem;
+  margin: 0 0 4px;
+}
+.ur-pub-meta {
+  display: block;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ur-saffron-deep);
+  margin-bottom: 12px;
+}
+.ur-pub-card p {
+  color: var(--ur-text-muted);
+  font-size: 0.94rem;
+  line-height: 1.7;
+  margin: 0;
+}
+
+/* ---------- Communication ---------- */
+.ur-comm-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px;
+}
+.ur-comm-card {
+  background: linear-gradient(135deg, rgba(224, 91, 44, 0.08), rgba(19, 136, 8, 0.06));
+  border: 1px solid var(--ur-border);
+  border-radius: 20px;
+  padding: 28px;
+}
+.ur-comm-icon {
+  font-size: 1.8rem;
+  display: inline-block;
+  margin-bottom: 12px;
+}
+.ur-comm-card h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.2rem;
+  margin: 0 0 10px;
+}
+.ur-comm-card p {
+  color: var(--ur-text-muted);
+  font-size: 0.94rem;
+  line-height: 1.7;
+  margin: 0;
+}
+
+/* ---------- Two-column text ---------- */
+.ur-grid-2col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 34px;
+  margin-bottom: 40px;
+}
+.ur-text-block h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.3rem;
+  margin: 0 0 12px;
+}
+
+/* ---------- Students ---------- */
+.ur-student-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+}
+.ur-student-card {
+  background: var(--ur-card);
+  border: 1px solid var(--ur-border);
+  border-radius: 20px;
+  padding: 26px;
+  transition: transform 0.28s ease, border-color 0.28s ease;
+}
+.ur-student-card:hover {
+  transform: translateY(-6px);
+  border-color: var(--ur-gold);
+}
+.ur-student-avatar {
+  width: 54px;
+  height: 54px;
+  display: grid;
+  place-items: center;
+  font-size: 1.7rem;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(255, 153, 51, 0.2), rgba(19, 136, 8, 0.14));
+  margin-bottom: 16px;
+}
+.ur-student-card h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.1rem;
+  margin: 0 0 10px;
+}
+.ur-student-card p {
+  color: var(--ur-text-muted);
+  font-size: 0.9rem;
+  line-height: 1.65;
+  margin: 0;
+}
+
+/* ---------- Regional organisers ---------- */
+.ur-region-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+}
+.ur-region-card {
+  background: var(--ur-card);
+  border: 1px solid var(--ur-border);
+  border-radius: 20px;
+  padding: 26px;
+  transition: transform 0.28s ease, border-color 0.28s ease;
+}
+.ur-region-card:hover {
+  transform: translateY(-6px);
+  border-color: var(--ur-saffron);
+}
+.ur-region-icon {
+  font-size: 1.8rem;
+  display: inline-block;
+  margin-bottom: 12px;
+}
+.ur-region-card h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.15rem;
+  margin: 0 0 4px;
+}
+.ur-region-meta {
+  display: block;
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--ur-saffron-deep);
+  margin-bottom: 12px;
+  line-height: 1.5;
+}
+.ur-region-card p {
+  color: var(--ur-text-muted);
+  font-size: 0.92rem;
+  line-height: 1.68;
+  margin: 0;
+}
+
+/* ---------- Timeline ---------- */
+.ur-timeline {
+  position: relative;
+  max-width: 820px;
+  margin: 0 auto;
+  padding-left: 34px;
+}
+.ur-timeline::before {
+  content: "";
+  position: absolute;
+  left: 9px;
+  top: 6px;
+  bottom: 6px;
+  width: 2px;
+  background: linear-gradient(180deg, var(--ur-saffron), var(--ur-green));
+  opacity: 0.5;
+}
+.ur-timeline-step {
+  position: relative;
+  margin-bottom: 28px;
+}
+.ur-timeline-marker {
+  position: absolute;
+  left: -34px;
+  top: 22px;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--ur-bg-soft);
+  border: 3px solid var(--ur-saffron);
+  box-shadow: 0 0 0 4px rgba(255, 153, 51, 0.15);
+}
+.ur-timeline-card {
+  background: var(--ur-card);
+  border: 1px solid var(--ur-border);
+  border-radius: 18px;
+  padding: 24px 26px;
+}
+.ur-timeline-card:hover {
+  border-color: var(--ur-saffron);
+}
+.ur-timeline-year {
+  display: inline-block;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ur-gold);
+  margin-bottom: 8px;
+}
+.ur-timeline-icon {
+  float: right;
+  font-size: 1.5rem;
+  margin-left: 10px;
+}
+.ur-timeline-card h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.15rem;
+  margin: 0 0 8px;
+}
+.ur-timeline-card p {
+  color: var(--ur-text-muted);
+  line-height: 1.7;
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+/* ---------- Participants ---------- */
+.ur-participant-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+}
+.ur-participant-card {
+  text-align: left;
+  background: var(--ur-card);
+  border: 1px solid var(--ur-border);
+  border-radius: 20px;
+  padding: 24px;
+  cursor: pointer;
+  color: var(--ur-text);
+  font-family: inherit;
+  transition: transform 0.28s ease, border-color 0.28s ease, background 0.28s ease;
+}
+.ur-participant-card:hover {
+  transform: translateY(-6px);
+  border-color: var(--ur-gold);
+}
+.ur-participant-card.is-active {
+  background: linear-gradient(135deg, rgba(255, 153, 51, 0.14), rgba(19, 136, 8, 0.1));
+  border-color: var(--ur-saffron);
+}
+.ur-participant-avatar {
+  width: 50px;
+  height: 50px;
+  display: grid;
+  place-items: center;
+  font-size: 1.6rem;
+  border-radius: 16px;
+  background: linear-gradient(135deg, rgba(255, 153, 51, 0.2), rgba(19, 136, 8, 0.14));
+  margin-bottom: 14px;
+}
+.ur-participant-card h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.08rem;
+  margin: 0 0 4px;
+}
+.ur-participant-role {
+  display: block;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ur-saffron-deep);
+  margin-bottom: 10px;
+  line-height: 1.5;
+}
+.ur-participant-card p {
+  color: var(--ur-text-muted);
+  font-size: 0.88rem;
+  line-height: 1.65;
+  margin: 0;
+}
+
+/* ---------- Surveillance / disruption ---------- */
+.ur-disruption-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+  margin-top: 40px;
+}
+.ur-disruption-card {
+  background: var(--ur-card);
+  border: 1px solid var(--ur-border);
+  border-radius: 20px;
+  padding: 24px;
+  transition: transform 0.28s ease, border-color 0.28s ease;
+}
+.ur-disruption-card:hover {
+  transform: translateY(-6px);
+  border-color: var(--ur-ember);
+}
+.ur-disruption-icon {
+  font-size: 1.7rem;
+  display: inline-block;
+  margin-bottom: 12px;
+}
+.ur-disruption-card h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.1rem;
+  margin: 0 0 10px;
+}
+.ur-disruption-card p {
+  color: var(--ur-text-muted);
+  font-size: 0.9rem;
+  line-height: 1.68;
+  margin: 0;
+}
+
+/* ---------- Roll call ---------- */
+.ur-roll-call {
+  background: linear-gradient(135deg, rgba(19, 136, 8, 0.14), rgba(255, 153, 51, 0.1));
+  border: 1px solid var(--ur-border);
+  border-radius: 22px;
+  padding: 32px 36px;
+}
+.ur-roll-call h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.25rem;
+  margin: 0 0 12px;
+  color: var(--ur-gold);
+}
+.ur-roll-call p {
+  color: var(--ur-text-muted);
+  line-height: 1.75;
+  margin: 0;
+}
+.ur-roll-call p strong {
+  color: var(--ur-text);
+}
+
+/* ---------- References ---------- */
+.ur-ref-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px;
+}
+.ur-ref-card {
+  display: flex;
+  gap: 18px;
+  background: var(--ur-card);
+  border: 1px solid var(--ur-border);
+  border-radius: 18px;
+  padding: 26px;
+}
+.ur-ref-card:hover {
+  border-color: var(--ur-saffron);
+}
+.ur-ref-icon {
+  font-size: 1.6rem;
+  flex: 0 0 auto;
+}
+.ur-ref-card h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.08rem;
+  margin: 0 0 8px;
+}
+.ur-ref-card p {
+  color: var(--ur-text-muted);
+  font-size: 0.92rem;
+  line-height: 1.7;
+  margin: 0;
+}
+.ur-ref-card a {
+  color: var(--ur-saffron);
+  text-decoration: none;
+}
+.ur-ref-card a:hover {
+  text-decoration: underline;
+}
+.ur-ref-card a + a {
+  margin-left: 12px;
+}
+
+/* ---------- Footer ---------- */
+.ur-footer {
+  background: var(--ur-bg-soft);
+  border-top: 1px solid var(--ur-border);
+  padding: 64px 24px 30px;
+}
+.ur-footer .footer-container {
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: 44px;
+}
+.ur-footer-logo {
+  display: inline-flex;
+  gap: 4px;
+  font-family: 'Playfair Display', serif;
+  font-size: 1.55rem;
+  font-weight: 700;
+  letter-spacing: -0.5px;
+  text-decoration: none;
+  margin-bottom: 16px;
+}
+.ur-footer-logo .saffron { color: var(--ur-saffron); }
+.ur-footer-logo .gold { color: var(--ur-gold); }
+.ur-footer-logo .green { color: var(--ur-green); }
+.ur-footer .footer-brand p {
+  color: var(--ur-text-muted);
+  font-size: 0.92rem;
+  line-height: 1.65;
+  max-width: 420px;
+}
+.ur-footer .ur-footer-note {
+  margin-top: 14px;
+  padding-top: 14px;
+  border-top: 1px dashed var(--ur-border);
+  color: var(--ur-text-soft);
+  font-size: 0.82rem;
+}
+.ur-footer .footer-links h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+  color: var(--ur-gold);
+  margin-bottom: 18px;
+}
+.ur-footer .footer-links ul {
+  margin-left: 0 !important;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 11px;
+  justify-content: start;
+}
+.ur-footer .footer-links a {
+  color: var(--ur-text-muted);
+  font-size: 0.9rem;
+}
+.ur-footer .footer-links a:hover {
+  color: var(--ur-saffron);
+  padding-left: 5px;
+}
+.ur-footer .footer-credits {
+  border-top-color: var(--ur-border);
+  color: var(--ur-text-muted);
+  font-size: 0.85rem;
+}
+.ur-footer .footer-credits a {
+  color: var(--ur-gold);
+  text-decoration: none;
+}
+.ur-footer .footer-credits a:hover {
+  color: var(--ur-saffron);
+  text-decoration: underline;
+}
+
+body.light-theme .ur-footer .footer-links h3,
+body.light-theme .ur-footer .footer-credits a {
+  color: var(--ur-saffron-deep);
+}
+body.light-theme .ur-footer .footer-links a:hover,
+body.light-theme .ur-footer .footer-credits a:hover {
+  color: var(--ur-green-deep);
+}
+
+/* ---------- Scroll reveal ---------- */
+.reveal {
+  opacity: 0;
+  transform: translateY(26px);
+  transition: opacity 0.7s ease, transform 0.7s ease;
+}
+.reveal.is-visible {
+  opacity: 1;
+  transform: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  .reveal {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}
+
+/* ---------- Responsive ---------- */
+@media (max-width: 1100px) {
+  .ur-theme-grid,
+  .ur-student-grid,
+  .ur-disruption-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .ur-participant-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  .ur-region-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .ur-map-layout,
+  .ur-network-layout {
+    grid-template-columns: 1fr;
+  }
+  .ur-map-detail,
+  .ur-network-detail {
+    position: static;
+  }
+}
+
+@media (max-width: 768px) {
+  .ur-section {
+    padding: 64px 0;
+  }
+  .ur-bio-grid,
+  .ur-grid-2col,
+  .ur-comm-grid,
+  .ur-pub-grid {
+    grid-template-columns: 1fr;
+  }
+  .ur-bio-profile {
+    position: static;
+  }
+  .ur-participant-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+  .ur-ref-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .ur-container {
+    padding: 0 18px;
+  }
+  .ur-theme-grid,
+  .ur-student-grid,
+  .ur-participant-grid,
+  .ur-region-grid,
+  .ur-disruption-grid {
+    grid-template-columns: 1fr;
+  }
+  .ur-hero {
+    min-height: auto;
+    padding: 110px 18px 80px;
+  }
+  .ur-india-map {
+    height: 420px;
+  }
+  .ur-map-legend {
+    gap: 10px;
+    font-size: 0.72rem;
+  }
+}

--- a/tests/unit/underground-resistance-explorer.test.js
+++ b/tests/unit/underground-resistance-explorer.test.js
@@ -1,0 +1,334 @@
+/**
+ * underground-resistance-explorer.test.js
+ * Unit tests for the Underground Resistance Networks of 1942–44 Explorer page.
+ * Validates required sections, key historical content, accessibility,
+ * interactive features (network graph, map, publications, timeline), and
+ * landing page integration on the Freedom Fighters Knowledge Hub page and
+ * the Quit India Movement Explorer.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function readExplorerFile(file) {
+    return readFileSync(
+        resolve(__dirname, '../../frontend/underground-resistance-explorer', file),
+        'utf-8'
+    );
+}
+
+function readLandingPage() {
+    return readFileSync(
+        resolve(__dirname, '../../frontend/freedom-fighters-hub/index.html'),
+        'utf-8'
+    );
+}
+
+describe('Underground Resistance Explorer — Page Structure', () => {
+    let html;
+
+    beforeAll(() => {
+        html = readExplorerFile('index.html');
+    });
+
+    it('contains a hero section with page title and kicker', () => {
+        expect(html).toContain('class="ur-hero"');
+        expect(html).toContain('<h1>');
+        expect(html).toContain('Underground Resistance');
+        expect(html).toContain('1942');
+    });
+
+    it('contains all required content sections from the issue', () => {
+        const sections = ['overview', 'network', 'map', 'publications', 'communication', 'students', 'regional', 'timeline', 'participants', 'surveillance', 'significance', 'references'];
+        sections.forEach(id => {
+            expect(html).toContain(`id="${id}"`);
+        });
+    });
+
+    it('covers all the topics required by the issue', () => {
+        [
+            'Why the Underground Emerged',
+            'Secret Communication',
+            'Underground Publications',
+            'Congress Radio',
+            'Student Networks',
+            'Regional Organisers',
+            'Major Participants',
+            'Government Surveillance',
+            'Arrests',
+            'Historical Significance'
+        ].forEach(topic => {
+            expect(html).toContain(topic);
+        });
+        expect(html).toContain('The Networks Wind Down');
+        expect(html).toContain('The Slow Erosion');
+    });
+
+    it('contains premium immersive features', () => {
+        expect(html).toContain('ur-hero-orbs');
+        expect(html).toContain('ur-hero-badges');
+        expect(html).toContain('ur-cta-btn');
+        expect(html).toContain('ur-section-nav');
+        expect(html).toMatch(/class="[^"]*reveal"/);
+        expect(html).toContain('ur-timeline-step');
+        expect(html).toContain('ur-participant-card');
+        expect(html).toContain('ur-network-board');
+        expect(html).toContain('ur-india-map');
+    });
+
+    it('contains the key historical and structural details', () => {
+        expect(html).toContain('9 August 1942');
+        expect(html).toContain('Operation Zero Hour');
+        expect(html).toContain('Aga Khan Palace');
+        expect(html).toContain('Inquilab');
+        expect(html).toContain('Congress Bulletin');
+        expect(html).toContain('Biplabi');
+        expect(html).toContain('Aruna Asaf Ali');
+        expect(html).toContain('Jayaprakash Narayan');
+        expect(html).toContain('Ram Manohar Lohia');
+        expect(html).toContain('Usha Mehta');
+        expect(html).toContain('Nana Patil');
+        expect(html).toContain('Satara');
+        expect(html).toContain('Tamluk');
+        expect(html).toContain('Azad Dastas');
+    });
+
+    it('has a semantic heading hierarchy (single h1, multiple section h2s)', () => {
+        const h1Count = (html.match(/<h1[\s>]/g) || []).length;
+        const h2Count = (html.match(/<h2[\s>]/g) || []).length;
+        expect(h1Count).toBe(1);
+        expect(h2Count).toBeGreaterThanOrEqual(8);
+    });
+
+    it('uses HTTPS OG image URLs', () => {
+        const ogImages = html.match(/property="og:image" content="([^"]*)"/g) || [];
+        expect(ogImages.length).toBeGreaterThanOrEqual(1);
+        ogImages.forEach(tag => {
+            expect(tag).toMatch(/https:\/\//);
+        });
+    });
+
+    it('links the shared stylesheet, page stylesheet, and script', () => {
+        expect(html).toContain('href="../../styles.css"');
+        expect(html).toContain('href="style.css"');
+        expect(html).toContain('src="script.js"');
+    });
+
+    it('loads the shared Journey module before its own script', () => {
+        const journeyIdx = html.indexOf('journey/journey.js');
+        const scriptIdx = html.indexOf('src="script.js"');
+        expect(journeyIdx).toBeGreaterThan(-1);
+        expect(scriptIdx).toBeGreaterThan(journeyIdx);
+    });
+});
+
+describe('Underground Resistance Explorer — Interactive Features', () => {
+    let html;
+    let js;
+
+    beforeAll(() => {
+        html = readExplorerFile('index.html');
+        js = readExplorerFile('script.js');
+    });
+
+    it('includes an interactive network graph with nodes and links', () => {
+        expect(html).toContain('ur-network');
+        expect(html).toContain('ur-network-detail');
+        expect(js).toContain('NETWORK_NODES');
+        expect(js).toContain('NETWORK_LINKS');
+        expect(js).toContain('renderNetwork');
+        expect(js).toContain('selectNetworkNode');
+        expect(js).toContain('svg');
+        expect(js).toContain('Congress Radio');
+        expect(js).toContain('Inquilab');
+    });
+
+    it('includes an interactive India map with real markers and routes', () => {
+        expect(html).toContain('ur-india-map');
+        expect(html).toContain('ur-map-detail');
+        expect(js).toContain('MAP_POINTS');
+        expect(js).toContain('L.map');
+        expect(js).toContain('L.tileLayer');
+        expect(js).toContain('ur-map-marker');
+        expect(js).toContain('Bombay');
+        expect(js).toContain('Satara');
+        expect(js).toContain('Tamluk');
+        expect(js).toContain('Hazaribagh');
+        expect(js).toContain('ROUTES');
+    });
+
+    it('includes underground publication markers on the map', () => {
+        expect(js).toContain('PUB_POINTS');
+        expect(js).toContain('ur-pub-marker');
+        expect(js).toContain('Biplabi Press');
+        expect(js).toContain('Inquilab Press');
+    });
+
+    it('includes a timeline covering the major period 1942–44', () => {
+        expect(html).toContain('ur-timeline-step');
+        expect(html).toContain('8 Aug 1942');
+        expect(html).toContain('27 Aug 1942');
+        expect(html).toContain('12 Nov 1942');
+        expect(html).toContain('9 Nov 1942');
+        expect(html).toContain('Dec 1942');
+        expect(html).toContain('1943');
+        expect(html).toContain('Dec 1943');
+        expect(html).toContain('1944');
+    });
+
+    it('connects participant cards to the network graph and map', () => {
+        expect(html).toContain('data-node="aruna"');
+        expect(html).toContain('data-node="jp"');
+        expect(html).toContain('data-node="usha"');
+        expect(html).toContain('data-map="satara"');
+        expect(html).toContain('data-map="patna"');
+        expect(js).toContain('initParticipantCards');
+    });
+
+    it('connects to related explorers in the freedom struggle collection', () => {
+        expect(html).toContain('../quit-india-movement-explorer/index.html');
+        expect(html).toContain('../congress-radio-explorer/index.html');
+        expect(html).toContain('../freedom-fighters-hub/index.html');
+    });
+
+    it('provides sources and references', () => {
+        expect(html).toContain('References');
+        expect(html).toContain('Bipan Chandra');
+        expect(html).toContain('Chopra, P. N.');
+        expect(html).toContain('Congress Radio');
+        expect(html).toContain('en.wikipedia.org/wiki/Congress_Radio');
+    });
+});
+
+describe('Underground Resistance Explorer — Assets', () => {
+    let js;
+
+    beforeAll(() => {
+        js = readExplorerFile('script.js');
+    });
+
+    it('includes a non-empty stylesheet', () => {
+        const css = readExplorerFile('style.css');
+        expect(css.length).toBeGreaterThan(1000);
+        expect(css).toContain('.ur-hero');
+        expect(css).toContain('.ur-timeline');
+        expect(css).toContain('.ur-map-canvas');
+        expect(css).toContain('.ur-network-board');
+        expect(css).toContain('.ur-node');
+        expect(css).toContain('.reveal');
+    });
+
+    it('includes a valid interactive script with required features', () => {
+        expect(js).toContain('registerSearchItems');
+        expect(js).toContain('Journey');
+        expect(js).toContain('app:route-changed');
+        expect(js).toContain('IntersectionObserver');
+        expect(js).toContain('prefers-reduced-motion');
+        expect(js).toContain('MAP_POINTS');
+        expect(js).toContain('showMapPoint');
+        expect(js).toContain('underground-resistance-main');
+    });
+});
+
+const CARD_MARKER = '<div class="featured-explorer-card">';
+
+function extractFeaturedCards(html) {
+    const cards = [];
+    let cursor = 0;
+    while (cursor < html.length) {
+        const start = html.indexOf(CARD_MARKER, cursor);
+        if (start === -1) break;
+        const end = html.indexOf('</section>', start);
+        cards.push(html.slice(start, end === -1 ? start + 2000 : end));
+        cursor = end === -1 ? start + CARD_MARKER.length : end;
+    }
+    return cards;
+}
+
+function extractFooter(html) {
+    const start = html.indexOf('<footer');
+    const end = start === -1 ? -1 : html.indexOf('</footer>', start);
+    return start === -1 || end === -1 ? '' : html.slice(start, end);
+}
+
+describe('Underground Resistance — Landing Page Integration', () => {
+    it('is listed as a featured explorer card on the Freedom Fighters Hub landing page', () => {
+        const index = readLandingPage();
+        const cards = extractFeaturedCards(index);
+        expect(cards.length).toBeGreaterThan(0);
+        const undergroundCard = cards.find(card => card.includes('Underground Resistance'));
+        expect(undergroundCard).toBeDefined();
+        expect(undergroundCard).toContain('../underground-resistance-explorer/index.html');
+    });
+
+    it('matches the existing featured card pattern (badge, heading, button)', () => {
+        const index = readLandingPage();
+        const cards = extractFeaturedCards(index);
+        const undergroundCard = cards.find(card => card.includes('Underground Resistance'));
+        expect(undergroundCard).toBeDefined();
+        expect(undergroundCard).toContain('featured-explorer-badge');
+        expect(undergroundCard).toContain('featured-explorer-btn');
+        expect(undergroundCard).toContain('1942');
+        expect(undergroundCard).toContain('Congress Radio');
+    });
+
+    it('appears in the footer Freedom Fighters list on the landing page', () => {
+        const index = readLandingPage();
+        const footer = extractFooter(index);
+        expect(footer.length).toBeGreaterThan(0);
+        expect(footer).toContain('Underground Resistance Explorer');
+        expect(footer).toContain('../underground-resistance-explorer/index.html');
+    });
+
+    it('registers the Underground Resistance in the hub FREEDOM_FIGHTERS_DATA', () => {
+        const js = readFileSync(
+            resolve(__dirname, '../../frontend/freedom-fighters-hub/script.js'),
+            'utf-8'
+        );
+        expect(js).toContain("id: 'underground-resistance-networks'");
+        expect(js).toContain('Underground Resistance Networks');
+        expect(js).toContain('Azad Dastas');
+        expect(js).toContain("explorerLink: '../underground-resistance-explorer/index.html'");
+    });
+
+    it('is registered in the service worker precache list', () => {
+        const sw = readFileSync(
+            resolve(__dirname, '../../frontend/sw.js'),
+            'utf-8'
+        );
+        expect(sw).toContain("'./underground-resistance-explorer/index.html'");
+        expect(sw).toContain("'./underground-resistance-explorer/style.css'");
+        expect(sw).toContain("'./underground-resistance-explorer/script.js'");
+    });
+
+    it('is listed in the offline page cache map', () => {
+        const offline = readFileSync(
+            resolve(__dirname, '../../frontend/offline.html'),
+            'utf-8'
+        );
+        expect(offline).toContain("'/frontend/underground-resistance-explorer/'");
+        expect(offline).toContain('Underground Resistance Explorer');
+    });
+
+    it('is registered in the global search index', () => {
+        const searchIndex = readFileSync(
+            resolve(__dirname, '../../frontend/search-index.js'),
+            'utf-8'
+        );
+        expect(searchIndex).toContain('Underground Resistance Networks');
+        expect(searchIndex).toContain('frontend/underground-resistance-explorer/index.html');
+    });
+
+    it('is surfaced as an interactive layer of the Quit India map explorer', () => {
+        const quitIndia = readFileSync(
+            resolve(__dirname, '../../frontend/quit-india-movement-explorer/index.html'),
+            'utf-8'
+        );
+        expect(quitIndia).toContain('../underground-resistance-explorer/index.html');
+        expect(quitIndia).toContain('Underground Resistance');
+    });
+});


### PR DESCRIPTION
## Summary

- Added an interactive Underground Resistance explorer for 1942–44.
- Added underground resistance network relationships.
- Added historical locations and publication markers.
- Added Congress Radio coverage.
- Added student networks and regional organizers.
- Added participant connections.
- Added surveillance, arrests, and network disruption context.
- Added a 1942–44 timeline.
- Added historical sources.
- Integrated Underground Resistance into the Quit India map.

## Interactive Features

- Network graph
- Location-based map
- Underground publication markers
- Communication relationships
- Timeline
- Participant connections

## Validation

- [x] Lint passes
- [x] Build passes
- [x] Tests pass (49 tests: 26 new + 23 existing)
- [x] Responsive UI checked
- [x] Accessibility checked
- [x] Sources verified
- [x] No unrelated files changed

Closes #1989


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an interactive Underground Resistance Networks explorer covering 1942–44.
  - Explore historical publications, communication routes, participants, regional networks, timelines, and locations through maps and visualizations.
  - Added responsive layouts, navigation, search, bookmarks, accessibility support, and reduced-motion options.

- **Enhancements**
  - Linked the explorer from the Freedom Fighters Hub and Quit India Movement pages.
  - Added search, offline availability, and service-worker caching for the new experience.

- **Tests**
  - Added comprehensive coverage for the explorer and its integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->