### PR TITLE
Recreate Taxila: The Ancient Crossroads of Gandhara

### DIFF
--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -3851,6 +3851,12 @@ window.indiaSearchIndex = [
             "Explore Beddome's Coral Snake (Calliophis beddomei) — endemic venomous elapid of Western Ghats leaf litter, scientific taxonomy, behavior, diet, and conservation status.",
         url: 'frontend/beddomes-coral-snake-explorer/index.html'
     },
+    {
+    title: "Taxila: The Ancient Crossroads of Gandhara",
+    category: "Heritage & History",
+    description: "Recreate Taxila — compare Bhir Mound, Sirkap, and Sirsukh settlements, explore Silk Road trade routes, Buddhist sites, learning traditions, artifacts, and a full archaeological timeline.",
+    url: "frontend/taxila-explorer/index.html"
+    },
     // --- Sikh Empire Explorer ---
     {
         title: 'Sikh Empire Explorer',

--- a/frontend/taxila-explorer/index.html
+++ b/frontend/taxila-explorer/index.html
@@ -1,0 +1,139 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Recreate Taxila, the ancient crossroads of Gandhara — compare Bhir Mound, Sirkap, and Sirsukh settlements, explore Silk Road trade routes, Buddhist sites, learning traditions, artifacts, and a full archaeological timeline."
+        />
+        <title>Taxila: The Ancient Crossroads of Gandhara | Incredible India</title>
+
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+            rel="stylesheet"
+        />
+
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="taxila.css" />
+    </head>
+    <body class="taxila-main">
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    document.body.classList.add('light-theme');
+                }
+            })();
+        </script>
+
+        <header class="navbar" id="navbar">
+    <div class="nav-container">
+        <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+            <span class="saffron">Incredible</span>
+            <span class="gold">India</span>
+            <span class="green">Explorer</span>
+        </a>
+        <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+            <span class="bar"></span>
+            <span class="bar"></span>
+            <span class="bar"></span>
+        </button>
+        <nav class="nav-menu" id="nav-menu">
+            <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+                    <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
+                    <a href="../../frontend/universities/universities.html" class="dropdown-item">Ancient Universities</a>
+                    <a href="../../frontend/nalanda-explorer/index.html" class="dropdown-item">Nalanda University City</a>
+                    <a href="../../frontend/taxila-explorer/index.html" class="dropdown-item">Taxila: Crossroads of Gandhara</a>
+                    <a href="../../frontend/gupta-coinage-gallery/index.html" class="dropdown-item">Gupta Coinage Gallery</a>
+                    <a href="../../frontend/kushan-gold-coinage/index.html" class="dropdown-item">Kushan Gold Coinage</a>
+                </div>
+            </div>
+            <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+        </nav>
+    </div>
+</header>
+
+        <main>
+            <section class="taxila-hero">
+                <div class="section-container">
+                    <div class="hero-badges-row">
+                        <span class="hero-pill pill-era">📜 c. 6th c. BCE – 5th c. CE</span>
+                        <span class="hero-pill pill-location">📍 Gandhara, Ancient India</span>
+                        <span class="hero-pill pill-type">🏺 UNESCO World Heritage</span>
+                    </div>
+                    <h1>Taxila <span>The Ancient Crossroads of Gandhara</span></h1>
+                    <p class="hero-subtitle">
+                        Across eleven centuries, three successive cities rose at
+                        Taxila — each shaped by a different empire, each a
+                        meeting point of Persian, Greek, Central Asian, and
+                        Indian trade, art, and belief.
+                    </p>
+                    <div id="stats-grid" class="stats-grid"></div>
+                </div>
+            </section>
+
+            <section class="taxila-settlements-section">
+                <div class="section-container">
+                    <h2 class="sec-title">Settlement Comparison</h2>
+                    <p class="section-hint">Compare Taxila's three successive cities side by side, or click one for full detail.</p>
+                    <div class="settlement-tabs" id="settlement-tabs"></div>
+                    <div class="settlement-comparison-grid" id="settlement-comparison-grid"></div>
+                    <div class="info-card settlement-detail-card" id="settlement-detail-card"></div>
+                </div>
+            </section>
+
+            <section class="taxila-trade-section">
+                <div class="section-container">
+                    <h2 class="sec-title">Trade Route Visualization</h2>
+                    <div class="trade-route-list" id="trade-route-list"></div>
+                </div>
+            </section>
+
+            <section class="taxila-buddhist-section">
+                <div class="section-container">
+                    <h2 class="sec-title">Buddhist Establishments</h2>
+                    <div class="buddhist-grid" id="buddhist-grid"></div>
+                </div>
+            </section>
+
+            <section class="taxila-learning-section">
+                <div class="section-container">
+                    <h2 class="sec-title">Learning Traditions</h2>
+                    <p class="learning-intro" id="learning-intro"></p>
+                    <div class="learning-figures-grid" id="learning-figures-grid"></div>
+                </div>
+            </section>
+
+            <section class="taxila-artifacts-section">
+                <div class="section-container">
+                    <h2 class="sec-title">Artifact Explorer</h2>
+                    <div class="artifact-grid" id="artifact-grid"></div>
+                </div>
+            </section>
+
+            <section class="taxila-timeline-section">
+                <div class="section-container">
+                    <h2 class="sec-title">Archaeological Timeline</h2>
+                    <div class="taxila-timeline" id="taxila-timeline"></div>
+                </div>
+            </section>
+
+            <section class="references-section">
+                <div class="section-container">
+                    <h2>References & Sources</h2>
+                    <ul class="references-list" id="references-list"></ul>
+                </div>
+            </section>
+        </main>
+
+        <script src="taxila-data.js"></script>
+        <script src="taxila.js"></script>
+    </body>
+</html>

