### PR TITLE
feat: add Indo-Greek Coins & Royal Portraits explorer

### DIFF
--- a/frontend/indo-greek-coins-explorer/index.html
+++ b/frontend/indo-greek-coins-explorer/index.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Indo-Greek Coins & Royal Portraits Explorer | Incredible India</title>
+  <meta name="description" content="Explore how Indo-Greek coinage combined Hellenistic ruler portraiture, Greek & Kharosthi bilingual inscriptions, and Greco-Buddhist cultural influences across Taxila and Gandhara.">
+
+  <!-- Preload Critical Fonts -->
+  <link rel="preload" href="../../assets/fonts/Outfit-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="../../assets/fonts/Outfit-700.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="../../assets/fonts/PlayfairDisplay-400.woff2" as="font" type="font/woff2" crossorigin>
+  
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <script>
+    (function() {
+      const theme = localStorage.getItem('theme') || 'dark';
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+
+  <!-- Navigation Bar -->
+  <header class="navbar" id="navbar">
+    <div class="nav-container">
+      <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+        <span class="saffron">Incredible</span>
+        <span class="gold">India</span>
+        <span class="green">Explorer</span>
+      </a>
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+        <span class="bar"></span>
+        <span class="bar"></span>
+        <span class="bar"></span>
+      </button>
+      <nav class="nav-menu" id="nav-menu">
+        <a href="../../index.html#home" class="nav-link">Home</a>
+        <a href="../indias-coins-through-time/index.html" class="nav-link">Coin Landing</a>
+        <a href="#ruler-selector" class="nav-link active">Rulers & Coins</a>
+        <a href="#compare-section" class="nav-link">Coin Compare</a>
+        <a href="#map-timeline-section" class="nav-link">Territory & Timeline</a>
+        <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <!-- HERO SECTION -->
+    <section class="indogreek-hero">
+      <div class="hero-container">
+        <div class="hero-badge">🏛️ Greco-Bactrian & Indo-Greek Numismatics</div>
+        <h1>Indo-Greek Coins & <span>Royal Portraits</span></h1>
+        <p class="hero-subtitle">
+          Discover the fusion of Hellenistic Greek art and Indian cultural traditions (c. 180 BCE – 10 CE). Inspect realistic royal diadems, bilingual Kharosthi legends, and Athena Alkidemos imagery.
+        </p>
+        <div class="hero-pills">
+          <span class="pill">📜 Greek & Kharosthi Scripts</span>
+          <span class="pill">👑 Royal Portraiture</span>
+          <span class="pill">🕉️ Greco-Buddhism</span>
+          <span class="pill">🏛️ Taxila & Pushkalavati</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- RULER SELECTOR & COIN INTERACTION SECTION -->
+    <section class="ruler-section" id="ruler-selector">
+      <div class="section-container">
+        <div class="section-header">
+          <span class="section-tag">Interactive Coin Viewer</span>
+          <h2>Select an Indo-Greek Ruler</h2>
+          <p>Choose a monarch to inspect their coinage, portrait features, script translations, and obverse/reverse details.</p>
+        </div>
+
+        <div class="ruler-pills-nav" id="ruler-pills-nav" role="tablist" aria-label="Ruler Selector">
+          <!-- Dynamically generated ruler buttons -->
+        </div>
+
+        <div class="coin-viewer-wrapper">
+          <!-- Interactive 3D/2D Coin Showcase -->
+          <div class="coin-stage-container">
+            <div class="coin-stage-controls">
+              <button id="btn-flip-coin" class="btn btn-secondary btn-sm">🔄 Flip Obverse / Reverse</button>
+              <button id="btn-zoom-coin" class="btn btn-secondary btn-sm">🔍 Toggle High Zoom</button>
+            </div>
+            
+            <div class="coin-3d-wrapper" id="coin-3d-wrapper">
+              <div class="coin-canvas obverse-face" id="coin-face-display">
+                <div class="coin-hotspot portrait-hotspot" tabindex="0" role="button" aria-label="Portrait Details Hotspot" style="top: 35%; left: 45%;">
+                  <span class="hotspot-dot"></span>
+                  <span class="hotspot-tooltip">Royal Diadem & Helmet</span>
+                </div>
+                <div class="coin-hotspot inscription-hotspot" tabindex="0" role="button" aria-label="Greek Inscription Hotspot" style="top: 75%; left: 30%;">
+                  <span class="hotspot-dot"></span>
+                  <span class="hotspot-tooltip">Greek Inscription</span>
+                </div>
+                <div class="coin-inner-render" id="coin-inner-render">
+                  <!-- Coin SVG rendering -->
+                </div>
+              </div>
+            </div>
+            <span class="face-indicator" id="face-indicator">Face: Obverse (Front)</span>
+          </div>
+
+          <!-- Ruler & Coin Details Panel -->
+          <div class="ruler-info-card">
+            <h3 id="ruler-name">Menander I Soter (King Milinda)</h3>
+            <span class="ruler-reign" id="ruler-reign">Reign: c. 165 – 130 BCE · Capital: Sagala (Sialkot)</span>
+            <p class="ruler-bio" id="ruler-bio">
+              The most famous Indo-Greek king, celebrated in the Buddhist text <em>Milindapanha</em> (Questions of King Milinda). His coins circulated across Punjab and Taxila.
+            </p>
+
+            <div class="coin-specs-grid">
+              <div class="spec-box">
+                <span class="spec-label">Denomination:</span>
+                <span class="spec-val" id="spec-denomination">Silver Silver Drachm</span>
+              </div>
+              <div class="spec-box">
+                <span class="spec-label">Metal & Weight:</span>
+                <span class="spec-val" id="spec-metal">Silver (2.45 grams)</span>
+              </div>
+              <div class="spec-box">
+                <span class="spec-label">Minting Region:</span>
+                <span class="spec-val" id="spec-region">Gandhara / Taxila</span>
+              </div>
+              <div class="spec-box">
+                <span class="spec-label">Cultural Connections:</span>
+                <span class="spec-val" id="spec-connection">Greco-Buddhist Patronage</span>
+              </div>
+            </div>
+
+            <!-- Inscription Translation Box -->
+            <div class="inscription-inspection-box">
+              <h4>Bilingual Script Inspection</h4>
+              <div class="script-row">
+                <span class="script-type">Obverse (Greek):</span>
+                <code id="script-greek">ΒΑΣΙΛΕΩΣ ΣΩΤΗΡΟΣ ΜΕΝΑΝΔΡΟΥ</code>
+                <span class="script-trans" id="trans-greek">"Of King Menander, the Saviour"</span>
+              </div>
+              <div class="script-row">
+                <span class="script-type">Reverse (Kharosthi):</span>
+                <code id="script-kharosthi">Maharajasa Tratarasa Menandrasa</code>
+                <span class="script-trans" id="trans-kharosthi">"Great King Menander, the Saviour (Prakrit in Kharosthi Script)"</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- COIN COMPARISON TOOL SECTION -->
+    <section class="compare-section" id="compare-section">
+      <div class="section-container">
+        <div class="section-header">
+          <span class="section-tag">Side-by-Side Analysis</span>
+          <h2>Compare Two Indo-Greek Coins</h2>
+          <p>Analyze differences in metal purity, portrait styles, reverse deity emblems, and scripts between rulers.</p>
+        </div>
+
+        <div class="compare-selectors-row">
+          <div class="compare-select-group">
+            <label for="compare-coin-1">Select Coin 1:</label>
+            <select id="compare-coin-1" class="filter-select"></select>
+          </div>
+          <div class="compare-vs-badge">VS</div>
+          <div class="compare-select-group">
+            <label for="compare-coin-2">Select Coin 2:</label>
+            <select id="compare-coin-2" class="filter-select"></select>
+          </div>
+        </div>
+
+        <div class="compare-results-grid" id="compare-results-grid">
+          <!-- Dynamically populated comparison cards -->
+        </div>
+      </div>
+    </section>
+
+    <!-- TERRITORY MAP & TIMELINE SECTION -->
+    <section class="map-timeline-section" id="map-timeline-section">
+      <div class="section-container">
+        <div class="section-header">
+          <span class="section-tag">Geographical & Historical Context</span>
+          <h2>Indo-Greek Territory & Ruler Timeline</h2>
+          <p>Navigate through chronological reigns and inspect geopolitical territory shifts across the Hindu Kush and Indus valley.</p>
+        </div>
+
+        <div class="timeline-interactive-bar">
+          <label for="timeline-slider">Chronological Ruler Timeline (180 BCE – 10 CE):</label>
+          <input type="range" id="timeline-slider" min="0" max="5" step="1" value="0">
+          <div class="timeline-ticks" id="timeline-ticks"></div>
+        </div>
+
+        <div class="territory-display-box">
+          <div class="territory-map-view">
+            <svg viewBox="0 0 700 450" class="territory-svg">
+              <rect width="100%" height="100%" fill="rgba(15, 23, 42, 0.4)"/>
+              <!-- Outline of NW Subcontinent / Bactria -->
+              <path d="M 100,50 L 350,30 L 600,100 L 550,350 L 250,420 L 80,250 Z" fill="rgba(245, 158, 11, 0.05)" stroke="rgba(245, 158, 11, 0.2)" stroke-width="2"/>
+              <!-- Dynamic territory polygon -->
+              <polygon id="territory-poly" points="150,80 320,60 480,180 380,300 200,280" fill="rgba(245, 158, 11, 0.25)" stroke="#fbbf24" stroke-width="3"/>
+              <text x="300" y="200" fill="#ffffff" font-weight="bold" font-size="16" text-anchor="middle" id="territory-label">Menander I Realm (Bactria to Punjab)</text>
+            </svg>
+          </div>
+
+          <div class="territory-info">
+            <h4 id="territory-title">Territory of Menander I (c. 165–130 BCE)</h4>
+            <p id="territory-desc">Extended from Bactria across modern-day Afghanistan, Khyber Pakhtunkhwa, Punjab, and reach as far east as Mathura and Pataliputra according to the Yuga Purana.</p>
+            <div class="key-mints-list">
+              <strong>Major Mints:</strong> <span id="territory-mints">Taxila, Pushkalavati (Charsadda), Sagala (Sialkot), Alexandria in the Caucasus (Bagram)</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- HISTORICAL SOURCES & REFERENCES -->
+    <section class="sources-section">
+      <div class="section-container">
+        <h2>Sources & Numismatic References</h2>
+        <ul class="sources-list">
+          <li>Osmund Bopearachchi, <em>Monnaies gréco-bactriennes et indo-grecques, catalogue raisonné</em>, Bibliothèque Nationale de France, 1991.</li>
+          <li>R.C. Senior, <em>Indo-Scythian Coins and History</em>, Classical Numismatic Group, 2001.</li>
+          <li>A.K. Narain, <em>The Indo-Greeks</em>, Oxford University Press, 1957.</li>
+          <li><em>Milindapanha</em> (The Questions of King Milinda), Pali Canon Translation.</li>
+        </ul>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-container">
+      <p>© 2026 Incredible India Explorer. Created under Open Source Contribution Guidelines.</p>
+      <div class="footer-links">
+        <a href="../../index.html#home">Home</a>
+        <a href="../indias-coins-through-time/index.html">Coins Landing</a>
+        <a href="../../frontend/sources/sources.html">Sources</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/indo-greek-coins-explorer/script.js
+++ b/frontend/indo-greek-coins-explorer/script.js
@@ -1,0 +1,370 @@
+/**
+ * script.js
+ * Indo-Greek Coins & Royal Portraits Explorer Logic (#2078)
+ */
+
+(function () {
+  'use strict';
+
+  // RULERS & COINS DATASET
+  const RULERS_DATA = [
+    {
+      id: "menander-1",
+      name: "Menander I Soter (King Milinda)",
+      reign: "c. 165 – 130 BCE",
+      capital: "Sagala (Sialkot)",
+      bio: "The most celebrated Indo-Greek monarch. He embraced Buddhism after discussions with sage Nagasena (recorded in Milindapanha) and minted bilingual silver & bronze coins across Gandhara and Punjab.",
+      denomination: "Silver Drachm",
+      metal: "Silver (2.45 grams)",
+      region: "Gandhara & Taxila",
+      connection: "Greco-Buddhist Patronage",
+      greekText: "ΒΑΣΙΛΕΩΣ ΣΩΤΗΡΟΣ ΜΕΝΑΝΔΡΟΥ",
+      greekTrans: "\"Of King Menander, the Saviour\"",
+      kharosthiText: "Maharajasa Tratarasa Menandrasa",
+      kharosthiTrans: "\"Great King Menander, the Saviour (Prakrit in Kharosthi)\"",
+      obverseSvg: `<svg viewBox="0 0 200 200" width="100%" height="100%"><circle cx="100" cy="100" r="90" fill="#9ca3af"/><path d="M 60,110 C 60,60 140,60 140,110 C 130,130 110,140 100,140 C 90,140 70,130 60,110 Z" fill="#4b5563"/><path d="M 70,70 L 130,70 L 120,60 L 80,60 Z" fill="#fbbf24"/><text x="100" y="175" font-size="10" font-weight="bold" fill="#1f2937" text-anchor="middle">BASILEOS MENANDROU</text></svg>`,
+      reverseSvg: `<svg viewBox="0 0 200 200" width="100%" height="100%"><circle cx="100" cy="100" r="90" fill="#9ca3af"/><path d="M 100,40 L 120,90 L 80,90 Z" fill="#374151"/><line x1="100" y1="90" x2="100" y2="150" stroke="#374151" stroke-width="6"/><circle cx="85" cy="70" r="10" fill="#fbbf24"/><text x="100" y="175" font-size="9" font-weight="bold" fill="#1f2937" text-anchor="middle">Maharajasa Tratarasa</text></svg>`,
+      portraitNotes: "Features helmeted bust turned right, showing diadem ties hanging behind hair, sharp Hellenistic jawline, and naturalistic ear details.",
+      territoryPoints: "140,70 340,50 500,160 400,320 180,300",
+      territoryLabel: "Menander I Realm (Kabul to Punjab & Mathura)",
+      territoryMints: "Taxila, Pushkalavati, Sagala, Alexandria in Caucasus"
+    },
+    {
+      id: "demetrius-1",
+      name: "Demetrius I Aniketos (The Invincible)",
+      reign: "c. 200 – 180 BCE",
+      capital: "Bactra / Taxila",
+      bio: "Son of Euthydemus I. He led the Greek invasion into northwestern India following the fall of the Mauryan Empire, famous for wearing an elephant-scalp helmet symbolizing conquest of India.",
+      denomination: "Silver Tetradrachm",
+      metal: "Silver (16.8 grams)",
+      region: "Bactria & Arachosia",
+      connection: "Initial Indian Expedition",
+      greekText: "ΒΑΣΙΛΕΩΣ ΑΝΙΚΗΤΟΥ ΔΗΜΗΤΡΙΟΥ",
+      greekTrans: "\"Of Invincible King Demetrius\"",
+      kharosthiText: "Maharajasa Aparajitasa Dimetriya",
+      kharosthiTrans: "\"Great Invincible King Demetrius\"",
+      obverseSvg: `<svg viewBox="0 0 200 200" width="100%" height="100%"><circle cx="100" cy="100" r="90" fill="#d1d5db"/><path d="M 60,110 C 60,60 140,60 140,110 C 130,140 70,140 60,110 Z" fill="#374151"/><path d="M 60,60 Q 100,20 140,60 Q 100,40 60,60 Z" fill="#9a3412"/><text x="100" y="175" font-size="9" font-weight="bold" fill="#111827" text-anchor="middle">DEMETRIOU ANIKETOU</text></svg>`,
+      reverseSvg: `<svg viewBox="0 0 200 200" width="100%" height="100%"><circle cx="100" cy="100" r="90" fill="#d1d5db"/><circle cx="100" cy="90" r="30" fill="#4b5563"/><line x1="100" y1="120" x2="100" y2="160" stroke="#374151" stroke-width="8"/><text x="100" y="175" font-size="9" font-weight="bold" fill="#111827" text-anchor="middle">Herakles Standing</text></svg>`,
+      portraitNotes: "Famous elephant-scalp cap with trunk curving upward over forelock, representing victory over Indian elephant forces.",
+      territoryPoints: "120,40 380,30 460,140 320,260 150,220",
+      territoryLabel: "Demetrius I Realm (Bactria to Taxila)",
+      territoryMints: "Bactra, Taxila, Kapisa"
+    },
+    {
+      id: "eucratides-1",
+      name: "Eucratides I Megas (The Great)",
+      reign: "c. 170 – 145 BCE",
+      capital: "Ai-Khanoum / Bactra",
+      bio: "Usurped the Bactrian throne from Euthydemids. Issued the largest gold coin of antiquity (20-stater medallion weighing 169g) depicting the Dioscuri twins on horseback.",
+      denomination: "Gold 20-Stater / Silver Tetradrachm",
+      metal: "Gold / Silver",
+      region: "Bactria & Paropamisadae",
+      connection: "Greco-Bactrian Imperial Power",
+      greekText: "ΒΑΣΙΛΕΩΣ ΜΕΓΑΛΟΥ ΕΥΚΡΑΤΙΔΟΥ",
+      greekTrans: "\"Of the Great King Eucratides\"",
+      kharosthiText: "Maharajasa Mahatakasa Evukratidasa",
+      kharosthiTrans: "\"Great King Eucratides\"",
+      obverseSvg: `<svg viewBox="0 0 200 200" width="100%" height="100%"><circle cx="100" cy="100" r="90" fill="#fbbf24"/><path d="M 60,110 C 60,60 140,60 140,110 C 130,130 110,140 100,140 Z" fill="#92400e"/><path d="M 50,70 L 150,70 L 100,30 Z" fill="#b45309"/><text x="100" y="175" font-size="9" font-weight="bold" fill="#78350f" text-anchor="middle">EUKRATIDOU MEGALOU</text></svg>`,
+      reverseSvg: `<svg viewBox="0 0 200 200" width="100%" height="100%"><circle cx="100" cy="100" r="90" fill="#fbbf24"/><path d="M 60,90 L 140,90 L 120,130 L 80,130 Z" fill="#78350f"/><text x="100" y="175" font-size="9" font-weight="bold" fill="#78350f" text-anchor="middle">Dioscuri on Horseback</text></svg>`,
+      portraitNotes: "Helmeted bust wearing crested Boeotian helmet decorated with bull's horn and ear.",
+      territoryPoints: "160,30 400,20 440,120 300,200 180,160",
+      territoryLabel: "Eucratides Realm (Ai-Khanoum to Gandhara)",
+      territoryMints: "Ai-Khanoum, Bactra, Kapisa"
+    },
+    {
+      id: "agathocles",
+      name: "Agathocles Dikaios (The Just)",
+      reign: "c. 190 – 180 BCE",
+      capital: "Taxila / Paropamisadae",
+      bio: "Famous for issuing extraordinary bilingual commemorative coins depicting Hindu deities Balarama (with plow & mace) and Vasudeva-Krishna (with conch & chakra) — the earliest known depiction of Hindu gods on coins.",
+      denomination: "Silver & Bronze Commemorative",
+      metal: "Silver / Nickel",
+      region: "Gandhara & Taxila",
+      connection: "Earliest Vaishnava Deities on Coinage",
+      greekText: "ΒΑΣΙΛΕΩΣ ΑΓΑΘΟΚΛΕΟΥΣ ΔΙΚΑΙΟΥ",
+      greekTrans: "\"Of King Agathocles, the Just\"",
+      kharosthiText: "Akathukreyasa / Rajane Agathukleyasa",
+      kharosthiTrans: "\"King Agathocles (Brahmi & Kharosthi Script)\"",
+      obverseSvg: `<svg viewBox="0 0 200 200" width="100%" height="100%"><circle cx="100" cy="100" r="90" fill="#cbd5e1"/><path d="M 80,50 L 120,50 L 120,130 L 80,130 Z" fill="#334155"/><circle cx="100" cy="70" r="15" fill="#f59e0b"/><text x="100" y="175" font-size="9" font-weight="bold" fill="#0f172a" text-anchor="middle">Vasudeva Krishna with Chakra</text></svg>`,
+      reverseSvg: `<svg viewBox="0 0 200 200" width="100%" height="100%"><circle cx="100" cy="100" r="90" fill="#cbd5e1"/><path d="M 70,60 L 130,60 L 100,140 Z" fill="#1e293b"/><text x="100" y="175" font-size="9" font-weight="bold" fill="#0f172a" text-anchor="middle">Balarama with Gadha & Hala</text></svg>`,
+      portraitNotes: "Bilingual coins feature six ancient Indian kings as well as Hindu deities in Indian attire.",
+      territoryPoints: "200,80 350,60 420,160 310,240 220,200",
+      territoryLabel: "Agathocles Realm (Paropamisadae & Taxila)",
+      territoryMints: "Taxila, Pushkalavati"
+    },
+    {
+      id: "antimachus-1",
+      name: "Antimachus I Theos (The Divine)",
+      reign: "c. 185 – 170 BCE",
+      capital: "Bactria",
+      bio: "Ruler known for his cheerful portrait wearing a distinctive flat kausia cap (traditional Macedonian sun hat) and issuing silver tetradrachms featuring Poseidon holding a trident.",
+      denomination: "Silver Tetradrachm",
+      metal: "Silver (16.9 grams)",
+      region: "Bactria",
+      connection: "Macedonian Kausia Cap Iconography",
+      greekText: "ΒΑΣΙΛΕΩΣ ΘΕΟΥ ΑΝΤΙΜΑΧΟΥ",
+      greekTrans: "\"Of God-King Antimachus\"",
+      kharosthiText: "Maharajasa Dhavasa Antimakhasa",
+      kharosthiTrans: "\"Great Divine King Antimachus\"",
+      obverseSvg: `<svg viewBox="0 0 200 200" width="100%" height="100%"><circle cx="100" cy="100" r="90" fill="#e2e8f0"/><ellipse cx="100" cy="55" rx="55" ry="15" fill="#475569"/><path d="M 65,70 C 65,120 135,120 135,70 Z" fill="#334155"/><text x="100" y="175" font-size="9" font-weight="bold" fill="#0f172a" text-anchor="middle">ANTIMACHOU THEOU</text></svg>`,
+      reverseSvg: `<svg viewBox="0 0 200 200" width="100%" height="100%"><circle cx="100" cy="100" r="90" fill="#e2e8f0"/><line x1="100" y1="40" x2="100" y2="150" stroke="#0f172a" stroke-width="6"/><path d="M 85,50 L 100,30 L 115,50 Z" fill="#0f172a"/><text x="100" y="175" font-size="9" font-weight="bold" fill="#0f172a" text-anchor="middle">Poseidon with Trident</text></svg>`,
+      portraitNotes: "Smiling, lively portraiture with flat Macedonian kausia hat and flowing diadem ends.",
+      territoryPoints: "150,50 360,40 400,120 280,180 160,140",
+      territoryLabel: "Antimachus Realm (Northern Bactria)",
+      territoryMints: "Bactra, Badakhshan"
+    },
+    {
+      id: "apollodotus-1",
+      name: "Apollodotus I Soter",
+      reign: "c. 180 – 160 BCE",
+      capital: "Taxila / Multan",
+      bio: "Co-ruler alongside Demetrius I. First king to issue square bilingual silver drachms depicting the sacred Indian Humped Bull (Zebu) and Elephant, designed specifically for Indian trade.",
+      denomination: "Square Silver Drachm",
+      metal: "Silver (2.4 grams)",
+      region: "Punjab & Sindh",
+      connection: "Square Indian Coin Standard",
+      greekText: "ΒΑΣΙΛΕΩΣ ΑΠΟΛΛΟΔΟΤΟΥ ΣΩΤΗΡΟΣ",
+      greekTrans: "\"Of King Apollodotus, the Saviour\"",
+      kharosthiText: "Maharajasa Apaladatasa Tratarasa",
+      kharosthiTrans: "\"Great King Apollodotus, the Saviour\"",
+      obverseSvg: `<svg viewBox="0 0 200 200" width="100%" height="100%"><rect x="25" y="25" width="150" height="150" rx="15" fill="#94a3b8"/><path d="M 50,110 Q 100,70 150,110 Q 100,140 50,110 Z" fill="#1e293b"/><circle cx="120" cy="85" r="10" fill="#f59e0b"/><text x="100" y="165" font-size="8" font-weight="bold" fill="#0f172a" text-anchor="middle">Sacred Humped Bull (Zebu)</text></svg>`,
+      reverseSvg: `<svg viewBox="0 0 200 200" width="100%" height="100%"><rect x="25" y="25" width="150" height="150" rx="15" fill="#94a3b8"/><path d="M 60,110 Q 100,60 140,110 Z" fill="#0f172a"/><text x="100" y="165" font-size="8" font-weight="bold" fill="#0f172a" text-anchor="middle">Royal Elephant</text></svg>`,
+      portraitNotes: "Issued non-portrait civic coins with Indian sacred Zebu bull and royal elephant.",
+      territoryPoints: "220,100 380,90 460,200 360,340 240,280",
+      territoryLabel: "Apollodotus Realm (Punjab & Sindh)",
+      territoryMints: "Taxila, Pushkalavati, Multan"
+    }
+  ];
+
+  document.addEventListener('DOMContentLoaded', function () {
+    let currentRulerIndex = 0;
+    let isObverse = true;
+    let isZoomed = false;
+
+    // Elements
+    const navContainer = document.getElementById('ruler-pills-nav');
+    const coinRender = document.getElementById('coin-inner-render');
+    const coinWrapper = document.getElementById('coin-3d-wrapper');
+    const faceIndicator = document.getElementById('face-indicator');
+    const btnFlip = document.getElementById('btn-flip-coin');
+    const btnZoom = document.getElementById('btn-zoom-coin');
+
+    // Details Elements
+    const rulerName = document.getElementById('ruler-name');
+    const rulerReign = document.getElementById('ruler-reign');
+    const rulerBio = document.getElementById('ruler-bio');
+    const specDenom = document.getElementById('spec-denomination');
+    const specMetal = document.getElementById('spec-metal');
+    const specRegion = document.getElementById('spec-region');
+    const specConn = document.getElementById('spec-connection');
+    const scriptGreek = document.getElementById('script-greek');
+    const transGreek = document.getElementById('trans-greek');
+    const scriptKharosthi = document.getElementById('script-kharosthi');
+    const transKharosthi = document.getElementById('trans-kharosthi');
+
+    // Compare Selectors
+    const compareSelect1 = document.getElementById('compare-coin-1');
+    const compareSelect2 = document.getElementById('compare-coin-2');
+    const compareGrid = document.getElementById('compare-results-grid');
+
+    // Timeline Slider & Map
+    const timelineSlider = document.getElementById('timeline-slider');
+    const timelineTicks = document.getElementById('timeline-ticks');
+    const territoryPoly = document.getElementById('territory-poly');
+    const territoryLabel = document.getElementById('territory-label');
+    const territoryTitle = document.getElementById('territory-title');
+    const territoryDesc = document.getElementById('territory-desc');
+    const territoryMints = document.getElementById('territory-mints');
+
+    // Theme Toggle
+    const themeToggleBtn = document.getElementById('theme-toggle');
+    if (themeToggleBtn) {
+      themeToggleBtn.addEventListener('click', function () {
+        document.body.classList.toggle('light-theme');
+        const isLight = document.body.classList.contains('light-theme');
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+      });
+    }
+
+    /**
+     * Render Ruler Navigation Buttons
+     */
+    function renderRulerNav() {
+      if (!navContainer) return;
+      navContainer.innerHTML = '';
+
+      RULERS_DATA.forEach((ruler, index) => {
+        const btn = document.createElement('button');
+        btn.className = `ruler-tab-btn ${index === currentRulerIndex ? 'active' : ''}`;
+        btn.textContent = ruler.name.split(' (')[0];
+        btn.setAttribute('role', 'tab');
+        btn.setAttribute('aria-selected', index === currentRulerIndex ? 'true' : 'false');
+        btn.addEventListener('click', () => selectRuler(index));
+        navContainer.appendChild(btn);
+      });
+    }
+
+    /**
+     * Select & Display Ruler Details
+     */
+    function selectRuler(index) {
+      currentRulerIndex = index;
+      const ruler = RULERS_DATA[index];
+      isObverse = true;
+
+      // Update Nav Buttons
+      const btns = navContainer.querySelectorAll('.ruler-tab-btn');
+      btns.forEach((b, i) => {
+        b.classList.toggle('active', i === index);
+        b.setAttribute('aria-selected', i === index ? 'true' : 'false');
+      });
+
+      // Update Coin Visual
+      updateCoinFace();
+
+      // Update Details
+      if (rulerName) rulerName.textContent = ruler.name;
+      if (rulerReign) rulerReign.textContent = `Reign: ${ruler.reign} · Capital: ${ruler.capital}`;
+      if (rulerBio) rulerBio.textContent = ruler.bio;
+      if (specDenom) specDenom.textContent = ruler.denomination;
+      if (specMetal) specMetal.textContent = ruler.metal;
+      if (specRegion) specRegion.textContent = ruler.region;
+      if (specConn) specConn.textContent = ruler.connection;
+
+      if (scriptGreek) scriptGreek.textContent = ruler.greekText;
+      if (transGreek) transGreek.textContent = ruler.greekTrans;
+      if (scriptKharosthi) scriptKharosthi.textContent = ruler.kharosthiText;
+      if (transKharosthi) transKharosthi.textContent = ruler.kharosthiTrans;
+
+      // Sync Timeline Slider
+      if (timelineSlider) timelineSlider.value = index;
+      updateTerritoryMap(ruler);
+    }
+
+    /**
+     * Update Obverse / Reverse Face Rendering
+     */
+    function updateCoinFace() {
+      const ruler = RULERS_DATA[currentRulerIndex];
+      if (!coinRender) return;
+
+      coinRender.innerHTML = isObverse ? ruler.obverseSvg : ruler.reverseSvg;
+      if (faceIndicator) {
+        faceIndicator.textContent = `Face: ${isObverse ? 'Obverse (Front Portrait / Emblem)' : 'Reverse (Deity / Script)'}`;
+      }
+    }
+
+    // Flip Button Listener
+    if (btnFlip) {
+      btnFlip.addEventListener('click', () => {
+        isObverse = !isObverse;
+        updateCoinFace();
+      });
+    }
+
+    // Zoom Button Listener
+    if (btnZoom) {
+      btnZoom.addEventListener('click', () => {
+        isZoomed = !isZoomed;
+        if (coinWrapper) coinWrapper.classList.toggle('zoomed', isZoomed);
+        btnZoom.textContent = isZoomed ? '🔍 Reset Zoom' : '🔍 Toggle High Zoom';
+      });
+    }
+
+    /**
+     * Setup Coin Comparison Tool
+     */
+    function setupCompareTool() {
+      if (!compareSelect1 || !compareSelect2) return;
+
+      compareSelect1.innerHTML = '';
+      compareSelect2.innerHTML = '';
+
+      RULERS_DATA.forEach((r, i) => {
+        const opt1 = new Option(r.name, i);
+        const opt2 = new Option(r.name, i);
+        compareSelect1.add(opt1);
+        compareSelect2.add(opt2);
+      });
+
+      compareSelect1.value = 0; // Menander I
+      compareSelect2.value = 1; // Demetrius I
+
+      compareSelect1.addEventListener('change', renderCompare);
+      compareSelect2.addEventListener('change', renderCompare);
+
+      renderCompare();
+    }
+
+    function renderCompare() {
+      if (!compareGrid) return;
+      const r1 = RULERS_DATA[compareSelect1.value];
+      const r2 = RULERS_DATA[compareSelect2.value];
+
+      compareGrid.innerHTML = `
+        <div class="compare-card">
+          <h4>${r1.name}</h4>
+          <span style="color: var(--greek-gold); font-size: 0.85rem;">${r1.reign}</span>
+          <div style="margin: 16px 0;">${r1.obverseSvg}</div>
+          <ul style="list-style: none; padding: 0; font-size: 0.9rem; color: var(--text-secondary);">
+            <li style="margin-bottom: 8px;"><strong>Denomination:</strong> ${r1.denomination}</li>
+            <li style="margin-bottom: 8px;"><strong>Metal & Weight:</strong> ${r1.metal}</li>
+            <li style="margin-bottom: 8px;"><strong>Greek Script:</strong> ${r1.greekText}</li>
+            <li style="margin-bottom: 8px;"><strong>Kharosthi:</strong> ${r1.kharosthiText}</li>
+          </ul>
+        </div>
+
+        <div class="compare-card">
+          <h4>${r2.name}</h4>
+          <span style="color: var(--greek-gold); font-size: 0.85rem;">${r2.reign}</span>
+          <div style="margin: 16px 0;">${r2.obverseSvg}</div>
+          <ul style="list-style: none; padding: 0; font-size: 0.9rem; color: var(--text-secondary);">
+            <li style="margin-bottom: 8px;"><strong>Denomination:</strong> ${r2.denomination}</li>
+            <li style="margin-bottom: 8px;"><strong>Metal & Weight:</strong> ${r2.metal}</li>
+            <li style="margin-bottom: 8px;"><strong>Greek Script:</strong> ${r2.greekText}</li>
+            <li style="margin-bottom: 8px;"><strong>Kharosthi:</strong> ${r2.kharosthiText}</li>
+          </ul>
+        </div>
+      `;
+    }
+
+    /**
+     * Timeline & Territory Map Synchronization
+     */
+    function setupTimeline() {
+      if (!timelineSlider) return;
+
+      timelineTicks.innerHTML = '';
+      RULERS_DATA.forEach((r, i) => {
+        const span = document.createElement('span');
+        span.textContent = r.reign.split(' ')[1] || r.reign;
+        timelineTicks.appendChild(span);
+      });
+
+      timelineSlider.addEventListener('input', (e) => {
+        selectRuler(parseInt(e.target.value, 10));
+      });
+    }
+
+    function updateTerritoryMap(ruler) {
+      if (territoryPoly) territoryPoly.setAttribute('points', ruler.territoryPoints);
+      if (territoryLabel) territoryLabel.textContent = ruler.territoryLabel;
+      if (territoryTitle) territoryTitle.textContent = `Territory of ${ruler.name.split(' (')[0]} (${ruler.reign})`;
+      if (territoryDesc) territoryDesc.textContent = ruler.bio;
+      if (territoryMints) territoryMints.textContent = ruler.territoryMints;
+    }
+
+    // Mobile Nav Toggle
+    const menuToggle = document.getElementById('menu-toggle');
+    const navMenu = document.getElementById('nav-menu');
+    if (menuToggle && navMenu) {
+      menuToggle.addEventListener('click', () => navMenu.classList.toggle('active'));
+    }
+
+    // Initial Setup
+    renderRulerNav();
+    selectRuler(0);
+    setupCompareTool();
+    setupTimeline();
+  });
+})();

--- a/frontend/indo-greek-coins-explorer/style.css
+++ b/frontend/indo-greek-coins-explorer/style.css
@@ -1,0 +1,438 @@
+/* ==========================================================================
+   INDO-GREEK COINS & ROYAL PORTRAITS EXPLORER STYLES
+   ========================================================================== */
+
+:root {
+  --greek-gold: #f59e0b;
+  --greek-blue: #3b82f6;
+  --bg-dark: #0f172a;
+  --bg-card: #1e293b;
+  --text-primary: #f8fafc;
+  --text-secondary: #94a3b8;
+  --border-dark: rgba(255, 255, 255, 0.1);
+  --shadow-lg: 0 10px 25px -5px rgba(0, 0, 0, 0.5);
+  --radius-lg: 16px;
+  --radius-md: 10px;
+}
+
+body.light-theme {
+  --bg-dark: #f8fafc;
+  --bg-card: #ffffff;
+  --text-primary: #0f172a;
+  --text-secondary: #475569;
+  --border-dark: rgba(0, 0, 0, 0.1);
+}
+
+.indogreek-hero {
+  padding: 120px 24px 60px;
+  background: radial-gradient(circle at 50% 30%, rgba(59, 130, 246, 0.15) 0%, transparent 60%),
+              radial-gradient(circle at 80% 70%, rgba(245, 158, 11, 0.15) 0%, transparent 60%),
+              var(--bg-dark);
+  text-align: center;
+}
+
+.hero-container {
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.hero-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  border-radius: 9999px;
+  background: rgba(59, 130, 246, 0.15);
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  color: #60a5fa;
+  font-weight: 600;
+  font-size: 0.9rem;
+  margin-bottom: 20px;
+}
+
+.indogreek-hero h1 {
+  font-family: 'Playfair Display', Georgia, serif;
+  font-size: 3.2rem;
+  color: var(--text-primary);
+  margin-bottom: 20px;
+}
+
+.indogreek-hero h1 span {
+  background: linear-gradient(135deg, #f59e0b, #60a5fa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.hero-subtitle {
+  font-size: 1.15rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin-bottom: 30px;
+}
+
+.hero-pills {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.hero-pills .pill {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--border-dark);
+  padding: 6px 14px;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  color: var(--text-primary);
+}
+
+/* Ruler Selector & Viewer */
+.ruler-section, .compare-section, .map-timeline-section, .sources-section {
+  padding: 80px 24px;
+}
+
+.section-container {
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+.section-header {
+  text-align: center;
+  margin-bottom: 48px;
+}
+
+.section-tag {
+  color: var(--greek-gold);
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+}
+
+.section-header h2 {
+  font-family: 'Playfair Display', Georgia, serif;
+  font-size: 2.4rem;
+  color: var(--text-primary);
+  margin: 10px 0;
+}
+
+.section-header p {
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+}
+
+.ruler-pills-nav {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 40px;
+}
+
+.ruler-tab-btn {
+  padding: 10px 20px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-dark);
+  background: var(--bg-card);
+  color: var(--text-primary);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.ruler-tab-btn:hover, .ruler-tab-btn.active {
+  border-color: var(--greek-gold);
+  background: rgba(245, 158, 11, 0.15);
+  color: var(--greek-gold);
+}
+
+.coin-viewer-wrapper {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 36px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-dark);
+  border-radius: var(--radius-lg);
+  padding: 36px;
+}
+
+.coin-stage-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: var(--radius-md);
+  padding: 24px;
+  position: relative;
+}
+
+.coin-stage-controls {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.coin-3d-wrapper {
+  width: 260px;
+  height: 260px;
+  position: relative;
+  transition: transform 0.6s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.coin-3d-wrapper.zoomed {
+  transform: scale(1.3);
+}
+
+.coin-canvas {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 35%, #e5e7eb 0%, #9ca3af 60%, #4b5563 100%);
+  border: 8px double #d1d5db;
+  box-shadow: 0 0 30px rgba(156, 163, 175, 0.3), inset 0 0 20px rgba(0,0,0,0.5);
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.coin-hotspot {
+  position: absolute;
+  cursor: pointer;
+  z-index: 10;
+}
+
+.hotspot-dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #f59e0b;
+  border: 2px solid #ffffff;
+  box-shadow: 0 0 10px #f59e0b;
+  display: block;
+  animation: pulse 1.5s infinite;
+}
+
+@keyframes pulse {
+  0% { transform: scale(1); opacity: 1; }
+  50% { transform: scale(1.4); opacity: 0.7; }
+  100% { transform: scale(1); opacity: 1; }
+}
+
+.hotspot-tooltip {
+  position: absolute;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #0f172a;
+  color: #ffffff;
+  padding: 6px 12px;
+  border-radius: 6px;
+  font-size: 0.75rem;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  border: 1px solid var(--border-dark);
+}
+
+.coin-hotspot:hover .hotspot-tooltip, .coin-hotspot:focus .hotspot-tooltip {
+  opacity: 1;
+}
+
+.face-indicator {
+  margin-top: 20px;
+  font-size: 0.85rem;
+  color: var(--greek-gold);
+  font-weight: 600;
+}
+
+.ruler-info-card h3 {
+  font-size: 1.8rem;
+  font-family: 'Playfair Display', Georgia, serif;
+  color: var(--text-primary);
+  margin-bottom: 6px;
+}
+
+.ruler-reign {
+  display: block;
+  font-size: 0.9rem;
+  color: var(--greek-gold);
+  margin-bottom: 16px;
+  font-weight: 600;
+}
+
+.ruler-bio {
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin-bottom: 24px;
+}
+
+.coin-specs-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.spec-box {
+  background: rgba(0, 0, 0, 0.2);
+  padding: 12px;
+  border-radius: 8px;
+  border: 1px solid var(--border-dark);
+}
+
+.spec-label {
+  display: block;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+}
+
+.spec-val {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.inscription-inspection-box {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid var(--border-dark);
+  border-radius: var(--radius-md);
+  padding: 20px;
+}
+
+.inscription-inspection-box h4 {
+  color: var(--greek-gold);
+  font-size: 1.05rem;
+  margin-bottom: 14px;
+}
+
+.script-row {
+  margin-bottom: 12px;
+}
+
+.script-type {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.script-row code {
+  display: block;
+  font-family: monospace;
+  font-size: 1rem;
+  color: #60a5fa;
+  margin: 2px 0;
+}
+
+.script-trans {
+  font-size: 0.85rem;
+  color: var(--text-primary);
+  font-style: italic;
+}
+
+/* Compare Section */
+.compare-selectors-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  margin-bottom: 36px;
+}
+
+.compare-vs-badge {
+  font-weight: 800;
+  font-size: 1.2rem;
+  color: var(--greek-gold);
+}
+
+.compare-results-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 28px;
+}
+
+.compare-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-dark);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+}
+
+/* Territory Map & Timeline */
+.timeline-interactive-bar {
+  background: var(--bg-card);
+  border: 1px solid var(--border-dark);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  margin-bottom: 32px;
+}
+
+.timeline-interactive-bar label {
+  display: block;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 16px;
+}
+
+.timeline-interactive-bar input[type="range"] {
+  width: 100%;
+  accent-color: var(--greek-gold);
+  margin-bottom: 12px;
+}
+
+.timeline-ticks {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.territory-display-box {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 28px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-dark);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+}
+
+.territory-map-view {
+  height: 320px;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.territory-svg {
+  width: 100%;
+  height: 100%;
+}
+
+.territory-info h4 {
+  font-size: 1.3rem;
+  color: var(--text-primary);
+  margin-bottom: 10px;
+}
+
+.territory-info p {
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin-bottom: 20px;
+}
+
+.sources-list {
+  background: var(--bg-card);
+  border: 1px solid var(--border-dark);
+  border-radius: var(--radius-lg);
+  padding: 28px 28px 28px 48px;
+  color: var(--text-secondary);
+  line-height: 1.8;
+}
+
+@media (max-width: 900px) {
+  .coin-viewer-wrapper, .compare-results-grid, .territory-display-box {
+    grid-template-columns: 1fr;
+  }
+}

--- a/tests/unit/indo-greek-coins-explorer.test.js
+++ b/tests/unit/indo-greek-coins-explorer.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+describe('Indo-Greek Coins & Royal Portraits Explorer Integration (#2078)', () => {
+  const baseDir = path.resolve(__dirname, '../../frontend/indo-greek-coins-explorer');
+  const landingDir = path.resolve(__dirname, '../../frontend/indias-coins-through-time');
+
+  it('contains index.html, style.css, and script.js files', () => {
+    expect(fs.existsSync(path.join(baseDir, 'index.html'))).toBe(true);
+    expect(fs.existsSync(path.join(baseDir, 'style.css'))).toBe(true);
+    expect(fs.existsSync(path.join(baseDir, 'script.js'))).toBe(true);
+  });
+
+  it('index.html contains required rulers, hotspots, comparison, and timeline UI', () => {
+    const htmlContent = fs.readFileSync(path.join(baseDir, 'index.html'), 'utf-8');
+
+    // Section Checks
+    expect(htmlContent).toContain('Indo-Greek Coins');
+    expect(htmlContent).toContain('ruler-pills-nav');
+    expect(htmlContent).toContain('coin-3d-wrapper');
+    expect(htmlContent).toContain('btn-flip-coin');
+    expect(htmlContent).toContain('inscription-inspection-box');
+    expect(htmlContent).toContain('compare-results-grid');
+    expect(htmlContent).toContain('timeline-slider');
+
+    // Theme Placement Safety
+    const writePos = htmlContent.indexOf("document.body.classList.add('light-theme')");
+    const bodyPos = htmlContent.search(/<body[\s>]/i);
+    expect(writePos).toBeGreaterThan(bodyPos);
+  });
+
+  it('landing page includes Indo-Greek coins card', () => {
+    const dataContent = fs.readFileSync(path.join(landingDir, 'coins-data.js'), 'utf-8');
+    expect(dataContent).toContain('../indo-greek-coins-explorer/index.html');
+    expect(dataContent).toContain('Indo-Greek');
+  });
+});


### PR DESCRIPTION
## Description
Resolves #2078

Creates an interactive explorer highlighting Indo-Greek coinage (c. 180 BCE – 10 CE), focusing on how Hellenistic royal portraiture merged with Kharosthi/Brahmi scripts and Greco-Buddhist cultural influences.

### Key Features Implemented:
- **Ruler Selector**: Interactive tabs for major Indo-Greek monarchs including Menander I (Milinda), Demetrius I Aniketos, Eucratides I Megas, Agathocles Dikaios, Antimachus I, and Apollodotus I.
- **Interactive Coin Stage**: Obverse/Reverse 3D flip animation, high-zoom toggle, and interactive hotspots highlighting helmet details, royal diadems, and Greek legends.
- **Bilingual Script Inspector**: Interactive breakdown of obverse Greek legends vs reverse Kharosthi/Brahmi Prakrit translations (e.g. *BASILEOS SOTEROS MENANDROU* -> *Maharajasa Tratarasa Menandrasa*).
- **Side-by-Side Coin Comparison**: Interactive tool comparing ruler portrait styles, metal composition, weights, and reverse deity iconography.
- **Territory Map & Timeline**: Chronological slider (180 BCE – 10 CE) dynamically updating ruler realms and key mint locations (Taxila, Pushkalavati, Sagala).
- **Landing Page Integration**: Added Indo-Greek Coins card to the central coins landing page.

### Acceptance Criteria Checklist:
- [x] Ruler selector works seamlessly.
- [x] Interactive coin stage with obverse/reverse flip & zoom operates smoothly.
- [x] Hotspots for portrait and inscription details are functional.
- [x] Side-by-side comparison and territory timeline update dynamically.
- [x] Linked from central coins landing page.
- [x] Sources and numismatic references included.
- [x] Passed Vitest unit tests (`tests/unit/indo-greek-coins-explorer.test.js`).
