### PR TITLE
feat: Implements a comprehensive **Shivanasamudra Falls Explorer** page covering the Kaveri River's twin cascades (Gaganachukki & Bharachukki), interactive river map, seasonal flow visualization, historical timeline

### DIFF
--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -2757,4 +2757,11 @@ window.indiaSearchIndex = [
         description: "Explore the Nilgiri Pipit (Anthus nilghiriensis) — an endemic bird of the montane grasslands of southern India's Western Ghats, covering taxonomy, distribution, habitat, diet, behaviour, conservation status, and threats.",
         url: "frontend/nilgiri-pipit-explorer/index.html"
     },
+    // --- Shivanasamudra Falls Explorer ---
+    {
+        title: "Shivanasamudra Falls Explorer",
+        category: "Nature & Wildlife",
+        description: "Explore Shivanasamudra Falls on the Kaveri River in Karnataka — Gaganachukki and Bharachukki twin falls comparison, river map, seasonal flow visualization, hydroelectric history (Asia's first, 1902), and nearby attractions.",
+        url: "frontend/shivanasamudra-falls-explorer/index.html"
+    },
 ];

--- a/frontend/shivanasamudra-falls-explorer/index.html
+++ b/frontend/shivanasamudra-falls-explorer/index.html
@@ -1,0 +1,413 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description"
+        content="Explore Shivanasamudra Falls on the Kaveri River in Karnataka — Gaganachukki and Bharachukki twin falls, hydroelectric history, seasonal flow, and nearby attractions.">
+    <title>Shivanasamudra Falls Explorer | Incredible India</title>
+    <link rel="icon" href="data:,">
+    <link rel="preload" href="../../assets/fonts/Outfit-400.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="../../assets/fonts/PlayfairDisplay-400.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+    <script>
+        (function () {
+            let theme = 'dark';
+            try { theme = JSON.parse(localStorage.getItem('iie_storage') || '{}').theme || 'dark'; } catch (e) { }
+            if (theme === 'light') document.body.classList.add('light-theme');
+        })();
+    </script>
+
+    <header class="navbar" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo"><span class="saffron">Incredible</span><span
+                    class="gold">India</span><span class="green">Explorer</span></a>
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu"><span class="bar"></span><span
+                    class="bar"></span><span class="bar"></span></button>
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html#home" class="nav-link active">Home</a>
+                <div class="nav-dropdown"><button class="nav-link dropdown-toggle">Nature ▾</button>
+                    <div class="dropdown-menu"><a href="../wildlife/wildlife.html" class="dropdown-item">Nature &
+                            Wildlife</a><a href="../waterfalls-of-india/index.html" class="dropdown-item">Waterfalls</a>
+                    </div>
+                </div>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+            </nav>
+        </div>
+    </header>
+
+    <nav class="sf-section-nav" id="sf-section-nav" aria-label="Page sections">
+        <div class="sf-section-nav-inner">
+            <a href="#overview" class="sf-nav-link active">Overview</a>
+            <a href="#comparison" class="sf-nav-link">Twin Falls</a>
+            <a href="#river-map" class="sf-nav-link">River Map</a>
+            <a href="#seasonal" class="sf-nav-link">Seasonal Flow</a>
+            <a href="#history" class="sf-nav-link">History</a>
+            <a href="#hydroelectric" class="sf-nav-link">Hydroelectric</a>
+            <a href="#attractions" class="sf-nav-link">Nearby</a>
+            <a href="#sources" class="sf-nav-link">Sources</a>
+        </div>
+    </nav>
+
+    <main class="sf-main" id="app-root">
+        <section class="sf-hero" id="overview">
+            <div class="sf-hero-backdrop" aria-hidden="true"></div>
+            <div class="sf-hero-content reveal">
+                <span class="hero-kicker">🌊 Waterfall · Kaveri River · Karnataka</span>
+                <h1 class="hero-title">Shivanasamudra Falls</h1>
+                <p class="hero-subtitle">Where the Kaveri splits into twin cascades — Gaganachukki and Bharachukki —
+                    creating one of South India's most spectacular natural wonders and the birthplace of Asia's first
+                    hydroelectric power station.</p>
+                <div class="hero-stats">
+                    <div class="hero-stat"><span class="stat-number">98 m</span><span
+                            class="stat-label">Gaganachukki</span></div>
+                    <div class="hero-stat"><span class="stat-number">69 m</span><span
+                            class="stat-label">Bharachukki</span></div>
+                    <div class="hero-stat"><span class="stat-number">1902</span><span class="stat-label">First Hydro
+                            Plant</span></div>
+                    <div class="hero-stat"><span class="stat-number">Monsoon</span><span class="stat-label">Peak
+                            Season</span></div>
+                </div>
+            </div>
+        </section>
+
+        <section class="sf-section" id="intro">
+            <div class="sf-container">
+                <div class="section-header reveal"><span class="section-tag">📖 Introduction</span>
+                    <h2>The Kaveri's Grand Descent</h2>
+                </div>
+                <div class="grid-2">
+                    <div class="sf-card reveal">
+                        <h3>A Natural Wonder</h3>
+                        <p>Shivanasamudra Falls is located on the Kaveri River in the Mandya district of Karnataka,
+                            approximately 139 km from Bengaluru. The river, after flowing through the Deccan plateau,
+                            reaches the edge of the Biligiri Rangan Hills and plunges dramatically, splitting into two
+                            distinct waterfalls separated by a rocky island.</p>
+                        <p>The name "Shivanasamudra" translates to "Shiva's Sea," reflecting the immense volume of water
+                            during monsoon season when the falls transform into a thundering torrent visible from
+                            kilometres away.</p>
+                    </div>
+                    <div class="sf-card reveal">
+                        <h3>Geological Setting</h3>
+                        <p>The falls occur where the Kaveri crosses a fault line between the Deccan plateau and the
+                            southern highlands. The river drops approximately 98 metres at Gaganachukki and 69 metres at
+                            Bharachukki, creating segmented cataracts rather than single vertical drops.</p>
+                        <p>The surrounding landscape consists of dry deciduous forest and rocky outcrops typical of the
+                            eastern Deccan, contrasting sharply with the lush greenery immediately around the falls
+                            during the wet season.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="sf-section sf-section-alt" id="comparison">
+            <div class="sf-container">
+                <div class="section-header reveal"><span class="section-tag">🌊 Twin Falls</span>
+                    <h2>Gaganachukki vs. Bharachukki</h2>
+                </div>
+                <div class="comparison-grid reveal">
+                    <div class="compare-card gaga">
+                        <div class="compare-icon">💨</div>
+                        <h3>Gaganachukki</h3>
+                        <p class="compare-meaning">"Sky Fall"</p>
+                        <dl class="compare-specs">
+                            <dt>Height</dt>
+                            <dd>98 metres (322 ft)</dd>
+                            <dt>Type</dt>
+                            <dd>Segmented cascade</dd>
+                            <dt>Character</dt>
+                            <dd>Powerful, wide curtain of water</dd>
+                            <dt>Best View</dt>
+                            <dd>Darga viewpoint (western side)</dd>
+                            <dt>Access</dt>
+                            <dd>Viewing platform with safety railings</dd>
+                        </dl>
+                        <p class="compare-desc">The larger and more dramatic of the two falls, Gaganachukki creates a
+                            magnificent curtain of water during monsoon. The spray can be felt from the viewing platform
+                            200 metres away.</p>
+                    </div>
+                    <div class="compare-card bhara">
+                        <div class="compare-icon">🌿</div>
+                        <h3>Bharachukki</h3>
+                        <p class="compare-meaning">"Earth Fall"</p>
+                        <dl class="compare-specs">
+                            <dt>Height</dt>
+                            <dd>69 metres (226 ft)</dd>
+                            <dt>Type</dt>
+                            <dd>Cascade with pools</dd>
+                            <dt>Character</dt>
+                            <dd>Elegant, multi-tiered descent</dd>
+                            <dt>Best View</dt>
+                            <dd>Eastern viewpoint near temple</dd>
+                            <dt>Access</dt>
+                            <dd>Steps leading to lower viewpoints</dd>
+                        </dl>
+                        <p class="compare-desc">Bharachukki is considered more picturesque, with water cascading through
+                            rocky channels into natural pools below. During low-water seasons, individual streams are
+                            clearly visible.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="sf-section" id="river-map">
+            <div class="sf-container">
+                <div class="section-header reveal"><span class="section-tag">🗺️ River Map</span>
+                    <h2>Kaveri River at Shivanasamudra</h2>
+                </div>
+                <div class="map-container reveal">
+                    <div class="map-wrapper glass-card">
+                        <svg viewBox="0 0 600 400" class="map-svg"
+                            aria-label="Map showing Kaveri River splitting at Shivanasamudra">
+                            <!-- River path -->
+                            <path d="M50,200 C150,200 200,180 280,180" stroke="#3b82f6" stroke-width="4" fill="none"
+                                stroke-linecap="round" />
+                            <!-- Split -->
+                            <path d="M280,180 C320,140 380,100 500,80" stroke="#3b82f6" stroke-width="3" fill="none"
+                                stroke-linecap="round" class="river-gaga" />
+                            <path d="M280,180 C320,220 380,280 500,320" stroke="#3b82f6" stroke-width="3" fill="none"
+                                stroke-linecap="round" class="river-bhara" />
+                            <!-- Island -->
+                            <ellipse cx="300" cy="180" rx="30" ry="15" fill="#16a34a" opacity="0.6" />
+                            <!-- Labels -->
+                            <text x="260" y="170" fill="currentColor" font-size="11" font-family="Outfit">Island</text>
+                            <text x="400" y="75" fill="#3b82f6" font-size="12" font-weight="bold"
+                                font-family="Outfit">Gaganachukki ↓</text>
+                            <text x="400" y="340" fill="#3b82f6" font-size="12" font-weight="bold"
+                                font-family="Outfit">Bharachukki ↓</text>
+                            <text x="80" y="195" fill="currentColor" font-size="11" font-family="Outfit">← Kaveri
+                                River</text>
+                            <!-- Markers -->
+                            <circle cx="280" cy="180" r="6" fill="#f97316" class="map-marker" data-point="split" />
+                            <circle cx="480" cy="85" r="6" fill="#3b82f6" class="map-marker" data-point="gaga" />
+                            <circle cx="480" cy="315" r="6" fill="#10b981" class="map-marker" data-point="bhara" />
+                        </svg>
+                    </div>
+                    <div class="map-info glass-card" id="sf-map-info">
+                        <h3 id="map-info-title">Select a point</h3>
+                        <p id="map-info-desc">Click a marker on the map to learn about that location along the Kaveri at
+                            Shivanasamudra.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="sf-section sf-section-alt" id="seasonal">
+            <div class="sf-container">
+                <div class="section-header reveal"><span class="section-tag">🌧️ Seasonal Flow</span>
+                    <h2>When to Visit</h2>
+                </div>
+                <div class="seasonal-grid reveal">
+                    <div class="season-card peak">
+                        <span class="season-badge">Peak</span>
+                        <h3>Monsoon (Jul–Oct)</h3>
+                        <p>The Kaveri swells to full capacity. Both falls are at their most spectacular with massive
+                            water volume. Gaganachukki becomes a roaring curtain. Spray fills the air. Roads may be
+                            slippery.</p>
+                        <div class="flow-bar">
+                            <div class="flow-fill" style="width:100%"></div>
+                        </div>
+                    </div>
+                    <div class="season-card good">
+                        <span class="season-badge">Good</span>
+                        <h3>Post-Monsoon (Nov–Jan)</h3>
+                        <p>Water levels remain healthy but crowds thin. Pleasant weather makes exploration comfortable.
+                            Best balance of water volume and accessibility. Ideal for photography.</p>
+                        <div class="flow-bar">
+                            <div class="flow-fill" style="width:65%"></div>
+                        </div>
+                    </div>
+                    <div class="season-card low">
+                        <span class="season-badge">Low</span>
+                        <h3>Summer (Feb–Jun)</h3>
+                        <p>Water reduces to trickles. Individual rock formations become visible. Less impressive but
+                            easier to access lower viewpoints. Hot weather; carry water.</p>
+                        <div class="flow-bar">
+                            <div class="flow-fill" style="width:20%"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="sf-section" id="history">
+            <div class="sf-container">
+                <div class="section-header reveal"><span class="section-tag">📜 History</span>
+                    <h2>Historical Timeline</h2>
+                </div>
+                <div class="timeline reveal">
+                    <div class="timeline-item">
+                        <div class="timeline-marker">Ancient</div>
+                        <div class="timeline-content">
+                            <h3>Sacred Site</h3>
+                            <p>The falls have been revered since antiquity. The Sri Ranganathaswamy temple on the island
+                                dates to the Chola period. Pilgrims have visited for centuries during Kaveri festivals.
+                            </p>
+                        </div>
+                    </div>
+                    <div class="timeline-item">
+                        <div class="timeline-marker">1898</div>
+                        <div class="timeline-content">
+                            <h3>Survey Begins</h3>
+                            <p>British engineer Sir K. Seshadri Iyer identifies Shivanasamudra as a potential
+                                hydroelectric site to power the Kolar Gold Fields, 147 km away.</p>
+                        </div>
+                    </div>
+                    <div class="timeline-item">
+                        <div class="timeline-marker">1902</div>
+                        <div class="timeline-content">
+                            <h3>Asia's First Hydro Station</h3>
+                            <p>The Shivanasamudra hydroelectric station begins operations, becoming the first in Asia.
+                                It transmits power over 147 km to KGF — then the world's longest transmission line.</p>
+                        </div>
+                    </div>
+                    <div class="timeline-item">
+                        <div class="timeline-marker">1905</div>
+                        <div class="timeline-content">
+                            <h3>Bengaluru Electrified</h3>
+                            <p>Power from Shivanasamudra begins supplying Bengaluru, making it one of the first Asian
+                                cities with electric street lighting.</p>
+                        </div>
+                    </div>
+                    <div class="timeline-item">
+                        <div class="timeline-marker">1948</div>
+                        <div class="timeline-content">
+                            <h3>Post-Independence Expansion</h3>
+                            <p>The station is expanded under the Mysore government. Additional generators increase
+                                capacity to serve growing industrial demand.</p>
+                        </div>
+                    </div>
+                    <div class="timeline-item">
+                        <div class="timeline-marker">Present</div>
+                        <div class="timeline-content">
+                            <h3>Heritage & Tourism</h3>
+                            <p>The original plant is now a heritage site. Shivanasamudra attracts over 500,000 visitors
+                                annually. Conservation efforts protect the surrounding ecosystem.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="sf-section sf-section-alt" id="hydroelectric">
+            <div class="sf-container">
+                <div class="section-header reveal"><span class="section-tag">⚡ Hydroelectric</span>
+                    <h2>Birthplace of Asian Hydropower</h2>
+                </div>
+                <div class="grid-2">
+                    <div class="sf-card reveal">
+                        <h3>Pioneering Achievement</h3>
+                        <p>The Shivanasamudra hydroelectric project was visionary for its era. Commissioned in 1902
+                            under the guidance of Diwan Sir K. Seshadri Iyer and chief engineer Capt. A.C.G. de
+                            Lotbiniere, it demonstrated that India could harness modern technology independently.</p>
+                        <p>The 147-km transmission line to Kolar Gold Fields was an engineering marvel. At the time, no
+                            comparable long-distance AC transmission existed anywhere in the world.</p>
+                    </div>
+                    <div class="sf-card reveal">
+                        <h3>Legacy & Impact</h3>
+                        <p>The station originally generated 4.5 MW. Today's upgraded facility produces approximately 42
+                            MW. More importantly, it established the template for India's hydropower development,
+                            inspiring subsequent projects at Mettur, Krishna Raja Sagara, and beyond.</p>
+                        <p>The original machinery and buildings are preserved as an industrial heritage site, open to
+                            visitors interested in the history of Indian engineering.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="sf-section" id="attractions">
+            <div class="sf-container">
+                <div class="section-header reveal"><span class="section-tag">📍 Nearby</span>
+                    <h2>Nearby Attractions</h2>
+                </div>
+                <div class="grid-3">
+                    <div class="sf-card reveal">
+                        <h3>Ranganathaswamy Temple</h3>
+                        <p>Ancient temple on the island between the two falls. Dedicated to Lord Vishnu as Ranganatha.
+                            Dates to the Chola period with later Hoysala additions.</p>
+                    </div>
+                    <div class="sf-card reveal">
+                        <h3>Talakadu</h3>
+                        <p>Historic town 30 km away, once capital of the Western Gangas. Famous for buried temples and
+                            the Panchalinga Darshana festival held every 12 years.</p>
+                    </div>
+                    <div class="sf-card reveal">
+                        <h3>Somanathapura</h3>
+                        <p>Home to the exquisite Chennakeshava Temple (1268 CE), a masterpiece of Hoysala architecture
+                            with intricate soapstone carvings. 45 km from the falls.</p>
+                    </div>
+                    <div class="sf-card reveal">
+                        <h3>Krishna Raja Sagara</h3>
+                        <p>Massive dam and reservoir on the Kaveri, 50 km downstream. Features the famous Brindavan
+                            Gardens with musical fountain shows.</p>
+                    </div>
+                    <div class="sf-card reveal">
+                        <h3>Biligiri Rangan Hills</h3>
+                        <p>Wildlife sanctuary and tiger reserve adjacent to the falls. Home to elephants, leopards, and
+                            diverse birdlife. Trekking trails available.</p>
+                    </div>
+                    <div class="sf-card reveal">
+                        <h3>Maddur</h3>
+                        <p>Town en route from Bengaluru known for Maddur Vada, a crispy lentil fritter that has become
+                            synonymous with the journey to Shivanasamudra.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="sf-section sf-section-alt" id="sources">
+            <div class="sf-container">
+                <div class="section-header reveal"><span class="section-tag">📚 Sources</span>
+                    <h2>References</h2>
+                </div>
+                <div class="references-list reveal">
+                    <div class="reference-item">
+                        <h3>Karnataka Power Corporation Limited</h3>
+                        <p>Official records and heritage documentation of the Shivanasamudra Hydroelectric Station.</p>
+                    </div>
+                    <div class="reference-item">
+                        <h3>Karnataka Forest Department</h3>
+                        <p>Biligiri Rangan Wildlife Sanctuary management plan and biodiversity assessment reports.</p>
+                    </div>
+                    <div class="reference-item">
+                        <h3>Central Water Commission (2023)</h3>
+                        <p>Kaveri Basin Water Resources Assessment. Government of India, Ministry of Jal Shakti.</p>
+                    </div>
+                    <div class="reference-item">
+                        <h3>Seshadri Iyer Memorial Trust</h3>
+                        <p>Archival documents relating to the commissioning of Asia's first hydroelectric station at
+                            Shivanasamudra.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="footer-container">
+            <div class="footer-brand"><a href="../../index.html#home" class="nav-logo"><span
+                        class="saffron">Incredible</span><span class="gold">India</span><span
+                        class="green">Explorer</span></a>
+                <p>An interactive digital guide to India's natural heritage.</p>
+            </div>
+            <div class="footer-links">
+                <h4>Quick Links</h4><a href="../../index.html">Home</a><a
+                    href="../waterfalls-of-india/index.html">Waterfalls</a>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2026 Incredible India Explorer.</p>
+        </div>
+    </footer>
+
+    <script src="script.js"></script>
+    <script src="../app.js" defer></script>
+    <script src="../router.js" defer></script>
+</body>
+
+</html>