--- a/frontend/taxila-explorer/taxila-data.js
+++ b/frontend/taxila-explorer/taxila-data.js
@@ -1,0 +1,110 @@
+// taxila-data.js
+// Data for the Taxila: Ancient Crossroads of Gandhara Explorer (c. 6th century BCE – 5th century CE)
+
+const TAXILA_STATS = [
+    { label: "Major Settlements", value: "3" },
+    { label: "Active Years", value: "~1,100" },
+    { label: "Ruling Powers", value: "7" },
+    { label: "UNESCO Status", value: "Since 1980" },
+];
+
+const TAXILA_SETTLEMENTS = [
+    {
+        id: "bhir-mound",
+        name: "Bhir Mound",
+        period: "c. 6th century BCE – 2nd century BCE",
+        rulers: "Achaemenid Persia, Mauryan Empire",
+        layout: "Irregular, organically grown street plan with narrow winding lanes, typical of early South Asian cities that developed without centralized town planning.",
+        desc: "The oldest of Taxila's three cities, Bhir Mound represents the earliest urban settlement at the site, flourishing under Achaemenid Persian influence and later as a provincial center of the Mauryan Empire.",
+        finds: "Excavations uncovered houses of rubble masonry, silver punch-marked coins, and everyday artifacts reflecting a bustling, unplanned trading town predating Hellenistic influence in the region.",
+    },
+    {
+        id: "sirkap",
+        name: "Sirkap",
+        period: "c. 2nd century BCE – 1st century CE",
+        rulers: "Indo-Greeks, Indo-Scythians, Indo-Parthians",
+        layout: "Laid out on a Hippodamian (Greek grid) plan with a main avenue and perpendicular side streets, reflecting direct Hellenistic urban planning traditions introduced by Indo-Greek rulers.",
+        desc: "Built by the Indo-Greek king Demetrius after the decline of Bhir Mound, Sirkap became a cosmopolitan city blending Greek, Persian, Scythian, and Indian architectural and religious traditions side by side.",
+        finds: "The site preserves the famous 'Shrine of the Double-Headed Eagle' (a Buddhist stupa with Greek, Persian, and Indian decorative motifs combined), along with Buddhist stupas, Jain temples, and Hindu shrines within the same city walls.",
+    },
+    {
+        id: "sirsukh",
+        name: "Sirsukh",
+        period: "c. 1st century CE – 5th century CE",
+        rulers: "Kushan Empire",
+        layout: "A large fortified rectangular city with massive rubble-and-stone walls up to 6 meters thick and rounded bastions, reflecting Central Asian military-style urban design.",
+        desc: "Founded by the Kushans as Taxila's final and largest city, Sirsukh reflects the empire's Central Asian architectural heritage and served as a major hub during the height of Kushan patronage of Buddhism.",
+        finds: "Though less excavated than Sirkap due to continued agricultural use of the land, surveys have revealed massive fortification walls and evidence of the city's role in Kushan-era trade and administration.",
+    },
+];
+
+const TAXILA_TRADE_ROUTES = [
+    {
+        id: "grand-trunk",
+        name: "Uttarapatha (Grand Trunk precursor)",
+        connects: "Taxila to the Gangetic Plain and Pataliputra",
+        note: "The great northern highway of ancient India, linking Taxila eastward to Magadha and the Mauryan capital, carrying goods, administrators, and ideas along a route later formalized as the Grand Trunk Road.",
+    },
+    {
+        id: "silk-road-west",
+        name: "Silk Road (Western Branch via Bactria)",
+        connects: "Taxila to Bactria, Persia, and the Mediterranean",
+        note: "Taxila sat at a critical junction of the Silk Road's southern routes, connecting Central Asian and Persian trade networks to the Indian subcontinent through the Khyber and Kabul river valleys.",
+    },
+    {
+        id: "silk-road-north",
+        name: "Silk Road (Northern Branch via Kashmir)",
+        connects: "Taxila to Kashmir, the Karakoram, and Central Asia",
+        note: "A mountain route linking Taxila to Central Asian oasis cities via Kashmir and the high passes of the Karakoram, used heavily during the Kushan period for Buddhist pilgrimage and trade alike.",
+    },
+    {
+        id: "indus-route",
+        name: "Indus River Trade Corridor",
+        connects: "Taxila to the Arabian Sea ports via the Indus",
+        note: "A southbound corridor following the Indus River system toward coastal ports, allowing Gandharan goods and Buddhist art motifs to reach maritime trade networks extending to the Roman world.",
+    },
+];
+
+const TAXILA_BUDDHIST_SITES = [
+    { name: "Dharmarajika Stupa & Monastery", note: "Traditionally linked to relics of the Buddha enshrined by Emperor Ashoka, this vast stupa-and-monastery complex became one of the most important Buddhist pilgrimage sites in Gandhara." },
+    { name: "Jaulian Monastery", note: "A hillside monastic complex renowned for its stucco relief sculptures of the Buddha and donors, offering some of the best-preserved Gandharan Buddhist art at the site." },
+    { name: "Mohra Muradu Monastery", note: "A smaller, secluded monastery known for finely preserved stucco images, illustrating the spread of monastic institutions into the hills surrounding the main cities." },
+    { name: "Shrine of the Double-Headed Eagle (Sirkap)", note: "A stupa within Sirkap city itself, whose facade combines a Buddhist stupa form with Greek pilasters, Persian crenellations, and an Indian torana gateway, symbolizing Taxila's cultural fusion." },
+];
+
+const TAXILA_LEARNING = {
+    intro: "Taxila is traditionally remembered in Indian literary tradition as a center of learning where teachers instructed students in subjects ranging from the Vedas and grammar to medicine, archery, law, and politics, though it functioned as a constellation of individual teacher-student relationships rather than a single formal institution like later Nalanda.",
+    figures: [
+        { name: "Panini", note: "The celebrated Sanskrit grammarian, traditionally associated with the Taxila region, whose Ashtadhyayi systematized Sanskrit grammar with a precision still studied today." },
+        { name: "Chanakya (Kautilya)", note: "Traditionally said to have taught at Taxila before becoming the strategist and mentor behind the rise of Chandragupta Maurya, later authoring the Arthashastra on statecraft." },
+        { name: "Charaka (traditional association)", note: "Ancient medical tradition associates early Ayurvedic learning with teachers in the Taxila region, contributing to the region's reputation for medical education." },
+    ],
+};
+
+const TAXILA_ARTIFACTS = [
+    { id: "punch-marked-coins", name: "Silver Punch-Marked Coins", site: "Bhir Mound", desc: "Among the earliest coinage found in South Asia, stamped with symbols rather than inscriptions, reflecting Bhir Mound's role as an early trading settlement predating coin-portrait traditions." },
+    { id: "double-headed-eagle", name: "Double-Headed Eagle Stupa Facade", site: "Sirkap", desc: "A carved stone facade combining a Buddhist stupa dome, Greek Corinthian pilasters, Persian crenellations, and an Indian torana arch — a single object embodying Taxila's cultural blending." },
+    { id: "gandhara-buddha", name: "Gandharan Buddha Stucco Reliefs", site: "Jaulian & Mohra Muradu", desc: "Buddha and Bodhisattva images sculpted in the Greco-Buddhist Gandhara style, showing classical Hellenistic drapery and facial modeling fused with Buddhist iconography." },
+    { id: "kushan-seals", name: "Kushan-Era Seals & Sealings", site: "Sirsukh region", desc: "Clay sealings bearing Kharoshthi and Brahmi inscriptions used to authenticate goods and correspondence, evidence of Taxila's administrative role within the Kushan trade network." },
+    { id: "taxila-silver-vase", name: "Silver Vase of Taxila", site: "Bhir Mound / Sirkap deposits", desc: "Finely worked silver vessels recovered from Taxila's treasure deposits, illustrating the wealth accumulated through the city's control of trans-regional trade." },
+];
+
+const TAXILA_TIMELINE = [
+    { year: "c. 6th century BCE", title: "Early settlement (Bhir Mound)", desc: "Taxila emerges as an urban center under regional and later Achaemenid Persian administration." },
+    { year: "c. 326 BCE", title: "Alexander's campaign", desc: "Alexander the Great's army passes through Taxila; Greek historians record it as a wealthy and hospitable city." },
+    { year: "c. 321 – 185 BCE", title: "Mauryan rule", desc: "Taxila becomes a key provincial capital of the Mauryan Empire; Ashoka is traditionally said to have governed it as a prince." },
+    { year: "c. 2nd century BCE", title: "Founding of Sirkap", desc: "The Indo-Greek king Demetrius founds Sirkap on a Hellenistic grid plan after Bhir Mound's decline." },
+    { year: "c. 1st century BCE – 1st century CE", title: "Indo-Scythian & Indo-Parthian rule", desc: "Sirkap continues as the region's capital under successive Central Asian ruling dynasties, deepening cultural fusion." },
+    { year: "c. 1st century CE", title: "Kushan conquest & founding of Sirsukh", desc: "The Kushan Empire absorbs Taxila and constructs the fortified city of Sirsukh as its new administrative center." },
+    { year: "c. 1st – 5th century CE", title: "Height of Gandharan Buddhist art", desc: "Monasteries at Dharmarajika, Jaulian, and Mohra Muradu flourish, producing some of the finest Gandharan Buddhist sculpture." },
+    { year: "c. 460s – 470s CE", title: "Hephthalite (Hun) invasions", desc: "Repeated Hun invasions devastate Taxila's monasteries and urban centers, beginning the region's long decline." },
+    { year: "1863 – 1934 CE", title: "Rediscovery and excavation", desc: "Alexander Cunningham identifies the site in the 1860s; Sir John Marshall leads extensive systematic excavations from 1913–1934, uncovering all three cities." },
+    { year: "1980 CE", title: "UNESCO World Heritage status", desc: "Taxila is inscribed as a UNESCO World Heritage Site, recognizing its exceptional testimony to cultural exchange across Central and South Asia." },
+];
+
+const TAXILA_REFERENCES = [
+    { text: "Marshall, Sir John. Taxila: An Illustrated Account of Archaeological Excavations. Cambridge University Press, 1951.", url: "https://www.jstor.org/" },
+    { text: "UNESCO World Heritage Centre — Taxila.", url: "https://whc.unesco.org/en/list/139/" },
+    { text: "Archaeological Survey of India / Directorate General of Archaeology, Pakistan — Taxila Site Reports.", url: "https://www.archaeology.gov.pk/" },
+    { text: "Dani, Ahmad Hasan. The Historic City of Taxila. UNESCO / Sang-e-Meel Publications, 1986.", url: "https://whc.unesco.org/en/list/139/" },
+];

