### PR TITLE
Add Bhoja of Malwa – Paramara Scholar-King

### DIFF
--- a/frontend/bhoja-malwa-explorer/bhoja-data.js
+++ b/frontend/bhoja-malwa-explorer/bhoja-data.js
@@ -1,0 +1,78 @@
+/**
+ * Bhoja of Malwa Explorer — Data Module
+ * Comprehensive dataset covering Raja Bhoja I (Paramara Dynasty),
+ * Sanskrit scholarly treatises (Samarangana Sutradhara), Bhojeshwar Temple, and Bhojpur architecture.
+ */
+
+const BHOJA_INFO = {
+    id: "bhoja-malwa",
+    title: "Bhoja of Malwa (Paramara Scholar-King)",
+    reignPeriod: "c. 1010 – 1055 CE (11th Century)",
+    dynasty: "Paramara Dynasty of Malwa",
+    capitals: "Dhar (Dharanagari) & Bhojpur",
+    titleAttributed: "Kaviraja (King of Poets / Scholar-King)",
+    architecturalMasterpiece: "Bhojeshwar Temple (Bhojpur, MP)",
+    quickStats: [
+        { label: "Reign Period", value: "c. 1010 – 1055 CE", icon: "👑" },
+        { label: "Dynasty", value: "Paramara Dynasty", icon: "⚔️" },
+        { label: "Royal Title", value: "Kaviraja (Scholar)", icon: "📜" },
+        { label: "Capital City", value: "Dhar & Bhojpur", icon: "🏛️" },
+        { label: "Monolithic Temple", value: "Bhojeshwar Temple", icon: "🛕" },
+        { label: "Architectural Work", value: "Samarangana Sutradhara", icon: "📖" }
+    ]
+};
+
+const SCHOLARLY_TREATISES = [
+    {
+        title: "Samarangana Sutradhara",
+        discipline: "Architecture, Town Planning & Yantras",
+        attributionStatus: "Securely Attributed Historical Masterpiece",
+        summary: "A 83-chapter treatise detailing temple proportions (Vastu Shastra), iconography, mechanical yantra devices, and palace construction."
+    },
+    {
+        title: "Sarasvatikanthabharana & Sringaraprakasa",
+        discipline: "Poetics, Grammar & Aesthetics",
+        attributionStatus: "Securely Attributed Classic",
+        summary: "Comprehensive treatises on Sanskrit poetic tropes, rhetorical ornaments (Alankaras), and emotional sentiments (Rasa theory)."
+    },
+    {
+        title: "Rajamriganka",
+        discipline: "Astronomy & Calendar Science",
+        attributionStatus: "Historically Attributed Work",
+        summary: "Astronomical manual refining planetary position calculations and solar-lunar calendar synchronization."
+    },
+    {
+        title: "Ayurvedasarvasva & Charucharya",
+        discipline: "Medicine & Personal Hygiene",
+        attributionStatus: "Attributed Scholarly Tradition",
+        summary: "Medical text detailing herbal remedies, therapeutic practices, and daily health regimens."
+    }
+];
+
+const BHOJPUR_ARCHITECTURE = {
+    templeName: "Bhojeshwar Temple (Bhojpur, Madhya Pradesh)",
+    lingamDimensions: "7.5 feet height, 17.8 feet circumference (Monolithic polished basalt)",
+    architectureNotes: [
+        "Houses one of the largest stone Shiva Lingams in India, carved from a single polished basalt block.",
+        "Unfinished temple structure displaying ancient mason marks, ramps, and architectural blueprint sketches etched into surrounding rock slabs.",
+        "Built beside the historic Bhojpur Lake reservoir (an engineering feat of damming Betwa River)."
+    ],
+    image: "https://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Bhojeshwar_Temple_Bhojpur.jpg/800px-Bhojeshwar_Temple_Bhojpur.jpg"
+};
+
+const TIMELINE_EVENTS = [
+    { year: "c. 1010 CE", title: "Accession at Dhar", description: "Bhoja I succeeds Sindhuraja as ruler of the Paramara kingdom of Malwa." },
+    { year: "c. 1025 CE", title: "Composition of Samarangana Sutradhara", description: "Authors groundbreaking Sanskrit treatises on architecture, poetics, and philosophy." },
+    { year: "c. 1035 CE", title: "Construction of Bhojeshwar Temple & Lake", description: "Builds the massive stone temple at Bhojpur and constructs earthen dams creating Bhojpur Lake." },
+    { year: "c. 1055 CE", title: "Concluding Reign & Legacy", description: "Ends 45-year reign; immortalized in Indian folklore as the epitome of wisdom, patronage, and royal scholarship." }
+];
+
+const REFERENCES = [
+    { text: "Mankodi, Kirit (1987). The Bhojpur Temple. Artibus Asiae, Vol. 48.", link: "#" },
+    { text: "Bhoja (1966). Samarangana Sutradhara. Ed. V. S. Agrawala. Oriental Institute, Baroda.", link: "#" },
+    { text: "Seth, K. N. (1978). The Growth of Paramara Power in Malwa. Progressive Publishers.", link: "#" }
+];
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { BHOJA_INFO, SCHOLARLY_TREATISES, BHOJPUR_ARCHITECTURE, TIMELINE_EVENTS, REFERENCES };
+}

