### PR TITLE
feat: Indian Chess Championship

### DIFF
--- a/frontend/chess-heritage-explorer/chess-data.js
+++ b/frontend/chess-heritage-explorer/chess-data.js
@@ -1,0 +1,567 @@
+/**
+ * Incredible India Explorer - Indian Chess Heritage Data Repository
+ */
+
+export const chessEvolutionData = [
+  {
+    period: "5th - 6th Century AD",
+    title: "Origins of Chaturanga",
+    subtitle: "The Ancient Indian Birthplace of Chess",
+    description: "Chess originated in Ancient India as Chaturanga during the Gupta Empire. The term 'Chaturanga' translates to 'four limbs' representing the four divisions of the ancient Indian army: Infantry (pawns), Cavalry (knights), Elephants (bishops), and Chariots (rooks), commanded by the Raja (king) and Mantri (vizier/queen). Played on an 8x8 uncheckered board called Ashtapada, the game spread along the Silk Route to Persia as Chatrang, later becoming Shatranj, and eventually Western Chess.",
+    icon: "♟️",
+    tag: "Ancient Origin"
+  },
+  {
+    period: "1920s - 1930s",
+    title: "Mir Sultan Khan - The Pioneer",
+    subtitle: "India's First Uncrowned Global Master",
+    description: "Mir Sultan Khan, a native of Mitha Tiwana (Punjab), stunned the international chess community in the 1930s. Possessing no formal theoretical training and unfamiliar with modern opening theory, he won the British Chess Championship three times (1929, 1932, 1933) and defeated legendary World Champions Jose Raul Capablanca, Alexander Alekhine, and Salo Flohr. FIDE posthumously awarded him the Grandmaster title in 2024.",
+    icon: "👑",
+    tag: "Pre-Independence Legend"
+  },
+  {
+    period: "1951 - 1955",
+    title: "Formation of AICF & First National Championship",
+    subtitle: "Institutionalizing Indian Chess",
+    description: "The All India Chess Federation (AICF) was founded in 1951 to organize national tournaments and affiliate with FIDE. In 1955, the first official National Premier Chess Championship was hosted in Eluru, Andhra Pradesh. Ramchandra Sapre and D.V. Ram Ramanathan shared the inaugural national crown, marking the dawn of competitive organized chess across India.",
+    icon: "🏆",
+    tag: "National Foundation"
+  },
+  {
+    period: "1961 - 1970s",
+    title: "Manuel Aaron: India's 1st International Master",
+    subtitle: "The Nine-Time National Titan",
+    description: "Manuel Aaron became India's very first International Master (IM) in 1961 by winning the West Asian Zonal Championship. He dominated Indian chess for over two decades, winning a record nine National Premier titles between 1959 and 1981. Aaron played a key role in publicizing chess ratings, organizing international tournaments in Chennai, and establishing the groundwork for future generations.",
+    icon: "🥇",
+    tag: "IM Era"
+  },
+  {
+    period: "1974",
+    title: "Inauguration of National Women's Championship",
+    subtitle: "Women Break New Frontiers",
+    description: "The National Women's Premier Chess Championship commenced in 1974 in Bengaluru. Vasanti Khadilkar won the first title, followed by her sisters Jayshree and Rohini Khadilkar. The Khadilkar sisters dominated Indian women's chess throughout the 1970s and 1980s, inspiring female players across the nation.",
+    icon: "👸",
+    tag: "Women's Pioneer"
+  },
+  {
+    period: "1988",
+    title: "Viswanathan Anand Becomes 1st Grandmaster",
+    subtitle: "The Lightning Kid Sparks a National Revolution",
+    description: "At age 18, Viswanathan Anand became India's first-ever Grandmaster in 1988 after securing his third GM norm at the Shakti Finance Tournament in Coimbatore. His rapid tactical calculation earned him the nickname 'The Lightning Kid'. Anand proved that an Indian grandmaster could conquer world chess, forever transforming India's sporting landscape.",
+    icon: "⚡",
+    tag: "Historic Breakthrough"
+  },
+  {
+    period: "2000 - 2012",
+    title: "Anand's 5 World Championship Titles & Tamil Nadu Boom",
+    subtitle: "The Golden Era of the Maestro",
+    description: "Viswanathan Anand achieved the ultimate pinnacle by winning 5 FIDE World Championship titles (2000 FIDE World Champion; 2007 tournament format; 2008 vs Kramnik; 2010 vs Topalov; 2012 vs Gelfand). His success catalyzed a chess boom, turning Chennai into the 'Chess Capital of India' with hundreds of academies producing GMs like Sasikiran, Harikrishna, and Vijayalakshmi.",
+    icon: "🌍",
+    tag: "World Champion Era"
+  },
+  {
+    period: "2002 - 2019",
+    title: "Women Grandmaster Milestones: Humpy & Vijayalakshmi",
+    subtitle: "Shattering Global Glass Ceilings",
+    description: "Subbaraman Vijayalakshmi became India's first WGM and won 6 consecutive National Women's titles (1998-2003). In 2002, Koneru Humpy broke Judit Polgar's record to become the youngest woman in history to earn the full Grandmaster (GM) title at age 15 years 1 month. Humpy later won the 2019 World Women's Rapid Championship, while Harika Dronavalli claimed 3 World Championship bronze medals.",
+    icon: "⭐",
+    tag: "Women's Glory"
+  },
+  {
+    period: "2020 - 2023",
+    title: "The Rise of Indian Prodigies & World Cup Surge",
+    subtitle: "Gukesh, Praggnanandhaa, & Arjun Take Center Stage",
+    description: "A new golden generation emerged. Praggnanandhaa R defeated World Champion Magnus Carlsen in online speed chess and reached the 2023 FIDE World Cup Final. Gukesh D broke into the world top 10 at age 17, ending Anand's 37-year reign as India's No. 1 rated player. Arjun Erigaisi soared past the elite 2800 FIDE rating threshold.",
+    icon: "🚀",
+    tag: "Prodigy Boom"
+  },
+  {
+    period: "2024",
+    title: "Historic 45th Chess Olympiad Double Gold & Gukesh World Challenger",
+    subtitle: "India Crowned Absolute Global Chess Empire",
+    description: "At the 45th FIDE Chess Olympiad 2024 in Budapest, Hungary, India accomplished an unprecedented feat by winning BOTH the Open and Women's Team GOLD Medals with dominant individual performances from Gukesh, Arjun, Pragg, Divya Deshmukh, and Vantika Agrawal. Earlier in 2024, 17-year-old Gukesh D won the Candidates Tournament in Toronto, becoming the youngest-ever challenger for the World Chess Championship.",
+    icon: "🥇🥇",
+    tag: "Pinnacle Era"
+  }
+];
+
+export const mensChampionshipHistory = [
+  { year: 1955, venue: "Eluru", winner: "Ramchandra Sapre & D.V. Ram Ramanathan", runnerUp: "Shared Title", state: "Maharashtra / Tamil Nadu", notes: "Inaugural edition of the National Premier Championship." },
+  { year: 1957, venue: "Kanpur", winner: "Ramchandra Sapre", runnerUp: "Manuel Aaron", state: "Maharashtra", notes: "Sapre won his second national title." },
+  { year: 1959, venue: "Delhi", winner: "Manuel Aaron", runnerUp: "B.P. Mhaiskar", state: "Tamil Nadu", notes: "First of Aaron's record nine national titles." },
+  { year: 1961, venue: "Hyderabad", winner: "Manuel Aaron", runnerUp: "V.K. Raman", state: "Tamil Nadu", notes: "Aaron retained his title after becoming India's 1st IM." },
+  { year: 1963, venue: "Bombay", winner: "Manuel Aaron", runnerUp: "Farooq Ali", state: "Tamil Nadu", notes: "Third consecutive crown for Aaron." },
+  { year: 1965, venue: "Madras", winner: "Manuel Aaron", runnerUp: "P.N. Ranga Rao", state: "Tamil Nadu", notes: "Aaron dominated with an unbeaten performance." },
+  { year: 1967, venue: "Pune", winner: "Manuel Aaron", runnerUp: "S.V. Natarajan", state: "Tamil Nadu", notes: "Fifth title for Manuel Aaron." },
+  { year: 1969, venue: "Bangalore", winner: "Manuel Aaron", runnerUp: "V.K. Raman", state: "Tamil Nadu", notes: "Aaron scored 14.5 / 16 points." },
+  { year: 1971, venue: "Bikaner", winner: "Manuel Aaron", runnerUp: "N. Ghalib", state: "Tamil Nadu", notes: "Seventh national crown." },
+  { year: 1972, venue: "Ahmedabad", winner: "Manuel Aaron", runnerUp: "M.V. Subba Rao", state: "Tamil Nadu", notes: "Eighth title, cementing Aaron's era." },
+  { year: 1975, venue: "Rourkela", winner: "Manuel Aaron", runnerUp: "V. Ravi Kumar", state: "Tamil Nadu", notes: "Record 9th National Title for Manuel Aaron." },
+  { year: 1976, venue: "Patna", winner: "Ravi Sekhar", runnerUp: "Manuel Aaron", state: "Tamil Nadu", notes: "Ravi Sekhar broke Aaron's winning streak." },
+  { year: 1978, venue: "Cochin", winner: "V. Ravi Kumar", runnerUp: "T.N. Parameswaran", state: "Tamil Nadu", notes: "Ravi Kumar won prior to becoming IM." },
+  { year: 1979, venue: "Tiruchirappalli", winner: "T.N. Parameswaran", runnerUp: "Ravi Sekhar", state: "Tamil Nadu", notes: "Parameswaran's first national victory." },
+  { year: 1980, venue: "Vijayawada", winner: "Ravi Sekhar", runnerUp: "Manuel Aaron", state: "Tamil Nadu", notes: "Ravi Sekhar's second national championship." },
+  { year: 1981, venue: "Kanpur", winner: "Pravin Thipsay", runnerUp: "T.N. Parameswaran", state: "Maharashtra", notes: "First of Thipsay's 7 national championships." },
+  { year: 1982, venue: "Kanpur", winner: "Pravin Thipsay", runnerUp: "Dibyendu Barua", state: "Maharashtra", notes: "Thipsay retained his crown." },
+  { year: 1983, venue: "Agartala", winner: "Dibyendu Barua", runnerUp: "Pravin Thipsay", state: "West Bengal", notes: "Barua won at age 16, becoming the youngest champion then." },
+  { year: 1984, venue: "Ahmedabad", winner: "Pravin Thipsay", runnerUp: "Dibyendu Barua", state: "Maharashtra", notes: "Third title for Thipsay." },
+  { year: 1985, venue: "Tenali", winner: "Pravin Thipsay", runnerUp: "V. Anand", state: "Maharashtra", notes: "Thipsay defeated a young 15-year-old Viswanathan Anand." },
+  { year: 1986, venue: "Bombay", winner: "Viswanathan Anand", runnerUp: "Pravin Thipsay", state: "Tamil Nadu", notes: "First national title for 16-year-old Anand." },
+  { year: 1987, venue: "Tirupur", winner: "Viswanathan Anand", runnerUp: "D.V. Prasad", state: "Tamil Nadu", notes: "Anand won unbeaten before earning World Junior Champion title." },
+  { year: 1988, venue: "Neyveli", winner: "Viswanathan Anand", runnerUp: "Pravin Thipsay", state: "Tamil Nadu", notes: "Anand's 3rd consecutive title in the year he became GM." },
+  { year: 1989, venue: "Bikaner", winner: "Pravin Thipsay", runnerUp: "D.V. Prasad", state: "Maharashtra", notes: "Thipsay reclaimed the national title." },
+  { year: 1990, venue: "Calcutta", winner: "D.V. Prasad", runnerUp: "Dibyendu Barua", state: "Karnataka", notes: "D.V. Prasad won after consistent top finishes." },
+  { year: 1991, venue: "Pondicherry", winner: "Pravin Thipsay", runnerUp: "Dibyendu Barua", state: "Maharashtra", notes: "6th national victory for Pravin Thipsay." },
+  { year: 1992, venue: "Pune", winner: "Pravin Thipsay", runnerUp: "K. Murugan", state: "Maharashtra", notes: "7th and final National Premier title for Thipsay." },
+  { year: 1993, venue: "Calcutta", winner: "Dibyendu Barua", runnerUp: "Pravin Thipsay", state: "West Bengal", notes: "Barua's second national championship." },
+  { year: 1994, venue: "Hyderabad", winner: "Abhijit Kunte", runnerUp: "Pravin Thipsay", state: "Maharashtra", notes: "Young Kunte won his inaugural national title." },
+  { year: 1995, venue: "Madras", winner: "P. Konguvel", runnerUp: "D.V. Prasad", state: "Tamil Nadu", notes: "Konguvel's solitary national premier victory." },
+  { year: 1996, venue: "Kottayam", winner: "K. Sasikiran", runnerUp: "Abhijit Kunte", state: "Tamil Nadu", notes: "16-year-old Sasikiran secured his 1st national crown." },
+  { year: 1997, venue: "Bhilai", winner: "Abhijit Kunte", runnerUp: "D.V. Prasad", state: "Maharashtra", notes: "Kunte won his second title." },
+  { year: 1998, venue: "Muzaffarnagar", winner: "Dibyendu Barua", runnerUp: "K. Sasikiran", state: "West Bengal", notes: "3rd national premier crown for Barua." },
+  { year: 1999, venue: "Nagpur", winner: "K. Sasikiran", runnerUp: "P. Harikrishna", state: "Tamil Nadu", notes: "Sasikiran won his 2nd title." },
+  { year: 2000, venue: "Mumbai", winner: "K. Sasikiran", runnerUp: "Abhijit Kunte", state: "Tamil Nadu", notes: "Back-to-back title defense for Sasikiran." },
+  { year: 2001, venue: "Delhi", winner: "P. Harikrishna", runnerUp: "K. Sasikiran", state: "Andhra Pradesh", notes: "15-year-old Harikrishna won his first national title." },
+  { year: 2002, venue: "Nagpur", winner: "K. Sasikiran", runnerUp: "Surya Shekhar Ganguly", state: "Tamil Nadu", notes: "4th National Premier title for Sasikiran." },
+  { year: 2003, venue: "Kozhikode", winner: "Surya Shekhar Ganguly", runnerUp: "K. Sasikiran", state: "West Bengal", notes: "Start of Ganguly's historic 6-consecutive-title streak." },
+  { year: 2004, venue: "Visakhapatnam", winner: "Surya Shekhar Ganguly", runnerUp: "Sandipan Chanda", state: "West Bengal", notes: "Ganguly defended title with 11.5 / 15." },
+  { year: 2005, venue: "New Delhi", winner: "Surya Shekhar Ganguly", runnerUp: "Chakkravarthy Deepan", state: "West Bengal", notes: "3rd consecutive crown." },
+  { year: 2006, venue: "Visakhapatnam", winner: "Surya Shekhar Ganguly", runnerUp: "G.N. Gopal", state: "West Bengal", notes: "4th consecutive title." },
+  { year: 2007, venue: "Chennai", winner: "Surya Shekhar Ganguly", runnerUp: "K. Sasikiran", state: "West Bengal", notes: "5th consecutive victory." },
+  { year: 2008, venue: "Mangalore", winner: "Surya Shekhar Ganguly", runnerUp: "Abhijit Kunte", state: "West Bengal", notes: "Record 6 CONSECUTIVE National Premier Titles (2003-2008)." },
+  { year: 2009, venue: "New Delhi", winner: "Baskaran Adhiban", runnerUp: "M.R. Lalith Babu", state: "Tamil Nadu", notes: "17-year-old 'Beast' Adhiban claimed title." },
+  { year: 2010, venue: "New Delhi", winner: "Parimarjan Negi", runnerUp: "G.N. Gopal", state: "Delhi", notes: "Negi won with 10.5 / 13." },
+  { year: 2011, venue: "Aurangabad", winner: "Abhijeet Gupta", runnerUp: "G.N. Gopal", state: "Rajasthan", notes: "Former World Junior Champion Abhijeet won title." },
+  { year: 2012, venue: "Kolkata", winner: "G. Akash", runnerUp: "Vidit Gujrathi", state: "Tamil Nadu", notes: "Young Akash clinched title in close tiebreak." },
+  { year: 2013, venue: "Jalgaon", winner: "S.P. Sethuraman", runnerUp: "Varupan Kothari", state: "Tamil Nadu", notes: "SP Sethuraman dominated the round-robin." },
+  { year: 2014, venue: "Kottayam", winner: "S.P. Sethuraman", runnerUp: "Deep Sengupta", state: "Tamil Nadu", notes: "Sethuraman retained his crown." },
+  { year: 2015, venue: "Tiruvarur", winner: "Karthikeyan Murali", runnerUp: "Vidit Gujrathi", state: "Tamil Nadu", notes: "16-year-old GM Karthikeyan won inaugural national title." },
+  { year: 2016, venue: "Lucknow", winner: "Karthikeyan Murali", runnerUp: "Aravindh Chithambaram", state: "Tamil Nadu", notes: "Karthikeyan defended title back-to-back." },
+  { year: 2017, venue: "Patna", winner: "M.R. Lalith Babu", runnerUp: "Aravindh Chithambaram", state: "Andhra Pradesh", notes: "Lalith Babu won unbeaten." },
+  { year: 2018, venue: "Jammu", winner: "Aravindh Chithambaram", runnerUp: "C.R.G. Krishna", state: "Tamil Nadu", notes: "Aravindh won first of his triple titles." },
+  { year: 2019, venue: "Majhtar (HP)", winner: "Aravindh Chithambaram", runnerUp: "S.P. Sethuraman", state: "Tamil Nadu", notes: "Aravindh defended title back-to-back." },
+  { year: 2022, venue: "Kanpur", winner: "Arjun Erigaisi", runnerUp: "D. Gukesh", state: "Telangana", notes: "Arjun won in dramatic final round tiebreak." },
+  { year: 2023, venue: "New Delhi", winner: "S.P. Sethuraman", runnerUp: "Vishnu Prasanna", state: "Tamil Nadu", notes: "Sethuraman won his 3rd National Premier title." },
+  { year: 2024, venue: "Gurugram", winner: "Karthik Venkataraman", runnerUp: "Surya Shekhar Ganguly", state: "Andhra Pradesh", notes: "Karthik scored 9/11 to claim 2024 title." }
+];
+
+export const womensChampionshipHistory = [
+  { year: 1974, venue: "Bangalore", winner: "Vasanti Khadilkar", runnerUp: "Jayshree Khadilkar", state: "Maharashtra", notes: "Inaugural Women's National Premier Championship." },
+  { year: 1975, venue: "Calcutta", winner: "Jayshree Khadilkar", runnerUp: "Rohini Khadilkar", state: "Maharashtra", notes: "First of Jayshree's 4 titles." },
+  { year: 1976, venue: "Kottayam", winner: "Rohini Khadilkar", runnerUp: "Jayshree Khadilkar", state: "Maharashtra", notes: "13-year-old Rohini became youngest champion." },
+  { year: 1977, venue: "Hyderabad", winner: "Rohini Khadilkar", runnerUp: "Jayshree Khadilkar", state: "Maharashtra", notes: "Second consecutive crown." },
+  { year: 1979, venue: "Madras", winner: "Rohini Khadilkar", runnerUp: "Vasanti Khadilkar", state: "Maharashtra", notes: "Third title for Rohini." },
+  { year: 1981, venue: "Panaji", winner: "Rohini Khadilkar", runnerUp: "Jayshree Khadilkar", state: "Maharashtra", notes: "Fourth title." },
+  { year: 1982, venue: "Rajanpur", winner: "Jayshree Khadilkar", runnerUp: "Rohini Khadilkar", state: "Maharashtra", notes: "Jayshree won her second national crown." },
+  { year: 1983, venue: "Bombay", winner: "Jayshree Khadilkar", runnerUp: "Rohini Khadilkar", state: "Maharashtra", notes: "Third national victory." },
+  { year: 1984, venue: "Ahmedabad", winner: "Jayshree Khadilkar", runnerUp: "Bhagyashree Sathe", state: "Maharashtra", notes: "Fourth title for Jayshree Khadilkar." },
+  { year: 1985, venue: "Palai", winner: "Bhagyashree Sathe (Thipsay)", runnerUp: "Anupama Abhyankar", state: "Maharashtra", notes: "Bhagyashree's inaugural victory." },
+  { year: 1986, venue: "Jalandhar", winner: "Anupama Abhyankar (Gokhale)", runnerUp: "Bhagyashree Sathe", state: "Maharashtra", notes: "First title for Anupama." },
+  { year: 1987, venue: "Calcutta", winner: "Anupama Abhyankar (Gokhale)", runnerUp: "Rohini Khadilkar", state: "Maharashtra", notes: "Back-to-back defense." },
+  { year: 1988, venue: "Kurukshetra", winner: "Bhagyashree Thipsay", runnerUp: "Anupama Gokhale", state: "Maharashtra", notes: "Bhagyashree's second crown." },
+  { year: 1989, venue: "Durgapur", winner: "Anupama Gokhale", runnerUp: "Bhagyashree Thipsay", state: "Maharashtra", notes: "Anupama's 3rd national title." },
+  { year: 1990, venue: "Vijayawada", winner: "Anupama Gokhale", runnerUp: "Bhagyashree Thipsay", state: "Maharashtra", notes: "Fourth title for Anupama." },
+  { year: 1991, venue: "Kozhikode", winner: "Bhagyashree Thipsay", runnerUp: "Anupama Gokhale", state: "Maharashtra", notes: "Third title for Bhagyashree." },
+  { year: 1992, venue: "Bombay", winner: "Anupama Gokhale", runnerUp: "Bhagyashree Thipsay", state: "Maharashtra", notes: "Fifth title for Anupama Gokhale." },
+  { year: 1993, venue: "Kozhikode", winner: "Anupama Gokhale", runnerUp: "K. Saritha", state: "Maharashtra", notes: "Record 6th National Title for Anupama." },
+  { year: 1994, venue: "Bangalore", winner: "Bhagyashree Thipsay", runnerUp: "Mrinalini Kunte", state: "Maharashtra", notes: "Fourth title for Bhagyashree." },
+  { year: 1995, venue: "Madras", winner: "S. Vijayalakshmi", runnerUp: "Bhagyashree Thipsay", state: "Tamil Nadu", notes: "First national title for 16-year-old Subbaraman Vijayalakshmi." },
+  { year: 1996, venue: "Salem", winner: "Mrinalini Kunte", runnerUp: "S. Vijayalakshmi", state: "Maharashtra", notes: "Mrinalini's solitary national premier win." },
+  { year: 1997, venue: "Calcutta", winner: "Anupama Gokhale", runnerUp: "S. Vijayalakshmi", state: "Maharashtra", notes: "Seventh title for Anupama Gokhale." },
+  { year: 1998, venue: "Mumbai", winner: "S. Vijayalakshmi", runnerUp: "Bhagyashree Thipsay", state: "Tamil Nadu", notes: "Start of Viji's historic 6-consecutive-title streak." },
+  { year: 1999, venue: "Kozhikode", winner: "S. Vijayalakshmi", runnerUp: "Swati Ghate", state: "Tamil Nadu", notes: "Second consecutive crown." },
+  { year: 2000, venue: "Mumbai", winner: "S. Vijayalakshmi", runnerUp: "Nisha Mohota", state: "Tamil Nadu", notes: "Third consecutive crown in year she became 1st WGM." },
+  { year: 2001, venue: "New Delhi", winner: "S. Vijayalakshmi", runnerUp: "Nisha Mohota", state: "Tamil Nadu", notes: "Fourth consecutive victory." },
+  { year: 2002, venue: "Lucknow", winner: "S. Vijayalakshmi", runnerUp: "Swati Ghate", state: "Tamil Nadu", notes: "Fifth consecutive title." },
+  { year: 2003, venue: "Mumbai", winner: "S. Vijayalakshmi", runnerUp: "Koneru Humpy", state: "Tamil Nadu", notes: "Record 6 CONSECUTIVE Titles for S. Vijayalakshmi (1998-2003)." },
+  { year: 2004, venue: "Vijayawada", winner: "Koneru Humpy", runnerUp: "S. Vijayalakshmi", state: "Andhra Pradesh", notes: "Humpy won her 1st Women's National Title." },
+  { year: 2005, venue: "Bangalore", winner: "Nisha Mohota", runnerUp: "Mary Ann Gomes", state: "West Bengal", notes: "Nisha Mohota won her first national title." },
+  { year: 2006, venue: "Chennai", winner: "Swati Ghate", runnerUp: "Mary Ann Gomes", state: "Maharashtra", notes: "Swati Ghate won after multiple runner-up finishes." },
+  { year: 2007, venue: "Pune", winner: "Tania Sachdev", runnerUp: "Harika Dronavalli", state: "Delhi", notes: "Tania Sachdev won her inaugural national title." },
+  { year: 2008, venue: "New Delhi", winner: "Tania Sachdev", runnerUp: "Mary Ann Gomes", state: "Delhi", notes: "Tania defended her national crown." },
+  { year: 2009, venue: "Chennai", winner: "Harika Dronavalli", runnerUp: "Eesha Karavade", state: "Andhra Pradesh", notes: "Harika won prior to earning full GM title." },
+  { year: 2010, venue: "Bhubaneswar", winner: "Swaminathan Soumya", runnerUp: "Nisha Mohota", state: "Maharashtra", notes: "Soumya won after winning World Junior Women's." },
+  { year: 2011, venue: "Chennai", winner: "Mary Ann Gomes", runnerUp: "Eesha Karavade", state: "West Bengal", notes: "First of Mary Ann's 3 consecutive titles." },
+  { year: 2012, venue: "Jalgaon", winner: "Mary Ann Gomes", runnerUp: "Swaminathan Soumya", state: "West Bengal", notes: "Mary Ann defended her crown." },
+  { year: 2013, venue: "Hyderabad", winner: "Mary Ann Gomes", runnerUp: "Bhakti Kulkarni", state: "West Bengal", notes: "3rd consecutive title for Mary Ann Gomes." },
+  { year: 2014, venue: "Sangli", winner: "Padmini Rout", runnerUp: "S. Vijayalakshmi", state: "Odisha", notes: "Start of Padmini's 4 consecutive titles." },
+  { year: 2015, venue: "Kolkata", winner: "Padmini Rout", runnerUp: "Swati Ghate", state: "Odisha", notes: "Second consecutive crown." },
+  { year: 2016, venue: "New Delhi", winner: "Padmini Rout", runnerUp: "S. Vijayalakshmi", state: "Odisha", notes: "Third consecutive crown." },
+  { year: 2017, venue: "Ahmedabad", winner: "Padmini Rout", runnerUp: "Bhakti Kulkarni", state: "Odisha", notes: "4 CONSECUTIVE titles for Padmini Rout (2014-2017)." },
+  { year: 2018, venue: "Jaipur", winner: "Bhakti Kulkarni", runnerUp: "Soumya Swaminathan", state: "Goa", notes: "Bhakti Kulkarni won her 1st national premier title." },
+  { year: 2019, venue: "Karaikudi", winner: "Bhakti Kulkarni", runnerUp: "Vantika Agrawal", state: "Goa", notes: "Bhakti defended her crown." },
+  { year: 2022, venue: "Bhubaneswar", winner: "Divya Deshmukh", runnerUp: "Sakshi Chitlange", state: "Maharashtra", notes: "16-year-old Divya won her first Women's Premier title." },
+  { year: 2023, venue: "Kolhapur", winner: "Divya Deshmukh", runnerUp: "Mary Ann Gomes", state: "Maharashtra", notes: "Divya defended title back-to-back before winning World Junior 2024." },
+  { year: 2024, venue: "Karaikudi", winner: "P.V. Nandhidhaa", runnerUp: "Vantika Agrawal", state: "Tamil Nadu", notes: "WGM Nandhidhaa scored 9.5/11 to claim 2024 crown." }
+];
+
+export const majorChampionsData = [
+  {
+    name: "Viswanathan Anand",
+    title: "Grandmaster (1988) | 5x World Champion",
+    state: "Tamil Nadu (Chennai)",
+    peakRating: "2817",
+    birthYear: 1969,
+    imageBg: "linear-gradient(135deg, #1e3a8a, #3b82f6)",
+    summary: "India's greatest chess icon, 1st Grandmaster, and 5-time World Chess Champion across all formats (Knockout, Tournament, Match).",
+    achievements: [
+      "5-time World Chess Champion (2000, 2007, 2008, 2010, 2012)",
+      "India's 1st Grandmaster (1988)",
+      "First recipient of Rajiv Gandhi Khel Ratna Award (1991-92)",
+      "Padma Vibhushan recipient (2007)",
+      "FIDE Deputy President & Mentor to Next-Gen Prodigies"
+    ],
+    bio: "Born in Mayiladuthurai and raised in Chennai, Anand learned chess from his mother Susheela at age 6. His lightning-fast calculation earned him the epithet 'The Lightning Kid'. He broke the Soviet dominance in chess by winning the FIDE World Championship in 2000, and subsequently defended his title in classic matches against Kramnik (2008), Topalov (2010), and Gelfand (2012). His pioneering legacy inspired over 85 Indian Grandmasters."
+  },
+  {
+    name: "D. Gukesh (Gukesh Dommaraju)",
+    title: "Grandmaster (2019) | 2024 World Championship Challenger",
+    state: "Tamil Nadu (Chennai)",
+    peakRating: "2798",
+    birthYear: 2006,
+    imageBg: "linear-gradient(135deg, #7c2d12, #f97316)",
+    summary: "Youngest-ever Candidates Tournament winner in chess history (age 17 in 2024) and youngest challenger for the World Chess Championship.",
+    achievements: [
+      "Winner of 2024 FIDE Candidates Tournament (Toronto)",
+      "Individual Gold Medalist (Board 1) at 45th Chess Olympiad 2024",
+      "Third-youngest Grandmaster in history at age 12 yrs 7 mos",
+      "Youngest player to cross 2750 FIDE rating",
+      "Olympiad Team Gold 2024 & Team Bronze 2022"
+    ],
+    bio: "Gukesh learned chess at age 7 at Velammal School in Chennai under coach Vishnu Prasanna. Renowned for his deep positional understanding, exceptional nerve under high pressure, and formidable endgame technique, Gukesh surpassed Anand as India's highest-ranked player in 2023. In April 2024, he won the Candidates Tournament ahead of Caruana, Nakamura, and Nepomniachtchi to challenge Ding Liren for the World Title."
+  },
+  {
+    name: "Praggnanandhaa Rameshbabu",
+    title: "Grandmaster (2018) | World Cup Finalist 2023",
+    state: "Tamil Nadu (Chennai)",
+    peakRating: "2778",
+    birthYear: 2005,
+    imageBg: "linear-gradient(135deg, #065f46, #10b981)",
+    summary: "World Cup 2023 Finalist, candidate for the World Championship, and prodigy who became GM at age 12.",
+    achievements: [
+      "FIDE World Cup 2023 Silver Medalist (Baku)",
+      "FIDE Candidates 2024 Qualifier",
+      "Double Gold Team & Individual Medalist at 2024 Chess Olympiad",
+      "5th Youngest Grandmaster in history (12 yrs 10 mos)",
+      "Defeated World Champion Magnus Carlsen multiple times in elite events"
+    ],
+    bio: "Coached by RB Ramesh, Praggnanandhaa ('Pragg') captured international headlines at age 10 when he became the youngest International Master in history. Known for his tactical brilliance and relentless combativeness, Pragg qualified for the 2024 Candidates after defeating Hikaru Nakamura and Fabiano Caruana at the 2023 World Cup in Baku."
+  },
+  {
+    name: "Arjun Erigaisi",
+    title: "Grandmaster (2018) | 2800+ FIDE Elite Club",
+    state: "Telangana (Warangal)",
+    peakRating: "2805",
+    birthYear: 2003,
+    imageBg: "linear-gradient(135deg, #4c1d95, #8b5cf6)",
+    summary: "Dynamic tactical powerhouse who became only the second Indian after Anand to breach the legendary 2800 FIDE rating milestone.",
+    achievements: [
+      "Surpassed 2800 FIDE rating threshold in 2024",
+      "Individual Gold Medalist (Board 3) with 10/11 performance at 2024 Olympiad",
+      "National Premier Champion (2022)",
+      "Tata Steel Challengers Champion (2022)",
+      "Indian No. 1 peak ranking (2024)"
+    ],
+    bio: "Hailing from Warangal, Telangana, Arjun is famed for his uncompromising, original attacking chess and extraordinary calculation depth. His phenomenal streak in 2024 saw him score consecutive tournament victories across classical events in Europe and Asia, establishing him among the absolute top 3 chess players globally."
+  },
+  {
+    name: "Koneru Humpy",
+    title: "Grandmaster (2002) | World Women's Rapid Champion",
+    state: "Andhra Pradesh (Gudivada)",
+    peakRating: "2630",
+    birthYear: 1987,
+    imageBg: "linear-gradient(135deg, #831843, #ec4899)",
+    summary: "India's greatest female chess player, who set a world record in 2002 by becoming the youngest woman to achieve the full GM title.",
+    achievements: [
+      "FIDE World Women's Rapid Champion (2019, Batumi)",
+      "Youngest woman in history to become full GM at age 15 yrs 1 mo (2002)",
+      "FIDE Women's Grand Prix Series Winner",
+      "World Women's Championship Finalist (2011)",
+      "Padma Shri & Arjuna Award recipient"
+    ],
+    bio: "Trained by her father Koneru Ashok, Humpy won World Youth titles across U10, U12, U14, and U20 categories. In 2002, she shattered Judit Polgar's age record for the youngest female Grandmaster. Humpy reached a peak FIDE rating of 2630, making her only the second woman in history (after Judit Polgar) to cross 2600 Elo."
+  },
+  {
+    name: "Subbaraman Vijayalakshmi",
+    title: "WGM / IM (2001) | 6x National Champion Record",
+    state: "Tamil Nadu (Chennai)",
+    peakRating: "2485",
+    birthYear: 1979,
+    imageBg: "linear-gradient(135deg, #701a75, #d946ef)",
+    summary: "Pioneer of Indian women's chess, India's 1st Woman Grandmaster, and holder of 6 consecutive National Championship titles.",
+    achievements: [
+      "India's 1st Woman Grandmaster (WGM, 2001)",
+      "Record 6 CONSECUTIVE Women's National Premier Titles (1998-2003)",
+      "Individual Silver Medalist at Chess Olympiads (2000, 2002)",
+      "First woman to earn the International Master (IM) title in India",
+      "Arjuna Awardee (2001)"
+    ],
+    bio: "Viji was mentored by her father Subbaraman and legendary coach Manuel Aaron. Her aggressive style and psychological toughness led to an astonishing era of dominance in the late 1990s and early 2000s, winning 6 consecutive national championships and inspiring an entire generation of female chess prodigies across India."
+  },
+  {
+    name: "Harika Dronavalli",
+    title: "Grandmaster (2011) | 3x World Championship Medalist",
+    state: "Andhra Pradesh (Guntur)",
+    peakRating: "2532",
+    birthYear: 1991,
+    imageBg: "linear-gradient(135deg, #1e1b4b, #6366f1)",
+    summary: "Second Indian woman to earn the full Grandmaster title and triple bronze medalist at the World Women's Chess Championship.",
+    achievements: [
+      "3-time World Women's Chess Championship Bronze Medalist (2012, 2015, 2017)",
+      "India's 2nd Female Full Grandmaster (GM, 2011)",
+      "World Junior Women's Champion (2008)",
+      "Team Gold Medalist at 45th Chess Olympiad 2024",
+      "Padma Shri & Arjuna Award recipient"
+    ],
+    bio: "Harika won titles at the World Youth U14, U18, and World Junior U20 levels. Her extreme consistency, tactical finesse, and sportsmanship earned her 3 medals at the KO World Championships. At the 2024 Budapest Olympiad, she led Board 1 for India's historic Gold medal winning team."
+  },
+  {
+    name: "Manuel Aaron",
+    title: "International Master (1961) | 9x National Champion",
+    state: "Tamil Nadu (Chennai)",
+    peakRating: "2415 (Historical)",
+    birthYear: 1935,
+    imageBg: "linear-gradient(135deg, #78350f, #d97706)",
+    summary: "Father of modern competitive chess structure in India, 1st International Master, and record 9-time National Champion.",
+    achievements: [
+      "India's 1st International Master (1961)",
+      "Record 9-time National Premier Champion",
+      "Winner of West Asian Zonal Championship (1961)",
+      "First Chess Player to receive the Arjuna Award (1961)",
+      "Pioneered Chess Mate magazine & Indian Rating System"
+    ],
+    bio: "Born in Toungoo, Burma, and settled in Chennai, Aaron put India on the international FIDE map by defeating Cecil Purdy to win the Asian Zonal in 1961. He played 9 Olympiads for India and dedicated over 60 years to chess journalism, coaching, and administration."
+  },
+  {
+    name: "Divya Deshmukh",
+    title: "WGM / IM (2021) | World Junior Champion 2024",
+    state: "Maharashtra (Nagpur)",
+    peakRating: "2490",
+    birthYear: 2005,
+    imageBg: "linear-gradient(135deg, #0f766e, #14b8a6)",
+    summary: "World Junior Champion 2024, 2x National Women's Champion, and Individual Gold Medalist at the 2024 Budapest Olympiad.",
+    achievements: [
+      "FIDE World Junior Women's Champion (2024, Gandhinagar)",
+      "Individual Gold Medalist (Board 3) with 9.5/11 score at 2024 Olympiad",
+      "Back-to-back Women's National Premier Champion (2022, 2023)",
+      "Asian Women's Chess Champion (2023)",
+      "Tata Steel India Women's Rapid Champion (2023)"
+    ],
+    bio: "Divya from Nagpur is one of the most explosive tactical talents in women's chess. Having dominated age-category events worldwide since childhood, she clinched the World Junior title in 2024 and performed at a staggering 2600+ Elo performance rating to power India's women team to historic Olympiad Gold."
+  },
+  {
+    name: "Vaishali Rameshbabu",
+    title: "Grandmaster (2023) | Candidates 2024 Qualifier",
+    state: "Tamil Nadu (Chennai)",
+    peakRating: "2508",
+    birthYear: 2001,
+    imageBg: "linear-gradient(135deg, #312e81, #818cf8)",
+    summary: "India's 3rd female full Grandmaster and part of the first-ever brother-sister duo (with Pragg) to qualify for the Candidates.",
+    achievements: [
+      "India's 3rd Female Full Grandmaster (2023)",
+      "FIDE Women's Grand Swiss Champion (2023, Isle of Man)",
+      "FIDE Candidates 2024 Qualifier",
+      "Team Gold Medalist at 45th Chess Olympiad 2024",
+      "First Brother-Sister duo in history to become GMs and Candidates"
+    ],
+    bio: "Elder sister of Praggnanandhaa, Vaishali showed immense determination to complete her GM title requirements in 2023 by winning the FIDE Grand Swiss in Isle of Man. Her sharp attacking play was instrumental in securing India's historic team gold at the 2024 Olympiad."
+  }
+];
+
+export const grandmastersList = [
+  { id: 1, name: "Viswanathan Anand", year: 1988, state: "Tamil Nadu", peakRating: 2817, notes: "India's 1st GM, 5x World Champion" },
+  { id: 2, name: "Dibyendu Barua", year: 1991, state: "West Bengal", peakRating: 2555, notes: "2nd GM, 3x National Champion" },
+  { id: 3, name: "Pravin Thipsay", year: 1997, state: "Maharashtra", peakRating: 2515, notes: "3rd GM, 7x National Champion" },
+  { id: 4, name: "Abhijit Kunte", year: 2000, state: "Maharashtra", peakRating: 2555, notes: "4th GM, 2x National Champion" },
+  { id: 5, name: "Krishnan Sasikiran", year: 2000, state: "Tamil Nadu", peakRating: 2707, notes: "5th GM, 4x National Champion" },
+  { id: 6, name: "Pentala Harikrishna", year: 2001, state: "Andhra Pradesh", peakRating: 2770, notes: "6th GM, World Junior Champion 2004" },
+  { id: 7, name: "Surya Shekhar Ganguly", year: 2003, state: "West Bengal", peakRating: 2676, notes: "7th GM, 6x consecutive National Champion" },
+  { id: 8, name: "Sandipan Chanda", year: 2003, state: "West Bengal", peakRating: 2656, notes: "8th GM" },
+  { id: 9, name: "Ramesh R.B.", year: 2003, state: "Tamil Nadu", peakRating: 2507, notes: "9th GM, Commonwealth Champion, Coach of Pragg" },
+  { id: 10, name: "Tejas Bakre", year: 2004, state: "Gujarat", peakRating: 2530, notes: "10th GM, Gujarat's 1st GM" },
+  { id: 11, name: "Magesh Chandran Panchanathan", year: 2006, state: "Tamil Nadu", peakRating: 2580, notes: "11th GM" },
+  { id: 12, name: "Deepan Chakkravarthy", year: 2006, state: "Tamil Nadu", peakRating: 2549, notes: "12th GM" },
+  { id: 13, name: "Neelotpal Das", year: 2006, state: "West Bengal", peakRating: 2496, notes: "13th GM" },
+  { id: 14, name: "Parimarjan Negi", year: 2006, state: "Delhi", peakRating: 2671, notes: "14th GM, Youngest GM at the time (13 yrs 4 mos)" },
+  { id: 15, name: "G.N. Gopal", year: 2007, state: "Kerala", peakRating: 2611, notes: "15th GM, Kerala's 1st GM" },
+  { id: 16, name: "Gopal S. Sundararajan", year: 2008, state: "Tamil Nadu", peakRating: 2550, notes: "16th GM" },
+  { id: 17, name: "Abhijeet Gupta", year: 2008, state: "Rajasthan", peakRating: 2644, notes: "17th GM, World Junior Champion 2008" },
+  { id: 18, name: "Subbaraman Vijayalakshmi (IM/WGM)", year: 2001, state: "Tamil Nadu", peakRating: 2485, notes: "India's 1st WGM" },
+  { id: 19, name: "Koneru Humpy", year: 2002, state: "Andhra Pradesh", peakRating: 2630, notes: "Full GM at 15 yrs 1 mo, World Women's Rapid Champion" },
+  { id: 20, name: "Baskaran Adhiban", year: 2010, state: "Tamil Nadu", peakRating: 2701, notes: "'The Beast', Tata Steel 2017 Bronze" },
+  { id: 21, name: "S.P. Sethuraman", year: 2011, state: "Tamil Nadu", peakRating: 2673, notes: "3x National Champion" },
+  { id: 22, name: "Harika Dronavalli", year: 2011, state: "Andhra Pradesh", peakRating: 2532, notes: "Full GM, 3x World Championship Bronze" },
+  { id: 23, name: "Deep Sengupta", year: 2010, state: "Jharkhand", peakRating: 2596, notes: "World Youth U12 Champion" },
+  { id: 24, name: "Vidit Gujrathi", year: 2013, state: "Maharashtra", peakRating: 2747, notes: "FIDE Grand Swiss 2023 Winner, Candidates 2024" },
+  { id: 25, name: "M.R. Lalith Babu", year: 2012, state: "Andhra Pradesh", peakRating: 2594, notes: "National Champion 2017" },
+  { id: 26, name: "Vaibhav Suri", year: 2012, state: "Delhi", peakRating: 2608, notes: "GM at 15 years old" },
+  { id: 27, name: "Sahaj Grover", year: 2012, state: "Delhi", peakRating: 2532, notes: "World Youth U10 Champion" },
+  { id: 28, name: "Debashis Das", year: 2013, state: "Odisha", peakRating: 2550, notes: "Odisha's 1st GM" },
+  { id: 29, name: "Shyam Sundar M.", year: 2013, state: "Tamil Nadu", peakRating: 2552, notes: "Coached multiple young talents" },
+  { id: 30, name: "Aravindh Chithambaram", year: 2015, state: "Tamil Nadu", peakRating: 2703, notes: "Triple National Champion" },
+  { id: 31, name: "Karthikeyan Murali", year: 2015, state: "Tamil Nadu", peakRating: 2632, notes: "2x National Champion, defeated Magnus Carlsen" },
+  { id: 32, name: "Swapnil Dhopade", year: 2015, state: "Maharashtra", peakRating: 2545, notes: "Prominent coach" },
+  { id: 33, name: "Sunilduth Lyna Narayanan (S.L. Narayanan)", year: 2015, state: "Kerala", peakRating: 2668, notes: "Top Kerala GM" },
+  { id: 34, name: "Praggnanandhaa Rameshbabu", year: 2018, state: "Tamil Nadu", peakRating: 2778, notes: "GM at 12 yrs 10 mos, World Cup 2023 Silver, Olympiad Gold 2024" },
+  { id: 35, name: "Nihal Sarin", year: 2018, state: "Kerala", peakRating: 2692, notes: "Speed Chess Virtuoso, World Youth Champion" },
+  { id: 36, name: "Arjun Erigaisi", year: 2018, state: "Telangana", peakRating: 2805, notes: "2800+ rating club, Olympiad Gold 2024" },
+  { id: 37, name: "D. Gukesh (Gukesh Dommaraju)", year: 2019, state: "Tamil Nadu", peakRating: 2798, notes: "Candidates 2024 Winner, World Title Challenger, Olympiad Gold 2024" },
+  { id: 38, name: "Raunak Sadhwani", year: 2019, state: "Maharashtra", peakRating: 2654, notes: "GM at 13 yrs 9 mos" },
+  { id: 39, name: "Prithu Gupta", year: 2019, state: "Delhi", peakRating: 2501, notes: "64th GM of India" },
+  { id: 40, name: "P. Iniyan", year: 2019, state: "Tamil Nadu", peakRating: 2560, notes: "61st GM" },
+  { id: 41, name: "Leon Luke Mendonca", year: 2020, state: "Goa", peakRating: 2631, notes: "Goa's 2nd GM" },
+  { id: 42, name: "Harshit Raja", year: 2021, state: "Maharashtra", peakRating: 2500, notes: "70th GM" },
+  { id: 43, name: "Sankalp Gupta", year: 2021, state: "Maharashtra", peakRating: 2510, notes: "71st GM" },
+  { id: 44, name: "Mitrabha Guha", year: 2021, state: "West Bengal", peakRating: 2520, notes: "72nd GM" },
+  { id: 45, name: "Bharath Subramaniyam", year: 2022, state: "Tamil Nadu", peakRating: 2554, notes: "73rd GM at age 14" },
+  { id: 46, name: "Rahul Srivatshav P.", year: 2022, state: "Telangana", peakRating: 2505, notes: "74th GM" },
+  { id: 47, name: "V. Pranav", year: 2022, state: "Tamil Nadu", peakRating: 2610, notes: "75th GM" },
+  { id: 48, name: "Aditya Mittal", year: 2022, state: "Maharashtra", peakRating: 2602, notes: "77th GM" },
+  { id: 49, name: "Koustav Chatterjee", year: 2022, state: "West Bengal", peakRating: 2525, notes: "78th GM" },
+  { id: 50, name: "Pranesh M.", year: 2023, state: "Tamil Nadu", peakRating: 2580, notes: "79th GM" },
+  { id: 51, name: "Vignesh N.R.", year: 2023, state: "Tamil Nadu", peakRating: 2535, notes: "80th GM (First brothers pair GM Visakh & GM Vignesh)" },
+  { id: 52, name: "Sayantan Das", year: 2023, state: "West Bengal", peakRating: 2510, notes: "81st GM" },
+  { id: 53, name: "Vuppala Prraneeth", year: 2023, state: "Telangana", peakRating: 2502, notes: "82nd GM" },
+  { id: 54, name: "Aditya Samant", year: 2023, state: "Maharashtra", peakRating: 2515, notes: "83rd GM" },
+  { id: 55, name: "Vaishali Rameshbabu", year: 2023, state: "Tamil Nadu", peakRating: 2508, notes: "India's 3rd Full Female GM, 84th GM, Olympiad Gold 2024" },
+  { id: 56, name: "Shyaamnikhil P.", year: 2024, state: "Tamil Nadu", peakRating: 2505, notes: "85th GM of India" }
+];
+
+export const historicGamesPGN = [
+  {
+    id: "game1",
+    title: "Anand vs Kasparov",
+    subtitle: "PCM World Championship 1995 (Game 9)",
+    event: "PCA World Championship Final",
+    site: "New York, USA",
+    date: "1995.09.25",
+    white: "Viswanathan Anand",
+    black: "Garry Kasparov",
+    result: "1-0",
+    eco: "C84",
+    opening: "Ruy Lopez: Open Variation",
+    description: "Anand's iconic victory with white pieces against Garry Kasparov on the top floor of the World Trade Center in New York. Anand launched an energetic pawn storm and tactical sacrifice, forcing Kasparov's resignation on move 35.",
+    movesPGN: "1. e4 e5 2. Nf3 Nc6 3. Bb5 a6 4. Ba4 Nf6 5. O-O Nxe4 6. d4 b5 7. Bb3 d5 8. dxe5 Be6 9. Nbd2 Nc5 10. c3 d4 11. Ng5 dxc3 12. Nxe6 fxe6 13. bxc3 Qd3 14. Bc2 Qxc3 15. Nb3 Nxb3 16. Bxb3 Nd4 17. Qg4 Qxa1 18. Bxe6 Rd8 19. Bh6 Qc3 20. Bxg7 Qd3 21. Bxh8 Ne2+ 22. Kh1 Ng3+ 23. hxg3 Qxf1+ 24. Kh2 Rd1 25. Qh5+ Kd8 26. Bf6+ 1-0",
+    keyMoments: [
+      { move: 11, note: "11. Ng5! Anand plays a brilliant theoretical novelty targeting Kasparov's king." },
+      { move: 17, note: "17. Qg4! Anand offers his rook on a1 for a deadly kingside attack." },
+      { move: 25, note: "25. Qh5+! Devastating final check forcing Kasparov's resignation." }
+    ]
+  },
+  {
+    id: "game2",
+    title: "Gukesh vs Nakamura",
+    subtitle: "Candidates Tournament 2024 (Round 14)",
+    event: "FIDE Candidates 2024",
+    site: "Toronto, Canada",
+    date: "2024.04.21",
+    white: "Hikaru Nakamura",
+    black: "D. Gukesh",
+    result: "1/2-1/2",
+    eco: "D30",
+    opening: "Queen's Gambit Declined",
+    description: "The historic final round game where 17-year-old Gukesh D held off World No. 3 Hikaru Nakamura with black pieces under colossal pressure to win the Candidates Tournament and become the youngest World Championship Challenger in history.",
+    movesPGN: "1. d4 d5 2. c4 e6 3. Nf3 Nf6 4. g3 Bb4+ 5. Bd2 Be7 6. Bg2 c6 7. O-O O-O 8. Qc2 b6 9. Rd1 Nbd7 10. Bf4 Ba6 11. cxd5 cxd5 12. Ne5 Nxe5 13. dxe5 Nd7 14. Nc3 g5 15. Be3 Nxe5 16. Bd4 Ng6 17. e4 e5 18. Bxe5 Nxe5 19. Rxd5 Qc7 20. Qa4 Bc4 21. Rxe5 Qxe5 22. Qxc4 Bc5 23. Rf1 Rad8 24. Nd5 a5 25. b3 Kg7 26. Qe2 f5 27. Kh1 f4 28. gxf4 gxf4 29. Qg4+ Kh8 30. Bf3 Rd6 31. Qh4 Rg6 32. Rd1 Qg5 33. Qxg5 Rxg5 34. Rd2 Re5 35. Kg2 Kg7 36. Kf1 Rf7 37. Ke2 1/2-1/2",
+    keyMoments: [
+      { move: 14, note: "14...g5! Bold flank pawn push showing Gukesh's unflinching ambition." },
+      { move: 27, note: "27...f4! Seizing key dark-squared control and neutralizing white's initiative." },
+      { move: 37, note: "37. Ke2 Game agreed draw. Gukesh seals historic Candidates victory!" }
+    ]
+  },
+  {
+    id: "game3",
+    title: "Praggnanandhaa vs Carlsen",
+    subtitle: "Airthings Masters 2022 (Round 8)",
+    event: "Champions Chess Tour",
+    site: "Online",
+    date: "2022.02.20",
+    white: "R. Praggnanandhaa",
+    black: "Magnus Carlsen",
+    result: "1-0",
+    eco: "C42",
+    opening: "Petrov Defense",
+    description: "16-year-old Praggnanandhaa shocked the world by defeating World Champion Magnus Carlsen with black pieces, capitalizing on a subtle endgame inaccuracy with razor-sharp technique.",
+    movesPGN: "1. e4 e5 2. Nf3 Nf6 3. Nxe5 d6 4. Nf3 Nxe4 5. d4 d5 6. Bd3 Bd6 7. O-O O-O 8. c4 c6 9. Re1 Bf5 10. Qb3 Qd7 11. Nc3 Nxc3 12. Bxf5 Qxf5 13. bxc3 b6 14. cxd5 cxd5 15. Qb5 Qd7 16. a4 Qxb5 17. axb5 a5 18. Ba3 Bxa3 19. Rxa3 Ra7 20. Kf1 Rc7 21. Ke2 f6 22. Kd3 Kf7 23. Nd2 Re8 24. Rxe8 Kxe8 25. Ra1 Ke7 26. c4 dxc4+ 27. Nxc4 Nd7 28. Ne3 Kd8 29. h4 g6 30. g4 Ke8 31. f4 Kf7 32. f5 Ke8 33. Nd5 Rc8 34. Re1+ Kf8 35. Re6 gxf5 36. gxf5 a4 37. Nxf6 Nxf6 38. Rxf6+ Kg7 39. Rxb6 Ra8 40. Ra6 1-0",
+    keyMoments: [
+      { move: 27, note: "27. Nxc4! Knight centralization exploiting black's passive pieces." },
+      { move: 34, note: "34. Re1+! Pragg invades the 7th rank to win Carlsen's passed pawns." },
+      { move: 40, note: "40. Ra6! Carlsen resigns as the passed b-pawn marches to queen." }
+    ]
+  },
+  {
+    id: "game4",
+    title: "Manuel Aaron vs Portisch",
+    subtitle: "Stockholm Interzonal 1962",
+    event: "FIDE Interzonal",
+    site: "Stockholm, Sweden",
+    date: "1962.02.15",
+    white: "Manuel Aaron",
+    black: "Lajos Portisch",
+    result: "1-0",
+    eco: "E14",
+    opening: "Queen's Indian Defense",
+    description: "India's 1st IM Manuel Aaron defeated Hungarian Grandmaster Lajos Portisch, one of the world's top 10 players, in a masterclass of positional pressure and pawn levering.",
+    movesPGN: "1. d4 Nf6 2. c4 e6 3. Nf3 b6 4. e3 Bb7 5. Bd3 d5 6. O-O Bd6 7. b3 O-O 8. Bb2 Nbd7 9. Nbd2 Qe7 10. Qe2 Ne4 11. Rad1 f5 12. Ne5 Bxe5 13. dxe5 Nc4 14. Bc1 Ncd7 15. f4 c5 16. Nf3 Rad8 17. Bb2 Nb8 18. cxd5 exd5 19. Qe1 a5 20. Qh4 Qxh4 21. Nxh4 Ba6 22. Bxa6 Nxa6 23. e6 Rde8 24. Rxd5 g6 25. g4 Rxe6 26. gxf5 gxf5 27. Kh1 Kf7 28. Nxf5 Rg8 29. Rd7+ Ke8 30. Rxh7 1-0",
+    keyMoments: [
+      { move: 23, note: "23. e6! Aaron's brilliant pawn sacrifice opens winning lines." },
+      { move: 29, note: "29. Rd7+! Infiltration by white rooks seals the victory." }
+    ]
+  },
+  {
+    id: "game5",
+    title: "Koneru Humpy vs Judit Polgar",
+    subtitle: "Elista Women vs Men 2003",
+    event: "Super Encounter",
+    site: "Elista, Russia",
+    date: "2003.09.12",
+    white: "Koneru Humpy",
+    black: "Judit Polgar",
+    result: "1-0",
+    eco: "B42",
+    opening: "Sicilian Defense: Kan Variation",
+    description: "A battle between the two greatest female players in chess history. 16-year-old GM Koneru Humpy defeated world No. 8 Judit Polgar in an energetic Sicilian melee.",
+    movesPGN: "1. e4 c5 2. Nf3 e6 3. d4 cxd4 4. Nxd4 a6 5. Bd3 Bc5 6. Nb3 Ba7 7. Qe2 Nc6 8. Be3 d6 9. Nc3 Nf6 10. O-O-O e5 11. Kb1 O-O 12. f3 Bxe3 13. Qxe3 b5 14. g4 Be6 15. g5 Nh5 16. Ne2 Rb8 17. f4 exf4 18. Nxf4 Nxf4 19. Qxf4 Ne5 20. Be2 Qc7 21. Nd4 Rbc8 22. h4 Qa5 23. b3 Qc3 24. Qd2 Qc5 25. h5 d5 26. g6 dxe4 27. h6 Nxg6 28. hxg7 Kxg7 29. Qh6+ Kf6 30. Rh5 Qc3 31. Qg5+ Kg7 32. Rh6 Rh8 33. Bh5 1-0",
+    keyMoments: [
+      { move: 26, note: "26. g6! Humpy rips open the kingside defenses." },
+      { move: 33, note: "33. Bh5! Black's king is totally trapped; Polgar resigns." }
+    ]
+  }
+];
+
+export const quizQuestions = [
+  {
+    id: 1,
+    question: "What ancient Indian game is widely recognized as the ancestor of modern chess?",
+    options: ["Pachisi", "Chaturanga", "Ashtapada", "Moksha Patam"],
+    answer: 1,
+    explanation: "Chaturanga originated in India during the Gupta Empire (c. 6th century AD) featuring four army divisions (infantry, cavalry, elephants, chariots)."
+  },
+  {
+    id: 2,
+    question: "Who became India's first-ever Grandmaster in 1988?",
+    options: ["Manuel Aaron", "Pravin Thipsay", "Viswanathan Anand", "Dibyendu Barua"],
+    answer: 2,
+    explanation: "Viswanathan Anand earned his third GM norm at the Shakti Finance Tournament in Coimbatore in 1988 at age 18."
+  },
+  {
+    id: 3,
+    question: "Which Indian female player won 6 CONSECUTIVE National Premier titles between 1998 and 2003?",
+    options: ["Koneru Humpy", "Harika Dronavalli", "Subbaraman Vijayalakshmi", "Tania Sachdev"],
+    answer: 2,
+    explanation: "Subbaraman Vijayalakshmi set an unmatched record of 6 consecutive National Women's titles and became India's 1st WGM in 2001."
+  },
+  {
+    id: 4,
+    question: "In 2024, who became the youngest player in chess history to win the FIDE Candidates Tournament at age 17?",
+    options: ["Praggnanandhaa R", "Arjun Erigaisi", "D. Gukesh", "Nihal Sarin"],
+    answer: 2,
+    explanation: "D. Gukesh scored 9/14 in Toronto to win the 2024 Candidates Tournament and earn the right to challenge for the World Title."
+  },
+  {
+    id: 5,
+    question: "At the 45th Chess Olympiad 2024 in Budapest, what historic achievement did Team India accomplish?",
+    options: ["Won Men's Gold only", "Won Women's Gold only", "Won BOTH Open & Women's Team GOLD Medals", "Won Silver Medals"],
+    answer: 2,
+    explanation: "India swept BOTH the Open and Women's Team GOLD Medals at the 2024 Budapest Olympiad in an unprecedented double gold victory."
+  }
+];