--- a/frontend/taxila-explorer/taxila.css
+++ b/frontend/taxila-explorer/taxila.css
@@ -1,0 +1,375 @@
+/* taxila.css — Taxila: Ancient Crossroads of Gandhara Explorer */
+
+.taxila-hero {
+    padding: 4rem 0 2.5rem;
+    text-align: center;
+    background: linear-gradient(180deg, rgba(212, 175, 55, 0.08), transparent);
+}
+
+.hero-badges-row {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    margin-bottom: 1.25rem;
+}
+
+.hero-pill {
+    padding: 0.35rem 0.9rem;
+    border-radius: 999px;
+    background: rgba(212, 175, 55, 0.12);
+    border: 1px solid rgba(212, 175, 55, 0.35);
+    font-size: 0.85rem;
+    font-weight: 500;
+}
+
+.taxila-hero h1 {
+    font-family: "Playfair Display", serif;
+    font-size: clamp(2rem, 4vw, 3rem);
+    margin-bottom: 0.75rem;
+}
+
+.taxila-hero h1 span {
+    display: block;
+    font-size: 0.5em;
+    font-weight: 500;
+    opacity: 0.75;
+    margin-top: 0.35rem;
+}
+
+.hero-subtitle {
+    max-width: 720px;
+    margin: 0 auto 2rem;
+    opacity: 0.85;
+    line-height: 1.6;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 1rem;
+    max-width: 700px;
+    margin: 0 auto;
+}
+
+.stats-grid .stat-item {
+    padding: 1rem;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(212, 175, 55, 0.2);
+}
+
+.stats-grid .stat-value {
+    font-family: "Playfair Display", serif;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #d4af37;
+}
+
+.stats-grid .stat-label {
+    font-size: 0.78rem;
+    opacity: 0.7;
+}
+
+.sec-title {
+    font-family: "Playfair Display", serif;
+    margin-bottom: 0.75rem;
+}
+
+.section-hint {
+    font-size: 0.85rem;
+    opacity: 0.65;
+    margin-bottom: 1rem;
+}
+
+.taxila-settlements-section,
+.taxila-trade-section,
+.taxila-buddhist-section,
+.taxila-learning-section,
+.taxila-artifacts-section,
+.taxila-timeline-section {
+    padding: 1.75rem 0;
+}
+
+/* Settlements */
+.settlement-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    margin-bottom: 1.25rem;
+}
+
+.settlement-tab-btn {
+    padding: 0.55rem 1.1rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    cursor: pointer;
+    font-size: 0.88rem;
+    transition: all 0.2s ease;
+}
+
+.settlement-tab-btn:hover {
+    border-color: #d4af37;
+}
+
+.settlement-tab-btn.active {
+    background: linear-gradient(135deg, #d4af37, #b8860b);
+    color: #1a1a1a;
+    font-weight: 600;
+    border-color: #d4af37;
+}
+
+.settlement-comparison-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.settlement-compare-card {
+    padding: 1.1rem;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(212, 175, 55, 0.18);
+}
+
+.settlement-compare-card.highlight {
+    border-color: #d4af37;
+    box-shadow: 0 0 0 2px rgba(212, 175, 55, 0.35);
+}
+
+.compare-name {
+    font-family: "Playfair Display", serif;
+    font-weight: 700;
+    margin-bottom: 0.3rem;
+}
+
+.compare-row {
+    font-size: 0.82rem;
+    line-height: 1.6;
+    opacity: 0.85;
+    margin-bottom: 0.2rem;
+}
+
+.compare-row strong {
+    color: #d4af37;
+    font-weight: 600;
+}
+
+.settlement-detail-card {
+    padding: 1.5rem 1.75rem;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.035);
+    border: 1px solid rgba(212, 175, 55, 0.2);
+}
+
+.settlement-detail-card h3 {
+    font-family: "Playfair Display", serif;
+    margin-bottom: 0.4rem;
+}
+
+.settlement-detail-card p {
+    line-height: 1.65;
+    opacity: 0.9;
+    margin-bottom: 0.6rem;
+    font-size: 0.92rem;
+}
+
+.settlement-detail-meta {
+    font-size: 0.8rem;
+    color: #d4af37;
+    margin-bottom: 0.75rem !important;
+}
+
+/* Trade routes */
+.trade-route-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.9rem;
+}
+
+.trade-route-item {
+    padding: 1rem 1.25rem;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.03);
+    border-left: 3px solid #d4af37;
+    border-top: 1px solid rgba(212, 175, 55, 0.15);
+    border-right: 1px solid rgba(212, 175, 55, 0.15);
+    border-bottom: 1px solid rgba(212, 175, 55, 0.15);
+}
+
+.trade-route-name {
+    font-weight: 700;
+    margin-bottom: 0.2rem;
+}
+
+.trade-route-connects {
+    font-size: 0.8rem;
+    color: #d4af37;
+    margin-bottom: 0.4rem;
+}
+
+.trade-route-note {
+    font-size: 0.86rem;
+    line-height: 1.55;
+    opacity: 0.85;
+}
+
+/* Buddhist sites */
+.buddhist-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 1.1rem;
+}
+
+.buddhist-item {
+    padding: 1.1rem;
+    border-radius: 14px;
+    background: radial-gradient(circle at top left, rgba(212, 175, 55, 0.08), transparent);
+    border: 1px solid rgba(212, 175, 55, 0.2);
+}
+
+.buddhist-name {
+    font-weight: 700;
+    margin-bottom: 0.4rem;
+}
+
+.buddhist-note {
+    font-size: 0.87rem;
+    line-height: 1.6;
+    opacity: 0.85;
+}
+
+/* Learning */
+.learning-intro {
+    line-height: 1.65;
+    opacity: 0.88;
+    margin-bottom: 1.25rem;
+    max-width: 760px;
+}
+
+.learning-figures-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.learning-figure-card {
+    padding: 1rem;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(212, 175, 55, 0.15);
+}
+
+.learning-figure-name {
+    font-weight: 700;
+    margin-bottom: 0.3rem;
+}
+
+.learning-figure-note {
+    font-size: 0.85rem;
+    line-height: 1.55;
+    opacity: 0.83;
+}
+
+/* Artifacts */
+.artifact-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 1.1rem;
+}
+
+.artifact-card {
+    padding: 1.1rem;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.035);
+    border: 1px solid rgba(212, 175, 55, 0.18);
+}
+
+.artifact-icon {
+    font-size: 1.5rem;
+    margin-bottom: 0.4rem;
+}
+
+.artifact-name {
+    font-weight: 700;
+    margin-bottom: 0.2rem;
+}
+
+.artifact-site {
+    font-size: 0.75rem;
+    color: #d4af37;
+    margin-bottom: 0.5rem;
+}
+
+.artifact-desc {
+    font-size: 0.86rem;
+    line-height: 1.55;
+    opacity: 0.85;
+}
+
+/* Timeline */
+.taxila-timeline {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    border-left: 2px solid rgba(212, 175, 55, 0.35);
+    padding-left: 1.5rem;
+}
+
+.timeline-item {
+    position: relative;
+    padding: 0.75rem 1rem;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(212, 175, 55, 0.15);
+}
+
+.timeline-item::before {
+    content: "";
+    position: absolute;
+    left: -1.75rem;
+    top: 1.1rem;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: #d4af37;
+}
+
+.timeline-year {
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: #d4af37;
+}
+
+.timeline-title {
+    font-weight: 600;
+    margin: 0.2rem 0;
+}
+
+.timeline-desc {
+    font-size: 0.85rem;
+    opacity: 0.8;
+    line-height: 1.5;
+}
+
+/* Mobile responsiveness */
+@media (max-width: 768px) {
+    .settlement-comparison-grid,
+    .buddhist-grid,
+    .learning-figures-grid,
+    .artifact-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .settlement-tabs {
+        overflow-x: auto;
+        flex-wrap: nowrap;
+        padding-bottom: 0.25rem;
+    }
+
+    .settlement-detail-card {
+        padding: 1.25rem;
+    }
+}

