### PR TITLE
feat: Journey Through Sarnath: From Ancient Settlement to Buddhist Centre #2068

### DIFF
--- a/frontend/sarnath-explorer/index.html
+++ b/frontend/sarnath-explorer/index.html
@@ -1,0 +1,295 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore Sarnath: The sacred Buddhist centre near Varanasi where Gautama Buddha delivered his first sermon (Dharmachakrapravartana), featuring Ashokan pillars, Dhamek Stupa, and Gupta-period art.">
+  <title>Sarnath Explorer | Incredible India</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="../js-modules/page-progress/page-progress.css">
+
+  <!-- Open Graph / Social Media Tags -->
+  <meta property="og:title" content="Sarnath Explorer | Incredible India Explorer">
+  <meta property="og:description" content="Discover Sarnath — sacred Buddhist heritage site near Varanasi, showcasing Dhamek Stupa, Ashokan lion capital, monastic ruins, and ancient relics.">
+  <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/frontend/assets/dhollywood_cinema_hall.svg">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/sarnath-explorer/index.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Incredible India Explorer">
+  <meta property="og:locale" content="en_IN">
+
+  <!-- Canonical URL -->
+  <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/sarnath-explorer/index.html">
+</head>
+<body>
+  <script>
+    (function() {
+      const theme = localStorage.getItem('theme') || 'dark';
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+
+  <!-- Sticky Navigation Bar -->
+  <header class="navbar" id="navbar">
+    <div class="nav-container">
+        <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+            <span class="saffron">Incredible</span>
+            <span class="gold">India</span>
+            <span class="green">Explorer</span>
+        </a>
+        <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+            <span class="bar"></span>
+            <span class="bar"></span>
+            <span class="bar"></span>
+        </button>
+        <nav class="nav-menu" id="nav-menu">
+            <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
+                    <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                    <a href="../../frontend/islands/islands.html" class="dropdown-item">Islands of India</a>
+                    <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    <a href="../../frontend/route-planner/route-planner.html" class="dropdown-item">Route Planner</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+                    <a href="../../frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
+                    <a href="../../frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
+                    <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
+                    <a href="../../frontend/indian-cinema-timeline/index.html" class="dropdown-item">Indian Cinema Timeline</a>
+                    <a href="../rakhigarhi-explorer/index.html" class="dropdown-item">Rakhigarhi Explorer</a>
+                    <a href="../kalibangan-explorer/index.html" class="dropdown-item">Kalibangan Explorer</a>
+                    <a href="../surkotada-explorer/index.html" class="dropdown-item">Surkotada Explorer</a>
+                    <a href="../ropar-explorer/index.html" class="dropdown-item">Ropar Explorer</a>
+                    <a href="../desalpur-explorer/index.html" class="dropdown-item">Desalpur Explorer</a>
+                    <a href="../pataliputra-explorer/index.html" class="dropdown-item">Pataliputra Explorer</a>
+                    <a href="index.html" class="dropdown-item" style="color: var(--saffron)">Sarnath Explorer</a>
+                    <a href="../hoysala-dynasty-explorer/index.html" class="dropdown-item">Hoysala Dynasty</a>
+                    <a href="../kachwaha-dynasty-explorer/index.html" class="dropdown-item">Kachwaha Dynasty</a>
+                    <a href="../../frontend/national-symbols-gallery/national-symbols-gallery.html" class="dropdown-item">National Symbols</a>
+                    <a href="../../frontend/cuisine-discovery-hub/index.html" class="dropdown-item">UP Cuisine</a>
+                    <a href="../../frontend/handicrafts-showcase/index.html" class="dropdown-item">UP Handicrafts</a>
+                    <a href="../../frontend/national-days-calendar/index.html" class="dropdown-item">National Days</a>
+                    <a href="../../frontend/ganga-ghats-experience/index.html" class="dropdown-item">Ganga Ghats</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Nature ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/national-parks-explorer/index.html" class="dropdown-item">National Parks</a>
+                    <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                    <a href="../../frontend/wildlife-rescue/wildlife-rescue.html" class="dropdown-item">Wildlife Rescue</a>
+                    <a href="../../frontend/endemic-flora-fauna-explorer/index.html" class="dropdown-item">Endemic Flora & Fauna</a>
+                    <a href="../../frontend/harike-wetland/harike-wetland.html" class="dropdown-item">Harike Wetland</a>
+                    <a href="../../frontend/wular-lake/wular-lake.html" class="dropdown-item">Wular Lake</a>
+                    <a href="../../frontend/crowd-density/index.html" class="dropdown-item">Crowd Density Predictor</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Games ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/passport-quest/passport-quest.html" class="dropdown-item">Passport Quest</a>
+                    <a href="../../frontend/culinary-game/culinary-game.html" class="dropdown-item">Culinary Challenge</a>
+                    <a href="../../frontend/monsoon-game/monsoon-game.html" class="dropdown-item">Monsoon Game</a>
+                    <a href="../../frontend/river-game/river-game.html" class="dropdown-item">River Explorer</a>
+                    <a href="../../frontend/geo-guesser-india/index.html" class="dropdown-item">GeoGuesser</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Community ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/contributors/contributors.html" class="dropdown-item">Contributors</a>
+                    <a href="../../frontend/world-records-india/index.html" class="dropdown-item">World Records</a>
+                </div>
+            </div>
+
+            <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+        </nav>
+    </div>
+</header>
+
+  <!-- SPA Router Target Container -->
+  <main id="app-root" class="sarnath-main">
+
+    <!-- Hero Banner with Bold Theme-Adaptive Gradient -->
+    <section class="sarnath-hero">
+      <div class="sarnath-hero-content">
+        <span class="sarnath-kicker">☸️ Varanasi, Uttar Pradesh, India · Sacred Buddhist Heritage</span>
+        <h1>Sarnath <span>Explorer</span></h1>
+        <p>Journey through Sarnath, the sacred deer park where Gautama Buddha delivered his first sermon—setting in motion the Wheel of Dharma (Dharmachakrapravartana). Explore majestic Ashokan monuments, the imposing Dhamek Stupa, ancient monasteries, and classical Gupta sculpture.</p>
+        <div class="sarnath-bookmark-container">
+          <button class="sarnath-bookmark-btn journey-bookmark-btn" type="button" data-bookmark-id="sarnath-site-main" aria-pressed="false" aria-label="Bookmark Sarnath Explorer">
+            ♡ Save to Journey
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Geographic Setting & Connection with Varanasi -->
+    <section class="sarnath-section" id="overview">
+      <div class="sarnath-container sarnath-grid-2col">
+        <div class="sarnath-text-block">
+          <span class="sarnath-eyebrow">Gateway of the First Sermon</span>
+          <h2>The Sacred Deer Park Near Ancient Varanasi</h2>
+          <p>Located just 10 kilometers northeast of Varanasi in Uttar Pradesh, Sarnath (historically known as Mrigadava or the deer park) occupies a position of supreme sanctity in Buddhism. It was here, following his enlightenment in Bodh Gaya, that Gautama Buddha met his five former ascetic companions and preached the Four Noble Truths.</p>
+          <p>Connected closely to the spiritual vibrancy of Varanasi, Sarnath evolved over centuries from a tranquil forest retreat into a sprawling monastic university and architectural masterpiece.</p>
+        </div>
+        <div class="sarnath-highlight-box">
+          <h3>☸️ Heritage at a Glance</h3>
+          <ul>
+            <li><strong>Location</strong>: 10 km from Varanasi, Uttar Pradesh, India.</li>
+            <li><strong>Sacred Event</strong>: Dharmachakrapravartana (Turning the Wheel of Dharma).</li>
+            <li><strong>Key Monuments</strong>: Dhamek Stupa, Chaukhandi Stupa, Ashokan Pillar.</li>
+            <li><strong>Artistic Peak</strong>: Renowned for exquisite Gupta-period Buddha sculptures.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Monuments & Architectural Marvels -->
+    <section class="sarnath-section" id="monuments">
+      <div class="sarnath-container">
+        <div class="sarnath-section-header">
+          <span class="sarnath-eyebrow">Architectural Wonders</span>
+          <h2>Monuments &amp; Monastic Complexes</h2>
+          <p>Explore the enduring structures that mark centuries of devotion, royal patronage, and monastic scholarship.</p>
+        </div>
+
+        <div class="sarnath-card-grid">
+          <div class="sarnath-card">
+            <span class="sarnath-card-icon">🏛️</span>
+            <h3>Dhamek Stupa</h3>
+            <p>An imposing cylindrical stupa standing 43.6 meters high, built of brick and stone, marking the spot of the Buddha's first sermon.</p>
+          </div>
+          <div class="sarnath-card">
+            <span class="sarnath-card-icon">🦁</span>
+            <h3>Ashokan Pillar &amp; Lion Capital</h3>
+            <p>Erected by Emperor Ashoka, featuring the famous Four-Lion Capital that now serves as the National Emblem of India.</p>
+          </div>
+          <div class="sarnath-card">
+            <span class="sarnath-card-icon">⛩️</span>
+            <h3>Chaukhandi Stupa</h3>
+            <p>A towering tiered brick structure topped by an octagonal tower, commemorating the spot where Buddha met his first disciples.</p>
+          </div>
+          <div class="sarnath-card">
+            <span class="sarnath-card-icon">🏘️</span>
+            <h3>Ancient Monasteries (Mulagandha Kuti Vihara)</h3>
+            <p>Extensive brick ruins of monastic quarters where monks resided, studied, and meditated through successive eras.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Timeline -->
+    <section class="sarnath-section" id="timeline">
+      <div class="sarnath-container">
+        <div class="sarnath-section-header">
+          <span class="sarnath-eyebrow">Chronology</span>
+          <h2>Buddhist Timeline &amp; Historical Evolution</h2>
+          <p>Tracing Sarnath's journey from the Buddha's lifetime through Mauryan expansion, Gupta renaissance, and rediscovery.</p>
+        </div>
+
+        <div class="sarnath-timeline">
+          <div class="sarnath-timeline-step">
+            <div class="sarnath-timeline-marker"></div>
+            <div class="sarnath-timeline-card">
+              <span class="sarnath-timeline-year">c. 6th Century BCE</span>
+              <h3>The First Sermon</h3>
+              <p>Gautama Buddha preaches the Dharmachakrapravartana Sutra to five ascetics in the Mrigadava deer park.</p>
+            </div>
+          </div>
+          <div class="sarnath-timeline-step">
+            <div class="sarnath-timeline-marker"></div>
+            <div class="sarnath-timeline-card">
+              <span class="sarnath-timeline-year">c. 3rd Century BCE</span>
+              <h3>Ashokan Golden Age</h3>
+              <p>Emperor Ashoka visits Sarnath, erecting stupas, the monolithic lion capital pillar, and expanding monastic sites.</p>
+            </div>
+          </div>
+          <div class="sarnath-timeline-step">
+            <div class="sarnath-timeline-marker"></div>
+            <div class="sarnath-timeline-card">
+              <span class="sarnath-timeline-year">c. 4th – 6th Century CE</span>
+              <h3>Gupta Dynasty Renaissance</h3>
+              <p>Sarnath flourishes as a premier center of Buddhist art, producing masterpieces like the seated Buddha teaching in Sarnath Museum.</p>
+            </div>
+          </div>
+          <div class="sarnath-timeline-step">
+            <div class="sarnath-timeline-marker"></div>
+            <div class="sarnath-timeline-card">
+              <span class="sarnath-timeline-year">19th Century Onwards</span>
+              <h3>Rediscovery &amp; Archaeological Excavation</h3>
+              <p>British archaeologists systematically excavate the site, unearthing stupas, sculptures, and restoring Sarnath to global prominence.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: References & Sources -->
+    <section class="sarnath-section" id="references">
+      <div class="sarnath-container">
+        <div class="sarnath-references">
+          <h3>📚 Archaeological Evidence, Sources &amp; Further Reading</h3>
+          <ul>
+            <li><strong>Archaeological Survey of India (ASI)</strong>: Sarnath Site Museum Catalogues and Excavation Memoirs.</li>
+            <li><strong>Historical Accounts</strong>: Travelogues of Chinese pilgrims Faxian (Fa-Hien) and Xuanzang (Hiuen Tsiang).</li>
+            <li><strong>Cunningham, Alexander</strong>: <em>Archaeological Survey of India Reports on Sarnath</em>.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- Interactive Detail Modal -->
+  <div class="museum-modal" id="sarnath-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-hidden="true">
+    <div class="museum-modal-card">
+      <button class="museum-modal-close" id="sarnath-modal-close" type="button" aria-label="Close details">✕</button>
+      <span class="modal-category" id="modal-category">Heritage Highlight</span>
+      <h2 id="modal-title"></h2>
+      <p class="modal-location" style="color: var(--saffron);" id="modal-heading"></p>
+      <div style="border-top: 1px solid rgba(255,255,255,0.1); margin-top: 15px; padding-top: 15px;">
+        <p class="modal-description" id="modal-description"></p>
+      </div>
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <footer class="sarnath-footer">
+    <div class="sarnath-container">
+      <p>Part of <a href="../../index.html">Incredible India Explorer</a> · Explore the ancient sacred heritage and spiritual capitals of India.</p>
+    </div>
+  </footer>
+
+  <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+
+  <!-- JS Dependencies -->
+  <script src="../js-modules/config.js"></script>
+  <script src="../pages-common.js"></script>
+  <script src="../app.js" defer></script>
+  <script src="../../frontend/journey/journey.js" defer></script>
+  <script src="script.js" defer></script>
+  <script type="module" src="../firebase-config.js"></script>
+  <script type="module" src="../auth.js"></script>
+  <script src="../router.js" defer></script>
+  <script src="../js-modules/page-progress/page-progress.js"></script>
+</body>
+</html>

--- a/frontend/sarnath-explorer/script.js
+++ b/frontend/sarnath-explorer/script.js
@@ -1,0 +1,24 @@
+/**
+ * Sarnath Explorer Interactivity Script
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+  // Scroll to Top Button
+  const scrollTopBtn = document.getElementById('btn-scroll-top');
+  if (scrollTopBtn) {
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 400) {
+        scrollTopBtn.style.display = 'flex';
+      } else {
+        scrollTopBtn.style.display = 'none';
+      }
+    });
+
+    scrollTopBtn.addEventListener('click', () => {
+      window.scrollTo({
+        top: 0,
+        behavior: 'smooth'
+      });
+    });
+  }
+});

--- a/frontend/sarnath-explorer/style.css
+++ b/frontend/sarnath-explorer/style.css
@@ -1,0 +1,424 @@
+/* ==========================================================================
+   Sarnath Explorer Stylesheet (Bold Theme-Adaptive Gradients)
+   ========================================================================== */
+
+:root {
+  --sarnath-primary: #c41e3a;
+  --sarnath-primary-hover: #a01830;
+  --sarnath-gold: #d4af37;
+  --sarnath-gold-light: #f3e5ab;
+  --sarnath-bg-dark: #0f1115;
+  --sarnath-card-dark: #1a1e24;
+  --sarnath-border-dark: rgba(212, 175, 55, 0.25);
+  --sarnath-text-light: #f8f9fa;
+  --sarnath-text-muted: #adb5bd;
+  /* Bold Theme-adaptive Hero Gradient (Dark Mode) */
+  --sarnath-hero-gradient: linear-gradient(135deg, #151821 0%, #2a1c18 50%, #101217 100%);
+}
+
+body.light-theme {
+  --sarnath-bg-dark: #f4f6f9;
+  --sarnath-card-dark: #ffffff;
+  --sarnath-border-dark: rgba(196, 30, 58, 0.2);
+  --sarnath-text-light: #212529;
+  --sarnath-text-muted: #6c757d;
+  /* Bold Theme-adaptive Hero Gradient (Light Mode) */
+  --sarnath-hero-gradient: linear-gradient(135deg, #e8edf5 0%, #fae6de 50%, #dfe7ef 100%);
+}
+
+.sarnath-main {
+  background-color: var(--sarnath-bg-dark);
+  color: var(--sarnath-text-light);
+  font-family: 'Outfit', sans-serif;
+  overflow-x: hidden;
+}
+
+.sarnath-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 20px;
+}
+
+/* Hero Section with Bold Gradient */
+.sarnath-hero {
+  position: relative;
+  padding: 150px 20px 110px;
+  text-align: center;
+  background: var(--sarnath-hero-gradient);
+  color: var(--sarnath-text-light);
+  border-bottom: 2px solid var(--sarnath-border-dark);
+}
+
+.sarnath-hero-content {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.sarnath-kicker {
+  display: inline-block;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: var(--sarnath-gold);
+  margin-bottom: 15px;
+  padding: 6px 16px;
+  background: rgba(212, 175, 55, 0.15);
+  border-radius: 50px;
+  border: 1px solid var(--sarnath-border-dark);
+}
+
+.sarnath-hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2.5rem, 5vw, 4.2rem);
+  font-weight: 700;
+  margin-bottom: 20px;
+  line-height: 1.2;
+}
+
+.sarnath-hero h1 span {
+  color: var(--sarnath-gold);
+}
+
+.sarnath-hero p {
+  font-size: clamp(1rem, 2vw, 1.2rem);
+  color: var(--sarnath-text-muted);
+  line-height: 1.6;
+  margin-bottom: 30px;
+}
+
+.sarnath-bookmark-container {
+  display: flex;
+  justify-content: center;
+}
+
+.sarnath-bookmark-btn {
+  background: transparent;
+  color: var(--sarnath-gold);
+  border: 2px solid var(--sarnath-gold);
+  padding: 10px 24px;
+  font-size: 1rem;
+  font-weight: 600;
+  border-radius: 30px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.sarnath-bookmark-btn:hover,
+.sarnath-bookmark-btn[aria-pressed="true"] {
+  background: var(--sarnath-gold);
+  color: #000;
+}
+
+/* Sections General */
+.sarnath-section {
+  padding: 80px 0;
+  border-bottom: 1px solid var(--sarnath-border-dark);
+}
+
+.sarnath-grid-2col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 50px;
+  align-items: center;
+}
+
+@media (max-width: 768px) {
+  .sarnath-grid-2col {
+    grid-template-columns: 1fr;
+    gap: 30px;
+  }
+}
+
+.sarnath-eyebrow {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: var(--sarnath-primary);
+  margin-bottom: 10px;
+}
+
+.sarnath-text-block h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2rem, 3.5vw, 2.8rem);
+  margin-bottom: 20px;
+  line-height: 1.3;
+}
+
+.sarnath-text-block p {
+  font-size: 1.05rem;
+  color: var(--sarnath-text-muted);
+  line-height: 1.7;
+  margin-bottom: 15px;
+}
+
+.sarnath-highlight-box {
+  background: var(--sarnath-card-dark);
+  border: 1px solid var(--sarnath-border-dark);
+  padding: 35px;
+  border-radius: 16px;
+  box-shadow: 0 10px 30px rgba(0,0,0,0.15);
+}
+
+.sarnath-highlight-box h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.5rem;
+  margin-bottom: 20px;
+  color: var(--sarnath-gold);
+}
+
+.sarnath-highlight-box ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sarnath-highlight-box li {
+  margin-bottom: 15px;
+  font-size: 1rem;
+  color: var(--sarnath-text-muted);
+  line-height: 1.5;
+}
+
+.sarnath-highlight-box li strong {
+  color: var(--sarnath-text-light);
+}
+
+/* Section Header */
+.sarnath-section-header {
+  text-align: center;
+  max-width: 700px;
+  margin: 0 auto 50px;
+}
+
+.sarnath-section-header h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2rem, 3.5vw, 2.8rem);
+  margin-bottom: 15px;
+}
+
+.sarnath-section-header p {
+  font-size: 1.05rem;
+  color: var(--sarnath-text-muted);
+  line-height: 1.6;
+}
+
+/* Card Grid */
+.sarnath-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 30px;
+}
+
+.sarnath-card {
+  background: var(--sarnath-card-dark);
+  border: 1px solid var(--sarnath-border-dark);
+  border-radius: 16px;
+  padding: 30px;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.sarnath-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 12px 35px rgba(196, 30, 58, 0.2);
+}
+
+.sarnath-card-icon {
+  font-size: 2.5rem;
+  display: block;
+  margin-bottom: 15px;
+}
+
+.sarnath-card h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.35rem;
+  margin-bottom: 12px;
+  color: var(--sarnath-text-light);
+}
+
+.sarnath-card p {
+  font-size: 0.95rem;
+  color: var(--sarnath-text-muted);
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* Timeline */
+.sarnath-timeline {
+  position: relative;
+  max-width: 800px;
+  margin: 0 auto;
+  padding-left: 30px;
+}
+
+.sarnath-timeline::before {
+  content: '';
+  position: absolute;
+  left: 6px;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--sarnath-border-dark);
+}
+
+.sarnath-timeline-step {
+  position: relative;
+  margin-bottom: 40px;
+}
+
+.sarnath-timeline-marker {
+  position: absolute;
+  left: -30px;
+  top: 5px;
+  width: 15px;
+  height: 15px;
+  border-radius: 50%;
+  background: var(--sarnath-primary);
+  border: 3px solid var(--sarnath-bg-dark);
+}
+
+.sarnath-timeline-card {
+  background: var(--sarnath-card-dark);
+  border: 1px solid var(--sarnath-border-dark);
+  padding: 25px;
+  border-radius: 12px;
+}
+
+.sarnath-timeline-year {
+  display: inline-block;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--sarnath-gold);
+  margin-bottom: 8px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.sarnath-timeline-card h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.25rem;
+  margin-bottom: 10px;
+}
+
+.sarnath-timeline-card p {
+  font-size: 0.95rem;
+  color: var(--sarnath-text-muted);
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* References */
+.sarnath-references {
+  background: var(--sarnath-card-dark);
+  border: 1px solid var(--sarnath-border-dark);
+  border-radius: 16px;
+  padding: 35px;
+}
+
+.sarnath-references h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.4rem;
+  margin-bottom: 20px;
+  color: var(--sarnath-gold);
+}
+
+.sarnath-references ul {
+  padding-left: 20px;
+  margin: 0;
+}
+
+.sarnath-references li {
+  font-size: 0.95rem;
+  color: var(--sarnath-text-muted);
+  margin-bottom: 12px;
+  line-height: 1.6;
+}
+
+.sarnath-references li strong {
+  color: var(--sarnath-text-light);
+}
+
+/* Footer */
+.sarnath-footer {
+  padding: 40px 0;
+  text-align: center;
+  background: var(--sarnath-card-dark);
+  border-top: 1px solid var(--sarnath-border-dark);
+  color: var(--sarnath-text-muted);
+  font-size: 0.95rem;
+}
+
+.sarnath-footer a {
+  color: var(--sarnath-gold);
+  text-decoration: none;
+}
+
+.sarnath-footer a:hover {
+  text-decoration: underline;
+}
+
+/* Modal adjustments */
+.museum-modal {
+  display: none;
+  position: fixed;
+  z-index: 1000;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0,0,0,0.85);
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.museum-modal.active {
+  display: flex;
+}
+
+.museum-modal-card {
+  background: var(--sarnath-card-dark);
+  border: 1px solid var(--sarnath-border-dark);
+  border-radius: 16px;
+  max-width: 550px;
+  width: 100%;
+  padding: 30px;
+  position: relative;
+  color: var(--sarnath-text-light);
+  box-shadow: 0 20px 40px rgba(0,0,0,0.6);
+}
+
+.museum-modal-close {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  background: transparent;
+  border: none;
+  font-size: 1.2rem;
+  color: var(--sarnath-text-light);
+  cursor: pointer;
+}
+
+.modal-category {
+  display: inline-block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 1.5px;
+  color: var(--sarnath-gold);
+  margin-bottom: 10px;
+  font-weight: 600;
+}
+
+.museum-modal-card h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.8rem;
+  margin-bottom: 5px;
+}
+
+.modal-description {
+  font-size: 1rem;
+  color: var(--sarnath-text-muted);
+  line-height: 1.6;
+}


