### PR TITLE
feat: add Simon Commission protests explorer

### DIFF
--- a/frontend/assets/simon_lahore_lathicharge.svg
+++ b/frontend/assets/simon_lahore_lathicharge.svg
@@ -1,0 +1,42 @@
+<svg viewBox="0 0 1024 640" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Stylised illustration of the October 1928 Lahore protest procession confronted by police">
+  <defs>
+    <linearGradient id="llBg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0c0d0a"/>
+      <stop offset="100%" stop-color="#241f14"/>
+    </linearGradient>
+  </defs>
+  <rect width="1024" height="640" fill="url(#llBg)"/>
+
+  <!-- Lahore railway station silhouette -->
+  <g fill="#1c1f19" stroke="#3a3222" stroke-width="3">
+    <rect x="120" y="150" width="784" height="120"/>
+    <path d="M120 150 Q512 60 904 150 Z"/>
+  </g>
+  <g fill="#d9a441" opacity="0.5">
+    <circle cx="260" cy="120" r="6"/><circle cx="400" cy="95" r="6"/><circle cx="512" cy="85" r="6"/>
+    <circle cx="624" cy="95" r="6"/><circle cx="764" cy="120" r="6"/>
+  </g>
+
+  <!-- Protest crowd (left, advancing) -->
+  <g fill="#0c0d0a">
+    <circle cx="300" cy="420" r="15"/><rect x="288" y="435" width="24" height="55" rx="6"/>
+    <circle cx="360" cy="430" r="15"/><rect x="348" y="445" width="24" height="55" rx="6"/>
+    <circle cx="420" cy="420" r="15"/><rect x="408" y="435" width="24" height="55" rx="6"/>
+  </g>
+  <line x1="360" y1="430" x2="360" y2="340" stroke="#3a3222" stroke-width="4"/>
+  <rect x="360" y="340" width="54" height="30" fill="#0c0d0a" stroke="#f0cc7a" stroke-width="2"/>
+
+  <!-- Police line (right, lathis raised) -->
+  <g fill="#241f14" stroke="#a1272d" stroke-width="2">
+    <circle cx="620" cy="420" r="15"/><rect x="608" y="435" width="24" height="55" rx="6"/>
+    <circle cx="680" cy="430" r="15"/><rect x="668" y="445" width="24" height="55" rx="6"/>
+    <circle cx="740" cy="420" r="15"/><rect x="728" y="435" width="24" height="55" rx="6"/>
+  </g>
+  <g stroke="#a1272d" stroke-width="5">
+    <line x1="620" y1="420" x2="660" y2="380"/>
+    <line x1="680" y1="430" x2="720" y2="390"/>
+    <line x1="740" y1="420" x2="780" y2="380"/>
+  </g>
+
+  <text x="512" y="560" text-anchor="middle" font-family="Georgia, serif" font-size="24" fill="#f0cc7a" letter-spacing="2">LAHORE · 30 OCTOBER 1928</text>
+</svg>

--- a/frontend/assets/simon_lajpat_rai.svg
+++ b/frontend/assets/simon_lajpat_rai.svg
@@ -1,0 +1,33 @@
+<svg viewBox="0 0 1024 640" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Stylised commemorative illustration honouring Lala Lajpat Rai, the Lion of Punjab">
+  <defs>
+    <radialGradient id="llrAura" cx="50%" cy="38%" r="45%">
+      <stop offset="0%" stop-color="#f0cc7a" stop-opacity="0.9"/>
+      <stop offset="100%" stop-color="#f0cc7a" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="llrBg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#12130f"/>
+      <stop offset="100%" stop-color="#3a1414"/>
+    </linearGradient>
+  </defs>
+  <rect width="1024" height="640" fill="url(#llrBg)"/>
+  <circle cx="512" cy="260" r="260" fill="url(#llrAura)"/>
+
+  <!-- Commemorative frame -->
+  <rect x="330" y="120" width="364" height="420" rx="12" fill="none" stroke="#d9a441" stroke-width="6"/>
+  <rect x="352" y="142" width="320" height="376" rx="8" fill="#1c1f19"/>
+
+  <!-- Silhouette bust -->
+  <g fill="#0c0d0a">
+    <circle cx="512" cy="270" r="70"/>
+    <path d="M400 470 Q512 360 624 470 L624 520 L400 520 Z"/>
+  </g>
+  <g fill="none" stroke="#f0cc7a" stroke-width="3">
+    <circle cx="512" cy="270" r="70"/>
+  </g>
+
+  <!-- Turban outline suggestion -->
+  <path d="M448 230 Q512 190 576 230 L576 250 Q512 220 448 250 Z" fill="#a1272d" stroke="#f0cc7a" stroke-width="2"/>
+
+  <text x="512" y="590" text-anchor="middle" font-family="Georgia, serif" font-size="24" fill="#f0cc7a" letter-spacing="2">LALA LAJPAT RAI</text>
+  <text x="512" y="615" text-anchor="middle" font-family="Outfit, sans-serif" font-size="15" fill="#cbd5e1">"Punjab Kesari" · 1865 – 1928</text>
+</svg>

--- a/frontend/assets/simon_protest_hartal.svg
+++ b/frontend/assets/simon_protest_hartal.svg
@@ -1,0 +1,48 @@
+<svg viewBox="0 0 1024 640" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Stylised illustration of a 1928 hartal protest with black flags and closed shops">
+  <defs>
+    <linearGradient id="shSky" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0c0d0a"/>
+      <stop offset="60%" stop-color="#1c1f19"/>
+      <stop offset="100%" stop-color="#a1272d"/>
+    </linearGradient>
+  </defs>
+  <rect width="1024" height="640" fill="url(#shSky)"/>
+
+  <!-- Street / shopfronts -->
+  <rect x="0" y="420" width="1024" height="220" fill="#181a14"/>
+  <g fill="#241f14" stroke="#3a3222" stroke-width="2">
+    <rect x="80" y="360" width="140" height="130"/>
+    <rect x="260" y="340" width="150" height="150"/>
+    <rect x="450" y="360" width="140" height="130"/>
+    <rect x="630" y="340" width="150" height="150"/>
+    <rect x="820" y="360" width="140" height="130"/>
+  </g>
+  <!-- shutters (closed shops) -->
+  <g stroke="#d9a441" stroke-width="3" opacity="0.6">
+    <line x1="90" y1="380" x2="210" y2="380"/><line x1="90" y1="400" x2="210" y2="400"/><line x1="90" y1="420" x2="210" y2="420"/>
+    <line x1="270" y1="365" x2="400" y2="365"/><line x1="270" y1="390" x2="400" y2="390"/><line x1="270" y1="415" x2="400" y2="415"/>
+    <line x1="460" y1="380" x2="580" y2="380"/><line x1="460" y1="400" x2="580" y2="400"/><line x1="460" y1="420" x2="580" y2="420"/>
+    <line x1="640" y1="365" x2="770" y2="365"/><line x1="640" y1="390" x2="770" y2="390"/><line x1="640" y1="415" x2="770" y2="415"/>
+    <line x1="830" y1="380" x2="930" y2="380"/><line x1="830" y1="400" x2="930" y2="400"/><line x1="830" y1="420" x2="930" y2="420"/>
+  </g>
+
+  <!-- Crowd silhouettes with black flags -->
+  <g fill="#0c0d0a">
+    <circle cx="260" cy="470" r="16"/><rect x="248" y="486" width="24" height="60" rx="6"/>
+    <circle cx="330" cy="480" r="16"/><rect x="318" y="496" width="24" height="60" rx="6"/>
+    <circle cx="400" cy="470" r="16"/><rect x="388" y="486" width="24" height="60" rx="6"/>
+    <circle cx="600" cy="480" r="16"/><rect x="588" y="496" width="24" height="60" rx="6"/>
+    <circle cx="670" cy="470" r="16"/><rect x="658" y="486" width="24" height="60" rx="6"/>
+    <circle cx="740" cy="480" r="16"/><rect x="728" y="496" width="24" height="60" rx="6"/>
+  </g>
+
+  <!-- Black flags on poles -->
+  <g>
+    <line x1="330" y1="480" x2="330" y2="380" stroke="#3a3222" stroke-width="4"/>
+    <rect x="330" y="380" width="60" height="34" fill="#0c0d0a" stroke="#d9a441" stroke-width="2"/>
+    <line x1="670" y1="470" x2="670" y2="370" stroke="#3a3222" stroke-width="4"/>
+    <rect x="670" y="370" width="60" height="34" fill="#0c0d0a" stroke="#d9a441" stroke-width="2"/>
+  </g>
+
+  <text x="512" y="120" text-anchor="middle" font-family="Georgia, serif" font-size="30" fill="#f0cc7a" letter-spacing="3">SIMON, GO BACK</text>
+</svg>