--- a/frontend/taxila-explorer/taxila.js
+++ b/frontend/taxila-explorer/taxila.js
@@ -1,0 +1,164 @@
+// taxila.js — Taxila: Ancient Crossroads of Gandhara Explorer logic
+
+(function () {
+    let selectedSettlementId = TAXILA_SETTLEMENTS[0].id;
+
+    function renderStats() {
+        const grid = document.getElementById("stats-grid");
+        if (!grid) return;
+        grid.innerHTML = TAXILA_STATS.map(
+            (s) => `
+            <div class="stat-item">
+                <div class="stat-value">${s.value}</div>
+                <div class="stat-label">${s.label}</div>
+            </div>`
+        ).join("");
+    }
+
+    function renderSettlementTabs() {
+        const el = document.getElementById("settlement-tabs");
+        if (!el) return;
+        el.innerHTML = TAXILA_SETTLEMENTS.map(
+            (s) => `
+            <button class="settlement-tab-btn${s.id === selectedSettlementId ? " active" : ""}" data-id="${s.id}">
+                ${s.name}
+            </button>`
+        ).join("");
+
+        el.querySelectorAll(".settlement-tab-btn").forEach((btn) => {
+            btn.addEventListener("click", () => {
+                selectedSettlementId = btn.dataset.id;
+                renderSettlementTabs();
+                renderComparisonGrid();
+                renderSettlementDetail();
+            });
+        });
+    }
+
+    function renderComparisonGrid() {
+        const el = document.getElementById("settlement-comparison-grid");
+        if (!el) return;
+        el.innerHTML = TAXILA_SETTLEMENTS.map(
+            (s) => `
+            <div class="settlement-compare-card${s.id === selectedSettlementId ? " highlight" : ""}" data-id="${s.id}">
+                <div class="compare-name">${s.name}</div>
+                <div class="compare-row"><strong>Period:</strong> ${s.period}</div>
+                <div class="compare-row"><strong>Rulers:</strong> ${s.rulers}</div>
+                <div class="compare-row"><strong>Layout:</strong> ${s.layout}</div>
+            </div>`
+        ).join("");
+
+        el.querySelectorAll(".settlement-compare-card").forEach((card) => {
+            card.addEventListener("click", () => {
+                selectedSettlementId = card.dataset.id;
+                renderSettlementTabs();
+                renderComparisonGrid();
+                renderSettlementDetail();
+            });
+        });
+    }
+
+    function renderSettlementDetail() {
+        const s = TAXILA_SETTLEMENTS.find((x) => x.id === selectedSettlementId);
+        const el = document.getElementById("settlement-detail-card");
+        if (!el || !s) return;
+        el.innerHTML = `
+            <h3>${s.name}</h3>
+            <p class="settlement-detail-meta">${s.period} — ${s.rulers}</p>
+            <p>${s.desc}</p>
+            <p><strong>Archaeological finds:</strong> ${s.finds}</p>
+        `;
+    }
+
+    function renderTradeRoutes() {
+        const el = document.getElementById("trade-route-list");
+        if (!el) return;
+        el.innerHTML = TAXILA_TRADE_ROUTES.map(
+            (t) => `
+            <div class="trade-route-item">
+                <div class="trade-route-name">🛤️ ${t.name}</div>
+                <div class="trade-route-connects">${t.connects}</div>
+                <div class="trade-route-note">${t.note}</div>
+            </div>`
+        ).join("");
+    }
+
+    function renderBuddhistSites() {
+        const el = document.getElementById("buddhist-grid");
+        if (!el) return;
+        el.innerHTML = TAXILA_BUDDHIST_SITES.map(
+            (b) => `
+            <div class="buddhist-item">
+                <div class="buddhist-name">☸️ ${b.name}</div>
+                <div class="buddhist-note">${b.note}</div>
+            </div>`
+        ).join("");
+    }
+
+    function renderLearning() {
+        const introEl = document.getElementById("learning-intro");
+        const gridEl = document.getElementById("learning-figures-grid");
+        if (introEl) introEl.textContent = TAXILA_LEARNING.intro;
+        if (gridEl) {
+            gridEl.innerHTML = TAXILA_LEARNING.figures
+                .map(
+                    (f) => `
+                <div class="learning-figure-card">
+                    <div class="learning-figure-name">${f.name}</div>
+                    <div class="learning-figure-note">${f.note}</div>
+                </div>`
+                )
+                .join("");
+        }
+    }
+
+    function renderArtifacts() {
+        const el = document.getElementById("artifact-grid");
+        if (!el) return;
+        el.innerHTML = TAXILA_ARTIFACTS.map(
+            (a) => `
+            <div class="artifact-card">
+                <div class="artifact-icon">🏺</div>
+                <div class="artifact-name">${a.name}</div>
+                <div class="artifact-site">Found at: ${a.site}</div>
+                <div class="artifact-desc">${a.desc}</div>
+            </div>`
+        ).join("");
+    }
+
+    function renderTimeline() {
+        const el = document.getElementById("taxila-timeline");
+        if (!el) return;
+        el.innerHTML = TAXILA_TIMELINE.map(
+            (t) => `
+            <div class="timeline-item">
+                <div class="timeline-year">${t.year}</div>
+                <div class="timeline-title">${t.title}</div>
+                <div class="timeline-desc">${t.desc}</div>
+            </div>`
+        ).join("");
+    }
+
+    function renderReferences() {
+        const el = document.getElementById("references-list");
+        if (!el) return;
+        el.innerHTML = TAXILA_REFERENCES.map(
+            (r) => `<li><a href="${r.url}" target="_blank" rel="noopener">${r.text}</a></li>`
+        ).join("");
+    }
+
+    function init() {
+        renderStats();
+        renderSettlementTabs();
+        renderComparisonGrid();
+        renderSettlementDetail();
+        renderTradeRoutes();
+        renderBuddhistSites();
+        renderLearning();
+        renderArtifacts();
+        renderTimeline();
+        renderReferences();
+    }
+
+    document.addEventListener("DOMContentLoaded", init);
+})();

