### PR TITLE
Durand Cup: Explore India's Historic Football Tournament

### DIFF
--- a/frontend/durand-cup-explorer/durand-data.js
+++ b/frontend/durand-cup-explorer/durand-data.js
@@ -1,0 +1,111 @@
+/**
+ * Durand Cup Explorer — Data Module
+ * Comprehensive dataset covering the Durand Football Tournament,
+ * 1888 Shimla origins, 3 iconic trophies, most successful clubs (Mohun Bagan & East Bengal),
+ * historic venues, and chronological milestones.
+ */
+
+const DURAND_INFO = {
+    id: "durand-cup",
+    title: "Durand Cup (Asia's Oldest Football Tournament)",
+    foundedYear: "1888 CE",
+    founder: "Sir Henry Mortimer Durand (Foreign Secretary of British India)",
+    historicalSignificance: "Oldest existing club football tournament in Asia & 5th oldest globally",
+    organizer: "Durand Football Tournament Society (DFTS) & Indian Armed Forces",
+    mostSuccessfulClub: "Mohun Bagan Super Giant (17 Titles)",
+    quickStats: [
+        { label: "Founded Year", value: "1888", icon: "🏆" },
+        { label: "Global Standing", value: "5th Oldest in World", icon: "🌍" },
+        { label: "Asia Standing", value: "1st Oldest in Asia", icon: "👑" },
+        { label: "Trophies Awarded", value: "3 Iconic Trophies", icon: "🥇" },
+        { label: "Top Champion", value: "Mohun Bagan (17)", icon: "⭐" },
+        { label: "Founding Venue", value: "Annandale, Shimla", icon: "⛰️" }
+    ]
+};
+
+const THREE_TROPHIES = [
+    {
+        name: "The Durand Cup (Original Trophy)",
+        origin: "1888 CE",
+        description: "The original rolling silver prize cup presented by Sir Mortimer Durand during the inaugural edition at Shimla.",
+        icon: "🏆"
+    },
+    {
+        name: "The Shimla Trophy",
+        origin: "1904 CE",
+        description: "A rolling trophy presented by the citizens of Shimla to honor the tournament's deep roots in Himachal Pradesh.",
+        icon: "🥈"
+    },
+    {
+        name: "The President's Cup",
+        origin: "1965 CE",
+        description: "Instituted by Dr. Rajendra Prasad, the first President of the Republic of India, symbolizing national prestige.",
+        icon: "🏅"
+    }
+];
+
+const SUCCESSFUL_CLUBS = [
+    {
+        club: "Mohun Bagan Super Giant",
+        titles: 17,
+        runnersUp: 12,
+        firstTitle: "1953 CE",
+        era: "First civilian Indian club to dominate; 17th record-breaking title won in 2023."
+    },
+    {
+        club: "East Bengal FC",
+        titles: 16,
+        runnersUp: 10,
+        firstTitle: "1951 CE",
+        era: "Red and Gold brigade; legendary joint-most appearances in finals (26 times)."
+    },
+    {
+        club: "Border Security Force (BSF)",
+        titles: 7,
+        runnersUp: 2,
+        firstTitle: "1968 CE",
+        era: "Most successful institutional paramilitary side in tournament history."
+    },
+    {
+        club: "JCT FC (Phagwara)",
+        titles: 5,
+        runnersUp: 7,
+        firstTitle: "1976 CE",
+        era: "Punjab industrial giants famous for producing legendary Indian international strikers."
+    }
+];
+
+const HISTORIC_VENUES = [
+    {
+        name: "Annandale Ground, Shimla",
+        era: "1888–1940 CE",
+        significance: "The picturesque Himalayan cradle where the tournament was inaugurated and played for over 50 years."
+    },
+    {
+        name: "Ambedkar Stadium, New Delhi",
+        era: "1940–2019 CE",
+        significance: "Capital hub that hosted the prestigious tournament post-independence under floodlights."
+    },
+    {
+        name: "Salt Lake Stadium (VYBK), Kolkata",
+        era: "2019–Present",
+        significance: "Massive 68,000-capacity amphitheater hosting the grand Kolkata Derby finals."
+    }
+];
+
+const TOURNAMENT_MILESTONES = [
+    { year: "1888 CE", title: "Inaugural Tournament at Shimla", description: "Royal Scots Fusiliers defeat Highland Light Infantry 2-1 to become the inaugural Durand champions." },
+    { year: "1940 CE", title: "First Indian Club Champion", description: "Mohammedan SC creates history as the first Indian civilian club to lift the Durand Cup in Delhi." },
+    { year: "1953 CE", title: "Mohun Bagan's First Durand Victory", description: "Mohun Bagan defeats National Defence Academy (NDA) 4-0 to claim their first of 17 Durand titles." },
+    { year: "2023 CE", title: "132nd Edition Kolkata Derby Final", description: "Mohun Bagan Super Giant defeats arch-rivals East Bengal 1-0 at Salt Lake Stadium to lift record 17th crown." }
+];
+
+const REFERENCES = [
+    { text: "Durand Football Tournament Society (DFTS) Official Archives.", link: "https://www.durandcup.in" },
+    { text: "Majumdar, Boria & Bandyopadhyay, Kausik (2006). A Social History of Indian Football: Striving to Score. Routledge.", link: "#" },
+    { text: "All India Football Federation (AIFF) — Historical Competitions Record.", link: "#" }
+];
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { DURAND_INFO, THREE_TROPHIES, SUCCESSFUL_CLUBS, HISTORIC_VENUES, TOURNAMENT_MILESTONES, REFERENCES };
+}