--- a/frontend/assets/simon_revolutionary_aftermath.svg
+++ b/frontend/assets/simon_revolutionary_aftermath.svg
@@ -1,0 +1,32 @@
+<svg viewBox="0 0 1024 640" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Stylised illustration symbolising the revolutionary response that followed the Lahore protest">
+  <defs>
+    <linearGradient id="raBg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#12130f"/>
+      <stop offset="100%" stop-color="#1c1f19"/>
+    </linearGradient>
+    <radialGradient id="raGlow" cx="50%" cy="35%" r="50%">
+      <stop offset="0%" stop-color="#a1272d" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#a1272d" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="1024" height="640" fill="url(#raBg)"/>
+  <circle cx="512" cy="240" r="260" fill="url(#raGlow)"/>
+
+  <!-- Torch -->
+  <g transform="translate(462,180)">
+    <rect x="30" y="140" width="20" height="200" fill="#7a4d1e"/>
+    <path d="M20 140 Q40 40 60 140 Q40 170 20 140 Z" fill="#f0cc7a"/>
+    <path d="M30 130 Q40 70 50 130 Q40 150 30 130 Z" fill="#a1272d"/>
+  </g>
+
+  <!-- Chains breaking motif -->
+  <g fill="none" stroke="#d9a441" stroke-width="6" opacity="0.8">
+    <circle cx="300" cy="480" r="26"/>
+    <circle cx="360" cy="500" r="26"/>
+    <circle cx="664" cy="500" r="26"/>
+    <circle cx="724" cy="480" r="26"/>
+  </g>
+  <line x1="386" y1="500" x2="638" y2="500" stroke="#3a3222" stroke-width="5" stroke-dasharray="10 12"/>
+
+  <text x="512" y="580" text-anchor="middle" font-family="Georgia, serif" font-size="24" fill="#f0cc7a" letter-spacing="2">A NEW GENERATION OF REVOLUTIONARIES</text>
+</svg>

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -725,6 +725,12 @@ window.indiaSearchIndex = [
         url: 'frontend/sanjhi-art-explorer/index.html'
     },
     {
+        title: "Simon Commission Protests (1928) Explorer",
+        category: "Political Movements",
+        description: "Explore the 1928 Simon Commission protests: an all-white Commission, the nationwide 'Simon Go Back' boycott, the Lahore lathi charge on Lala Lajpat Rai, and its revolutionary aftermath.",
+        url: "frontend/simon-commission-protests/index.html"
+    },
+    {
         title: 'Gujarati Cinema (Dhollywood) Explorer',
         category: 'Culture',
         description:
@@ -2560,130 +2566,130 @@ window.indiaSearchIndex = [
             "Explore the Battle of Ghaghra (1529 CE) - Babur's decisive riverine and amphibious campaign against the Eastern Afghan Confederacy and Bengal Sultanate.",
         url: 'frontend/battle-of-ghaghra-explorer/index.html'
     },
-  // --- Battle of Ghaghra Explorer ---
-  {
-    title: "Battle of Ghaghra Explorer",
-    category: "Featured Explorers",
-    description: "Explore the Battle of Ghaghra (1529 CE) - Babur's decisive riverine and amphibious campaign against the Eastern Afghan Confederacy and Bengal Sultanate.",
-    url: "frontend/battle-of-ghaghra-explorer/index.html"
-  },
-  // --- Vaduvur Wetland Explorer ---
-  {
-    title: "Vaduvur Wetland Explorer",
-    category: "Featured Explorers",
-    description: "Explore Vaduvur Wetland & Bird Sanctuary — Ramsar Site No. 2480 in Tiruvarur, Tamil Nadu. A 128-hectare human-made irrigation tank hosting over 20,000 wintering migratory waterfowl along the Central Asian Flyway.",
-    url: "frontend/vaduvur-wetland-explorer/index.html"
-  },
-  // --- Suchindram Wetland Explorer ---
-  {
-    title: "Suchindram Wetland Explorer",
-    category: "Featured Explorers",
-    description: "Explore Suchindram Wetland & Bird Sanctuary — Ramsar Site No. 2484 in Kanyakumari, Tamil Nadu. A 94-hectare freshwater tank complex serving as mainland India's southernmost sanctuary along the Central Asian Flyway.",
-    url: "frontend/suchindram-wetland-explorer/index.html"
-  },
-  // --- Mysore Painting Explorer ---
-  {
-    title: "Mysore Painting Explorer",
-    category: "Featured Explorers",
-    description: "Explore Mysore Paintings — classical South Indian art form celebrated for delicate brushwork, 24-karat pure gold gesso embossing, Sritattvanidhi iconographic tradition, and royal Wodeyar heritage.",
-    url: "frontend/mysore-painting-explorer/index.html"
-  },
-  // --- Jawaharlal Nehru Explorer ---
-  {
-    title: "Jawaharlal Nehru Explorer",
-    category: "Featured Explorers",
-    description: "Chronicle Jawaharlal Nehru's leadership in the Indian freedom movement, Congress presidency, Purna Swaraj declaration, 9 prison incarcerations, historic speeches, and nation-building.",
-    url: "frontend/jawaharlal-nehru-explorer/index.html"
-  },
-  // --- RIAF Revolt of 1946 Explorer ---
-  {
-    title: "RIAF Revolt of 1946 Explorer",
-    category: "Military Resistance",
-    description: "Explore the Royal Indian Air Force revolt of January 1946 - post-war grievances, discrimination, the strike across 20+ air force stations, and its link to the Royal Indian Navy Mutiny.",
-    url: "frontend/riaf-revolt-1946-explorer/index.html"
-  },
-  // --- Siege of Seringapatam Explorer ---
-  {
-    title: "Siege of Seringapatam Explorer",
-    category: "Featured Explorers",
-    description: "Explore the Siege of Seringapatam (1799 CE) - the final clash of the Fourth Anglo-Mysore War and the fall of the Kingdom of Mysore under Tipu Sultan.",
-    url: "frontend/siege-of-seringapatam-explorer/index.html"
-  },
-  // --- August Offer 1940 Explorer ---
-  {
-    title: "August Offer, 1940 Explorer",
-    category: "Constitutional Developments",
-    description: "Explore the August Offer of 8 August 1940 - Britain's wartime promise of Dominion Status, the expanded Executive Council, the minority veto, and how its rejection led to Individual Satyagraha.",
-    url: "frontend/august-offer-1940-explorer/index.html"
-  },
-  {
-    title: "August Offer, 1940 - Main Proposals",
-    category: "Constitutional Developments",
-    description: "The four clauses of the August Offer - Dominion Status as the objective, a future constitution-making body, expansion of the Executive Council, and constitutional commitments to minority interests.",
-    url: "frontend/august-offer-1940-explorer/index.html#proposals"
-  },
-  {
-    title: "August Offer, 1940 - Responses",
-    category: "Constitutional Developments",
-    description: "Congress rejected the August Offer, the Muslim League welcomed it as recognition of the two-nation theory, and Gandhi answered with Individual Satyagraha.",
-    url: "frontend/august-offer-1940-explorer/index.html#responses"
-  },
-  {
-    title: "August Offer, 1940 - Political Timeline",
-    category: "Constitutional Developments",
-    description: "A phase-filterable chronology from the outbreak of World War II and the Lahore Resolution to the August Offer, the Congress rejection, and Individual Satyagraha.",
-    url: "frontend/august-offer-1940-explorer/index.html#timeline"
-  },
-  // --- Non-Cooperation Movement Explorer ---
-  {
-    title: "Non-Cooperation Movement Explorer",
-    category: "Freedom Struggle",
-    description: "Explore the Non-Cooperation Movement (1920–1922) — India's first mass movement under Gandhi, covering boycotts, khadi promotion, regional participation, the Khilafat connection, Chauri Chaura, and long-term impact.",
-    url: "frontend/non-cooperation-movement-explorer/index.html"
-  },
-  // --- Parallel Governments of Quit India Explorer ---
-  {
-    title: "Parallel Governments of Quit India Explorer",
-    category: "Freedom Struggle",
-    description: "Explore the Tamralipta Jatiya Sarkar in Midnapore, the Prati Sarkar in Satara, and other underground administrations that ran courts, police, and relief systems during the Quit India Movement.",
-    url: "frontend/parallel-governments-explorer/index.html"
-  },
-  // --- Rowlatt Satyagraha Explorer ---
-  {
-    title: "Rowlatt Satyagraha Explorer",
-    category: "Freedom Struggle",
-    description: "Explore the Rowlatt Satyagraha of 1919 — Gandhi's first all-India protest against the Rowlatt Acts, covering the political background, nationwide hartals, major city protests, the Punjab unrest, Jallianwala Bagh connection, and historical significance.",
-    url: "frontend/rowlatt-satyagraha-explorer/index.html"
-  },
-  // --- Indian National Army Explorer ---
-  {
-    title: "Indian National Army (INA) Explorer",
-    category: "Freedom Struggle",
-    description: "Explore the INA's journey from Indian POWs in Southeast Asia and Mohan Singh's First INA, through Subhas Chandra Bose's Azad Hind Government and the Rani of Jhansi Regiment, to the Imphal-Kohima campaign and Red Fort Trials.",
-    url: "frontend/indian-national-army-explorer/index.html"
-  },
-  // --- Elvira Rat Explorer ---
-  {
-    title: "Elvira Rat Explorer",
-    category: "Nature & Wildlife",
-    description: "Explore the Elvira Rat (Cremnomys elvira) — one of India's rarest endemic rodents, found only in isolated boulder habitats of southern India, covering its taxonomy, distribution, behaviour, conservation status, threats, and protected areas.",
-    url: "frontend/elvira-rat-explorer/index.html"
-  },
-  // --- Imphal-Kohima Campaign Explorer ---
-  {
-    title: "Imphal–Kohima Campaign Explorer",
-    category: "Military Resistance",
-    description: "Map the INA's 1944 march alongside the Japanese 15th Army toward India's northeastern frontier - the Burma Campaign, the sieges of Imphal and Kohima, the monsoon retreat, and the campaign's historical significance.",
-    url: "frontend/imphal-kohima-campaign-explorer/index.html"
-  },
-  // --- Neelakurinji Explorer ---
-  {
-    title: "Neelakurinji Explorer",
-    category: "Nature & Wildlife",
-    description: "Explore Neelakurinji (Strobilanthes kunthiana) — the famous flowering shrub endemic to the Western Ghats that blooms once every twelve years, covering its taxonomy, 12-year flowering cycle, ecology, conservation status, and cultural significance.",
-    url: "frontend/neelakurinji-explorer/index.html"
-  },
-  // --- INA Red Fort Trials Explorer ---
+    // --- Battle of Ghaghra Explorer ---
+    {
+        title: "Battle of Ghaghra Explorer",
+        category: "Featured Explorers",
+        description: "Explore the Battle of Ghaghra (1529 CE) - Babur's decisive riverine and amphibious campaign against the Eastern Afghan Confederacy and Bengal Sultanate.",
+        url: "frontend/battle-of-ghaghra-explorer/index.html"
+    },
+    // --- Vaduvur Wetland Explorer ---
+    {
+        title: "Vaduvur Wetland Explorer",
+        category: "Featured Explorers",
+        description: "Explore Vaduvur Wetland & Bird Sanctuary — Ramsar Site No. 2480 in Tiruvarur, Tamil Nadu. A 128-hectare human-made irrigation tank hosting over 20,000 wintering migratory waterfowl along the Central Asian Flyway.",
+        url: "frontend/vaduvur-wetland-explorer/index.html"
+    },
+    // --- Suchindram Wetland Explorer ---
+    {
+        title: "Suchindram Wetland Explorer",
+        category: "Featured Explorers",
+        description: "Explore Suchindram Wetland & Bird Sanctuary — Ramsar Site No. 2484 in Kanyakumari, Tamil Nadu. A 94-hectare freshwater tank complex serving as mainland India's southernmost sanctuary along the Central Asian Flyway.",
+        url: "frontend/suchindram-wetland-explorer/index.html"
+    },
+    // --- Mysore Painting Explorer ---
+    {
+        title: "Mysore Painting Explorer",
+        category: "Featured Explorers",
+        description: "Explore Mysore Paintings — classical South Indian art form celebrated for delicate brushwork, 24-karat pure gold gesso embossing, Sritattvanidhi iconographic tradition, and royal Wodeyar heritage.",
+        url: "frontend/mysore-painting-explorer/index.html"
+    },
+    // --- Jawaharlal Nehru Explorer ---
+    {
+        title: "Jawaharlal Nehru Explorer",
+        category: "Featured Explorers",
+        description: "Chronicle Jawaharlal Nehru's leadership in the Indian freedom movement, Congress presidency, Purna Swaraj declaration, 9 prison incarcerations, historic speeches, and nation-building.",
+        url: "frontend/jawaharlal-nehru-explorer/index.html"
+    },
+    // --- RIAF Revolt of 1946 Explorer ---
+    {
+        title: "RIAF Revolt of 1946 Explorer",
+        category: "Military Resistance",
+        description: "Explore the Royal Indian Air Force revolt of January 1946 - post-war grievances, discrimination, the strike across 20+ air force stations, and its link to the Royal Indian Navy Mutiny.",
+        url: "frontend/riaf-revolt-1946-explorer/index.html"
+    },
+    // --- Siege of Seringapatam Explorer ---
+    {
+        title: "Siege of Seringapatam Explorer",
+        category: "Featured Explorers",
+        description: "Explore the Siege of Seringapatam (1799 CE) - the final clash of the Fourth Anglo-Mysore War and the fall of the Kingdom of Mysore under Tipu Sultan.",
+        url: "frontend/siege-of-seringapatam-explorer/index.html"
+    },
+    // --- August Offer 1940 Explorer ---
+    {
+        title: "August Offer, 1940 Explorer",
+        category: "Constitutional Developments",
+        description: "Explore the August Offer of 8 August 1940 - Britain's wartime promise of Dominion Status, the expanded Executive Council, the minority veto, and how its rejection led to Individual Satyagraha.",
+        url: "frontend/august-offer-1940-explorer/index.html"
+    },
+    {
+        title: "August Offer, 1940 - Main Proposals",
+        category: "Constitutional Developments",
+        description: "The four clauses of the August Offer - Dominion Status as the objective, a future constitution-making body, expansion of the Executive Council, and constitutional commitments to minority interests.",
+        url: "frontend/august-offer-1940-explorer/index.html#proposals"
+    },
+    {
+        title: "August Offer, 1940 - Responses",
+        category: "Constitutional Developments",
+        description: "Congress rejected the August Offer, the Muslim League welcomed it as recognition of the two-nation theory, and Gandhi answered with Individual Satyagraha.",
+        url: "frontend/august-offer-1940-explorer/index.html#responses"
+    },
+    {
+        title: "August Offer, 1940 - Political Timeline",
+        category: "Constitutional Developments",
+        description: "A phase-filterable chronology from the outbreak of World War II and the Lahore Resolution to the August Offer, the Congress rejection, and Individual Satyagraha.",
+        url: "frontend/august-offer-1940-explorer/index.html#timeline"
+    },
+    // --- Non-Cooperation Movement Explorer ---
+    {
+        title: "Non-Cooperation Movement Explorer",
+        category: "Freedom Struggle",
+        description: "Explore the Non-Cooperation Movement (1920–1922) — India's first mass movement under Gandhi, covering boycotts, khadi promotion, regional participation, the Khilafat connection, Chauri Chaura, and long-term impact.",
+        url: "frontend/non-cooperation-movement-explorer/index.html"
+    },
+    // --- Parallel Governments of Quit India Explorer ---
+    {
+        title: "Parallel Governments of Quit India Explorer",
+        category: "Freedom Struggle",
+        description: "Explore the Tamralipta Jatiya Sarkar in Midnapore, the Prati Sarkar in Satara, and other underground administrations that ran courts, police, and relief systems during the Quit India Movement.",
+        url: "frontend/parallel-governments-explorer/index.html"
+    },
+    // --- Rowlatt Satyagraha Explorer ---
+    {
+        title: "Rowlatt Satyagraha Explorer",
+        category: "Freedom Struggle",
+        description: "Explore the Rowlatt Satyagraha of 1919 — Gandhi's first all-India protest against the Rowlatt Acts, covering the political background, nationwide hartals, major city protests, the Punjab unrest, Jallianwala Bagh connection, and historical significance.",
+        url: "frontend/rowlatt-satyagraha-explorer/index.html"
+    },
+    // --- Indian National Army Explorer ---
+    {
+        title: "Indian National Army (INA) Explorer",
+        category: "Freedom Struggle",
+        description: "Explore the INA's journey from Indian POWs in Southeast Asia and Mohan Singh's First INA, through Subhas Chandra Bose's Azad Hind Government and the Rani of Jhansi Regiment, to the Imphal-Kohima campaign and Red Fort Trials.",
+        url: "frontend/indian-national-army-explorer/index.html"
+    },
+    // --- Elvira Rat Explorer ---
+    {
+        title: "Elvira Rat Explorer",
+        category: "Nature & Wildlife",
+        description: "Explore the Elvira Rat (Cremnomys elvira) — one of India's rarest endemic rodents, found only in isolated boulder habitats of southern India, covering its taxonomy, distribution, behaviour, conservation status, threats, and protected areas.",
+        url: "frontend/elvira-rat-explorer/index.html"
+    },
+    // --- Imphal-Kohima Campaign Explorer ---
+    {
+        title: "Imphal–Kohima Campaign Explorer",
+        category: "Military Resistance",
+        description: "Map the INA's 1944 march alongside the Japanese 15th Army toward India's northeastern frontier - the Burma Campaign, the sieges of Imphal and Kohima, the monsoon retreat, and the campaign's historical significance.",
+        url: "frontend/imphal-kohima-campaign-explorer/index.html"
+    },
+    // --- Neelakurinji Explorer ---
+    {
+        title: "Neelakurinji Explorer",
+        category: "Nature & Wildlife",
+        description: "Explore Neelakurinji (Strobilanthes kunthiana) — the famous flowering shrub endemic to the Western Ghats that blooms once every twelve years, covering its taxonomy, 12-year flowering cycle, ecology, conservation status, and cultural significance.",
+        url: "frontend/neelakurinji-explorer/index.html"
+    },
+    // --- INA Red Fort Trials Explorer ---
     {
         title: "INA Red Fort Trials Explorer",
         category: "Military Resistance",
@@ -2692,8 +2698,8 @@ window.indiaSearchIndex = [
     },
     {
         title: "Nilgiri Pipit Explorer",
-    category: "Nature & Wildlife",
-    description: "Explore the Nilgiri Pipit (Anthus nilghiriensis) — an endemic bird of the montane grasslands of southern India's Western Ghats, covering taxonomy, distribution, habitat, diet, behaviour, conservation status, and threats.",
-    url: "frontend/nilgiri-pipit-explorer/index.html"
-  },
+        category: "Nature & Wildlife",
+        description: "Explore the Nilgiri Pipit (Anthus nilghiriensis) — an endemic bird of the montane grasslands of southern India's Western Ghats, covering taxonomy, distribution, habitat, diet, behaviour, conservation status, and threats.",
+        url: "frontend/nilgiri-pipit-explorer/index.html"
+    },
 ];