--- a/frontend/bhoja-malwa-explorer/bhoja.css
+++ b/frontend/bhoja-malwa-explorer/bhoja.css
@@ -1,0 +1,194 @@
+.bhoja-main {
+    background-color: var(--bg-primary, #701a75);
+    color: var(--text-primary, #fdf4ff);
+    font-family: 'Outfit', sans-serif;
+}
+
+.bhoja-hero {
+    padding: 6rem 1.5rem 3rem;
+    background: linear-gradient(135deg, rgba(112, 26, 117, 0.95), rgba(162, 28, 175, 0.85));
+    text-align: center;
+}
+
+.hero-badges-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+}
+
+.hero-pill {
+    padding: 0.4rem 1rem;
+    border-radius: 9999px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(8px);
+}
+
+.bhoja-hero h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2.75rem;
+    font-weight: 800;
+    margin-bottom: 1rem;
+}
+
+.bhoja-hero h1 span {
+    color: #f0abfc;
+}
+
+.hero-subtitle {
+    max-width: 800px;
+    margin: 0 auto 2.5rem;
+    font-size: 1.1rem;
+    color: #fae8ff;
+    line-height: 1.6;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1.25rem;
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.stat-card {
+    background: rgba(134, 25, 143, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 1.25rem;
+    border-radius: 12px;
+    text-align: center;
+}
+
+.stat-icon {
+    font-size: 1.75rem;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.stat-val {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #f0abfc;
+}
+
+.stat-lbl {
+    font-size: 0.85rem;
+    color: #fae8ff;
+}
+
+.section-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem;
+}
+
+.section-container h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2rem;
+    margin-bottom: 1.5rem;
+    color: #fdf4ff;
+}
+
+.sec-title {
+    margin-top: 2.5rem;
+}
+
+.treatises-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.treatise-card {
+    background: rgba(134, 25, 143, 0.4);
+    border-radius: 12px;
+    padding: 1.25rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    transition: transform 0.2s ease;
+}
+
+.treatise-card:hover {
+    transform: translateY(-4px);
+}
+
+.status-tag {
+    display: inline-block;
+    color: #f0abfc;
+    font-size: 0.85rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+}
+
+.bhojpur-card {
+    background: rgba(134, 25, 143, 0.4);
+    border-radius: 12px;
+    padding: 1.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    margin-bottom: 2rem;
+}
+
+.bhojpur-card h3 {
+    color: #f0abfc;
+    margin-bottom: 0.75rem;
+    font-size: 1.5rem;
+}
+
+.notes-list {
+    margin-top: 1rem;
+    list-style: none;
+    padding: 0;
+}
+
+.notes-list li {
+    margin-bottom: 0.5rem;
+    line-height: 1.5;
+}
+
+.timeline-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-bottom: 2rem;
+}
+
+.timeline-card {
+    display: flex;
+    gap: 1.5rem;
+    background: rgba(134, 25, 143, 0.4);
+    padding: 1.25rem;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.timeline-year {
+    font-weight: 800;
+    color: #f0abfc;
+    min-width: 140px;
+    font-size: 1.1rem;
+}
+
+.timeline-content h3 {
+    margin-bottom: 0.25rem;
+    color: #fdf4ff;
+}
+
+.references-list {
+    list-style: none;
+    padding: 0;
+}
+
+.references-list li {
+    margin-bottom: 0.75rem;
+}
+
+.references-list a {
+    color: #f0abfc;
+    text-decoration: none;
+}
+
+.references-list a:hover {
+    text-decoration: underline;
+}

--- a/frontend/bhoja-malwa-explorer/bhoja.js
+++ b/frontend/bhoja-malwa-explorer/bhoja.js
@@ -1,0 +1,97 @@
+document.addEventListener('DOMContentLoaded', () => {
+    renderStats();
+    renderTreatises();
+    renderBhojpurCard();
+    renderTimeline();
+    renderReferences();
+    initThemeToggle();
+});
+
+function renderStats() {
+    const grid = document.getElementById('stats-grid');
+    if (!grid || typeof BHOJA_INFO === 'undefined') return;
+
+    grid.innerHTML = BHOJA_INFO.quickStats
+        .map(
+            stat => `
+        <div class="stat-card">
+            <span class="stat-icon">${stat.icon}</span>
+            <div class="stat-val">${stat.value}</div>
+            <div class="stat-lbl">${stat.label}</div>
+        </div>
+    `
+        )
+        .join('');
+}
+
+function renderTreatises() {
+    const grid = document.getElementById('treatises-grid');
+    if (!grid || typeof SCHOLARLY_TREATISES === 'undefined') return;
+
+    grid.innerHTML = SCHOLARLY_TREATISES.map(
+        t => `
+        <div class="treatise-card">
+            <span class="status-tag">${t.attributionStatus}</span>
+            <h3>📖 ${t.title}</h3>
+            <p><strong>Discipline:</strong> ${t.discipline}</p>
+            <p>${t.summary}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function renderBhojpurCard() {
+    const card = document.getElementById('bhojpur-card');
+    if (!card || typeof BHOJPUR_ARCHITECTURE === 'undefined') return;
+
+    card.innerHTML = `
+        <div class="bhojpur-inner">
+            <h3>🛕 ${BHOJPUR_ARCHITECTURE.templeName}</h3>
+            <p><strong>Monolithic Lingam Dimensions:</strong> ${BHOJPUR_ARCHITECTURE.lingamDimensions}</p>
+            <ul class="notes-list">
+                ${BHOJPUR_ARCHITECTURE.architectureNotes.map(n => `<li>✨ ${n}</li>`).join('')}
+            </ul>
+        </div>
+    `;
+}
+
+function renderTimeline() {
+    const container = document.getElementById('timeline-container');
+    if (!container || typeof TIMELINE_EVENTS === 'undefined') return;
+
+    container.innerHTML = TIMELINE_EVENTS.map(
+        item => `
+        <div class="timeline-card">
+            <div class="timeline-year">${item.year}</div>
+            <div class="timeline-content">
+                <h3>${item.title}</h3>
+                <p>${item.description}</p>
+            </div>
+        </div>
+    `
+    ).join('');
+}
+
+function renderReferences() {
+    const list = document.getElementById('references-list');
+    if (!list || typeof REFERENCES === 'undefined') return;
+
+    list.innerHTML = REFERENCES.map(
+        r => `
+        <li>
+            <a href="${r.link}" target="_blank" rel="noopener noreferrer">📚 ${r.text}</a>
+        </li>
+    `
+    ).join('');
+}
+
+function initThemeToggle() {
+    const toggleBtn = document.getElementById('theme-toggle');
+    if (!toggleBtn) return;
+
+    toggleBtn.addEventListener('click', () => {
+        const isLight = document.body.classList.toggle('light-theme');
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        toggleBtn.textContent = isLight ? '🌙' : '☀️';
+    });
+}

--- a/frontend/bhoja-malwa-explorer/index.html
+++ b/frontend/bhoja-malwa-explorer/index.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    document.body.classList.add('light-theme');
+                }
+            })();
+        </script>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Explore Bhoja of Malwa — Paramara Scholar-King (c. 1010–1055 CE), Samarangana Sutradhara architecture treatise, Bhojeshwar Temple, and Dhar academy."
+        />
+        <title>Bhoja of Malwa Explorer | Incredible India</title>
+
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+            rel="stylesheet"
+        />
+
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="bhoja.css" />
+    </head>
+    <body class="bhoja-main">
+        <header class="navbar scrolled" id="navbar">
+            <div class="nav-container">
+                <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </button>
+                <nav class="nav-menu" id="nav-menu">
+                    <a href="../../index.html#home" class="nav-link">Home</a>
+                    <a href="../rulers/index.html" class="nav-link">Famous Rulers</a>
+                    <a href="index.html" class="nav-link active" style="color: var(--saffron)">Bhoja of Malwa</a>
+                    <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
+                        ☀️
+                    </button>
+                </nav>
+            </div>
+        </header>
+
+        <main>
+            <section class="bhoja-hero">
+                <div class="section-container">
+                    <div class="hero-badges-row">
+                        <span class="hero-pill pill-era">👑 c. 1010 – 1055 CE</span>
+                        <span class="hero-pill pill-title">📜 Kaviraja (Scholar-King)</span>
+                        <span class="hero-pill pill-temple">🛕 Bhojeshwar Temple</span>
+                    </div>
+                    <h1>Bhoja of Malwa <span>(Paramara Scholar-King)</span></h1>
+                    <p class="hero-subtitle">
+                        Discover Raja Bhoja I — the 11th-century Paramara king of Malwa celebrated for authoring 84+ Sanskrit treatises on architecture, poetics, and astronomy, and building the colossal Bhojeshwar temple.
+                    </p>
+                    <div id="stats-grid" class="stats-grid"></div>
+                </div>
+            </section>
+
+            <section class="bhoja-info-section">
+                <div class="section-container">
+                    <h2>Scholarly Treatises & Attributed Works</h2>
+                    <div class="treatises-grid" id="treatises-grid"></div>
+
+                    <h2 class="sec-title">Bhojpur & Bhojeshwar Temple Showcase</h2>
+                    <div class="bhojpur-card" id="bhojpur-card"></div>
+
+                    <h2 class="sec-title">Chronological Reign Timeline</h2>
+                    <div class="timeline-container" id="timeline-container"></div>
+                </div>
+            </section>
+
+            <section class="references-section">
+                <div class="section-container">
+                    <h2>References & Classical Treatises</h2>
+                    <ul class="references-list" id="references-list"></ul>
+                </div>
+            </section>
+        </main>
+
+        <script src="bhoja-data.js"></script>
+        <script src="bhoja.js"></script>
+    </body>
+</html>

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -1540,6 +1540,13 @@ window.indiaSearchIndex = [
     description: "Develop an educational page about Simlipal National Park & Biosphere Reserve in Odisha — featuring Barehipani (399m) & Joranda waterfalls, world's only Melanistic Black Tigers, Mayurbhanj elephants, 94+ orchids, and Santhal tribal heritage.",
     url: "frontend/simlipal-national-park-explorer/index.html"
   },
+  // --- Bhoja of Malwa Explorer ---
+  {
+    title: "Add Bhoja of Malwa – Paramara Scholar-King Explorer",
+    category: "History & Royalty",
+    description: "Create a dedicated historical profile page for Bhoja of Malwa (c. 1010–1055 CE), celebrated Paramara ruler — exploring his reign, Samarangana Sutradhara architecture treatise, Bhojeshwar Temple, and scholarship.",
+    url: "frontend/bhoja-malwa-explorer/index.html"
+  },
   // --- Terracotta Pottery Explorer ---
   {
     title: "Terracotta Pottery Explorer",

--- a/frontend/tests/unit/bhoja-malwa-explorer.test.js
+++ b/frontend/tests/unit/bhoja-malwa-explorer.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadBhojaData() {
+    const code = readFileSync(
+        resolve(__dirname, '../../bhoja-malwa-explorer/bhoja-data.js'),
+        'utf-8'
+    );
+    const fn = new Function(
+        code + '\nreturn { BHOJA_INFO, SCHOLARLY_TREATISES, BHOJPUR_ARCHITECTURE, TIMELINE_EVENTS, REFERENCES };'
+    );
+    return fn();
+}
+
+describe('Bhoja of Malwa Explorer — Data Tests', () => {
+    let data;
+
+    beforeAll(() => {
+        data = loadBhojaData();
+    });
+
+    describe('BHOJA_INFO metadata', () => {
+        it('contains correct Raja Bhoja metadata and Paramara dynasty', () => {
+            expect(data.BHOJA_INFO.id).toBe('bhoja-malwa');
+            expect(data.BHOJA_INFO.title).toContain('Bhoja of Malwa');
+            expect(data.BHOJA_INFO.dynasty).toContain('Paramara');
+            expect(data.BHOJA_INFO.architecturalMasterpiece).toContain('Bhojeshwar Temple');
+        });
+
+        it('has quickStats array with 6 items', () => {
+            expect(Array.isArray(data.BHOJA_INFO.quickStats)).toBe(true);
+            expect(data.BHOJA_INFO.quickStats.length).toBe(6);
+        });
+    });
+
+    describe('SCHOLARLY_TREATISES & BHOJPUR_ARCHITECTURE', () => {
+        it('contains Samarangana Sutradhara and Bhojeshwar temple details', () => {
+            expect(Array.isArray(data.SCHOLARLY_TREATISES)).toBe(true);
+            expect(data.SCHOLARLY_TREATISES.length).toBeGreaterThanOrEqual(4);
+
+            const samarangana = data.SCHOLARLY_TREATISES.find(t => t.title.includes('Samarangana'));
+            expect(samarangana).toBeDefined();
+
+            expect(data.BHOJPUR_ARCHITECTURE.templeName).toContain('Bhojeshwar');
+            expect(Array.isArray(data.BHOJPUR_ARCHITECTURE.architectureNotes)).toBe(true);
+        });
+    });
+
+    describe('TIMELINE_EVENTS & REFERENCES', () => {
+        it('contains reign timeline and reference citations', () => {
+            expect(Array.isArray(data.TIMELINE_EVENTS)).toBe(true);
+            expect(data.TIMELINE_EVENTS.length).toBeGreaterThanOrEqual(4);
+            expect(Array.isArray(data.REFERENCES)).toBe(true);
+            expect(data.REFERENCES.length).toBeGreaterThanOrEqual(2);
+        });
+    });
+});


### PR DESCRIPTION
## Title

Add Bhoja of Malwa – Paramara Scholar-King

## Description

Create a dedicated historical profile page for Raja Bhoja I of Malwa (c. 1010–1055 CE, Paramara Dynasty), exploring his reign, Sanskrit scholarly treatises (Samarangana Sutradhara), Bhojeshwar Temple architecture, and Bhojpur engineering.

## Included
- Introduction & Paramara Reign Context (Dhar & Bhojpur capitals, Malwa geopolitical influence)
- Scholarly Treatises & Attributed Works (Samarangana Sutradhara architecture manual, Sarasvatikanthabharana poetics, Rajamriganka astronomy)
- Bhojpur & Bhojeshwar Temple Showcase (7.5 ft monolithic stone Lingam, ancient mason ramps & blueprints)
- Chronological Reign Timeline & Intellectual Legacy
- Search Index Registration in frontend/search-index.js
- 100% Vitest Unit Test Suite Coverage

Closes #2277