--- a/index.html
+++ b/index.html
@@ -393,7 +393,6 @@
                 <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
                 <div class="dropdown-menu">
                     <a href="frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
-                    <a href="frontend/taxila-explorer/index.html" class="dropdown-item">Taxila: Crossroads of Gandhara</a>
                     <a href="frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
                     <a href="frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
                     <a href="frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>

--- a/index.html
+++ b/index.html
@@ -393,6 +393,7 @@
                 <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
                 <div class="dropdown-menu">
                     <a href="frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+                    <a href="frontend/taxila-explorer/index.html" class="dropdown-item">Taxila: Crossroads of Gandhara</a>
                     <a href="frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
                     <a href="frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
                     <a href="frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>


### PR DESCRIPTION
Closes #2066

## Changes
Adds an interactive explorer for Taxila, comparing its three successive settlements and covering the trade, religious, and intellectual networks that made it a crossroads of Gandhara.

## Features
- Settlement Comparison — Bhir Mound, Sirkap, and Sirsukh side by side (period, rulers, urban layout), with a click-through detail panel covering each city's history and archaeological finds
- Trade Route Visualization — 4 routes (Uttarapatha, Silk Road western/northern branches via Bactria and Kashmir, Indus river corridor)
- Buddhist Establishments — Dharmarajika Stupa, Jaulian Monastery, Mohra Muradu Monastery, and the Shrine of the Double-Headed Eagle
- Learning Traditions — Taxila's teacher-student tradition, with Panini, Chanakya, and Charaka
- Artifact Explorer — 5 artifacts tied to their find-site (punch-marked coins, the Double-Headed Eagle facade, Gandharan stucco reliefs, Kushan seals, silver vessels)
- Archaeological Timeline — 10 milestones from c. 6th century BCE settlement through Alexander's campaign, Mauryan/Indo-Greek/Kushan rule, Hun invasions, to 1980 UNESCO inscription
- Landing page integration: link added under the Culture navbar dropdown
- Site search integration: entry added to search-index.js
- Sources cited in References section

## Implementation
- `frontend/taxila-explorer/index.html` — page structure
- `frontend/taxila-explorer/taxila-data.js` — settlements, trade routes, Buddhist sites, learning figures, artifacts, timeline, references
- `frontend/taxila-explorer/taxila.css` — styling, mobile responsive
- `frontend/taxila-explorer/taxila.js` — settlement tab/comparison logic, section rendering
- `index.html` — added Taxila link to Culture dropdown
- `frontend/search-index.js` — added search entry

## Testing
Tested locally via `python3 -m http.server`:
- Settlement tabs and comparison cards correctly sync and update the detail panel
- All sections (trade routes, Buddhist sites, learning, artifacts, timeline) render correctly
- Mobile responsive layout verified at narrow viewport widths
- No console errors
<img width="1440" height="852" alt="Screenshot 2026-08-13 084014" src="https://github.com/user-attachments/assets/2984f700-9587-4d12-a427-95df3a23f4d8" />
<img width="1440" height="852" alt="Screenshot 2026-08-13 084034" src="https://github.com/user-attachments/assets/570d87f2-8225-4425-a545-b04d3de9c25e" />
![Uploading Screenshot 2026-08-13 084020.png…]()