--- a/frontend/simon-commission-protests/index.html
+++ b/frontend/simon-commission-protests/index.html
@@ -1,0 +1,764 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description"
+        content="Explore the 1928 Simon Commission protests: an all-white Commission, the nationwide 'Simon Go Back' boycott, the Lahore lathi charge on Lala Lajpat Rai, and its revolutionary aftermath.">
+    <title>Simon Commission Protests (1928) Explorer | Incredible India</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+        href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,400&display=swap"
+        rel="stylesheet">
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="../js-modules/page-progress/page-progress.css">
+
+    <!-- Open Graph / Social Media Tags -->
+    <meta property="og:title" content="Simon Commission Protests (1928) Explorer | Incredible India Explorer">
+    <meta property="og:description"
+        content="From an all-white Commission to the Lahore lathi charge on Lala Lajpat Rai — explore the nationwide protest movement of 1928 and its revolutionary consequences.">
+    <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/frontend/assets/simon_protest_hartal.svg">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:url"
+        content="https://incredibleindiaexplorer.gov.in/frontend/simon-commission-protests/index.html">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Incredible India Explorer">
+    <meta property="og:locale" content="en_IN">
+
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/simon-commission-protests/index.html">
+</head>
+
+<body>
+    <script>
+        (function () {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+
+    <!-- Sticky Navigation Bar -->
+    <header class="navbar" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+
+                <div class="nav-dropdown">
+                    <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations
+                        ▾</button>
+                    <div class="dropdown-menu">
+                        <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
+                        <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                        <a href="../../frontend/islands/islands.html" class="dropdown-item">Islands of India</a>
+                        <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                        <a href="../../frontend/route-planner/route-planner.html" class="dropdown-item">Route
+                            Planner</a>
+                    </div>
+                </div>
+
+                <div class="nav-dropdown">
+                    <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture
+                        ▾</button>
+                    <div class="dropdown-menu">
+                        <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+                        <a href="../../frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
+                        <a href="../../frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
+                        <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical
+                            Timeline</a>
+                        <a href="../../frontend/making-of-modern-india/index.html" class="dropdown-item">Making of
+                            Modern India</a>
+                        <a href="index.html" class="dropdown-item" style="color: var(--saffron)">Simon Commission
+                            Protests</a>
+                        <a href="../../frontend/national-symbols-gallery/national-symbols-gallery.html"
+                            class="dropdown-item">National Symbols</a>
+                        <a href="../../frontend/cuisine-discovery-hub/index.html" class="dropdown-item">UP Cuisine</a>
+                        <a href="../../frontend/handicrafts-showcase/index.html" class="dropdown-item">UP
+                            Handicrafts</a>
+                        <a href="../../frontend/national-days-calendar/index.html" class="dropdown-item">National
+                            Days</a>
+                        <a href="../../frontend/ganga-ghats-experience/index.html" class="dropdown-item">Ganga Ghats</a>
+                    </div>
+                </div>
+
+                <div class="nav-dropdown">
+                    <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Nature
+                        ▾</button>
+                    <div class="dropdown-menu">
+                        <a href="../../frontend/national-parks-explorer/index.html" class="dropdown-item">National
+                            Parks</a>
+                        <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                        <a href="../../frontend/wildlife-rescue/wildlife-rescue.html" class="dropdown-item">Wildlife
+                            Rescue</a>
+                        <a href="../../frontend/endemic-flora-fauna-explorer/index.html" class="dropdown-item">Endemic
+                            Flora & Fauna</a>
+                        <a href="../../frontend/harike-wetland/harike-wetland.html" class="dropdown-item">Harike
+                            Wetland</a>
+                        <a href="../../frontend/wular-lake/wular-lake.html" class="dropdown-item">Wular Lake</a>
+                        <a href="../../frontend/crowd-density/index.html" class="dropdown-item">Crowd Density
+                            Predictor</a>
+                    </div>
+                </div>
+
+                <div class="nav-dropdown">
+                    <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Games ▾</button>
+                    <div class="dropdown-menu">
+                        <a href="../../frontend/passport-quest/passport-quest.html" class="dropdown-item">Passport
+                            Quest</a>
+                        <a href="../../frontend/culinary-game/culinary-game.html" class="dropdown-item">Culinary
+                            Challenge</a>
+                        <a href="../../frontend/monsoon-game/monsoon-game.html" class="dropdown-item">Monsoon Game</a>
+                        <a href="../../frontend/river-game/river-game.html" class="dropdown-item">River Explorer</a>
+                        <a href="../../frontend/geo-guesser-india/index.html" class="dropdown-item">GeoGuesser</a>
+                    </div>
+                </div>
+
+                <div class="nav-dropdown">
+                    <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Community
+                        ▾</button>
+                    <div class="dropdown-menu">
+                        <a href="../../frontend/contributors/contributors.html" class="dropdown-item">Contributors</a>
+                        <a href="../../frontend/world-records-india/index.html" class="dropdown-item">World Records</a>
+                    </div>
+                </div>
+
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+            </nav>
+        </div>
+    </header>
+
+    <!-- SPA Router Target Container -->
+    <main id="app-root" class="simon-main">
+
+        <!-- Hero Banner -->
+        <section class="simon-hero">
+            <div class="simon-hero-content">
+                <span class="simon-kicker">✊ 1928 · Nationwide Protest Movement</span>
+                <h1>Simon Commission <span>Protests</span></h1>
+                <p>In 1928, an all-British Commission arrived to decide India's constitutional future without a single
+                    Indian member. The response — "Simon, Go Back" — united rival political factions in a nationwide
+                    boycott, and turned deadly on the streets of Lahore.</p>
+                <div class="simon-bookmark-container">
+                    <button class="simon-bookmark-btn journey-bookmark-btn" type="button"
+                        data-bookmark-id="simon-commission-main" aria-pressed="false"
+                        aria-label="Bookmark Simon Commission Protests Explorer">
+                        ♡ Save to Journey
+                    </button>
+                </div>
+            </div>
+        </section>
+
+        <!-- Section: Background -->
+        <section class="simon-section" id="background">
+            <div class="simon-container simon-grid-2col">
+                <div class="simon-text-block">
+                    <span class="simon-eyebrow">Why the Commission Was Formed</span>
+                    <h2>The Statutory Commission of 1927</h2>
+                    <p>The Government of India Act of 1919 required a review, after ten years, of how far Indians were
+                        ready for self-government. In November 1927, the British government appointed a seven-member
+                        Statutory Commission, chaired by Sir John Simon, to conduct that review. It landed in Bombay on
+                        3 February 1928 to begin its tour of the country.</p>
+                    <p>The Commission was tasked with examining the working of the 1919 reforms — including dyarchy in
+                        the provinces — and recommending whether and how India should move toward further constitutional
+                        change.</p>
+                </div>
+                <div class="simon-highlight-box">
+                    <h3>🗂️ At a Glance</h3>
+                    <ul>
+                        <li><strong>Appointed</strong>: November 1927, by the British government.</li>
+                        <li><strong>Chair</strong>: Sir John Simon, a British Member of Parliament.</li>
+                        <li><strong>Members</strong>: Seven British MPs — no Indian member.</li>
+                        <li><strong>Arrival</strong>: Bombay, 3 February 1928.</li>
+                        <li><strong>Mandate</strong>: Review the Government of India Act, 1919 and recommend further
+                            reforms.</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <!-- Section: Why Indians Opposed the Commission -->
+        <section class="simon-section" id="opposition">
+            <div class="simon-container">
+                <div class="simon-section-header">
+                    <span class="simon-eyebrow">"All White, No Indian"</span>
+                    <h2>Why Indians Opposed the Commission</h2>
+                    <p>The Commission's composition, more than its mandate, provoked near-universal condemnation across
+                        India's political spectrum.</p>
+                </div>
+
+                <div class="simon-card-grid">
+                    <div class="simon-card">
+                        <span class="simon-card-icon">🚫</span>
+                        <h3>No Indian Members</h3>
+                        <p>All seven members of the Commission were British; not a single Indian was included in a body
+                            deciding India's constitutional future.</p>
+                    </div>
+                    <div class="simon-card">
+                        <span class="simon-card-icon">🤝</span>
+                        <h3>Rare Political Unity</h3>
+                        <p>The exclusion united the Indian National Congress, the Muslim League, the Hindu Mahasabha,
+                            and other groups in common opposition.</p>
+                    </div>
+                    <div class="simon-card">
+                        <span class="simon-card-icon">📜</span>
+                        <h3>An Insult to Self-Rule</h3>
+                        <p>Many saw the all-white panel as proof that Britain did not consider Indians capable of
+                            judging their own readiness for self-government.</p>
+                    </div>
+                    <div class="simon-card">
+                        <span class="simon-card-icon">📢</span>
+                        <h3>The "Simon, Go Back" Slogan</h3>
+                        <p>The protest cry became a rallying slogan nationwide, chanted at every stop of the
+                            Commission's tour.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Section: Nationwide Boycott -->
+        <section class="simon-section" id="boycott">
+            <div class="simon-container simon-grid-2col">
+                <div class="simon-highlight-box">
+                    <h3>✊ Forms of Protest</h3>
+                    <ul>
+                        <li><strong>Hartals</strong>: Shops, schools and businesses shut down wherever the Commission
+                            travelled.</li>
+                        <li><strong>Black flag demonstrations</strong>: Crowds greeted the Commission with black flags
+                            and black balloons.</li>
+                        <li><strong>Boycotted proceedings</strong>: Most provincial legislatures and political parties
+                            refused to cooperate with or appear before the Commission.</li>
+                        <li><strong>The Nehru Report</strong>: An all-party conference, led by Motilal Nehru, drafted
+                            India's own constitutional blueprint in August 1928 as a direct counter-response.</li>
+                    </ul>
+                </div>
+                <div class="simon-text-block">
+                    <span class="simon-eyebrow">A Boycott Without Precedent</span>
+                    <h2>India Responds With One Voice</h2>
+                    <p>As the Commission moved from city to city between February 1928 and its final visit in 1929, it
+                        was met almost everywhere by hartals, black-flag processions, and chants of "Simon, Go Back."
+                        The scale of the boycott — cutting across Congress, League, and regional parties — was unusual
+                        for a period otherwise marked by political division.</p>
+                    <p>In parallel, Indian leaders moved to answer the Commission's implicit challenge — that Indians
+                        could not agree on a constitution of their own — by convening an all-party conference that
+                        produced the Nehru Report, proposing dominion status and a detailed constitutional framework
+                        drafted entirely by Indians.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Section: Interactive Protest Map -->
+        <section class="simon-section" id="protest-map">
+            <div class="simon-container">
+                <div class="simon-section-header">
+                    <span class="simon-eyebrow">Nationwide Reach</span>
+                    <h2>Major Protest Centres</h2>
+                    <p>Click a marker to read how each city responded to the Commission's visit.</p>
+                </div>
+
+                <div class="simon-map-layout">
+                    <div class="simon-map-box">
+                        <svg viewBox="0 0 800 450" class="simon-map-svg"
+                            aria-label="Map of major Simon Commission protest centres, 1928">
+                            <rect width="800" height="450" fill="rgba(15, 18, 15, 0.7)" rx="16"
+                                stroke="var(--simon-border)" />
+
+                            <g class="simon-map-node active" data-city="city-lahore" transform="translate(280,120)">
+                                <circle r="12" class="node-pulse" />
+                                <circle r="6" class="node-core" />
+                                <text y="-16" text-anchor="middle" class="node-label">Lahore</text>
+                            </g>
+                            <g class="simon-map-node" data-city="city-delhi" transform="translate(340,175)">
+                                <circle r="12" class="node-pulse" />
+                                <circle r="6" class="node-core" />
+                                <text y="-16" text-anchor="middle" class="node-label">Delhi</text>
+                            </g>
+                            <g class="simon-map-node" data-city="city-lucknow" transform="translate(440,190)">
+                                <circle r="12" class="node-pulse" />
+                                <circle r="6" class="node-core" />
+                                <text y="-16" text-anchor="middle" class="node-label">Lucknow</text>
+                            </g>
+                            <g class="simon-map-node" data-city="city-allahabad" transform="translate(455,225)">
+                                <circle r="12" class="node-pulse" />
+                                <circle r="6" class="node-core" />
+                                <text y="16" text-anchor="middle" class="node-label" dy="1em">Allahabad</text>
+                            </g>
+                            <g class="simon-map-node" data-city="city-calcutta" transform="translate(650,230)">
+                                <circle r="12" class="node-pulse" />
+                                <circle r="6" class="node-core" />
+                                <text y="-16" text-anchor="middle" class="node-label">Calcutta</text>
+                            </g>
+                            <g class="simon-map-node" data-city="city-bombay" transform="translate(210,320)">
+                                <circle r="12" class="node-pulse" />
+                                <circle r="6" class="node-core" />
+                                <text y="-16" text-anchor="middle" class="node-label">Bombay</text>
+                            </g>
+                            <g class="simon-map-node" data-city="city-poona" transform="translate(250,360)">
+                                <circle r="12" class="node-pulse" />
+                                <circle r="6" class="node-core" />
+                                <text y="16" text-anchor="middle" class="node-label" dy="1em">Poona</text>
+                            </g>
+                            <g class="simon-map-node" data-city="city-madras" transform="translate(430,410)">
+                                <circle r="12" class="node-pulse" />
+                                <circle r="6" class="node-core" />
+                                <text y="-16" text-anchor="middle" class="node-label">Madras</text>
+                            </g>
+                        </svg>
+                    </div>
+
+                    <div class="simon-city-detail" id="city-detail-display">
+                        <h3>Lahore</h3>
+                        <span class="simon-city-date">30 October 1928</span>
+                        <p>The Commission's Lahore visit drew the movement's largest and most consequential procession,
+                            led by Lala Lajpat Rai. Police met the marchers with a lathi charge that left Lajpat Rai
+                            severely injured; he died seventeen days later.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Section: Lala Lajpat Rai -->
+        <section class="simon-section" id="lajpat-rai">
+            <div class="simon-container simon-grid-2col">
+                <div class="simon-text-block">
+                    <span class="simon-eyebrow">"Punjab Kesari" — The Lion of Punjab</span>
+                    <h2>Lala Lajpat Rai and the Commission Protests</h2>
+                    <p>Lala Lajpat Rai was already one of India's most senior nationalist leaders — a founder of the
+                        Lal-Bal-Pal triumvirate alongside Bal Gangadhar Tilak and Bipin Chandra Pal, and a former
+                        Congress president — when he led the Lahore protest against the Simon Commission on 30 October
+                        1928.</p>
+                    <p>He personally led the march to the railway station, and was singled out and struck by police
+                        lathis during the ensuing charge. Though he initially seemed to recover, his health declined
+                        rapidly, and he died on 17 November 1928. His death is widely regarded as a direct consequence
+                        of the injuries he sustained that day, and it transformed him into a martyr of the independence
+                        movement.</p>
+                </div>
+                <div class="simon-highlight-box"
+                    style="background: rgba(161, 39, 45, 0.06); border-color: rgba(161, 39, 45, 0.25);">
+                    <h3>🦁 Lala Lajpat Rai</h3>
+                    <ul>
+                        <li><strong>Born</strong>: 28 January 1865, Punjab.</li>
+                        <li><strong>Known as</strong>: "Punjab Kesari" (Lion of Punjab).</li>
+                        <li><strong>Political legacy</strong>: Part of the Lal-Bal-Pal trio of assertive nationalist
+                            leaders; former Indian National Congress president.</li>
+                        <li><strong>Lahore protest</strong>: Led the 30 October 1928 march against the Commission.</li>
+                        <li><strong>Death</strong>: 17 November 1928, from injuries sustained in the police charge.</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+        <!-- Section: Lahore Protest & Police Action -->
+        <section class="simon-section" id="lahore-protest">
+            <div class="simon-container">
+                <div class="simon-section-header">
+                    <span class="simon-eyebrow">30 October 1928</span>
+                    <h2>The Lahore Protest and the Police Charge</h2>
+                    <p>The single most consequential confrontation of the entire boycott movement.</p>
+                </div>
+
+                <div class="simon-card-grid">
+                    <div class="simon-card">
+                        <span class="simon-card-icon">🚶</span>
+                        <h3>The Procession</h3>
+                        <p>A large, disciplined march set out toward Lahore railway station to greet the Commission's
+                            arrival with black flags and slogans, led by Lala Lajpat Rai.</p>
+                    </div>
+                    <div class="simon-card">
+                        <span class="simon-card-icon">🛑</span>
+                        <h3>The Police Cordon</h3>
+                        <p>Police, under Superintendent James A. Scott, moved to block the procession's path near the
+                            station, escalating a peaceful demonstration into confrontation.</p>
+                    </div>
+                    <div class="simon-card">
+                        <span class="simon-card-icon">💥</span>
+                        <h3>The Lathi Charge</h3>
+                        <p>Police baton-charged the marchers. Lala Lajpat Rai was struck directly and severely injured,
+                            along with several other leaders and demonstrators.</p>
+                    </div>
+                    <div class="simon-card">
+                        <span class="simon-card-icon">⚖️</span>
+                        <h3>Official Silence</h3>
+                        <p>No disciplinary action was taken against the officers responsible, deepening public outrage
+                            in the weeks that followed.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Section: Political Reactions -->
+        <section class="simon-section" id="political-reactions">
+            <div class="simon-container simon-grid-2col">
+                <div class="simon-highlight-box">
+                    <h3>🏛️ How Leaders Responded</h3>
+                    <ul>
+                        <li><strong>Indian National Congress</strong>: Condemned the police action and used the outrage
+                            to press for full independence rather than dominion status.</li>
+                        <li><strong>All-Party Conference</strong>: Convened under Motilal Nehru, producing the Nehru
+                            Report (August 1928) as India's own constitutional counter-proposal.</li>
+                        <li><strong>Muslim League</strong>: Divided over the Nehru Report's stance on separate
+                            electorates, a split that widened over the following years.</li>
+                        <li><strong>Congress, Calcutta 1928</strong>: Gave the British government a one-year ultimatum
+                            to grant dominion status, setting the stage for the 1929 Lahore session.</li>
+                    </ul>
+                </div>
+                <div class="simon-text-block">
+                    <span class="simon-eyebrow">From Outrage to Ultimatum</span>
+                    <h2>Political Reactions Across India</h2>
+                    <p>News of the Lahore lathi charge and Lajpat Rai's death travelled fast, hardening political
+                        opinion across the country. Younger Congress leaders, including Jawaharlal Nehru, argued that
+                        dominion status was no longer enough, and pushed the party toward a more assertive demand for
+                        complete independence.</p>
+                    <p>The Congress's December 1928 Calcutta session responded with an ultimatum: grant dominion status
+                        within a year, or face a countrywide civil disobedience movement. When the deadline passed
+                        unmet, the party's 1929 Lahore session adopted the Purna Swaraj (complete independence)
+                        resolution, with 26 January 1930 observed as the first Independence Day pledge.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Section: Revolutionary Consequences -->
+        <section class="simon-section" id="revolutionary-consequences">
+            <div class="simon-container">
+                <div class="simon-section-header">
+                    <span class="simon-eyebrow">Beyond Constitutional Politics</span>
+                    <h2>Revolutionary Consequences</h2>
+                    <p>For a younger generation of nationalists, Lajpat Rai's death was not just a political grievance —
+                        it was a call to direct action.</p>
+                </div>
+
+                <div class="simon-card-grid">
+                    <div class="simon-card">
+                        <span class="simon-card-icon">🔥</span>
+                        <h3>The HSRA Responds</h3>
+                        <p>Bhagat Singh, Rajguru, Chandrashekhar Azad and the Hindustan Socialist Republican Association
+                            resolved to avenge Lajpat Rai's death.</p>
+                    </div>
+                    <div class="simon-card">
+                        <span class="simon-card-icon">🎯</span>
+                        <h3>The Saunders Shooting</h3>
+                        <p>On 17 December 1928, HSRA members shot dead Assistant Superintendent J. P. Saunders in
+                            Lahore, believing him responsible for the fatal charge.</p>
+                    </div>
+                    <div class="simon-card">
+                        <span class="simon-card-icon">💣</span>
+                        <h3>The Assembly Bombing</h3>
+                        <p>On 8 April 1929, Bhagat Singh and Batukeshwar Dutt threw a non-lethal bomb inside the Central
+                            Legislative Assembly to protest repressive laws, then courted arrest.</p>
+                    </div>
+                    <div class="simon-card">
+                        <span class="simon-card-icon">⚰️</span>
+                        <h3>Trial and Execution</h3>
+                        <p>Bhagat Singh, Rajguru and Sukhdev were tried for Saunders's killing and executed on 23 March
+                            1931, becoming enduring symbols of revolutionary sacrifice.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Section: Protest Participation Visualization -->
+        <section class="simon-section" id="participation">
+            <div class="simon-container">
+                <div class="simon-section-header">
+                    <span class="simon-eyebrow">Relative Scale</span>
+                    <h2>Protest Intensity by City</h2>
+                    <p>An illustrative comparison of how strongly each major centre mobilised against the Commission,
+                        based on contemporary accounts.</p>
+                </div>
+
+                <div class="simon-bar-chart" id="participation-chart">
+                    <div class="simon-bar-row">
+                        <span class="simon-bar-label">Lahore</span>
+                        <div class="simon-bar-track">
+                            <div class="simon-bar-fill" data-value="100"></div>
+                        </div>
+                        <span class="simon-bar-value">Highest</span>
+                    </div>
+                    <div class="simon-bar-row">
+                        <span class="simon-bar-label">Calcutta</span>
+                        <div class="simon-bar-track">
+                            <div class="simon-bar-fill" data-value="85"></div>
+                        </div>
+                        <span class="simon-bar-value">Very High</span>
+                    </div>
+                    <div class="simon-bar-row">
+                        <span class="simon-bar-label">Bombay</span>
+                        <div class="simon-bar-track">
+                            <div class="simon-bar-fill" data-value="80"></div>
+                        </div>
+                        <span class="simon-bar-value">Very High</span>
+                    </div>
+                    <div class="simon-bar-row">
+                        <span class="simon-bar-label">Lucknow</span>
+                        <div class="simon-bar-track">
+                            <div class="simon-bar-fill" data-value="70"></div>
+                        </div>
+                        <span class="simon-bar-value">High</span>
+                    </div>
+                    <div class="simon-bar-row">
+                        <span class="simon-bar-label">Madras</span>
+                        <div class="simon-bar-track">
+                            <div class="simon-bar-fill" data-value="60"></div>
+                        </div>
+                        <span class="simon-bar-value">High</span>
+                    </div>
+                    <div class="simon-bar-row">
+                        <span class="simon-bar-label">Delhi</span>
+                        <div class="simon-bar-track">
+                            <div class="simon-bar-fill" data-value="55"></div>
+                        </div>
+                        <span class="simon-bar-value">Moderate</span>
+                    </div>
+                </div>
+                <p class="simon-bar-note">Illustrative visualization for educational purposes, based on the relative
+                    scale of hartals and demonstrations described in historical accounts.</p>
+            </div>
+        </section>
+
+        <!-- Section: Impact on the Independence Movement -->
+        <section class="simon-section" id="impact">
+            <div class="simon-container simon-grid-2col">
+                <div class="simon-highlight-box">
+                    <h3>🇮🇳 Lasting Impact</h3>
+                    <ul>
+                        <li>Fused constitutional politics and revolutionary action against a shared grievance.</li>
+                        <li>Produced the Nehru Report, India's first Indian-drafted constitutional blueprint.</li>
+                        <li>Hardened Congress's demand from dominion status to full independence (Purna Swaraj).</li>
+                        <li>Turned Lala Lajpat Rai and, later, Bhagat Singh into enduring symbols of sacrifice.</li>
+                    </ul>
+                </div>
+                <div class="simon-text-block">
+                    <span class="simon-eyebrow">A Turning Point</span>
+                    <h2>Impact on the Independence Movement</h2>
+                    <p>The Simon Commission protests did more than register opposition to one Commission — they
+                        demonstrated that Indians across parties could unite around a shared cause, and that colonial
+                        repression would be met with an increasingly assertive response, both political and
+                        revolutionary.</p>
+                    <p>The chain of events set in motion in 1928 — the Nehru Report, the Calcutta ultimatum, the Lahore
+                        Purna Swaraj resolution, and the trials and executions of the young revolutionaries who avenged
+                        Lajpat Rai — fed directly into the Civil Disobedience Movement and the Dandi March of 1930,
+                        marking 1928 as a pivotal year on the road to independence.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Section: Timeline -->
+        <section class="simon-section" id="timeline">
+            <div class="simon-container">
+                <div class="simon-section-header">
+                    <span class="simon-eyebrow">Chronology</span>
+                    <h2>Simon Commission Protests Timeline</h2>
+                    <p>From the Commission's appointment to the executions that followed the Lahore protest.</p>
+                </div>
+
+                <div class="simon-timeline">
+                    <div class="simon-timeline-step">
+                        <div class="simon-timeline-marker"></div>
+                        <div class="simon-timeline-card">
+                            <span class="simon-timeline-year">Nov 1927</span>
+                            <h3>Commission Appointed</h3>
+                            <p>The British government appoints a seven-member, all-British Statutory Commission chaired
+                                by Sir John Simon.</p>
+                        </div>
+                    </div>
+                    <div class="simon-timeline-step">
+                        <div class="simon-timeline-marker"></div>
+                        <div class="simon-timeline-card">
+                            <span class="simon-timeline-year">3 Feb 1928</span>
+                            <h3>Commission Lands in Bombay</h3>
+                            <p>The Commission arrives in India to hartals, black flags and cries of "Simon, Go Back" —
+                                the boycott begins immediately.</p>
+                        </div>
+                    </div>
+                    <div class="simon-timeline-step">
+                        <div class="simon-timeline-marker"></div>
+                        <div class="simon-timeline-card">
+                            <span class="simon-timeline-year">Aug 1928</span>
+                            <h3>The Nehru Report</h3>
+                            <p>An all-party conference led by Motilal Nehru produces India's own constitutional
+                                blueprint, proposing dominion status.</p>
+                        </div>
+                    </div>
+                    <div class="simon-timeline-step">
+                        <div class="simon-timeline-marker"></div>
+                        <div class="simon-timeline-card">
+                            <span class="simon-timeline-year">30 Oct 1928</span>
+                            <h3>Lahore Lathi Charge</h3>
+                            <p>Police baton-charge the procession led by Lala Lajpat Rai, injuring him severely along
+                                with other demonstrators.</p>
+                        </div>
+                    </div>
+                    <div class="simon-timeline-step">
+                        <div class="simon-timeline-marker"></div>
+                        <div class="simon-timeline-card">
+                            <span class="simon-timeline-year">17 Nov 1928</span>
+                            <h3>Death of Lala Lajpat Rai</h3>
+                            <p>Lajpat Rai dies from his injuries, becoming a martyr of the independence movement.</p>
+                        </div>
+                    </div>
+                    <div class="simon-timeline-step">
+                        <div class="simon-timeline-marker"></div>
+                        <div class="simon-timeline-card">
+                            <span class="simon-timeline-year">17 Dec 1928</span>
+                            <h3>Saunders Shot in Lahore</h3>
+                            <p>HSRA revolutionaries, including Bhagat Singh and Rajguru, kill Assistant Superintendent
+                                J. P. Saunders in retaliation.</p>
+                        </div>
+                    </div>
+                    <div class="simon-timeline-step">
+                        <div class="simon-timeline-marker"></div>
+                        <div class="simon-timeline-card">
+                            <span class="simon-timeline-year">8 Apr 1929</span>
+                            <h3>Central Assembly Bombing</h3>
+                            <p>Bhagat Singh and Batukeshwar Dutt bomb the Legislative Assembly to protest repressive
+                                laws and court arrest.</p>
+                        </div>
+                    </div>
+                    <div class="simon-timeline-step">
+                        <div class="simon-timeline-marker"></div>
+                        <div class="simon-timeline-card">
+                            <span class="simon-timeline-year">Dec 1929</span>
+                            <h3>Purna Swaraj Resolution</h3>
+                            <p>The Congress's Lahore session declares complete independence as the movement's goal,
+                                observed from 26 January 1930.</p>
+                        </div>
+                    </div>
+                    <div class="simon-timeline-step">
+                        <div class="simon-timeline-marker"></div>
+                        <div class="simon-timeline-card">
+                            <span class="simon-timeline-year">23 Mar 1931</span>
+                            <h3>Execution of Bhagat Singh, Rajguru & Sukhdev</h3>
+                            <p>The three revolutionaries are executed for Saunders's killing, cementing their place as
+                                icons of the freedom struggle.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Section: Gallery -->
+        <section class="simon-section" id="gallery">
+            <div class="simon-container">
+                <div class="simon-section-header">
+                    <span class="simon-eyebrow">Visual Tour</span>
+                    <h2>Scenes from the 1928 Protest Movement</h2>
+                    <p>Illustrated impressions of the hartals, the Lahore confrontation, and the revolutionary response
+                        that followed.</p>
+                </div>
+
+                <div class="simon-gallery-grid">
+                    <div class="simon-gallery-item" data-title="A Nationwide Hartal"
+                        data-desc="An illustrated impression of a 1928 hartal, with shuttered shops and black-flag processions chanting 'Simon, Go Back' as the Commission passed through.">
+                        <img src="../assets/simon_protest_hartal.svg"
+                            alt="Illustrated scene of a 1928 hartal protest with black flags and closed shops"
+                            loading="lazy">
+                        <div class="simon-gallery-overlay">
+                            <h4>Nationwide Hartal</h4>
+                            <p>"Simon, Go Back"</p>
+                        </div>
+                    </div>
+                    <div class="simon-gallery-item" data-title="Lala Lajpat Rai"
+                        data-desc="A commemorative illustration honouring Lala Lajpat Rai, 'Punjab Kesari', who led the Lahore protest and died from injuries sustained in the police charge.">
+                        <img src="../assets/simon_lajpat_rai.svg"
+                            alt="Commemorative illustration honouring Lala Lajpat Rai" loading="lazy">
+                        <div class="simon-gallery-overlay">
+                            <h4>Lala Lajpat Rai</h4>
+                            <p>The Lion of Punjab</p>
+                        </div>
+                    </div>
+                    <div class="simon-gallery-item" data-title="The Lahore Lathi Charge"
+                        data-desc="A stylised impression of the 30 October 1928 confrontation outside Lahore railway station, where police baton-charged the protest procession.">
+                        <img src="../assets/simon_lahore_lathicharge.svg"
+                            alt="Illustrated scene of the Lahore protest confrontation with police" loading="lazy">
+                        <div class="simon-gallery-overlay">
+                            <h4>Lahore, 30 Oct 1928</h4>
+                            <p>The Fatal Charge</p>
+                        </div>
+                    </div>
+                    <div class="simon-gallery-item" data-title="The Revolutionary Aftermath"
+                        data-desc="A symbolic illustration representing the younger generation of revolutionaries, including Bhagat Singh and Rajguru, who responded to Lajpat Rai's death.">
+                        <img src="../assets/simon_revolutionary_aftermath.svg"
+                            alt="Symbolic illustration representing the revolutionary aftermath of the Lahore protest"
+                            loading="lazy">
+                        <div class="simon-gallery-overlay">
+                            <h4>The Aftermath</h4>
+                            <p>A New Generation Responds</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Section: References -->
+        <section class="simon-section" id="references">
+            <div class="simon-container">
+                <div class="simon-references">
+                    <h3>📚 References &amp; Further Reading</h3>
+                    <ul>
+                        <li><strong>Wikipedia</strong>. <em>Simon Commission — Composition, Boycott and Aftermath</em>.
+                        </li>
+                        <li><strong>Wikipedia</strong>. <em>Lala Lajpat Rai — Biography and the Lahore Protest of
+                                1928</em>.</li>
+                        <li><strong>Wikipedia</strong>. <em>Nehru Report (1928)</em>.</li>
+                        <li><strong>Wikipedia</strong>. <em>Hindustan Socialist Republican Association</em>.</li>
+                        <li><strong>National Archives of India</strong>. <em>Records on the Indian Statutory Commission,
+                                1927–1930</em>.</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+
+    </main>
+
+    <!-- Interactive Detail Modal -->
+    <div class="museum-modal" id="simon-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title"
+        aria-hidden="true">
+        <div class="museum-modal-card">
+            <button class="museum-modal-close" id="simon-modal-close" type="button"
+                aria-label="Close details">✕</button>
+            <span class="modal-category" id="modal-category">Gallery Highlight</span>
+            <h2 id="modal-title"></h2>
+            <p class="modal-location" style="color: var(--simon-gold-light);" id="modal-heading"></p>
+            <div style="border-top: 1px solid rgba(255,255,255,0.1); margin-top: 15px; padding-top: 15px;">
+                <p class="modal-description" id="modal-description"></p>
+            </div>
+        </div>
+    </div>
+
+    <!-- Footer -->
+    <footer class="simon-footer">
+        <div class="simon-container">
+            <p>Part of <a href="../../index.html">Incredible India Explorer</a> · Explore the political movements of
+                India's freedom struggle.</p>
+        </div>
+    </footer>
+
+    <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+
+    <!-- JS Dependencies -->
+    <script src="../js-modules/config.js"></script>
+    <script src="../pages-common.js"></script>
+    <script src="../app.js" defer></script>
+    <script src="../../frontend/journey/journey.js" defer></script>
+    <script src="script.js" defer></script>
+    <script type="module" src="../firebase-config.js"></script>
+    <script type="module" src="../auth.js"></script>
+    <script src="../router.js" defer></script>
+    <script src="../js-modules/page-progress/page-progress.js"></script>
+</body>
+
+</html>

--- a/frontend/simon-commission-protests/script.js
+++ b/frontend/simon-commission-protests/script.js
@@ -1,0 +1,248 @@
+document.addEventListener("app:route-changed", () => {
+    const bookmarkButtons = [...document.querySelectorAll(".journey-bookmark-btn")];
+    const galleryItems = [...document.querySelectorAll(".simon-gallery-item")];
+
+    const modal = document.getElementById("simon-modal");
+    const modalClose = document.getElementById("simon-modal-close");
+    const modalTitle = document.getElementById("modal-title");
+    const modalHeading = document.getElementById("modal-heading");
+    const modalDescription = document.getElementById("modal-description");
+
+    // --- City-by-City Protest Map Data ---------------------------------
+    const cityData = {
+        "city-lahore": {
+            name: "Lahore",
+            date: "30 October 1928",
+            text: "The Commission's Lahore visit drew the movement's largest and most consequential procession, led by Lala Lajpat Rai. Police met the marchers with a lathi charge that left Lajpat Rai severely injured; he died seventeen days later."
+        },
+        "city-delhi": {
+            name: "Delhi",
+            date: "February 1928",
+            text: "Black-flag demonstrations and hartals greeted the Commission, with processions chanting 'Simon, Go Back' through the capital's streets."
+        },
+        "city-lucknow": {
+            name: "Lucknow",
+            date: "30 November 1928",
+            text: "A large protest procession was met with a police lathi charge; both Jawaharlal Nehru and Govind Ballabh Pant were injured while marching against the Commission."
+        },
+        "city-allahabad": {
+            name: "Allahabad",
+            date: "1928",
+            text: "As the base of the Nehru family and a Congress stronghold, Allahabad saw sustained hartals and organisational planning for the boycott, including work on the Nehru Report."
+        },
+        "city-calcutta": {
+            name: "Calcutta",
+            date: "February 1928",
+            text: "One of the largest hartals of the boycott shut down the city, with massive black-flag processions and student participation."
+        },
+        "city-bombay": {
+            name: "Bombay",
+            date: "3 February 1928",
+            text: "The Commission's port of arrival saw an immediate, city-wide hartal and black-flag demonstrations the day it landed in India."
+        },
+        "city-poona": {
+            name: "Poona",
+            date: "1928",
+            text: "Poona's protests drew on the city's long tradition of nationalist organising, with hartals and public meetings condemning the Commission's composition."
+        },
+        "city-madras": {
+            name: "Madras",
+            date: "1928–1929",
+            text: "Demonstrations and hartals accompanied the Commission's visits to the Madras Presidency, with local leaders boycotting official proceedings."
+        }
+    };
+
+    const mapNodes = [...document.querySelectorAll(".simon-map-node")];
+    const cityDetail = document.getElementById("city-detail-display");
+
+    function showCity(cityId) {
+        const data = cityData[cityId];
+        if (!data || !cityDetail) return;
+
+        cityDetail.innerHTML = `
+      <h3>${data.name}</h3>
+      <span class="simon-city-date">${data.date}</span>
+      <p>${data.text}</p>
+    `;
+
+        mapNodes.forEach((node) => {
+            node.classList.toggle("active", node.dataset.city === cityId);
+        });
+    }
+
+    mapNodes.forEach((node) => {
+        node.setAttribute("tabindex", "0");
+        node.setAttribute("role", "button");
+        node.addEventListener("click", () => showCity(node.dataset.city));
+        node.addEventListener("keydown", (e) => {
+            if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                showCity(node.dataset.city);
+            }
+        });
+    });
+
+    // --- Participation Bar Chart Animation ------------------------------
+    const barChart = document.getElementById("participation-chart");
+    if (barChart) {
+        const bars = [...barChart.querySelectorAll(".simon-bar-fill")];
+        const animateBars = () => {
+            bars.forEach((bar) => {
+                const value = bar.dataset.value || "0";
+                bar.style.width = `${value}%`;
+            });
+        };
+
+        if ("IntersectionObserver" in window) {
+            const observer = new IntersectionObserver((entries) => {
+                entries.forEach((entry) => {
+                    if (entry.isIntersecting) {
+                        animateBars();
+                        observer.disconnect();
+                    }
+                });
+            }, { threshold: 0.3 });
+            observer.observe(barChart);
+        } else {
+            animateBars();
+        }
+    }
+
+    // --- Journey Integration (Bookmarks & Global Search) -------------
+    function initJourney() {
+        if (!window.Journey) return;
+
+        bookmarkButtons.forEach((btn) => {
+            const id = btn.dataset.bookmarkId;
+            const title = "Simon Commission Protests (1928) Explorer";
+            const thumbnail = "frontend/assets/simon_protest_hartal.svg";
+            const category = "history";
+
+            const updateBookmarkUI = () => {
+                const isSaved = window.Journey.isSaved(id);
+                btn.classList.toggle("is-saved", isSaved);
+                btn.setAttribute("aria-pressed", String(isSaved));
+                btn.innerHTML = isSaved ? "♥ Saved to Journey" : "♡ Save to Journey";
+            };
+
+            updateBookmarkUI();
+
+            btn.addEventListener("click", (e) => {
+                e.stopPropagation();
+                window.Journey.toggle({
+                    id,
+                    explorerPage: "frontend/simon-commission-protests/index.html",
+                    title,
+                    thumbnail,
+                    category
+                });
+                updateBookmarkUI();
+            });
+        });
+
+        window.Journey.registerSearchItems("frontend/simon-commission-protests/index.html", [
+            {
+                id: "simon-commission-main",
+                title: "Simon Commission Protests (1928) Explorer",
+                description: "An all-white Commission, a nationwide 'Simon Go Back' boycott, and the Lahore lathi charge that killed Lala Lajpat Rai and radicalised a generation.",
+                link: "frontend/simon-commission-protests/index.html"
+            },
+            {
+                id: "simon-commission-map",
+                title: "Simon Commission Protest Centres",
+                description: "City-by-city protests against the Simon Commission across Lahore, Delhi, Lucknow, Calcutta, Bombay, Poona and Madras.",
+                link: "frontend/simon-commission-protests/index.html#protest-map"
+            },
+            {
+                id: "simon-commission-lajpat-rai",
+                title: "Lala Lajpat Rai and the Lahore Protest",
+                description: "How 'Punjab Kesari' Lala Lajpat Rai led the 1928 Lahore march and died from injuries sustained in the police lathi charge.",
+                link: "frontend/simon-commission-protests/index.html#lajpat-rai"
+            },
+            {
+                id: "simon-commission-revolutionary",
+                title: "Revolutionary Consequences of the Simon Commission Protests",
+                description: "How Bhagat Singh, Rajguru and the HSRA responded to Lajpat Rai's death, from the Saunders shooting to the Central Assembly bombing.",
+                link: "frontend/simon-commission-protests/index.html#revolutionary-consequences"
+            },
+            {
+                id: "simon-commission-timeline",
+                title: "Simon Commission Protests Timeline",
+                description: "A chronology from the Commission's 1927 appointment to the 1931 execution of Bhagat Singh, Rajguru and Sukhdev.",
+                link: "frontend/simon-commission-protests/index.html#timeline"
+            }
+        ]);
+    }
+
+    // --- Gallery Modal Logic -----------------------------------------
+    let lastFocusedElement = null;
+    let simonModalFocusTrap = null;
+
+    function openModal(item) {
+        lastFocusedElement = item;
+
+        modalTitle.textContent = item.dataset.title;
+        modalHeading.textContent = item.querySelector("p")?.textContent || "Gallery Highlight";
+        modalDescription.textContent = item.dataset.desc;
+
+        modal.classList.add("open");
+        modal.setAttribute("aria-hidden", "false");
+        document.body.classList.add("modal-open");
+
+        if (typeof window.setupFocusTrap === "function") {
+            simonModalFocusTrap = window.setupFocusTrap(modal);
+        }
+
+        if (modalClose) modalClose.focus();
+    }
+
+    function closeModal() {
+        modal.classList.remove("open");
+        modal.setAttribute("aria-hidden", "true");
+        document.body.classList.remove("modal-open");
+
+        if (simonModalFocusTrap) {
+            simonModalFocusTrap.deactivate();
+            simonModalFocusTrap = null;
+        }
+
+        if (lastFocusedElement) {
+            lastFocusedElement.focus();
+        }
+    }
+
+    galleryItems.forEach((item) => {
+        item.setAttribute("tabindex", "0");
+        item.setAttribute("role", "button");
+        item.setAttribute("aria-haspopup", "dialog");
+        item.setAttribute("aria-controls", "simon-modal");
+        item.addEventListener("click", () => openModal(item));
+        item.addEventListener("keydown", (e) => {
+            if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                openModal(item);
+            }
+        });
+    });
+
+    if (modalClose) {
+        modalClose.addEventListener("click", closeModal);
+    }
+
+    if (modal) {
+        modal.addEventListener("click", (e) => {
+            if (e.target === modal) {
+                closeModal();
+            }
+        });
+    }
+
+    document.addEventListener("keydown", (e) => {
+        if (e.key === "Escape" && modal && modal.classList.contains("open")) {
+            closeModal();
+        }
+    });
+
+    // Run initialization
+    initJourney();
+});