--- a/frontend/shivanasamudra-falls-explorer/script.js
+++ b/frontend/shivanasamudra-falls-explorer/script.js
@@ -1,0 +1,64 @@
+/**
+ * Shivanasamudra Falls Explorer - Interactive Script
+ * Handles section navigation, map interaction, scroll reveal, and Journey integration.
+ */
+(function () {
+    'use strict';
+
+    /* Map point data */
+    const mapPoints = {
+        split: { title: 'The Split Point', desc: 'Where the Kaveri River divides around a rocky island, creating the twin falls. The island hosts the ancient Ranganathaswamy temple and separates Gaganachukki (north) from Bharachukki (south).' },
+        gaga: { title: 'Gaganachukki Falls', desc: 'The western branch plunges 98 metres in a wide segmented cascade. During monsoon, the spray creates rainbows visible from the Darga viewpoint. The name means "Sky Fall" in Kannada.' },
+        bhara: { title: 'Bharachukki Falls', desc: 'The eastern branch descends 69 metres through rocky channels into natural pools. More picturesque than Gaganachukki, with visible individual streams during low-water seasons. Name means "Earth Fall."' }
+    };
+
+    /* Interactive Map */
+    function initMap() {
+        const markers = document.querySelectorAll('.map-marker');
+        const titleEl = document.getElementById('map-info-title');
+        const descEl = document.getElementById('map-info-desc');
+        if (!titleEl || !descEl) return;
+        markers.forEach(m => {
+            const key = m.dataset.point;
+            const update = () => { const d = mapPoints[key]; if (d) { titleEl.textContent = d.title; descEl.textContent = d.desc; } };
+            m.addEventListener('click', update);
+            m.addEventListener('keydown', e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); update(); } });
+        });
+    }
+
+    /* Section Navigation */
+    function initSectionNav() {
+        const navBar = document.getElementById('sf-section-nav');
+        const navLinks = document.querySelectorAll('.sf-nav-link');
+        if (!navBar) return;
+        const sections = Array.from(navLinks).map(link => ({ link, section: document.getElementById(link.getAttribute('href').replace('#', '')) })).filter(i => i.section);
+        const setActive = (activeLink) => { navLinks.forEach(l => l.classList.remove('active')); activeLink.classList.add('active'); };
+        navLinks.forEach(link => link.addEventListener('click', () => setActive(link)));
+        const observer = new IntersectionObserver(entries => {
+            entries.forEach(entry => { if (entry.isIntersecting) { const match = navBar.querySelector(`[href="#${entry.target.id}"]`); if (match) setActive(match); } });
+        }, { rootMargin: '-40% 0px -50% 0px' });
+        sections.forEach(item => observer.observe(item.section));
+    }
+
+    /* Scroll Reveal */
+    function initReveal() {
+        const targets = document.querySelectorAll('.reveal');
+        if (!('IntersectionObserver' in window)) { targets.forEach(el => el.classList.add('visible')); return; }
+        const observer = new IntersectionObserver(entries => {
+            entries.forEach(entry => { if (entry.isIntersecting) { entry.target.classList.add('visible'); observer.unobserve(entry.target); } });
+        }, { threshold: 0.08, rootMargin: '0px 0px -40px 0px' });
+        targets.forEach(el => observer.observe(el));
+    }
+
+    /* Journey Integration */
+    function initJourney() {
+        if (!window.Journey) return;
+        window.Journey.registerSearchItems('frontend/shivanasamudra-falls-explorer/index.html', [
+            { id: 'shivanasamudra-main', title: 'Shivanasamudra Falls Explorer', description: 'Explore Shivanasamudra Falls on the Kaveri River — Gaganachukki and Bharachukki twin falls, hydroelectric history, seasonal flow patterns, and nearby attractions in Karnataka.', link: 'frontend/shivanasamudra-falls-explorer/index.html' },
+            { id: 'shivanasamudra-comparison', title: 'Gaganachukki vs Bharachukki Comparison', description: 'Side-by-side comparison of the twin falls — heights, characteristics, viewpoints, and access details for both Gaganachukki (98m) and Bharachukki (69m).', link: 'frontend/shivanasamudra-falls-explorer/index.html#comparison' },
+            { id: 'shivanasamudra-history', title: 'Shivanasamudra Historical Timeline', description: 'From ancient sacred site to Asia\'s first hydroelectric station (1902) — the complete historical timeline of Shivanasamudra Falls.', link: 'frontend/shivanasamudra-falls-explorer/index.html#history' }
+        ]);
+    }
+
+    document.addEventListener('DOMContentLoaded', () => { initMap(); initSectionNav(); initReveal(); initJourney(); });
+})();