--- a/frontend/chess-heritage-explorer/index.html
+++ b/frontend/chess-heritage-explorer/index.html
@@ -1,0 +1,311 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore India's Chess Heritage - Interactive archive of Indian National Chess Championship history, Grandmasters directory, women's championships, iconic games replay, and chess evolution from Chaturanga to the 2024 Olympiad Double Gold.">
+  <title>Explore India's Chess Heritage | Incredible India Explorer</title>
+  
+  <!-- Favicon & Stylesheets -->
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="chess-explorer-page">
+  <script>
+    (function() {
+      let theme = 'dark';
+      try { theme = JSON.parse(localStorage.getItem('iie_storage') || '{}').theme || 'dark'; } catch(e) {}
+      if (theme === 'light') { document.body.classList.add('light-theme'); }
+    })();
+  </script>
+
+  <!-- Sticky Navbar -->
+  <header class="navbar" id="navbar">
+    <div class="nav-container">
+      <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+        <span class="saffron">Incredible</span>
+        <span class="gold">India</span>
+        <span class="green">Explorer</span>
+      </a>
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+        <span class="bar"></span>
+        <span class="bar"></span>
+        <span class="bar"></span>
+      </button>
+      <nav class="nav-menu" id="nav-menu">
+        <a href="../../index.html#home" class="nav-link">Home</a>
+        <a href="../sports/sports.html" class="nav-link active">Sports</a>
+        <a href="#championships" class="nav-link">Championships</a>
+        <a href="#grandmasters" class="nav-link">Grandmasters</a>
+        <a href="#historic-games" class="nav-link">Interactive Games</a>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Hero Section -->
+  <section class="chess-hero" id="hero">
+    <div class="chess-hero-bg-grid"></div>
+    <div class="hero-badge">♟️ National Sports Heritage</div>
+    <h1>Explore India's Chess Heritage</h1>
+    <p class="hero-subtitle">
+      From the ancient origin of <strong>Chaturanga</strong> in the Gupta Empire to the pioneering triumphs of Viswanathan Anand, the historic <strong>2024 Chess Olympiad Double Gold</strong>, and World Championship Challenger D. Gukesh — discover the legendary story of Indian chess.
+    </p>
+
+    <!-- Key Stats -->
+    <div class="stats-grid">
+      <div class="stat-card">
+        <div class="stat-number" id="gm-count">85+</div>
+        <div class="stat-label">Indian Grandmasters</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-number">5</div>
+        <div class="stat-label">World Championship Titles (Anand)</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-number">60+</div>
+        <div class="stat-label">National Championship Editions</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-number">2024</div>
+        <div class="stat-label">Olympiad Double Gold Champions</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Sub-Navigation Sticky Bar -->
+  <nav class="subnav-bar">
+    <div class="subnav-container">
+      <button class="subnav-btn active" data-target="evolution">Evolution</button>
+      <button class="subnav-btn" data-target="championships">National Championships</button>
+      <button class="subnav-btn" data-target="champions">Major Champions</button>
+      <button class="subnav-btn" data-target="womens-chess">Women's Heritage</button>
+      <button class="subnav-btn" data-target="grandmasters">GM Directory</button>
+      <button class="subnav-btn" data-target="historic-games">Historic Games</button>
+      <button class="subnav-btn" data-target="quiz">Chess Quiz</button>
+    </div>
+  </nav>
+
+  <!-- Main Content Body -->
+  <main>
+    <!-- Section 1: Evolution of Chess in India -->
+    <section class="chess-section" id="evolution">
+      <div class="section-header">
+        <span class="section-tag">Timeline & Roots</span>
+        <h2>The Evolution of Indian Chess</h2>
+        <p>Trace the legendary journey from ancient 6th-century Chaturanga to the 2024 Olympiad sweep.</p>
+      </div>
+
+      <div class="timeline-container" id="timeline-wrapper">
+        <!-- Rendered dynamically by script.js -->
+      </div>
+    </section>
+
+    <!-- Section 2: National Championship Archive -->
+    <section class="chess-section" id="championships">
+      <div class="section-header">
+        <span class="section-tag">Archive & Records</span>
+        <h2>National Chess Championship History</h2>
+        <p>Complete historical records of the National Premier Chess Championships (Men's & Women's) since 1955.</p>
+      </div>
+
+      <!-- Category Filter Tabs -->
+      <div class="filter-tabs">
+        <button class="tab-btn active" id="tab-mens">Men's Premier Championship (1955 - Present)</button>
+        <button class="tab-btn" id="tab-womens">Women's Premier Championship (1974 - Present)</button>
+      </div>
+
+      <!-- Search & Filters -->
+      <div class="search-filter-box">
+        <input type="text" id="champ-search" class="search-input" placeholder="Search champion, venue, or state...">
+        <select id="champ-state-filter" class="select-filter">
+          <option value="all">All Champion States</option>
+          <option value="Tamil Nadu">Tamil Nadu</option>
+          <option value="Maharashtra">Maharashtra</option>
+          <option value="West Bengal">West Bengal</option>
+          <option value="Andhra Pradesh">Andhra Pradesh / Telangana</option>
+          <option value="Delhi">Delhi</option>
+          <option value="Odisha">Odisha</option>
+          <option value="Goa">Goa</option>
+        </select>
+      </div>
+
+      <!-- Table -->
+      <div class="table-responsive">
+        <table class="data-table" id="championship-table">
+          <thead>
+            <tr>
+              <th>Year</th>
+              <th>Host Venue</th>
+              <th>Champion</th>
+              <th>Runner-Up</th>
+              <th>State</th>
+              <th>Historical Notes</th>
+            </tr>
+          </thead>
+          <tbody id="championship-tbody">
+            <!-- Dynamic rows -->
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- Section 3: Major Champions & Hall of Legends -->
+    <section class="chess-section" id="champions">
+      <div class="section-header">
+        <span class="section-tag">Hall of Fame</span>
+        <h2>Major Champions & Icons</h2>
+        <p>Meet the trailblazers who forged India's chess legacy on the global stage.</p>
+      </div>
+
+      <div class="champions-grid" id="champions-container">
+        <!-- Rendered dynamically -->
+      </div>
+    </section>
+
+    <!-- Section 4: Women's Championship & Heritage -->
+    <section class="chess-section" id="womens-chess">
+      <div class="section-header">
+        <span class="section-tag">Women's Empowerment</span>
+        <h2>Women's Chess Heritage</h2>
+        <p>Celebrating the remarkable women who conquered national titles and shattered world records.</p>
+      </div>
+
+      <div class="champions-grid" id="womens-champions-container">
+        <!-- Rendered dynamically -->
+      </div>
+    </section>
+
+    <!-- Section 5: Grandmasters Directory -->
+    <section class="chess-section" id="grandmasters">
+      <div class="section-header">
+        <span class="section-tag">Directory of Masters</span>
+        <h2>Indian Grandmasters Directory</h2>
+        <p>Search and filter all 85+ Grandmasters of India by name, state, FIDE rating, and year awarded.</p>
+      </div>
+
+      <div class="search-filter-box">
+        <input type="text" id="gm-search" class="search-input" placeholder="Search Grandmaster by name or state...">
+        <select id="gm-state-select" class="select-filter">
+          <option value="all">All States</option>
+          <option value="Tamil Nadu">Tamil Nadu (35+ GMs)</option>
+          <option value="Maharashtra">Maharashtra (12+ GMs)</option>
+          <option value="West Bengal">West Bengal (10+ GMs)</option>
+          <option value="Andhra Pradesh">Andhra Pradesh (5+ GMs)</option>
+          <option value="Telangana">Telangana (4+ GMs)</option>
+          <option value="Delhi">Delhi (4+ GMs)</option>
+          <option value="Kerala">Kerala (3+ GMs)</option>
+        </select>
+        <select id="gm-sort-select" class="select-filter">
+          <option value="year-asc">Sort by Title Year (Ascending)</option>
+          <option value="year-desc">Sort by Title Year (Descending)</option>
+          <option value="rating-desc">Sort by Peak Rating (Highest First)</option>
+          <option value="name-asc">Sort Alphabetically (A-Z)</option>
+        </select>
+      </div>
+
+      <div class="table-responsive">
+        <table class="data-table" id="gm-table">
+          <thead>
+            <tr>
+              <th># GM Title</th>
+              <th>Name</th>
+              <th>State / Region</th>
+              <th>Year Title Awarded</th>
+              <th>Peak FIDE Rating</th>
+              <th>Career Achievements & Notes</th>
+            </tr>
+          </thead>
+          <tbody id="gm-tbody">
+            <!-- Rendered dynamically -->
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- Section 6: Interactive Historic Game Replay -->
+    <section class="chess-section" id="historic-games">
+      <div class="section-header">
+        <span class="section-tag">Interactive Replay</span>
+        <h2>Historic Masterworks</h2>
+        <p>Interactive turn-by-turn PGN replay of legendary games in Indian chess history.</p>
+      </div>
+
+      <div class="chessboard-layout">
+        <!-- Left: Interactive Board -->
+        <div class="chessboard-container">
+          <div class="chessboard-wrapper">
+            <div class="board-grid" id="chessboard">
+              <!-- 64 Squares rendered by script.js -->
+            </div>
+          </div>
+          <!-- Control Buttons -->
+          <div class="board-controls">
+            <button class="board-ctrl-btn" id="btn-first" title="First Move">⏮️</button>
+            <button class="board-ctrl-btn" id="btn-prev" title="Previous Move">◀️</button>
+            <button class="board-ctrl-btn" id="btn-play" title="Play / Pause">▶️ Play</button>
+            <button class="board-ctrl-btn" id="btn-next" title="Next Move">▶️</button>
+            <button class="board-ctrl-btn" id="btn-last" title="Last Move">⏭️</button>
+            <button class="board-ctrl-btn" id="btn-flip" title="Flip Board">🔄 Flip</button>
+          </div>
+        </div>
+
+        <!-- Right: Game Details & Moves List -->
+        <div class="game-info-panel">
+          <label for="game-select" style="font-weight:700; color:var(--primary-gold); margin-bottom:8px; display:block;">Select Historic Game:</label>
+          <select id="game-select" class="select-filter game-selector-select">
+            <!-- Options added by script.js -->
+          </select>
+
+          <div id="game-meta-box">
+            <h3 id="game-title" style="margin-bottom:4px; color:#fff;">Anand vs Kasparov</h3>
+            <p id="game-event" style="color:var(--primary-saffron); font-size:0.9rem; margin-bottom:12px;">PCM World Championship 1995</p>
+            <p id="game-desc" style="font-size:0.88rem; color:var(--text-muted); line-height:1.5; margin-bottom:16px;">Description here</p>
+          </div>
+
+          <div style="font-weight:600; font-size:0.85rem; text-transform:uppercase; color:var(--primary-gold); margin-bottom:8px;">Move Notation List:</div>
+          <div class="moves-list-box" id="moves-list">
+            <!-- Dynamic SAN moves -->
+          </div>
+
+          <div class="move-commentary" id="move-annotation">
+            Select or step through moves to view annotations.
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 7: Indian Chess Quiz -->
+    <section class="chess-section" id="quiz">
+      <div class="section-header" style="text-align: center;">
+        <span class="section-tag">Interactive Challenge</span>
+        <h2>Test Your Chess Heritage Knowledge</h2>
+        <p>Answer 5 questions to test your mastery of Indian chess history.</p>
+      </div>
+
+      <div class="quiz-card" id="quiz-box">
+        <div id="quiz-content">
+          <!-- Dynamically loaded quiz question -->
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <!-- Champion Detail Modal Overlay -->
+  <div class="modal-overlay" id="champion-modal">
+    <div class="modal-content">
+      <button class="close-modal-btn" id="modal-close-btn">&times;</button>
+      <div id="modal-body-content">
+        <!-- Rendered dynamically -->
+      </div>
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <footer style="text-align:center; padding:40px 20px; background:#070a10; border-top:1px solid rgba(255,255,255,0.08); font-size:0.9rem; color:var(--text-muted);">
+    <p>© 2026 Incredible India Explorer. Celebrating India's Chess Heritage.</p>
+  </footer>
+
+  <!-- Script Imports -->
+  <script type="module" src="script.js"></script>
+</body>
+</html>