--- a/frontend/simon-commission-protests/style.css
+++ b/frontend/simon-commission-protests/style.css
@@ -1,0 +1,731 @@
+/* ==========================================================================
+   Simon Commission Protests (1928) Explorer - Stylesheet
+   Pure Vanilla CSS matching the application's premium aesthetic.
+   ========================================================================== */
+
+:root {
+    --simon-stone: #10120f;
+    --simon-stone-light: #1c1f19;
+    --simon-gold: #d9a441;
+    --simon-gold-light: #f0cc7a;
+    --simon-red: #a1272d;
+    --simon-red-light: #d64550;
+    --simon-glass: rgba(28, 31, 25, 0.6);
+    --simon-border: rgba(217, 164, 65, 0.2);
+}
+
+.simon-main {
+    background-color: var(--simon-stone);
+    color: #f1f5f9;
+    font-family: Outfit, sans-serif;
+    overflow-x: hidden;
+}
+
+/* Hero */
+.simon-hero {
+    min-height: 60vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+    overflow: hidden;
+    padding: 120px 0 60px;
+    background: linear-gradient(180deg, rgba(16, 18, 15, 0.4), rgba(16, 18, 15, 0.96)),
+        url('../assets/simon_protest_hartal.svg') center/cover no-repeat;
+    text-align: center;
+}
+
+.simon-hero::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 50% 50%, rgba(217, 164, 65, 0.12), transparent 60%);
+    z-index: 1;
+}
+
+.simon-hero-content {
+    position: relative;
+    z-index: 2;
+    width: min(880px, 90%);
+}
+
+.simon-kicker {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 20px;
+    padding: 6px 16px;
+    background: rgba(217, 164, 65, 0.1);
+    border: 1px solid rgba(217, 164, 65, 0.3);
+    border-radius: 100px;
+    color: var(--simon-gold-light);
+    font-weight: 700;
+    font-size: 0.85rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    backdrop-filter: blur(8px);
+}
+
+.simon-hero h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: clamp(2.5rem, 6vw, 4.5rem);
+    line-height: 1.1;
+    margin: 0 0 20px;
+    font-weight: 700;
+    color: #ffffff;
+}
+
+.simon-hero h1 span {
+    color: var(--simon-gold-light);
+    background: linear-gradient(135deg, var(--simon-gold-light), var(--simon-gold));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.simon-hero p {
+    font-size: clamp(1rem, 2vw, 1.2rem);
+    line-height: 1.6;
+    color: #cbd5e1;
+    margin: 0 auto;
+    max-width: 720px;
+}
+
+/* Sections */
+.simon-section {
+    padding: 80px 0;
+}
+
+.simon-section:nth-of-type(even) {
+    background-color: rgba(255, 255, 255, 0.01);
+}
+
+.simon-container {
+    width: min(1200px, 90%);
+    margin: 0 auto;
+}
+
+.simon-section-header {
+    margin-bottom: 50px;
+    text-align: center;
+}
+
+.simon-eyebrow {
+    color: var(--simon-gold-light);
+    font-size: 0.85rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    display: block;
+    margin-bottom: 8px;
+}
+
+.simon-section-header h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: clamp(2rem, 4vw, 2.8rem);
+    margin: 0 0 16px;
+    color: #ffffff;
+}
+
+.simon-section-header p {
+    color: #94a3b8;
+    max-width: 650px;
+    margin: 0 auto;
+    line-height: 1.6;
+    font-size: 1.05rem;
+}
+
+/* Two column grid */
+.simon-grid-2col {
+    display: grid;
+    grid-template-columns: 1.1fr 0.9fr;
+    gap: 50px;
+    align-items: center;
+}
+
+@media (max-width: 900px) {
+    .simon-grid-2col {
+        grid-template-columns: 1fr;
+        gap: 30px;
+    }
+}
+
+.simon-text-block p {
+    line-height: 1.75;
+    color: #cbd5e1;
+    margin-bottom: 20px;
+    font-size: 1.05rem;
+}
+
+.simon-text-block p:last-child {
+    margin-bottom: 0;
+}
+
+.simon-highlight-box {
+    background: var(--simon-glass);
+    border: 1px solid var(--simon-border);
+    border-radius: 16px;
+    padding: 30px;
+    backdrop-filter: blur(12px);
+}
+
+.simon-highlight-box h3 {
+    font-family: 'Playfair Display', serif;
+    font-size: 1.4rem;
+    margin: 0 0 16px;
+    color: var(--simon-gold-light);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.simon-highlight-box ul {
+    padding-left: 20px;
+    margin: 0;
+}
+
+.simon-highlight-box li {
+    color: #cbd5e1;
+    margin-bottom: 12px;
+    line-height: 1.6;
+}
+
+.simon-highlight-box li:last-child {
+    margin-bottom: 0;
+}
+
+/* Card grid (reasons, consequences, etc.) */
+.simon-card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 24px;
+}
+
+.simon-card {
+    background: var(--simon-glass);
+    border: 1px solid var(--simon-border);
+    border-radius: 16px;
+    padding: 30px;
+    transition: transform 0.3s, border-color 0.3s, box-shadow 0.3s;
+    backdrop-filter: blur(10px);
+}
+
+.simon-card:hover {
+    transform: translateY(-5px);
+    border-color: var(--simon-gold-light);
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
+}
+
+.simon-card-icon {
+    font-size: 2.2rem;
+    margin-bottom: 20px;
+    display: block;
+}
+
+.simon-card h3 {
+    margin: 0 0 12px;
+    font-family: 'Playfair Display', serif;
+    font-size: 1.3rem;
+    color: #ffffff;
+}
+
+.simon-card p {
+    margin: 0;
+    line-height: 1.6;
+    color: #cbd5e1;
+    font-size: 0.95rem;
+}
+
+/* Interactive Protest Map */
+.simon-map-layout {
+    display: grid;
+    grid-template-columns: 1.3fr 1fr;
+    gap: 30px;
+    align-items: start;
+}
+
+@media (max-width: 900px) {
+    .simon-map-layout {
+        grid-template-columns: 1fr;
+    }
+}
+
+.simon-map-box {
+    background: var(--simon-glass);
+    border: 1px solid var(--simon-border);
+    border-radius: 16px;
+    padding: 20px;
+}
+
+.simon-map-svg {
+    width: 100%;
+    height: auto;
+}
+
+.simon-map-node {
+    cursor: pointer;
+}
+
+.simon-map-node .node-pulse {
+    fill: rgba(217, 164, 65, 0.18);
+    transition: r 0.3s, fill 0.3s;
+}
+
+.simon-map-node .node-core {
+    fill: var(--simon-gold);
+    transition: fill 0.3s, r 0.3s;
+}
+
+.simon-map-node .node-label {
+    fill: #cbd5e1;
+    font-size: 13px;
+    font-family: Outfit, sans-serif;
+    pointer-events: none;
+}
+
+.simon-map-node:hover .node-core,
+.simon-map-node.active .node-core {
+    fill: var(--simon-red-light);
+}
+
+.simon-map-node.active .node-pulse {
+    r: 16;
+    fill: rgba(214, 69, 80, 0.25);
+}
+
+.simon-map-node.active .node-label {
+    fill: #ffffff;
+    font-weight: 700;
+}
+
+.simon-city-detail {
+    background: var(--simon-glass);
+    border: 1px solid var(--simon-border);
+    border-radius: 16px;
+    padding: 30px;
+    min-height: 260px;
+}
+
+.simon-city-detail h3 {
+    font-family: 'Playfair Display', serif;
+    font-size: 1.5rem;
+    margin: 0 0 6px;
+    color: #ffffff;
+}
+
+.simon-city-detail .simon-city-date {
+    display: inline-block;
+    margin-bottom: 16px;
+    color: var(--simon-gold-light);
+    font-weight: 700;
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.simon-city-detail p {
+    color: #cbd5e1;
+    line-height: 1.7;
+    margin: 0;
+}
+
+/* Participation Visualization (bar chart) */
+.simon-bar-chart {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+    max-width: 760px;
+    margin: 0 auto;
+}
+
+.simon-bar-row {
+    display: grid;
+    grid-template-columns: 140px 1fr 60px;
+    align-items: center;
+    gap: 14px;
+}
+
+.simon-bar-label {
+    font-weight: 600;
+    color: #f1f5f9;
+    font-size: 0.95rem;
+}
+
+.simon-bar-track {
+    background: rgba(255, 255, 255, 0.06);
+    border-radius: 100px;
+    overflow: hidden;
+    height: 16px;
+}
+
+.simon-bar-fill {
+    height: 100%;
+    border-radius: 100px;
+    background: linear-gradient(90deg, var(--simon-gold-dark, #96631f), var(--simon-gold-light));
+    width: 0;
+    transition: width 1.1s ease;
+}
+
+.simon-bar-value {
+    text-align: right;
+    color: var(--simon-gold-light);
+    font-weight: 700;
+    font-size: 0.9rem;
+}
+
+.simon-bar-note {
+    text-align: center;
+    color: #94a3b8;
+    font-size: 0.85rem;
+    margin-top: 20px;
+}
+
+/* Timeline */
+.simon-timeline {
+    position: relative;
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 20px 0;
+}
+
+.simon-timeline::before {
+    content: '';
+    position: absolute;
+    left: 50%;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: linear-gradient(180deg, transparent, var(--simon-border) 10%, var(--simon-border) 90%, transparent);
+    transform: translateX(-50%);
+}
+
+.simon-timeline-step {
+    display: flex;
+    justify-content: flex-end;
+    padding-right: 50%;
+    position: relative;
+    margin-bottom: 40px;
+}
+
+.simon-timeline-step:nth-child(even) {
+    justify-content: flex-start;
+    padding-right: 0;
+    padding-left: 50%;
+}
+
+.simon-timeline-marker {
+    position: absolute;
+    left: 50%;
+    top: 15px;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    background: var(--simon-stone);
+    border: 3px solid var(--simon-gold-light);
+    transform: translateX(-50%);
+    z-index: 2;
+    transition: background 0.3s;
+}
+
+.simon-timeline-step:hover .simon-timeline-marker {
+    background: var(--simon-gold);
+    box-shadow: 0 0 10px var(--simon-gold);
+}
+
+.simon-timeline-card {
+    background: var(--simon-glass);
+    border: 1px solid var(--simon-border);
+    border-radius: 12px;
+    padding: 24px;
+    width: 85%;
+    margin-right: 40px;
+    position: relative;
+    transition: transform 0.3s, border-color 0.3s;
+}
+
+.simon-timeline-step:nth-child(even) .simon-timeline-card {
+    margin-right: 0;
+    margin-left: 40px;
+}
+
+.simon-timeline-card:hover {
+    transform: translateY(-2px);
+    border-color: var(--simon-gold-light);
+}
+
+.simon-timeline-year {
+    color: var(--simon-gold);
+    font-weight: 800;
+    font-size: 1.25rem;
+    margin-bottom: 8px;
+    display: block;
+}
+
+.simon-timeline-card h3 {
+    margin: 0 0 8px;
+    font-size: 1.15rem;
+}
+
+.simon-timeline-card p {
+    margin: 0;
+    color: #94a3b8;
+    line-height: 1.6;
+    font-size: 0.95rem;
+}
+
+@media (max-width: 768px) {
+    .simon-timeline::before {
+        left: 20px;
+    }
+
+    .simon-timeline-step {
+        justify-content: flex-start;
+        padding-left: 45px;
+        padding-right: 0;
+    }
+
+    .simon-timeline-step:nth-child(even) {
+        padding-left: 45px;
+    }
+
+    .simon-timeline-marker {
+        left: 20px;
+    }
+
+    .simon-timeline-card {
+        width: 100%;
+        margin-right: 0;
+    }
+
+    .simon-timeline-step:nth-child(even) .simon-timeline-card {
+        margin-left: 0;
+    }
+}
+
+/* Gallery */
+.simon-gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 20px;
+}
+
+.simon-gallery-item {
+    position: relative;
+    border-radius: 12px;
+    overflow: hidden;
+    aspect-ratio: 4 / 3;
+    border: 1px solid var(--simon-border);
+    cursor: pointer;
+}
+
+.simon-gallery-item img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.5s ease;
+}
+
+.simon-gallery-item:hover img {
+    transform: scale(1.08);
+}
+
+.simon-gallery-overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(0deg, rgba(10, 10, 8, 0.95) 0%, rgba(10, 10, 8, 0.4) 60%, transparent 100%);
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    padding: 20px;
+    opacity: 0.9;
+    transition: opacity 0.3s;
+}
+
+.simon-gallery-overlay h4 {
+    margin: 0 0 4px;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #ffffff;
+}
+
+.simon-gallery-overlay p {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--simon-gold-light);
+}
+
+/* References */
+.simon-references {
+    background: var(--simon-glass);
+    border: 1px solid var(--simon-border);
+    border-radius: 16px;
+    padding: 40px;
+}
+
+.simon-references h3 {
+    font-family: 'Playfair Display', serif;
+    font-size: 1.4rem;
+    margin: 0 0 20px;
+    color: #ffffff;
+}
+
+.simon-references ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.simon-references li {
+    position: relative;
+    padding-left: 24px;
+    margin-bottom: 16px;
+    line-height: 1.6;
+    color: #cbd5e1;
+    font-size: 0.98rem;
+}
+
+.simon-references li:last-child {
+    margin-bottom: 0;
+}
+
+.simon-references li::before {
+    content: '📖';
+    position: absolute;
+    left: 0;
+    top: 2px;
+    font-size: 0.9rem;
+}
+
+/* Footer */
+.simon-footer {
+    padding: 40px 0;
+    text-align: center;
+    color: #94a3b8;
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.simon-footer a {
+    color: var(--simon-gold-light);
+    text-decoration: none;
+    font-weight: 600;
+    transition: color 0.2s;
+}
+
+.simon-footer a:hover {
+    color: var(--simon-gold);
+}
+
+/* Bookmark */
+.simon-bookmark-container {
+    display: flex;
+    justify-content: center;
+    margin-top: 30px;
+}
+
+.simon-bookmark-btn {
+    background: var(--simon-glass);
+    border: 1px solid var(--simon-border);
+    color: var(--simon-gold-light);
+    padding: 10px 24px;
+    border-radius: 30px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 600;
+    font-size: 0.95rem;
+    transition: all 0.2s ease;
+}
+
+.simon-bookmark-btn:hover {
+    border-color: var(--simon-gold-light);
+    background: rgba(217, 164, 65, 0.1);
+    transform: translateY(-1px);
+}
+
+.simon-bookmark-btn.is-saved {
+    background: var(--simon-gold-light);
+    color: var(--simon-stone);
+    border-color: var(--simon-gold-light);
+}
+
+/* Interactive Detail Modal (gallery) */
+.museum-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 1600;
+    display: none;
+    place-items: center;
+    padding: 20px;
+    background: rgba(0, 0, 0, 0.78);
+    backdrop-filter: blur(10px);
+}
+
+.museum-modal.open {
+    display: grid;
+}
+
+.museum-modal-card {
+    position: relative;
+    width: min(680px, 96vw);
+    max-height: 90vh;
+    overflow: auto;
+    padding: 30px;
+    border: 1px solid var(--simon-border);
+    border-radius: 22px;
+    background: var(--simon-stone-light);
+    color: #f1f5f9;
+    box-shadow: 0 28px 80px rgba(0, 0, 0, 0.45);
+}
+
+.museum-modal-close {
+    position: absolute;
+    top: 14px;
+    right: 14px;
+    width: 38px;
+    height: 38px;
+    border: 1px solid var(--simon-border);
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.05);
+    color: #cbd5e1;
+    font-size: 1.45rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+}
+
+.museum-modal-close:hover {
+    background: rgba(255, 255, 255, 0.15);
+}
+
+.modal-category {
+    display: inline-block;
+    margin-bottom: 10px;
+    color: var(--simon-gold-light);
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: .05em;
+}
+
+.museum-modal-card h2 {
+    margin: 0 42px 7px 0;
+    font-family: "Playfair Display", serif;
+    font-size: clamp(1.9rem, 4vw, 2.7rem);
+}
+
+.modal-location {
+    margin: 0 0 20px;
+    color: #cbd5e1;
+    font-weight: 600;
+}
+
+.modal-description {
+    margin: 0;
+    color: #cbd5e1;
+    line-height: 1.75;
+}
+
+body.modal-open {
+    overflow: hidden;
+}