--- a/frontend/shivanasamudra-falls-explorer/style.css
+++ b/frontend/shivanasamudra-falls-explorer/style.css
@@ -1,0 +1,575 @@
+:root {
+    --sf-blue: #3b82f6;
+    --sf-teal: #14b8a6;
+    --sf-green: #16a34a;
+    --sf-sand: #d4a574;
+    --sf-bg: linear-gradient(135deg, #0c1929, #0f2744, #0c1929);
+    --sf-bg-light: #0f2744;
+    --sf-card: rgba(15, 39, 68, 0.55);
+    --sf-border: rgba(59, 130, 246, 0.15);
+    --sf-text: #f1f5f9;
+    --sf-sub: rgba(241, 245, 249, 0.7);
+    --sf-navbar-height: 70px;
+}
+
+.light-theme {
+    --sf-bg: linear-gradient(135deg, #eff6ff, #dbeafe, #eff6ff);
+    --sf-bg-light: #dbeafe;
+    --sf-card: rgba(255, 255, 255, 0.88);
+    --sf-border: rgba(59, 130, 246, 0.12);
+    --sf-text: #0c1929;
+    --sf-sub: rgba(12, 25, 41, 0.7);
+}
+
+.glass-card {
+    background: var(--sf-card);
+    border: 1px solid var(--sf-border);
+    border-radius: 18px;
+    backdrop-filter: blur(12px);
+    padding: 1.5rem;
+}
+
+.sf-main {
+    background: var(--sf-bg);
+    color: var(--sf-text);
+    font-family: 'Outfit', sans-serif;
+    min-height: 100vh;
+    padding-top: var(--sf-navbar-height);
+}
+
+.sf-container {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+}
+
+.sf-section-nav {
+    position: sticky;
+    top: var(--sf-navbar-height);
+    z-index: 40;
+    background: rgba(12, 25, 41, 0.92);
+    backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--sf-border);
+    overflow-x: auto;
+    scrollbar-width: none;
+}
+
+.light-theme .sf-section-nav {
+    background: rgba(239, 246, 255, 0.92);
+}
+
+.sf-section-nav-inner {
+    display: flex;
+    gap: 0.25rem;
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0.5rem 1rem;
+    white-space: nowrap;
+}
+
+.sf-nav-link {
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    font-size: 0.82rem;
+    font-weight: 500;
+    color: var(--sf-blue);
+    text-decoration: none;
+    transition: all 0.25s;
+}
+
+.sf-nav-link:hover,
+.sf-nav-link:focus-visible {
+    background: rgba(59, 130, 246, 0.12);
+    color: var(--sf-text);
+    outline: none;
+}
+
+.sf-nav-link.active {
+    background: var(--sf-blue);
+    color: #fff;
+}
+
+.sf-hero {
+    position: relative;
+    min-height: 90vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 4rem 1.5rem;
+}
+
+.sf-hero-backdrop {
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 30% 30%, rgba(59, 130, 246, 0.2), transparent 55%), radial-gradient(circle at 70% 70%, rgba(20, 184, 166, 0.15), transparent 55%);
+    z-index: 0;
+}
+
+.sf-hero-content {
+    position: relative;
+    z-index: 1;
+    text-align: center;
+    max-width: 800px;
+}
+
+.hero-kicker {
+    display: inline-block;
+    padding: 0.4rem 1rem;
+    background: rgba(59, 130, 246, 0.15);
+    border: 1px solid var(--sf-blue);
+    border-radius: 999px;
+    color: var(--sf-blue);
+    font-size: 0.85rem;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 1.5rem;
+}
+
+.hero-title {
+    font-family: 'Playfair Display', serif;
+    font-size: clamp(2.5rem, 7vw, 4.5rem);
+    font-weight: 700;
+    line-height: 1.05;
+    margin-bottom: 1rem;
+    background: linear-gradient(135deg, #fff, var(--sf-teal));
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+
+.light-theme .hero-title {
+    background: linear-gradient(135deg, #0c1929, var(--sf-blue));
+    -webkit-background-clip: text;
+    background-clip: text;
+}
+
+.hero-subtitle {
+    font-size: clamp(1rem, 2vw, 1.2rem);
+    color: var(--sf-sub);
+    line-height: 1.7;
+    max-width: 720px;
+    margin: 0 auto 2rem;
+}
+
+.hero-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: center;
+}
+
+.hero-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    padding: 0.85rem 1.5rem;
+    background: var(--sf-card);
+    border: 1px solid var(--sf-border);
+    border-radius: 14px;
+    backdrop-filter: blur(10px);
+}
+
+.stat-number {
+    font-family: 'Playfair Display', serif;
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--sf-teal);
+}
+
+.stat-label {
+    font-size: 0.72rem;
+    color: var(--sf-sub);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.sf-section {
+    padding: 5rem 0;
+}
+
+.sf-section-alt {
+    background: var(--sf-bg-light);
+}
+
+.section-header {
+    text-align: center;
+    margin-bottom: 3rem;
+}
+
+.section-tag {
+    display: inline-block;
+    padding: 0.4rem 1rem;
+    background: rgba(59, 130, 246, 0.12);
+    border: 1px solid var(--sf-blue);
+    color: var(--sf-blue);
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 500;
+    margin-bottom: 1rem;
+}
+
+.section-header h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: clamp(1.8rem, 4vw, 2.75rem);
+    color: var(--sf-text);
+    margin: 0;
+}
+
+.grid-2 {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 1.5rem;
+}
+
+.grid-3 {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.sf-card {
+    padding: 1.75rem;
+    background: var(--sf-card);
+    border: 1px solid var(--sf-border);
+    border-radius: 16px;
+    backdrop-filter: blur(10px);
+    transition: transform 0.3s;
+    border-top: 3px solid var(--sf-blue);
+}
+
+.sf-card:hover {
+    transform: translateY(-4px);
+}
+
+.sf-card h3 {
+    font-family: 'Playfair Display', serif;
+    font-size: 1.25rem;
+    color: var(--sf-teal);
+    margin: 0 0 0.75rem;
+}
+
+.sf-card p {
+    font-size: 0.95rem;
+    line-height: 1.7;
+    color: var(--sf-sub);
+    margin: 0 0 0.75rem;
+}
+
+.sf-card p:last-child {
+    margin-bottom: 0;
+}
+
+/* Comparison */
+.comparison-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+}
+
+.compare-card {
+    padding: 2rem;
+    background: var(--sf-card);
+    border: 1px solid var(--sf-border);
+    border-radius: 18px;
+    backdrop-filter: blur(10px);
+}
+
+.compare-card.gaga {
+    border-top: 4px solid var(--sf-blue);
+}
+
+.compare-card.bhara {
+    border-top: 4px solid var(--sf-green);
+}
+
+.compare-icon {
+    font-size: 2.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.compare-card h3 {
+    font-family: 'Playfair Display', serif;
+    font-size: 1.6rem;
+    color: var(--sf-text);
+    margin: 0 0 0.25rem;
+}
+
+.compare-meaning {
+    font-size: 0.85rem;
+    color: var(--sf-sub);
+    font-style: italic;
+    margin-bottom: 1.25rem;
+    display: block;
+}
+
+.compare-specs {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.5rem 1rem;
+    margin-bottom: 1.25rem;
+    font-size: 0.9rem;
+}
+
+.compare-specs dt {
+    color: var(--sf-teal);
+    font-weight: 600;
+}
+
+.compare-specs dd {
+    color: var(--sf-sub);
+    margin: 0;
+}
+
+.compare-desc {
+    font-size: 0.92rem;
+    line-height: 1.65;
+    color: var(--sf-sub);
+}
+
+/* Map */
+.map-container {
+    display: grid;
+    grid-template-columns: 1.2fr 1fr;
+    gap: 2rem;
+    align-items: start;
+}
+
+.map-wrapper {
+    aspect-ratio: 3/2;
+}
+
+.map-svg {
+    width: 100%;
+    height: 100%;
+}
+
+.map-marker {
+    cursor: pointer;
+    transition: r 0.2s;
+}
+
+.map-marker:hover {
+    r: 9;
+}
+
+.map-info h3 {
+    font-family: 'Playfair Display', serif;
+    color: var(--sf-teal);
+    margin: 0 0 0.75rem;
+}
+
+.map-info p {
+    color: var(--sf-sub);
+    line-height: 1.7;
+}
+
+/* Seasonal */
+.seasonal-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.season-card {
+    padding: 1.75rem;
+    background: var(--sf-card);
+    border: 1px solid var(--sf-border);
+    border-radius: 16px;
+    backdrop-filter: blur(10px);
+}
+
+.season-badge {
+    display: inline-block;
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 0.75rem;
+}
+
+.season-card.peak .season-badge {
+    background: rgba(59, 130, 246, 0.2);
+    color: var(--sf-blue);
+}
+
+.season-card.good .season-badge {
+    background: rgba(22, 163, 74, 0.2);
+    color: var(--sf-green);
+}
+
+.season-card.low .season-badge {
+    background: rgba(212, 165, 116, 0.2);
+    color: var(--sf-sand);
+}
+
+.season-card h3 {
+    font-family: 'Playfair Display', serif;
+    font-size: 1.2rem;
+    margin: 0 0 0.75rem;
+}
+
+.season-card p {
+    font-size: 0.92rem;
+    line-height: 1.65;
+    color: var(--sf-sub);
+    margin-bottom: 1rem;
+}
+
+.flow-bar {
+    height: 8px;
+    background: var(--sf-border);
+    border-radius: 999px;
+    overflow: hidden;
+}
+
+.flow-fill {
+    height: 100%;
+    background: linear-gradient(90deg, var(--sf-blue), var(--sf-teal));
+    border-radius: 999px;
+    transition: width 0.6s ease;
+}
+
+/* Timeline */
+.timeline {
+    position: relative;
+    padding: 1rem 0;
+    max-width: 800px;
+    margin: 0 auto;
+}
+
+.timeline::before {
+    content: '';
+    position: absolute;
+    left: 30px;
+    top: 0;
+    bottom: 0;
+    width: 2px;
+    background: linear-gradient(180deg, transparent, var(--sf-blue), var(--sf-teal), transparent);
+}
+
+.timeline-item {
+    display: flex;
+    align-items: flex-start;
+    margin-bottom: 2rem;
+}
+
+.timeline-marker {
+    flex-shrink: 0;
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    background: var(--sf-blue);
+    color: #fff;
+    font-family: 'Playfair Display', serif;
+    font-weight: 700;
+    font-size: 0.8rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 3px solid var(--sf-teal);
+    box-shadow: 0 0 0 6px var(--sf-bg);
+    z-index: 2;
+    text-align: center;
+    padding: 0.25rem;
+}
+
+.sf-section-alt .timeline-marker {
+    box-shadow: 0 0 0 6px var(--sf-bg-light);
+}
+
+.timeline-content {
+    flex: 1;
+    margin-left: 1.5rem;
+    padding: 1.5rem;
+    background: var(--sf-card);
+    border: 1px solid var(--sf-border);
+    border-radius: 12px;
+    backdrop-filter: blur(10px);
+}
+
+.timeline-content h3 {
+    font-family: 'Playfair Display', serif;
+    color: var(--sf-teal);
+    font-size: 1.15rem;
+    margin: 0 0 0.5rem;
+}
+
+.timeline-content p {
+    color: var(--sf-sub);
+    line-height: 1.7;
+    font-size: 0.95rem;
+    margin: 0;
+}
+
+.references-list {
+    max-width: 800px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.reference-item {
+    padding: 1.5rem;
+    background: var(--sf-card);
+    border: 1px solid var(--sf-border);
+    border-left: 3px solid var(--sf-teal);
+    border-radius: 12px;
+}
+
+.reference-item h3 {
+    font-size: 1rem;
+    color: var(--sf-teal);
+    margin: 0 0 0.5rem;
+}
+
+.reference-item p {
+    color: var(--sf-sub);
+    line-height: 1.65;
+    font-size: 0.9rem;
+    margin: 0;
+}
+
+.reveal {
+    opacity: 0;
+    transform: translateY(24px);
+    transition: opacity 0.6s ease, transform 0.6s cubic-bezier(0.165, 0.84, 0.44, 1);
+}
+
+.reveal.visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .reveal {
+        opacity: 1;
+        transform: none;
+        transition: none;
+    }
+}
+
+@media (max-width: 768px) {
+
+    .comparison-grid,
+    .map-container {
+        grid-template-columns: 1fr;
+    }
+
+    .sf-section {
+        padding: 3rem 0;
+    }
+
+    .sf-hero {
+        min-height: 80vh;
+        padding: 3rem 1rem;
+    }
+
+    .hero-stats {
+        flex-direction: column;
+        align-items: center;
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

Implements a comprehensive **Shivanasamudra Falls Explorer** page covering the Kaveri River's twin cascades (Gaganachukki & Bharachukki), interactive river map, seasonal flow visualization, historical timeline from ancient times to Asia's first hydroelectric station (1902), nearby attractions, and academic sources. Registered in global search index.

Fixes #2171

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## Summary of Changes

| File | Change |
|------|--------|
| `frontend/shivanasamudra-falls-explorer/index.html` | NEW — Full explorer with 8 sections: overview, twin-fall comparison, river map, seasonal flow, history timeline, hydroelectric legacy, nearby attractions, sources |
| `frontend/shivanasamudra-falls-explorer/style.css` | NEW — Blue/teal water-themed palette, comparison cards, flow bars, timeline, responsive layout, dark/light themes |
| `frontend/shivanasamudra-falls-explorer/script.js` | NEW — Interactive SVG map, sticky section nav with scroll spy, scroll reveal, Journey search integration |
| `frontend/search-index.js` | MODIFIED — Added Shivanasamudra Falls entry to global search index |

## How Has This Been Tested?

- [x] Tested locally in browser
- [x] Tested in both dark and light themes
- [x] Tested at mobile viewport widths
- [x] Verified no console errors

## Checklist

- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)