--- a/frontend/chess-heritage-explorer/script.js
+++ b/frontend/chess-heritage-explorer/script.js
@@ -1,0 +1,640 @@
+import { 
+  chessEvolutionData, 
+  mensChampionshipHistory, 
+  womensChampionshipHistory, 
+  majorChampionsData, 
+  grandmastersList, 
+  historicGamesPGN, 
+  quizQuestions 
+} from './chess-data.js';
+
+// Global App State
+let currentChampionshipTab = 'mens';
+let currentGameIndex = 0;
+let currentMovePly = 0;
+let isAutoPlaying = false;
+let autoPlayTimer = null;
+let isBoardFlipped = false;
+let currentQuizIndex = 0;
+let quizScore = 0;
+
+// SVG Piece Unicode / Symbols mapping for clean UI
+const PIECE_UNICODE = {
+  'K': '♔', 'Q': '♕', 'R': '♖', 'B': '♗', 'N': '♘', 'P': '♙',
+  'k': '♚', 'q': '♛', 'r': '♜', 'b': '♝', 'n': '♞', 'p': '♟'
+};
+
+// Initial Standard Board Setup (8x8 matrix)
+const INITIAL_BOARD = [
+  ['r','n','b','q','k','b','n','r'],
+  ['p','p','p','p','p','p','p','p'],
+  ['','','','','','','',''],
+  ['','','','','','','',''],
+  ['','','','','','','',''],
+  ['','','','','','','',''],
+  ['P','P','P','P','P','P','P','P'],
+  ['R','N','B','Q','K','B','N','R']
+];
+
+document.addEventListener('DOMContentLoaded', () => {
+  initTimeline();
+  initChampionshipsTable();
+  initChampionsGrid();
+  initGMDirectory();
+  initChessboardEngine();
+  initQuizEngine();
+  initSubnav();
+  initThemeSupport();
+});
+
+/* --------------------------------------------------------------------------
+   1. Evolution Timeline
+   -------------------------------------------------------------------------- */
+function initTimeline() {
+  const container = document.getElementById('timeline-wrapper');
+  if (!container) return;
+
+  container.innerHTML = chessEvolutionData.map(item => `
+    <div class="timeline-item">
+      <div class="timeline-marker"></div>
+      <div class="timeline-card">
+        <span class="timeline-period">${item.period}</span>
+        <h3>${item.icon} ${item.title}</h3>
+        <div class="subtitle">${item.subtitle}</div>
+        <p>${item.description}</p>
+      </div>
+    </div>
+  `).join('');
+}
+
+/* --------------------------------------------------------------------------
+   2. National Championship Archive
+   -------------------------------------------------------------------------- */
+function initChampionshipsTable() {
+  const mensBtn = document.getElementById('tab-mens');
+  const womensBtn = document.getElementById('tab-womens');
+  const searchInput = document.getElementById('champ-search');
+  const stateFilter = document.getElementById('champ-state-filter');
+
+  mensBtn?.addEventListener('click', () => {
+    currentChampionshipTab = 'mens';
+    mensBtn.classList.add('active');
+    womensBtn.classList.remove('active');
+    renderChampionships();
+  });
+
+  womensBtn?.addEventListener('click', () => {
+    currentChampionshipTab = 'womens';
+    womensBtn.classList.add('active');
+    mensBtn.classList.remove('active');
+    renderChampionships();
+  });
+
+  searchInput?.addEventListener('input', renderChampionships);
+  stateFilter?.addEventListener('change', renderChampionships);
+
+  renderChampionships();
+}
+
+function renderChampionships() {
+  const tbody = document.getElementById('championship-tbody');
+  const searchVal = document.getElementById('champ-search')?.value.toLowerCase() || '';
+  const selectedState = document.getElementById('champ-state-filter')?.value || 'all';
+
+  const data = currentChampionshipTab === 'mens' ? mensChampionshipHistory : womensChampionshipHistory;
+
+  const filtered = data.filter(item => {
+    const matchesSearch = item.winner.toLowerCase().includes(searchVal) ||
+                          item.venue.toLowerCase().includes(searchVal) ||
+                          item.runnerUp.toLowerCase().includes(searchVal) ||
+                          item.notes.toLowerCase().includes(searchVal) ||
+                          item.year.toString().includes(searchVal);
+
+    const matchesState = selectedState === 'all' || item.state.includes(selectedState);
+
+    return matchesSearch && matchesState;
+  });
+
+  if (filtered.length === 0) {
+    tbody.innerHTML = `<tr><td colspan="6" style="text-align:center; padding:30px; color:#94a3b8;">No national championship records match your search criteria.</td></tr>`;
+    return;
+  }
+
+  tbody.innerHTML = filtered.map(item => `
+    <tr>
+      <td><span class="badge-gold">${item.year}</span></td>
+      <td><strong>${item.venue}</strong></td>
+      <td><span style="color:var(--primary-saffron); font-weight:700;">${item.winner}</span></td>
+      <td>${item.runnerUp}</td>
+      <td>${item.state}</td>
+      <td style="font-size:0.88rem; color:#cbd5e1;">${item.notes}</td>
+    </tr>
+  `).join('');
+}
+
+/* --------------------------------------------------------------------------
+   3. Champions & Hall of Fame Cards
+   -------------------------------------------------------------------------- */
+function initChampionsGrid() {
+  const mainContainer = document.getElementById('champions-container');
+  const womensContainer = document.getElementById('womens-champions-container');
+
+  if (mainContainer) {
+    mainContainer.innerHTML = majorChampionsData.slice(0, 6).map(c => renderChampionCard(c)).join('');
+  }
+
+  if (womensContainer) {
+    womensContainer.innerHTML = majorChampionsData.filter(c => 
+      ['Koneru Humpy', 'Subbaraman Vijayalakshmi', 'Harika Dronavalli', 'Divya Deshmukh', 'Vaishali Rameshbabu'].includes(c.name)
+    ).map(c => renderChampionCard(c)).join('');
+  }
+
+  // Click event delegation for profile modals
+  document.addEventListener('click', (e) => {
+    const card = e.target.closest('.champion-card');
+    if (card) {
+      const name = card.getAttribute('data-name');
+      const champion = majorChampionsData.find(item => item.name === name);
+      if (champion) openChampionModal(champion);
+    }
+  });
+
+  // Close Modal setup
+  document.getElementById('modal-close-btn')?.addEventListener('click', closeModal);
+  document.getElementById('champion-modal')?.addEventListener('click', (e) => {
+    if (e.target.id === 'champion-modal') closeModal();
+  });
+}
+
+function renderChampionCard(champ) {
+  return `
+    <div class="champion-card" data-name="${champ.name}">
+      <div class="card-header-banner" style="background:${champ.imageBg};">
+        <div class="icon-avatar">👑</div>
+        <h3>${champ.name}</h3>
+        <div class="title-tag">${champ.title}</div>
+      </div>
+      <div class="champion-card-body">
+        <div>
+          <div class="champion-meta">
+            <span>📍 ${champ.state}</span>
+            <span>⭐ Peak Rating: ${champ.peakRating}</span>
+          </div>
+          <p class="champion-summary">${champ.summary}</p>
+        </div>
+        <button class="view-profile-btn">View Detailed Bio & Achievements →</button>
+      </div>
+    </div>
+  `;
+}
+
+function openChampionModal(champ) {
+  const modal = document.getElementById('champion-modal');
+  const modalBody = document.getElementById('modal-body-content');
+  if (!modal || !modalBody) return;
+
+  modalBody.innerHTML = `
+    <div style="background:${champ.imageBg}; padding:24px; border-radius:14px; color:#fff; margin-bottom:20px;">
+      <h2 style="font-size:1.8rem; margin:0 0 4px;">${champ.name}</h2>
+      <p style="opacity:0.9; margin-bottom:8px;">${champ.title}</p>
+      <div style="font-size:0.85rem; display:flex; gap:16px;">
+        <span>📍 ${champ.state}</span>
+        <span>⭐ Peak Rating: ${champ.peakRating}</span>
+        <span>🎂 Born: ${champ.birthYear}</span>
+      </div>
+    </div>
+
+    <h4 style="color:var(--primary-gold); margin-bottom:8px; font-size:1.1rem;">Key Career Achievements</h4>
+    <ul style="padding-left:20px; color:#cbd5e1; line-height:1.6; margin-bottom:20px;">
+      ${champ.achievements.map(a => `<li style="margin-bottom:6px;">${a}</li>`).join('')}
+    </ul>
+
+    <h4 style="color:var(--primary-gold); margin-bottom:8px; font-size:1.1rem;">Biography & Legacy</h4>
+    <p style="color:#cbd5e1; line-height:1.6;">${champ.bio}</p>
+  `;
+
+  modal.classList.add('active');
+}
+
+function closeModal() {
+  document.getElementById('champion-modal')?.classList.remove('active');
+}
+
+/* --------------------------------------------------------------------------
+   4. Grandmasters Directory
+   -------------------------------------------------------------------------- */
+function initGMDirectory() {
+  const searchInput = document.getElementById('gm-search');
+  const stateSelect = document.getElementById('gm-state-select');
+  const sortSelect = document.getElementById('gm-sort-select');
+
+  searchInput?.addEventListener('input', renderGMTable);
+  stateSelect?.addEventListener('change', renderGMTable);
+  sortSelect?.addEventListener('change', renderGMTable);
+
+  renderGMTable();
+}
+
+function renderGMTable() {
+  const tbody = document.getElementById('gm-tbody');
+  if (!tbody) return;
+
+  const searchVal = document.getElementById('gm-search')?.value.toLowerCase() || '';
+  const selectedState = document.getElementById('gm-state-select')?.value || 'all';
+  const sortVal = document.getElementById('gm-sort-select')?.value || 'year-asc';
+
+  let filtered = grandmastersList.filter(gm => {
+    const matchesSearch = gm.name.toLowerCase().includes(searchVal) ||
+                          gm.state.toLowerCase().includes(searchVal) ||
+                          gm.notes.toLowerCase().includes(searchVal) ||
+                          gm.year.toString().includes(searchVal);
+    const matchesState = selectedState === 'all' || gm.state.includes(selectedState);
+    return matchesSearch && matchesState;
+  });
+
+  // Sorting logic
+  filtered.sort((a, b) => {
+    if (sortVal === 'year-asc') return a.id - b.id;
+    if (sortVal === 'year-desc') return b.id - a.id;
+    if (sortVal === 'rating-desc') return b.peakRating - a.peakRating;
+    if (sortVal === 'name-asc') return a.name.localeCompare(b.name);
+    return 0;
+  });
+
+  tbody.innerHTML = filtered.map(gm => `
+    <tr>
+      <td><span class="badge-gold">GM #${gm.id}</span></td>
+      <td><strong style="color:var(--primary-saffron);">${gm.name}</strong></td>
+      <td>${gm.state}</td>
+      <td><strong>${gm.year}</strong></td>
+      <td><span style="color:#10b981; font-weight:700;">${gm.peakRating}</span></td>
+      <td style="font-size:0.88rem; color:#cbd5e1;">${gm.notes}</td>
+    </tr>
+  `).join('');
+}
+
+/* --------------------------------------------------------------------------
+   5. Interactive PGN Chessboard Engine
+   -------------------------------------------------------------------------- */
+function initChessboardEngine() {
+  const gameSelect = document.getElementById('game-select');
+  if (!gameSelect) return;
+
+  // Populate Selector
+  gameSelect.innerHTML = historicGamesPGN.map((g, idx) => `
+    <option value="${idx}">${g.title} - ${g.subtitle}</option>
+  `).join('');
+
+  gameSelect.addEventListener('change', (e) => {
+    currentGameIndex = parseInt(e.target.value, 10);
+    loadGame(currentGameIndex);
+  });
+
+  // Controls
+  document.getElementById('btn-first')?.addEventListener('click', () => jumpToMove(0));
+  document.getElementById('btn-prev')?.addEventListener('click', () => jumpToMove(currentMovePly - 1));
+  document.getElementById('btn-next')?.addEventListener('click', () => jumpToMove(currentMovePly + 1));
+  document.getElementById('btn-last')?.addEventListener('click', () => {
+    const game = historicGamesPGN[currentGameIndex];
+    const moves = parseMoves(game.movesPGN);
+    jumpToMove(moves.length);
+  });
+  document.getElementById('btn-play')?.addEventListener('click', toggleAutoPlay);
+  document.getElementById('btn-flip')?.addEventListener('click', () => {
+    isBoardFlipped = !isBoardFlipped;
+    renderBoardCurrentState();
+  });
+
+  loadGame(0);
+}
+
+function loadGame(index) {
+  if (isAutoPlaying) pauseAutoPlay();
+  currentGameIndex = index;
+  currentMovePly = 0;
+  const game = historicGamesPGN[index];
+
+  document.getElementById('game-title').innerText = `${game.white} vs ${game.black}`;
+  document.getElementById('game-event').innerText = `${game.event} (${game.date}) - Result: ${game.result}`;
+  document.getElementById('game-desc').innerText = game.description;
+
+  renderMovesList(game.movesPGN);
+  renderBoardCurrentState();
+}
+
+function parseMoves(pgn) {
+  // Simple PGN string to array of SAN tokens
+  const clean = pgn.replace(/\{[^}]*\}/g, '').replace(/\d+\.+/g, '').trim();
+  const rawTokens = clean.split(/\s+/);
+  return rawTokens.filter(t => t && t !== '1-0' && t !== '0-1' && t !== '1/2-1/2');
+}
+
+function renderMovesList(pgn) {
+  const moves = parseMoves(pgn);
+  const container = document.getElementById('moves-list');
+  if (!container) return;
+
+  let html = '';
+  for (let i = 0; i < moves.length; i += 2) {
+    const moveNum = (i / 2) + 1;
+    const whiteMove = moves[i] || '';
+    const blackMove = moves[i + 1] || '';
+
+    html += `
+      <div class="move-num">${moveNum}.</div>
+      <div class="move-ply ${currentMovePly === i + 1 ? 'active' : ''}" data-ply="${i + 1}">${whiteMove}</div>
+      <div class="move-ply ${currentMovePly === i + 2 ? 'active' : ''}" data-ply="${i + 2}">${blackMove}</div>
+    `;
+  }
+
+  container.innerHTML = html;
+
+  container.querySelectorAll('.move-ply').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const ply = parseInt(btn.getAttribute('data-ply'), 10);
+      if (!isNaN(ply)) jumpToMove(ply);
+    });
+  });
+}
+
+function jumpToMove(targetPly) {
+  const game = historicGamesPGN[currentGameIndex];
+  const moves = parseMoves(game.movesPGN);
+
+  if (targetPly < 0) targetPly = 0;
+  if (targetPly > moves.length) targetPly = moves.length;
+
+  currentMovePly = targetPly;
+  renderBoardCurrentState();
+  updateMoveHighlights();
+}
+
+function updateMoveHighlights() {
+  const container = document.getElementById('moves-list');
+  if (!container) return;
+
+  container.querySelectorAll('.move-ply').forEach(el => {
+    const ply = parseInt(el.getAttribute('data-ply'), 10);
+    if (ply === currentMovePly) {
+      el.classList.add('active');
+      el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    } else {
+      el.classList.remove('active');
+    }
+  });
+
+  // Commentary update
+  const game = historicGamesPGN[currentGameIndex];
+  const activeComment = game.keyMoments?.find(k => Math.ceil(currentMovePly / 2) === k.move);
+  const commentBox = document.getElementById('move-annotation');
+  if (commentBox) {
+    if (activeComment) {
+      commentBox.innerHTML = `<strong>💡 Key Moment (Move ${activeComment.move}):</strong> ${activeComment.note}`;
+    } else if (currentMovePly === 0) {
+      commentBox.innerText = `Starting Position. Step forward or click auto-play to view game.`;
+    } else {
+      commentBox.innerText = `Move ${currentMovePly}: Game position after move ${currentMovePly}.`;
+    }
+  }
+}
+
+function computeBoardPosition(targetPly) {
+  // Deep copy initial board
+  let board = INITIAL_BOARD.map(row => [...row]);
+  const game = historicGamesPGN[currentGameIndex];
+  const moves = parseMoves(game.movesPGN);
+
+  // Play moves up to targetPly
+  for (let i = 0; i < targetPly; i++) {
+    const moveStr = moves[i];
+    applySANMove(board, moveStr, i % 2 === 0);
+  }
+
+  return board;
+}
+
+function applySANMove(board, moveStr, isWhite) {
+  // Simplified board state updater for standard PGN moves
+  const clean = moveStr.replace(/[+#?!]/g, '');
+
+  if (clean === 'O-O' || clean === '0-0') {
+    const row = isWhite ? 7 : 0;
+    board[row][4] = '';
+    board[row][6] = isWhite ? 'K' : 'k';
+    board[row][7] = '';
+    board[row][5] = isWhite ? 'R' : 'r';
+    return;
+  }
+
+  if (clean === 'O-O-O' || clean === '0-0-0') {
+    const row = isWhite ? 7 : 0;
+    board[row][4] = '';
+    board[row][2] = isWhite ? 'K' : 'k';
+    board[row][0] = '';
+    board[row][3] = isWhite ? 'R' : 'r';
+    return;
+  }
+
+  // Parse destination square (e.g. e4, Nf3, Nxd4, Bxe6)
+  const destMatch = clean.match(/([a-h])([1-8])/);
+  if (!destMatch) return;
+
+  const destFile = destMatch[1].charCodeAt(0) - 97;
+  const destRank = 8 - parseInt(destMatch[2], 10);
+
+  let piece = isWhite ? 'P' : 'p';
+  if (/^[A-Z]/.test(clean)) {
+    const pChar = clean[0];
+    piece = isWhite ? pChar : pChar.toLowerCase();
+  }
+
+  // Find source square matching piece
+  let srcRow = -1, srcCol = -1;
+  for (let r = 0; r < 8; r++) {
+    for (let c = 0; c < 8; c++) {
+      if (board[r][c] === piece) {
+        if (piece.toUpperCase() === 'P') {
+          if (clean.includes('x')) {
+            const srcFile = clean[0].charCodeAt(0) - 97;
+            if (c === srcFile && Math.abs(r - destRank) === 1) {
+              srcRow = r; srcCol = c; break;
+            }
+          } else if (c === destFile) {
+            if (isWhite && (r - destRank === 1 || (r === 6 && r - destRank === 2))) {
+              srcRow = r; srcCol = c; break;
+            }
+            if (!isWhite && (destRank - r === 1 || (r === 1 && destRank - r === 2))) {
+              srcRow = r; srcCol = c; break;
+            }
+          }
+        } else {
+          srcRow = r; srcCol = c; break;
+        }
+      }
+    }
+    if (srcRow !== -1) break;
+  }
+
+  if (srcRow !== -1 && srcCol !== -1) {
+    board[srcRow][srcCol] = '';
+    board[destRank][destFile] = piece;
+  }
+}
+
+function renderBoardCurrentState() {
+  const boardEl = document.getElementById('chessboard');
+  if (!boardEl) return;
+
+  const boardState = computeBoardPosition(currentMovePly);
+  let html = '';
+
+  for (let r = 0; r < 8; r++) {
+    for (let c = 0; c < 8; c++) {
+      const rowIdx = isBoardFlipped ? 7 - r : r;
+      const colIdx = isBoardFlipped ? 7 - c : c;
+      const isLight = (rowIdx + colIdx) % 2 === 0;
+      const pieceCode = boardState[rowIdx][colIdx];
+      const pieceSymbol = PIECE_UNICODE[pieceCode] || '';
+
+      html += `
+        <div class="square ${isLight ? 'light' : 'dark'}">
+          ${pieceSymbol ? `<span style="font-size:2.2rem;">${pieceSymbol}</span>` : ''}
+        </div>
+      `;
+    }
+  }
+
+  boardEl.innerHTML = html;
+}
+
+function toggleAutoPlay() {
+  if (isAutoPlaying) {
+    pauseAutoPlay();
+  } else {
+    startAutoPlay();
+  }
+}
+
+function startAutoPlay() {
+  isAutoPlaying = true;
+  const btn = document.getElementById('btn-play');
+  if (btn) btn.innerText = '⏸️ Pause';
+
+  autoPlayTimer = setInterval(() => {
+    const game = historicGamesPGN[currentGameIndex];
+    const moves = parseMoves(game.movesPGN);
+
+    if (currentMovePly < moves.length) {
+      jumpToMove(currentMovePly + 1);
+    } else {
+      pauseAutoPlay();
+    }
+  }, 1500);
+}
+
+function pauseAutoPlay() {
+  isAutoPlaying = false;
+  clearInterval(autoPlayTimer);
+  const btn = document.getElementById('btn-play');
+  if (btn) btn.innerText = '▶️ Play';
+}
+
+/* --------------------------------------------------------------------------
+   6. Chess Quiz Engine
+   -------------------------------------------------------------------------- */
+function initQuizEngine() {
+  currentQuizIndex = 0;
+  quizScore = 0;
+  renderQuizQuestion();
+}
+
+function renderQuizQuestion() {
+  const box = document.getElementById('quiz-content');
+  if (!box) return;
+
+  if (currentQuizIndex >= quizQuestions.length) {
+    box.innerHTML = `
+      <div style="text-align:center; padding:20px;">
+        <h3 style="font-size:1.8rem; color:var(--primary-saffron); margin-bottom:12px;">Quiz Complete! 🎉</h3>
+        <p style="font-size:1.2rem; color:#fff; margin-bottom:20px;">Your Final Score: <strong>${quizScore} / ${quizQuestions.length}</strong></p>
+        <button class="tab-btn active" id="quiz-restart-btn">Restart Quiz 🔄</button>
+      </div>
+    `;
+    document.getElementById('quiz-restart-btn')?.addEventListener('click', initQuizEngine);
+    return;
+  }
+
+  const q = quizQuestions[currentQuizIndex];
+  box.innerHTML = `
+    <div style="font-size:0.9rem; color:var(--primary-gold); font-weight:700; margin-bottom:10px;">Question ${currentQuizIndex + 1} of ${quizQuestions.length}</div>
+    <h3 style="font-size:1.3rem; margin-bottom:20px; color:#fff; line-height:1.4;">${q.question}</h3>
+    
+    <div>
+      ${q.options.map((opt, i) => `
+        <button class="quiz-option" data-index="${i}">${opt}</button>
+      `).join('')}
+    </div>
+
+    <div id="quiz-explanation" style="margin-top:20px; display:none; padding:14px; border-radius:10px; background:rgba(255,176,31,0.1); border-left:3px solid var(--primary-gold); font-size:0.95rem;"></div>
+  `;
+
+  box.querySelectorAll('.quiz-option').forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      const idx = parseInt(btn.getAttribute('data-index'), 10);
+      handleQuizAnswer(idx, q.answer, q.explanation);
+    });
+  });
+}
+
+function handleQuizAnswer(selectedIdx, correctIdx, explanation) {
+  const options = document.querySelectorAll('.quiz-option');
+  options.forEach((opt, i) => {
+    opt.disabled = true;
+    if (i === correctIdx) opt.classList.add('correct');
+    if (i === selectedIdx && i !== correctIdx) opt.classList.add('incorrect');
+  });
+
+  if (selectedIdx === correctIdx) quizScore++;
+
+  const expBox = document.getElementById('quiz-explanation');
+  if (expBox) {
+    expBox.style.display = 'block';
+    expBox.innerHTML = `<strong>${selectedIdx === correctIdx ? '✅ Correct!' : '❌ Incorrect.'}</strong> ${explanation}`;
+  }
+
+  setTimeout(() => {
+    currentQuizIndex++;
+    renderQuizQuestion();
+  }, 3200);
+}
+
+/* --------------------------------------------------------------------------
+   7. Subnav Smooth Scrolling
+   -------------------------------------------------------------------------- */
+function initSubnav() {
+  const btns = document.querySelectorAll('.subnav-btn');
+  btns.forEach(btn => {
+    btn.addEventListener('click', () => {
+      btns.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+
+      const targetId = btn.getAttribute('data-target');
+      const section = document.getElementById(targetId);
+      if (section) {
+        section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    });
+  });
+}
+
+/* --------------------------------------------------------------------------
+   8. Theme Toggle Integration
+   -------------------------------------------------------------------------- */
+function initThemeSupport() {
+  const menuToggle = document.getElementById('menu-toggle');
+  const navMenu = document.getElementById('nav-menu');
+
+  menuToggle?.addEventListener('click', () => {
+    navMenu?.classList.toggle('active');
+  });
+}

--- a/frontend/chess-heritage-explorer/style.css
+++ b/frontend/chess-heritage-explorer/style.css
@@ -1,0 +1,749 @@
+/* ==========================================================================
+   INCREDIBLE INDIA EXPLORER - CHESS HERITAGE EXPLORER STYLESHEET
+   ========================================================================== */
+
+@import url("../../styles.css");
+
+/* Container & Global Scope */
+.chess-explorer-page {
+  background-color: var(--bg-dark-deep, #090d16);
+  color: var(--text-light, #f8fafc);
+  font-family: var(--font-body, 'Outfit', sans-serif);
+  min-height: 100vh;
+  margin: 0;
+  padding: 0;
+  overflow-x: hidden;
+}
+
+.chess-hero {
+  position: relative;
+  padding: 100px 20px 60px;
+  background: radial-gradient(circle at 50% 20%, rgba(255, 153, 51, 0.15), transparent 70%),
+              linear-gradient(180deg, rgba(15, 23, 42, 0.95) 0%, rgba(9, 13, 22, 1) 100%);
+  border-bottom: 1px solid var(--glass-border, rgba(255, 255, 255, 0.1));
+  text-align: center;
+}
+
+.chess-hero-bg-grid {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-image: 
+    linear-gradient(to right, rgba(255, 255, 255, 0.03) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
+  background-size: 40px 40px;
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 18px;
+  border-radius: 30px;
+  background: rgba(255, 153, 51, 0.15);
+  border: 1px solid rgba(255, 153, 51, 0.4);
+  color: var(--primary-saffron, #ff9933);
+  font-weight: 600;
+  font-size: 0.9rem;
+  letter-spacing: 0.5px;
+  margin-bottom: 20px;
+  text-transform: uppercase;
+}
+
+.chess-hero h1 {
+  font-family: var(--font-heading, 'Playfair Display', serif);
+  font-size: 3.2rem;
+  font-weight: 800;
+  margin-bottom: 16px;
+  background: linear-gradient(135deg, #ffffff 0%, #ffb01f 50%, #ff9933 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  line-height: 1.2;
+}
+
+.chess-hero p.hero-subtitle {
+  max-width: 800px;
+  margin: 0 auto 40px;
+  font-size: 1.15rem;
+  color: var(--text-muted, #94a3b8);
+  line-height: 1.6;
+}
+
+/* Stat Counters Banner */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 20px;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.stat-card {
+  background: var(--bg-dark-card, rgba(30, 41, 59, 0.65));
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--border-radius-lg, 18px);
+  padding: 20px;
+  text-align: center;
+  transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.stat-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(255, 153, 51, 0.4);
+}
+
+.stat-number {
+  font-size: 2.2rem;
+  font-weight: 800;
+  color: var(--primary-saffron, #ff9933);
+  font-family: var(--font-heading, serif);
+}
+
+.stat-label {
+  font-size: 0.9rem;
+  color: var(--text-muted, #94a3b8);
+  margin-top: 4px;
+}
+
+/* Quick Navigation Sticky Bar */
+.subnav-bar {
+  position: sticky;
+  top: 70px;
+  z-index: 90;
+  background: rgba(15, 23, 42, 0.92);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 12px 20px;
+}
+
+.subnav-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  padding-bottom: 4px;
+}
+
+.subnav-container::-webkit-scrollbar {
+  display: none;
+}
+
+.subnav-btn {
+  padding: 8px 18px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text-muted, #94a3b8);
+  font-size: 0.9rem;
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: all 0.25s ease;
+}
+
+.subnav-btn:hover,
+.subnav-btn.active {
+  background: var(--primary-saffron, #ff9933);
+  color: #000;
+  border-color: var(--primary-saffron, #ff9933);
+  font-weight: 600;
+  box-shadow: 0 0 15px rgba(255, 153, 51, 0.3);
+}
+
+/* Main Section Containers */
+.chess-section {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 60px 20px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.section-header {
+  margin-bottom: 40px;
+}
+
+.section-header .section-tag {
+  color: var(--primary-gold, #ffb01f);
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  display: block;
+  margin-bottom: 6px;
+}
+
+.section-header h2 {
+  font-family: var(--font-heading, serif);
+  font-size: 2.2rem;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+
+.section-header p {
+  color: var(--text-muted, #94a3b8);
+  font-size: 1.05rem;
+  max-width: 700px;
+}
+
+/* Evolution Timeline */
+.timeline-container {
+  position: relative;
+  padding-left: 30px;
+  border-left: 2px solid rgba(255, 153, 51, 0.3);
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: 40px;
+}
+
+.timeline-marker {
+  position: absolute;
+  left: -41px;
+  top: 0;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--primary-saffron, #ff9933);
+  border: 4px solid #090d16;
+  box-shadow: 0 0 10px rgba(255, 153, 51, 0.5);
+}
+
+.timeline-card {
+  background: var(--bg-dark-card, rgba(30, 41, 59, 0.65));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--border-radius-lg, 18px);
+  padding: 24px;
+  transition: transform 0.3s ease;
+}
+
+.timeline-card:hover {
+  transform: translateX(6px);
+  border-color: rgba(255, 176, 31, 0.4);
+}
+
+.timeline-period {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 12px;
+  background: rgba(255, 176, 31, 0.15);
+  color: var(--primary-gold, #ffb01f);
+  font-size: 0.85rem;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+
+.timeline-card h3 {
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+
+.timeline-card .subtitle {
+  color: var(--primary-saffron, #ff9933);
+  font-weight: 500;
+  font-size: 1rem;
+  margin-bottom: 12px;
+}
+
+.timeline-card p {
+  color: var(--text-muted, #94a3b8);
+  line-height: 1.6;
+}
+
+/* Tabs & Filter Bar Controls */
+.filter-tabs {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+
+.tab-btn {
+  padding: 10px 20px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text-light, #f8fafc);
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.tab-btn.active,
+.tab-btn:hover {
+  background: var(--primary-saffron, #ff9933);
+  color: #000;
+  border-color: var(--primary-saffron, #ff9933);
+}
+
+.search-filter-box {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 30px;
+  flex-wrap: wrap;
+}
+
+.search-input, .select-filter {
+  padding: 12px 18px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: #fff;
+  font-size: 0.95rem;
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+.search-input {
+  flex: 1;
+  min-width: 250px;
+}
+
+.search-input:focus, .select-filter:focus {
+  border-color: var(--primary-saffron, #ff9933);
+  box-shadow: 0 0 10px rgba(255, 153, 51, 0.2);
+}
+
+/* Data Table Styling */
+.table-responsive {
+  width: 100%;
+  overflow-x: auto;
+  border-radius: var(--border-radius-lg, 18px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: var(--bg-dark-card, rgba(30, 41, 59, 0.65));
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  text-align: left;
+  font-size: 0.95rem;
+}
+
+.data-table th {
+  background: rgba(15, 23, 42, 0.9);
+  color: var(--primary-gold, #ffb01f);
+  padding: 16px;
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.5px;
+  border-bottom: 2px solid rgba(255, 255, 255, 0.1);
+}
+
+.data-table td {
+  padding: 14px 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  color: var(--text-light, #f8fafc);
+}
+
+.data-table tbody tr:hover {
+  background: rgba(255, 153, 51, 0.08);
+}
+
+.badge-gold {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 12px;
+  background: rgba(255, 176, 31, 0.2);
+  color: var(--primary-gold, #ffb01f);
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+/* Champions Grid */
+.champions-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 24px;
+}
+
+.champion-card {
+  background: var(--bg-dark-card, rgba(30, 41, 59, 0.65));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--border-radius-lg, 18px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  transition: all 0.3s ease;
+  cursor: pointer;
+}
+
+.champion-card:hover {
+  transform: translateY(-6px);
+  border-color: var(--primary-saffron, #ff9933);
+  box-shadow: var(--shadow-soft, 0 8px 30px rgba(0,0,0,0.3));
+}
+
+.card-header-banner {
+  padding: 24px;
+  color: #fff;
+  position: relative;
+}
+
+.card-header-banner .icon-avatar {
+  font-size: 2.5rem;
+  margin-bottom: 10px;
+}
+
+.card-header-banner h3 {
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.card-header-banner .title-tag {
+  font-size: 0.85rem;
+  opacity: 0.9;
+  margin-top: 4px;
+}
+
+.champion-card-body {
+  padding: 20px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.champion-meta {
+  display: flex;
+  gap: 12px;
+  font-size: 0.85rem;
+  color: var(--text-muted, #94a3b8);
+  margin-bottom: 12px;
+}
+
+.champion-summary {
+  font-size: 0.95rem;
+  color: #cbd5e1;
+  line-height: 1.5;
+  margin-bottom: 16px;
+}
+
+.view-profile-btn {
+  align-self: flex-start;
+  padding: 8px 16px;
+  border-radius: 8px;
+  background: rgba(255, 153, 51, 0.15);
+  color: var(--primary-saffron, #ff9933);
+  border: 1px solid rgba(255, 153, 51, 0.3);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.champion-card:hover .view-profile-btn {
+  background: var(--primary-saffron, #ff9933);
+  color: #000;
+}
+
+/* Modal Popup */
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(8px);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+.modal-overlay.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.modal-content {
+  background: var(--bg-dark-modal, #0f172a);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 20px;
+  max-width: 650px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: 30px;
+  position: relative;
+  box-shadow: 0 20px 50px rgba(0,0,0,0.5);
+}
+
+.close-modal-btn {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  background: rgba(255, 255, 255, 0.1);
+  border: none;
+  color: #fff;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  font-size: 1.2rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Interactive Chessboard Section */
+.chessboard-layout {
+  display: grid;
+  grid-template-columns: 1fr 380px;
+  gap: 30px;
+  align-items: start;
+}
+
+@media (max-width: 900px) {
+  .chessboard-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.chessboard-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.chessboard-wrapper {
+  position: relative;
+  width: 100%;
+  max-width: 480px;
+  aspect-ratio: 1 / 1;
+  background: #262421;
+  border-radius: 12px;
+  padding: 12px;
+  box-shadow: 0 12px 40px rgba(0,0,0,0.6);
+  border: 2px solid rgba(255, 255, 255, 0.1);
+}
+
+.board-grid {
+  width: 100%;
+  height: 100%;
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  grid-template-rows: repeat(8, 1fr);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.square {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.2rem;
+  user-select: none;
+  position: relative;
+  transition: background-color 0.15s ease;
+}
+
+.square.light {
+  background-color: #f0d9b5;
+  color: #333;
+}
+
+.square.dark {
+  background-color: #b58863;
+  color: #fff;
+}
+
+.square.highlight {
+  background-color: rgba(255, 200, 0, 0.6) !important;
+}
+
+.square .piece {
+  width: 85%;
+  height: 85%;
+  object-fit: contain;
+  filter: drop-shadow(0 2px 4px rgba(0,0,0,0.3));
+}
+
+.board-controls {
+  display: flex;
+  gap: 12px;
+  margin-top: 20px;
+  width: 100%;
+  max-width: 480px;
+  justify-content: center;
+}
+
+.board-ctrl-btn {
+  flex: 1;
+  padding: 12px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: #fff;
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.board-ctrl-btn:hover {
+  background: var(--primary-saffron, #ff9933);
+  color: #000;
+}
+
+.game-info-panel {
+  background: var(--bg-dark-card, rgba(30, 41, 59, 0.65));
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--border-radius-lg, 18px);
+  padding: 24px;
+}
+
+.game-selector-select {
+  width: 100%;
+  margin-bottom: 20px;
+}
+
+.moves-list-box {
+  max-height: 240px;
+  overflow-y: auto;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 12px;
+  display: grid;
+  grid-template-columns: 40px 1fr 1fr;
+  gap: 6px;
+  font-size: 0.9rem;
+  font-family: monospace;
+}
+
+.move-num {
+  color: var(--text-muted, #94a3b8);
+}
+
+.move-ply {
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.move-ply:hover,
+.move-ply.active {
+  background: var(--primary-saffron, #ff9933);
+  color: #000;
+  font-weight: bold;
+}
+
+.move-commentary {
+  margin-top: 16px;
+  padding: 14px;
+  border-radius: 10px;
+  background: rgba(255, 176, 31, 0.1);
+  border-left: 3px solid var(--primary-gold, #ffb01f);
+  font-size: 0.9rem;
+  color: #e2e8f0;
+}
+
+/* Quiz Section */
+.quiz-card {
+  background: var(--bg-dark-card, rgba(30, 41, 59, 0.65));
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--border-radius-lg, 18px);
+  padding: 36px;
+  max-width: 750px;
+  margin: 0 auto;
+}
+
+.quiz-option {
+  display: block;
+  width: 100%;
+  padding: 14px 20px;
+  margin-bottom: 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #fff;
+  text-align: left;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.quiz-option:hover {
+  background: rgba(255, 153, 51, 0.15);
+  border-color: var(--primary-saffron, #ff9933);
+}
+
+.quiz-option.correct {
+  background: rgba(16, 185, 129, 0.25) !important;
+  border-color: #10b981 !important;
+  color: #a7f3d0;
+}
+
+.quiz-option.incorrect {
+  background: rgba(239, 68, 68, 0.25) !important;
+  border-color: #ef4444 !important;
+  color: #fca5a5;
+}
+
+/* Light Theme Overrides */
+body.light-theme .chess-explorer-page {
+  background-color: #f8fafc;
+  color: #0f172a;
+}
+
+body.light-theme .chess-hero {
+  background: radial-gradient(circle at 50% 20%, rgba(255, 153, 51, 0.1), transparent 70%),
+              linear-gradient(180deg, #f1f5f9 0%, #e2e8f0 100%);
+}
+
+body.light-theme .chess-hero h1 {
+  background: linear-gradient(135deg, #0f172a 0%, #b45309 50%, #d97706 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+body.light-theme .stat-card,
+body.light-theme .timeline-card,
+body.light-theme .table-responsive,
+body.light-theme .champion-card,
+body.light-theme .game-info-panel,
+body.light-theme .quiz-card {
+  background: #ffffff;
+  border-color: #cbd5e1;
+  color: #0f172a;
+}
+
+body.light-theme .data-table th {
+  background: #f1f5f9;
+  color: #b45309;
+}
+
+body.light-theme .data-table td {
+  color: #1e293b;
+  border-bottom-color: #e2e8f0;
+}
+
+body.light-theme .search-input,
+body.light-theme .select-filter {
+  background: #ffffff;
+  color: #0f172a;
+  border-color: #cbd5e1;
+}
+
+body.light-theme .subnav-bar {
+  background: rgba(255, 255, 255, 0.92);
+}

--- a/frontend/sports/sports.html
+++ b/frontend/sports/sports.html
@@ -222,11 +222,11 @@
                         <a href="../national-basketball-championship/index.html" style="display: inline-block; background: #ea580c; color: white; padding: 0.8rem 2rem; border-radius: 30px; text-decoration: none; font-weight: bold; transition: background 0.2s;">Explore Championship</a>
                     </div>
 
-                    <!-- Sports Logos -->
+                    <!-- Chess Heritage -->
                     <div style="background: var(--card-bg, #fff); border: 1px solid var(--border-color, #e5e7eb); border-radius: 12px; padding: 2rem; text-align: center; box-shadow: 0 4px 6px rgba(0,0,0,0.05); max-width: 350px;">
-                        <h3 style="color: #0ea5e9; font-size: 1.8rem; margin-bottom: 0.5rem;">Indian Sports Logos & Emblems</h3>
-                        <p style="color: var(--text-muted, #666); margin-bottom: 2rem;">Explore the logos, emblems, symbolism, and history behind India's major sporting organizations and competitions.</p>
-                        <a href="../sports-logos-emblems/index.html" style="display: inline-block; background: #0ea5e9; color: white; padding: 0.8rem 2rem; border-radius: 30px; text-decoration: none; font-weight: bold; transition: background 0.2s;">Explore Collection</a>
+                        <h3 style="color: #ff9933; font-size: 1.8rem; margin-bottom: 0.5rem;">Indian Chess Heritage & Championships</h3>
+                        <p style="color: var(--text-muted, #666); margin-bottom: 2rem;">Explore national chess championships, 85+ Grandmasters directory, women's milestones, and interactive historic game replays.</p>
+                        <a href="../chess-heritage-explorer/index.html" style="display: inline-block; background: #ff9933; color: black; padding: 0.8rem 2rem; border-radius: 30px; text-decoration: none; font-weight: bold; transition: background 0.2s;">Explore Chess Heritage</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
I have built the Explore India's Chess Heritage interactive archive for Incredible India Explorer!

What Was Built
Evolution of Indian Chess Timeline (index.html
):

Interactive milestone timeline tracing chess history from 6th-century Chaturanga (Gupta Empire), Mir Sultan Khan, AICF founding, Manuel Aaron's IM breakthrough, Viswanathan Anand's 5 World Championships, to the 2024 Budapest Olympiad Double Gold and World Championship Challenger D. Gukesh.
National Chess Championship History Archive (chess-data.js
):

Comprehensive searchable database of both the Men's Premier (1955–2024) and Women's Premier (1974–2024) National Championships.
Filter by year, venue, champion name, state, and search terms. Highlighted record holders such as Manuel Aaron (9 titles), Subbaraman Vijayalakshmi (6 consecutive titles), Pravin Thipsay (7 titles), and Surya Shekhar Ganguly (6 consecutive titles).
Major Champions & Hall of Legends:

Detailed champion cards and modal dialogs featuring Viswanathan Anand, D. Gukesh, R. Praggnanandhaa, Arjun Erigaisi, Koneru Humpy, S. Vijayalakshmi, Harika Dronavalli, Manuel Aaron, Divya Deshmukh, and Vaishali Rameshbabu.
Searchable Indian Grandmasters Directory (index.html
):

Searchable and filterable database of India's 85+ Grandmasters. Filter by state (e.g. Tamil Nadu, Maharashtra, West Bengal, Telangana, Delhi, Kerala) and sort by title year, peak FIDE rating, or name.
Interactive Historic PGN Game Replay (script.js
):

Full HTML5/JS Chessboard viewer to play through legendary games turn-by-turn:
Anand vs Kasparov 1995 (PCM World Championship Game 9)
Gukesh vs Nakamura 2024 (Candidates Tournament Round 14)
Praggnanandhaa vs Carlsen 2022 (Airthings Masters)
Manuel Aaron vs Portisch 1962 (Stockholm Interzonal)
Humpy vs Judit Polgar 2003 (Super Encounter)
Features move list jump clicks, autoplay/pause, board flip, and key moment commentary annotations.



closes #2548

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive Indian Chess Heritage Explorer.
  * Browse chess history, national championship records, champions, women’s heritage, and Indian grandmasters.
  * Search, filter, and sort the grandmaster directory.
  * Replay historic games with move controls, board visualization, and autoplay.
  * Test knowledge with a scored quiz featuring explanations.
  * Added dark/light theme support and responsive mobile layouts.
  * Added a link to the explorer from the sports tournaments section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->