### PR DESCRIPTION
## Pull Request: Journey Through Sarnath: From Ancient Settlement to Buddhist Centre #2068

## Description

This pull request introduces a complete interactive explorer page for **Sarnath** (#2068) under the `frontend/sarnath-explorer/` directory, highlighting its transformation into one of the most sacred Buddhist pilgrimage centers in India where Gautama Buddha delivered his first sermon.

### Key Additions & Features:
- **Geographic Setting**: Explores Sarnath's location in Uttar Pradesh near Varanasi, preserving the ancient deer park setting.
- **First Sermon Tradition**: Details the Dharmachakrapravartana event and early Buddhist development.
- **Ashokan & Gupta Monuments**: Highlights the Dhamek Stupa, Chaukhandi Stupa, Ashokan Lion Capital pillar, and classical Gupta-period sculptural art.
- **Bold Theme-Adaptive Gradients**: Features custom, vibrant hero background gradients optimized for seamless adaptation across dark and light modes.
- **References & Navigation**: Includes authoritative archaeological sources and seamless navigation integration.

Fixes #2068

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Accessibility improvement (ARIA attributes, keyboard navigation, focus management)
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Tested locally in browser
- [x] Tested in both dark and light themes (verified bold theme-adaptive hero gradients)
- [x] Tested at mobile viewport widths
- [x] Verified no console errors

## Checklist

- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)

## Screenshots (if applicable)

https://github.com/user-attachments/assets/f4c437ae-593a-4c84-9ef2-70d79bb9a58f

*Integrated responsive layout, bold theme-adaptive hero gradient, and interactive sections active for the Sarnath Explorer across desktop and mobile viewports.*