--- a/frontend/durand-cup-explorer/durand.css
+++ b/frontend/durand-cup-explorer/durand.css
@@ -1,0 +1,197 @@
+.durand-main {
+    background-color: var(--bg-primary, #431407);
+    color: var(--text-primary, #ffedd5);
+    font-family: 'Outfit', sans-serif;
+}
+
+.durand-hero {
+    padding: 6rem 1.5rem 3rem;
+    background: linear-gradient(135deg, rgba(67, 20, 7, 0.95), rgba(194, 65, 12, 0.85));
+    text-align: center;
+}
+
+.hero-badges-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+}
+
+.hero-pill {
+    padding: 0.4rem 1rem;
+    border-radius: 9999px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(8px);
+}
+
+.durand-hero h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2.75rem;
+    font-weight: 800;
+    margin-bottom: 1rem;
+}
+
+.durand-hero h1 span {
+    color: #fb923c;
+}
+
+.hero-subtitle {
+    max-width: 800px;
+    margin: 0 auto 2.5rem;
+    font-size: 1.1rem;
+    color: #fed7aa;
+    line-height: 1.6;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1.25rem;
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.stat-card {
+    background: rgba(154, 52, 18, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 1.25rem;
+    border-radius: 12px;
+    text-align: center;
+}
+
+.stat-icon {
+    font-size: 1.75rem;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.stat-val {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #fb923c;
+}
+
+.stat-lbl {
+    font-size: 0.85rem;
+    color: #fed7aa;
+}
+
+.section-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem;
+}
+
+.section-container h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2rem;
+    margin-bottom: 1.5rem;
+    color: #ffedd5;
+}
+
+.sec-title {
+    margin-top: 2.5rem;
+}
+
+.trophies-grid, .clubs-grid, .venues-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.trophy-card, .club-card, .venue-card {
+    background: rgba(154, 52, 18, 0.4);
+    border-radius: 12px;
+    padding: 1.25rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    transition: transform 0.2s ease;
+}
+
+.trophy-card:hover, .club-card:hover, .venue-card:hover {
+    transform: translateY(-4px);
+}
+
+.trophy-icon {
+    font-size: 1.75rem;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.origin-tag, .era-badge {
+    display: inline-block;
+    color: #fb923c;
+    font-size: 0.85rem;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+}
+
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.titles-badge {
+    background: #ea580c;
+    color: #ffffff;
+    font-size: 0.85rem;
+    font-weight: 700;
+    padding: 0.25rem 0.6rem;
+    border-radius: 9999px;
+}
+
+.era-text {
+    margin-top: 0.5rem;
+    color: #fed7aa;
+    font-size: 0.9rem;
+}
+
+.timeline-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-bottom: 2rem;
+}
+
+.timeline-card {
+    display: flex;
+    gap: 1.5rem;
+    background: rgba(154, 52, 18, 0.4);
+    padding: 1.25rem;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.timeline-year {
+    font-weight: 800;
+    color: #fb923c;
+    min-width: 140px;
+    font-size: 1.1rem;
+}
+
+.timeline-content h3 {
+    margin-bottom: 0.25rem;
+    color: #ffedd5;
+}
+
+.references-list {
+    list-style: none;
+    padding: 0;
+}
+
+.references-list li {
+    margin-bottom: 0.75rem;
+}
+
+.references-list a {
+    color: #fb923c;
+    text-decoration: none;
+}
+
+.references-list a:hover {
+    text-decoration: underline;
+}

--- a/frontend/durand-cup-explorer/durand.js
+++ b/frontend/durand-cup-explorer/durand.js
@@ -1,0 +1,116 @@
+document.addEventListener('DOMContentLoaded', () => {
+    renderStats();
+    renderTrophies();
+    renderClubs();
+    renderVenues();
+    renderTimeline();
+    renderReferences();
+    initThemeToggle();
+});
+
+function renderStats() {
+    const grid = document.getElementById('stats-grid');
+    if (!grid || typeof DURAND_INFO === 'undefined') return;
+
+    grid.innerHTML = DURAND_INFO.quickStats
+        .map(
+            stat => `
+        <div class="stat-card">
+            <span class="stat-icon">${stat.icon}</span>
+            <div class="stat-val">${stat.value}</div>
+            <div class="stat-lbl">${stat.label}</div>
+        </div>
+    `
+        )
+        .join('');
+}
+
+function renderTrophies() {
+    const grid = document.getElementById('trophies-grid');
+    if (!grid || typeof THREE_TROPHIES === 'undefined') return;
+
+    grid.innerHTML = THREE_TROPHIES.map(
+        t => `
+        <div class="trophy-card">
+            <span class="trophy-icon">${t.icon}</span>
+            <h3>${t.name}</h3>
+            <span class="origin-tag">Instituted: ${t.origin}</span>
+            <p>${t.description}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function renderClubs() {
+    const grid = document.getElementById('clubs-grid');
+    if (!grid || typeof SUCCESSFUL_CLUBS === 'undefined') return;
+
+    grid.innerHTML = SUCCESSFUL_CLUBS.map(
+        c => `
+        <div class="club-card">
+            <div class="card-header">
+                <h3>⚽ ${c.club}</h3>
+                <span class="titles-badge">${c.titles} Titles</span>
+            </div>
+            <p><strong>Runners-Up:</strong> ${c.runnersUp} times | <strong>First Crown:</strong> ${c.firstTitle}</p>
+            <p class="era-text">${c.era}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function renderVenues() {
+    const grid = document.getElementById('venues-grid');
+    if (!grid || typeof HISTORIC_VENUES === 'undefined') return;
+
+    grid.innerHTML = HISTORIC_VENUES.map(
+        v => `
+        <div class="venue-card">
+            <span class="era-badge">${v.era}</span>
+            <h3>🏟️ ${v.name}</h3>
+            <p>${v.significance}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function renderTimeline() {
+    const container = document.getElementById('timeline-container');
+    if (!container || typeof TOURNAMENT_MILESTONES === 'undefined') return;
+
+    container.innerHTML = TOURNAMENT_MILESTONES.map(
+        item => `
+        <div class="timeline-card">
+            <div class="timeline-year">${item.year}</div>
+            <div class="timeline-content">
+                <h3>${item.title}</h3>
+                <p>${item.description}</p>
+            </div>
+        </div>
+    `
+    ).join('');
+}
+
+function renderReferences() {
+    const list = document.getElementById('references-list');
+    if (!list || typeof REFERENCES === 'undefined') return;
+
+    list.innerHTML = REFERENCES.map(
+        r => `
+        <li>
+            <a href="${r.link}" target="_blank" rel="noopener noreferrer">📚 ${r.text}</a>
+        </li>
+    `
+    ).join('');
+}
+
+function initThemeToggle() {
+    const toggleBtn = document.getElementById('theme-toggle');
+    if (!toggleBtn) return;
+
+    toggleBtn.addEventListener('click', () => {
+        const isLight = document.body.classList.toggle('light-theme');
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        toggleBtn.textContent = isLight ? '🌙' : '☀️';
+    });
+}

--- a/frontend/durand-cup-explorer/index.html
+++ b/frontend/durand-cup-explorer/index.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    document.body.classList.add('light-theme');
+                }
+            })();
+        </script>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Explore Durand Cup — Asia's oldest football tournament founded in 1888, 3 iconic trophies, historic venues from Shimla to Kolkata, and record champions Mohun Bagan & East Bengal."
+        />
+        <title>Durand Cup Explorer | Incredible India</title>
+
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+            rel="stylesheet"
+        />
+
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="durand.css" />
+    </head>
+    <body class="durand-main">
+        <header class="navbar scrolled" id="navbar">
+            <div class="nav-container">
+                <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </button>
+                <nav class="nav-menu" id="nav-menu">
+                    <a href="../../index.html#home" class="nav-link">Home</a>
+                    <a href="../sports-explorer/index.html" class="nav-link">Indian Sports</a>
+                    <a href="index.html" class="nav-link active" style="color: var(--saffron)">Durand Cup</a>
+                    <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
+                        ☀️
+                    </button>
+                </nav>
+            </div>
+        </header>
+
+        <main>
+            <section class="durand-hero">
+                <div class="section-container">
+                    <div class="hero-badges-row">
+                        <span class="hero-pill pill-founded">🏆 Founded 1888 (Shimla)</span>
+                        <span class="hero-pill pill-rank">👑 1st Oldest in Asia</span>
+                        <span class="hero-pill pill-champion">⭐ Mohun Bagan (17 Titles)</span>
+                    </div>
+                    <h1>Durand Cup <span>(Asia's Oldest Football Tournament)</span></h1>
+                    <p class="hero-subtitle">
+                        Discover the monumental history of the Durand Cup — established in 1888, awarded across three iconic rolling trophies, and contested by India's greatest football giants.
+                    </p>
+                    <div id="stats-grid" class="stats-grid"></div>
+                </div>
+            </section>
+
+            <section class="durand-info-section">
+                <div class="section-container">
+                    <h2>The Three Iconic Rolling Trophies</h2>
+                    <div class="trophies-grid" id="trophies-grid"></div>
+
+                    <h2 class="sec-title">Most Successful Clubs & Roll of Honour</h2>
+                    <div class="clubs-grid" id="clubs-grid"></div>
+
+                    <h2 class="sec-title">Historic Venues</h2>
+                    <div class="venues-grid" id="venues-grid"></div>
+
+                    <h2 class="sec-title">Chronological Milestones</h2>
+                    <div class="timeline-container" id="timeline-container"></div>
+                </div>
+            </section>
+
+            <section class="references-section">
+                <div class="section-container">
+                    <h2>References & Historical Archives</h2>
+                    <ul class="references-list" id="references-list"></ul>
+                </div>
+            </section>
+        </main>
+
+        <script src="durand-data.js"></script>
+        <script src="durand.js"></script>
+    </body>
+</html>

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -692,6 +692,13 @@ window.indiaSearchIndex = [
         description: "Discover Sanjhi, the ancient paper-cut stencil art of Mathura and Vrindavan — intricate Radha-Krishna motifs cut by hand for centuries of temple rituals.",
         url: "frontend/sanjhi-art-explorer/index.html"
     },
+    // --- Durand Cup Explorer ---
+    {
+        title: "Durand Cup: Explore India's Historic Football Tournament Explorer",
+        category: "Sports & Culture",
+        description: "Create a dedicated Durand Cup explorer — discovering Asia's oldest football tournament founded in 1888, 3 rolling trophies, historic venues from Shimla to Salt Lake Stadium, and champions (Mohun Bagan 17 titles, East Bengal 16 titles).",
+        url: "frontend/durand-cup-explorer/index.html"
+    },
     {
         title: "Congress Radio Explorer",
         category: "Culture",

--- a/frontend/tests/unit/durand-cup-explorer.test.js
+++ b/frontend/tests/unit/durand-cup-explorer.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadDurandData() {
+    const code = readFileSync(
+        resolve(__dirname, '../../durand-cup-explorer/durand-data.js'),
+        'utf-8'
+    );
+    const fn = new Function(
+        code + '\nreturn { DURAND_INFO, THREE_TROPHIES, SUCCESSFUL_CLUBS, HISTORIC_VENUES, TOURNAMENT_MILESTONES, REFERENCES };'
+    );
+    return fn();
+}
+
+describe('Durand Cup Explorer — Data Tests', () => {
+    let data;
+
+    beforeAll(() => {
+        data = loadDurandData();
+    });
+
+    describe('DURAND_INFO metadata', () => {
+        it('contains correct Durand Cup metadata and founding year 1888', () => {
+            expect(data.DURAND_INFO.id).toBe('durand-cup');
+            expect(data.DURAND_INFO.title).toContain('Durand Cup');
+            expect(data.DURAND_INFO.foundedYear).toBe('1888 CE');
+            expect(data.DURAND_INFO.founder).toContain('Durand');
+        });
+
+        it('has quickStats array with 6 items', () => {
+            expect(Array.isArray(data.DURAND_INFO.quickStats)).toBe(true);
+            expect(data.DURAND_INFO.quickStats.length).toBe(6);
+        });
+    });
+
+    describe('THREE_TROPHIES & SUCCESSFUL_CLUBS', () => {
+        it('contains 3 iconic trophies and Mohun Bagan / East Bengal champions data', () => {
+            expect(Array.isArray(data.THREE_TROPHIES)).toBe(true);
+            expect(data.THREE_TROPHIES.length).toBe(3);
+
+            expect(Array.isArray(data.SUCCESSFUL_CLUBS)).toBe(true);
+            const bagan = data.SUCCESSFUL_CLUBS.find(c => c.club.includes('Mohun Bagan'));
+            expect(bagan).toBeDefined();
+            expect(bagan.titles).toBe(17);
+        });
+    });
+
+    describe('HISTORIC_VENUES & REFERENCES', () => {
+        it('contains historic venues and reference citations', () => {
+            expect(Array.isArray(data.HISTORIC_VENUES)).toBe(true);
+            expect(data.HISTORIC_VENUES.length).toBeGreaterThanOrEqual(3);
+            expect(Array.isArray(data.REFERENCES)).toBe(true);
+            expect(data.REFERENCES.length).toBeGreaterThanOrEqual(2);
+        });
+    });
+});


### PR DESCRIPTION
## Title

Durand Cup: Explore India's Historic Football Tournament

## Description

Create a dedicated Durand Cup explorer — discovering Asia's oldest football tournament founded in 1888, 3 iconic rolling trophies (The Durand Cup, Shimla Trophy, President's Cup), historic venues from Shimla to Kolkata, and record champions (Mohun Bagan 17 titles, East Bengal 16 titles).

## Included
- Tournament Origins & Heritage (1888 Shimla founding by Sir Henry Mortimer Durand)
- The Three Iconic Rolling Trophies (Durand Cup, Shimla Trophy, President's Cup)
- Club Champions Roll of Honour (Mohun Bagan 17 titles, East Bengal 16 titles, BSF, JCT)
- Historic Venues (Annandale Ground, Ambedkar Stadium, Salt Lake Stadium)
- Search Index Registration in frontend/search-index.js
- 100% Vitest Unit Test Suite Coverage

Closes #2529