### PR DESCRIPTION
## Description

Adds an interactive Simon Commission Protests explorer documenting the 1928 nationwide opposition to the Simon Commission and its significance in India's freedom movement.

The explorer includes:

* Background and reasons for opposition to the Simon Commission
* Major protest centres across India
* Lahore protest and police action
* Lala Lajpat Rai and the political response
* Revolutionary consequences
* Interactive protest timeline and location-based content
* Historical context and references
* Supporting visual assets

Fixes #1978

## Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Accessibility improvement
* [ ] Performance improvement

## How Has This Been Tested?

* [x] Tested locally in browser
* [x] Tested in both dark and light themes
* [x] Tested at mobile viewport widths
* [x] Verified no console errors

## Checklist

* [x] My code follows the coding standards of this project
* [x] I have performed a self-review of my own code
* [x] My changes generate no new warnings or errors
* [x] I have tested responsive layout (if UI change)
* [x] I have considered accessibility (aria labels, keyboard nav, focus)

## Screenshots
<img width="1876" height="810" alt="Screenshot 2026-08-12 104925" src="https://github.com/user-attachments/assets/ace967ba-9e39-4910-bc18-ee9b51ffc5ea" />
<img width="1882" height="898" alt="Screenshot 2026-08-12 104941" src="https://github.com/user-attachments/assets/c6db0990-1a81-41f4-9d86-d3853bebb809" />
<img width="1893" height="887" alt="Screenshot 2026-08-12 104954" src="https://github.com/user-attachments/assets/89a89b3c-585e-412f-9803-331adba6dab0" />
<img width="1862" height="846" alt="Screenshot 2026-08-12 105009" src="https://github.com/user-attachments/assets/5d6e57e3-3d6a-4857-b869-73131c4a7ae7" />
<img width="1900" height="889" alt="Screenshot 2026-08-12 105030" src="https://github.com/user-attachments/assets/32a41fe6-db12-4933-b390-8d0c8ddcd0a5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive educational explorer about the Simon Commission Protests of 1928.
  * Includes historical sections, timeline, references, protest map, participation details, and image gallery.
  * Added bookmarking, search integration, responsive layouts, and accessible gallery interactions.
  * Added keyboard-friendly map navigation and mobile-responsive presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->