### PR TITLE
feat: Explore Indian Table Tennis

### DIFF
--- a/frontend/sports/sports.html
+++ b/frontend/sports/sports.html
@@ -222,11 +222,11 @@
                         <a href="../national-basketball-championship/index.html" style="display: inline-block; background: #ea580c; color: white; padding: 0.8rem 2rem; border-radius: 30px; text-decoration: none; font-weight: bold; transition: background 0.2s;">Explore Championship</a>
                     </div>
 
-                    <!-- Sports Logos -->
+                    <!-- Table Tennis -->
                     <div style="background: var(--card-bg, #fff); border: 1px solid var(--border-color, #e5e7eb); border-radius: 12px; padding: 2rem; text-align: center; box-shadow: 0 4px 6px rgba(0,0,0,0.05); max-width: 350px;">
-                        <h3 style="color: #0ea5e9; font-size: 1.8rem; margin-bottom: 0.5rem;">Indian Sports Logos & Emblems</h3>
-                        <p style="color: var(--text-muted, #666); margin-bottom: 2rem;">Explore the logos, emblems, symbolism, and history behind India's major sporting organizations and competitions.</p>
-                        <a href="../sports-logos-emblems/index.html" style="display: inline-block; background: #0ea5e9; color: white; padding: 0.8rem 2rem; border-radius: 30px; text-decoration: none; font-weight: bold; transition: background 0.2s;">Explore Collection</a>
+                        <h3 style="color: #0284c7; font-size: 1.8rem; margin-bottom: 0.5rem;">Indian Table Tennis Explorer</h3>
+                        <p style="color: var(--text-muted, #666); margin-bottom: 2rem;">Explore Senior National Championships, 10x Champion Sharath Kamal, Manika Batra, doubles records & historic milestones.</p>
+                        <a href="../table-tennis-explorer/index.html" style="display: inline-block; background: #0284c7; color: white; padding: 0.8rem 2rem; border-radius: 30px; text-decoration: none; font-weight: bold; transition: background 0.2s;">Explore Table Tennis</a>
                     </div>
                 </div>
             </div>

--- a/frontend/table-tennis-explorer/index.html
+++ b/frontend/table-tennis-explorer/index.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore Indian Table Tennis - Interactive archive of National Table Tennis Championship history, Singles, Doubles, Mixed Doubles, 10x Champion Sharath Kamal, Manika Batra, Indu Puri, and historic Olympic breakthroughs.">
+  <title>Explore Indian Table Tennis | Incredible India Explorer</title>
+
+  <!-- Favicon & Stylesheets -->
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="tt-explorer-page">
+  <script>
+    (function() {
+      let theme = 'dark';
+      try { theme = JSON.parse(localStorage.getItem('iie_storage') || '{}').theme || 'dark'; } catch(e) {}
+      if (theme === 'light') { document.body.classList.add('light-theme'); }
+    })();
+  </script>
+
+  <!-- Sticky Navbar -->
+  <header class="navbar" id="navbar">
+    <div class="nav-container">
+      <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+        <span class="saffron">Incredible</span>
+        <span class="gold">India</span>
+        <span class="green">Explorer</span>
+      </a>
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+        <span class="bar"></span>
+        <span class="bar"></span>
+        <span class="bar"></span>
+      </button>
+      <nav class="nav-menu" id="nav-menu">
+        <a href="../../index.html#home" class="nav-link">Home</a>
+        <a href="../sports/sports.html" class="nav-link active">Sports</a>
+        <a href="#championships" class="nav-link">Championships</a>
+        <a href="#champions" class="nav-link">Major Champions</a>
+        <a href="#tactics" class="nav-link">Tactics & Rallies</a>
+      </nav>
+    </div>
+  </header>
+
+  <!-- Hero Section -->
+  <section class="tt-hero" id="hero">
+    <div class="tt-hero-grid-bg"></div>
+    <div class="hero-badge">🏓 National Sports Archive</div>
+    <h1>Explore Indian Table Tennis</h1>
+    <p class="hero-subtitle">
+      From the inaugural 1937 Calcutta Championship and the historic 1952 Bombay World Championship to Kamlesh Mehta's 8 titles, Achanta Sharath Kamal's record <strong>10 Senior National Titles</strong>, Manika Batra's CWG Gold, and the Paris 2024 Olympic team quarterfinals — discover India's table tennis legacy.
+    </p>
+
+    <!-- Key Stats -->
+    <div class="stats-grid">
+      <div class="stat-card">
+        <div class="stat-number">10</div>
+        <div class="stat-label">National Titles (Sharath Kamal)</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-number">8</div>
+        <div class="stat-label">National Titles (Indu Puri & Kamlesh Mehta)</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-number">1937</div>
+        <div class="stat-label">TTFI Founding & 1st National</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-number">2024</div>
+        <div class="stat-label">Paris Olympic Team Quarterfinalists</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- Sub-Navigation Sticky Bar -->
+  <nav class="subnav-bar">
+    <div class="subnav-container">
+      <button class="subnav-btn active" data-target="evolution">Evolution</button>
+      <button class="subnav-btn" data-target="championships">National Championships</button>
+      <button class="subnav-btn" data-target="champions">Major Champions</button>
+      <button class="subnav-btn" data-target="womens-tt">Women's Heritage</button>
+      <button class="subnav-btn" data-target="tactics">Tactics & Spin</button>
+      <button class="subnav-btn" data-target="quiz">Table Tennis Quiz</button>
+    </div>
+  </nav>
+
+  <!-- Main Content Body -->
+  <main>
+    <!-- Section 1: Evolution of Indian Table Tennis -->
+    <section class="tt-section" id="evolution">
+      <div class="section-header">
+        <span class="section-tag">Timeline & Evolution</span>
+        <h2>The Story of Indian Table Tennis</h2>
+        <p>Trace the historic evolution of table tennis in India across 8 decades of competitive excellence.</p>
+      </div>
+
+      <div class="timeline-container" id="timeline-wrapper">
+        <!-- Rendered dynamically by script.js -->
+      </div>
+    </section>
+
+    <!-- Section 2: National Championship Archive -->
+    <section class="tt-section" id="championships">
+      <div class="section-header">
+        <span class="section-tag">Archive & Records</span>
+        <h2>Senior National Championship Archive</h2>
+        <p>Complete historical records of Men's Singles, Women's Singles, Doubles, and Mixed Doubles championships since 1937.</p>
+      </div>
+
+      <!-- Category Filter Tabs -->
+      <div class="filter-tabs">
+        <button class="tab-btn active" id="tab-mens-singles">Men's Singles (1937 - Present)</button>
+        <button class="tab-btn" id="tab-womens-singles">Women's Singles (1937 - Present)</button>
+        <button class="tab-btn" id="tab-doubles">Doubles & Mixed Doubles</button>
+      </div>
+
+      <!-- Search & Filters -->
+      <div class="search-filter-box">
+        <input type="text" id="tt-search" class="search-input" placeholder="Search champion, venue, state, or notes...">
+        <select id="tt-state-filter" class="select-filter">
+          <option value="all">All Champion States</option>
+          <option value="Tamil Nadu">Tamil Nadu</option>
+          <option value="Maharashtra">Maharashtra / Bombay</option>
+          <option value="West Bengal">West Bengal / Bengal</option>
+          <option value="Delhi">Delhi</option>
+          <option value="Gujarat">Gujarat</option>
+          <option value="Telangana">Telangana / AP</option>
+          <option value="Karnataka">Karnataka / Mysore</option>
+        </select>
+      </div>
+
+      <!-- Table -->
+      <div class="table-responsive">
+        <table class="data-table" id="tt-table">
+          <thead>
+            <tr id="tt-table-head">
+              <th>Year</th>
+              <th>Host Venue</th>
+              <th>Champion</th>
+              <th>Runner-Up</th>
+              <th>State</th>
+              <th>Notes & Milestones</th>
+            </tr>
+          </thead>
+          <tbody id="tt-tbody">
+            <!-- Dynamic rows -->
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- Section 3: Major Champions & Hall of Fame -->
+    <section class="tt-section" id="champions">
+      <div class="section-header">
+        <span class="section-tag">Hall of Legends</span>
+        <h2>Major Champions & Icons</h2>
+        <p>Discover the legendary players who elevated Indian table tennis onto the world stage.</p>
+      </div>
+
+      <div class="champions-grid" id="champions-container">
+        <!-- Rendered dynamically -->
+      </div>
+    </section>
+
+    <!-- Section 4: Women's Championship & Heritage -->
+    <section class="tt-section" id="womens-tt">
+      <div class="section-header">
+        <span class="section-tag">Women's Legacy</span>
+        <h2>Women's Table Tennis Heritage</h2>
+        <p>Celebrating the women who shattered records and conquered global arenas.</p>
+      </div>
+
+      <div class="champions-grid" id="womens-container">
+        <!-- Rendered dynamically -->
+      </div>
+    </section>
+
+    <!-- Section 5: Interactive Tactics & Spin Showcase -->
+    <section class="tt-section" id="tactics">
+      <div class="section-header">
+        <span class="section-tag">Mechanics & Strategy</span>
+        <h2>Interactive Tactics & Spin Showcase</h2>
+        <p>Learn how grip styles, rubber pimple variations, and 9,000 RPM topspin rotation shape elite table tennis.</p>
+      </div>
+
+      <div class="tactics-grid" id="tactics-container">
+        <!-- Rendered dynamically -->
+      </div>
+    </section>
+
+    <!-- Section 6: Table Tennis Quiz -->
+    <section class="tt-section" id="quiz">
+      <div class="section-header" style="text-align: center;">
+        <span class="section-tag">Interactive Challenge</span>
+        <h2>Test Your Table Tennis Knowledge</h2>
+        <p>Answer 5 questions to test your knowledge of Indian table tennis history.</p>
+      </div>
+
+      <div class="quiz-card" id="quiz-box">
+        <div id="quiz-content">
+          <!-- Dynamically loaded quiz question -->
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <!-- Champion Detail Modal Overlay -->
+  <div class="modal-overlay" id="champion-modal">
+    <div class="modal-content">
+      <button class="close-modal-btn" id="modal-close-btn">&times;</button>
+      <div id="modal-body-content">
+        <!-- Rendered dynamically -->
+      </div>
+    </div>
+  </div>
+
+  <!-- Footer -->
+  <footer style="text-align:center; padding:40px 20px; background:#070a10; border-top:1px solid rgba(255,255,255,0.08); font-size:0.9rem; color:var(--text-muted);">
+    <p>© 2026 Incredible India Explorer. Celebrating Indian Table Tennis Heritage.</p>
+  </footer>
+
+  <!-- Script Imports -->
+  <script type="module" src="script.js"></script>
+</body>
+</html>

--- a/frontend/table-tennis-explorer/script.js
+++ b/frontend/table-tennis-explorer/script.js
@@ -1,0 +1,368 @@
+import { 
+  ttEvolutionData, 
+  mensSinglesHistory, 
+  womensSinglesHistory, 
+  doublesHistoryData, 
+  majorChampionsData, 
+  tacticsGuideData, 
+  quizQuestions 
+} from './tt-data.js';
+
+// Global App State
+let currentTab = 'mens-singles';
+let currentQuizIndex = 0;
+let quizScore = 0;
+
+document.addEventListener('DOMContentLoaded', () => {
+  initTimeline();
+  initChampionshipsTable();
+  initChampionsGrid();
+  initTacticsShowcase();
+  initQuizEngine();
+  initSubnav();
+  initThemeSupport();
+});
+
+/* --------------------------------------------------------------------------
+   1. Evolution Timeline
+   -------------------------------------------------------------------------- */
+function initTimeline() {
+  const container = document.getElementById('timeline-wrapper');
+  if (!container) return;
+
+  container.innerHTML = ttEvolutionData.map(item => `
+    <div class="timeline-item">
+      <div class="timeline-marker"></div>
+      <div class="timeline-card">
+        <span class="timeline-period">${item.period}</span>
+        <h3>${item.icon} ${item.title}</h3>
+        <div class="subtitle">${item.subtitle}</div>
+        <p>${item.description}</p>
+      </div>
+    </div>
+  `).join('');
+}
+
+/* --------------------------------------------------------------------------
+   2. National Championship Archive
+   -------------------------------------------------------------------------- */
+function initChampionshipsTable() {
+  const mensBtn = document.getElementById('tab-mens-singles');
+  const womensBtn = document.getElementById('tab-womens-singles');
+  const doublesBtn = document.getElementById('tab-doubles');
+
+  const searchInput = document.getElementById('tt-search');
+  const stateFilter = document.getElementById('tt-state-filter');
+
+  mensBtn?.addEventListener('click', () => {
+    currentTab = 'mens-singles';
+    setActiveTabBtn(mensBtn);
+    renderTable();
+  });
+
+  womensBtn?.addEventListener('click', () => {
+    currentTab = 'womens-singles';
+    setActiveTabBtn(womensBtn);
+    renderTable();
+  });
+
+  doublesBtn?.addEventListener('click', () => {
+    currentTab = 'doubles';
+    setActiveTabBtn(doublesBtn);
+    renderTable();
+  });
+
+  searchInput?.addEventListener('input', renderTable);
+  stateFilter?.addEventListener('change', renderTable);
+
+  renderTable();
+}
+
+function setActiveTabBtn(activeBtn) {
+  [document.getElementById('tab-mens-singles'), 
+   document.getElementById('tab-womens-singles'), 
+   document.getElementById('tab-doubles')].forEach(btn => {
+    if (btn) btn.classList.remove('active');
+  });
+  if (activeBtn) activeBtn.classList.add('active');
+}
+
+function renderTable() {
+  const tbody = document.getElementById('tt-tbody');
+  const theadRow = document.getElementById('tt-table-head');
+  if (!tbody || !theadRow) return;
+
+  const searchVal = document.getElementById('tt-search')?.value.toLowerCase() || '';
+  const selectedState = document.getElementById('tt-state-filter')?.value || 'all';
+
+  if (currentTab === 'doubles') {
+    theadRow.innerHTML = `
+      <th>Event / Competition</th>
+      <th>Champions</th>
+      <th>Runner-Up / Opponents</th>
+      <th>Historical Significance & Notes</th>
+    `;
+
+    const filtered = doublesHistoryData.filter(d => 
+      d.event.toLowerCase().includes(searchVal) ||
+      d.champions.toLowerCase().includes(searchVal) ||
+      d.runnerUp.toLowerCase().includes(searchVal) ||
+      d.notes.toLowerCase().includes(searchVal)
+    );
+
+    if (filtered.length === 0) {
+      tbody.innerHTML = `<tr><td colspan="4" style="text-align:center; padding:30px; color:#94a3b8;">No doubles records match your search.</td></tr>`;
+      return;
+    }
+
+    tbody.innerHTML = filtered.map(item => `
+      <tr>
+        <td><span class="badge-blue">${item.event}</span></td>
+        <td><strong style="color:#38bdf8;">${item.champions}</strong></td>
+        <td>${item.runnerUp}</td>
+        <td style="font-size:0.88rem; color:#cbd5e1;">${item.notes}</td>
+      </tr>
+    `).join('');
+  } else {
+    theadRow.innerHTML = `
+      <th>Year</th>
+      <th>Host Venue</th>
+      <th>Champion</th>
+      <th>Runner-Up</th>
+      <th>State / Unit</th>
+      <th>Notes & Milestones</th>
+    `;
+
+    const data = currentTab === 'mens-singles' ? mensSinglesHistory : womensSinglesHistory;
+
+    const filtered = data.filter(item => {
+      const matchesSearch = item.winner.toLowerCase().includes(searchVal) ||
+                            item.venue.toLowerCase().includes(searchVal) ||
+                            item.runnerUp.toLowerCase().includes(searchVal) ||
+                            item.notes.toLowerCase().includes(searchVal) ||
+                            item.year.toString().includes(searchVal);
+
+      const matchesState = selectedState === 'all' || item.state.includes(selectedState);
+      return matchesSearch && matchesState;
+    });
+
+    if (filtered.length === 0) {
+      tbody.innerHTML = `<tr><td colspan="6" style="text-align:center; padding:30px; color:#94a3b8;">No national championship records match your search criteria.</td></tr>`;
+      return;
+    }
+
+    tbody.innerHTML = filtered.map(item => `
+      <tr>
+        <td><span class="badge-blue">${item.year}</span></td>
+        <td><strong>${item.venue}</strong></td>
+        <td><strong style="color:#38bdf8;">${item.winner}</strong></td>
+        <td>${item.runnerUp}</td>
+        <td>${item.state}</td>
+        <td style="font-size:0.88rem; color:#cbd5e1;">${item.notes}</td>
+      </tr>
+    `).join('');
+  }
+}
+
+/* --------------------------------------------------------------------------
+   3. Champions & Hall of Fame
+   -------------------------------------------------------------------------- */
+function initChampionsGrid() {
+  const mainContainer = document.getElementById('champions-container');
+  const womensContainer = document.getElementById('womens-container');
+
+  if (mainContainer) {
+    mainContainer.innerHTML = majorChampionsData.slice(0, 6).map(c => renderChampionCard(c)).join('');
+  }
+
+  if (womensContainer) {
+    womensContainer.innerHTML = majorChampionsData.filter(c => 
+      ['Manika Batra', 'Indu Puri', 'Sreeja Akula', 'Ayhika & Sutirtha Mukherjee'].includes(c.name)
+    ).map(c => renderChampionCard(c)).join('');
+  }
+
+  // Profile modal click listener
+  document.addEventListener('click', (e) => {
+    const card = e.target.closest('.champion-card');
+    if (card) {
+      const name = card.getAttribute('data-name');
+      const champion = majorChampionsData.find(item => item.name === name);
+      if (champion) openChampionModal(champion);
+    }
+  });
+
+  document.getElementById('modal-close-btn')?.addEventListener('click', closeModal);
+  document.getElementById('champion-modal')?.addEventListener('click', (e) => {
+    if (e.target.id === 'champion-modal') closeModal();
+  });
+}
+
+function renderChampionCard(champ) {
+  return `
+    <div class="champion-card" data-name="${champ.name}">
+      <div class="card-header-banner" style="background:${champ.imageBg};">
+        <div class="icon-avatar">🏓</div>
+        <h3>${champ.name}</h3>
+        <div class="title-tag">${champ.title}</div>
+      </div>
+      <div class="champion-card-body">
+        <div>
+          <div class="champion-meta">
+            <span>📍 ${champ.state}</span>
+            <span>⭐ Peak World Rank: #${champ.peakWorldRank}</span>
+          </div>
+          <p class="champion-summary">${champ.summary}</p>
+        </div>
+        <button class="view-profile-btn">View Detailed Bio & Achievements →</button>
+      </div>
+    </div>
+  `;
+}
+
+function openChampionModal(champ) {
+  const modal = document.getElementById('champion-modal');
+  const modalBody = document.getElementById('modal-body-content');
+  if (!modal || !modalBody) return;
+
+  modalBody.innerHTML = `
+    <div style="background:${champ.imageBg}; padding:24px; border-radius:14px; color:#fff; margin-bottom:20px;">
+      <h2 style="font-size:1.8rem; margin:0 0 4px;">${champ.name}</h2>
+      <p style="opacity:0.9; margin-bottom:8px;">${champ.title}</p>
+      <div style="font-size:0.85rem; display:flex; gap:16px;">
+        <span>📍 ${champ.state}</span>
+        <span>⭐ Peak World Rank: #${champ.peakWorldRank}</span>
+        <span>🎂 Born: ${champ.birthYear}</span>
+      </div>
+    </div>
+
+    <h4 style="color:#38bdf8; margin-bottom:8px; font-size:1.1rem;">Key Achievements & Milestones</h4>
+    <ul style="padding-left:20px; color:#cbd5e1; line-height:1.6; margin-bottom:20px;">
+      ${champ.achievements.map(a => `<li style="margin-bottom:6px;">${a}</li>`).join('')}
+    </ul>
+
+    <h4 style="color:#38bdf8; margin-bottom:8px; font-size:1.1rem;">Biography & Legacy</h4>
+    <p style="color:#cbd5e1; line-height:1.6;">${champ.bio}</p>
+  `;
+
+  modal.classList.add('active');
+}
+
+function closeModal() {
+  document.getElementById('champion-modal')?.classList.remove('active');
+}
+
+/* --------------------------------------------------------------------------
+   4. Tactics Showcase
+   -------------------------------------------------------------------------- */
+function initTacticsShowcase() {
+  const container = document.getElementById('tactics-container');
+  if (!container) return;
+
+  container.innerHTML = tacticsGuideData.map(t => `
+    <div class="tactic-card">
+      <div class="tactic-icon">${t.icon}</div>
+      <h3>${t.title}</h3>
+      <p>${t.description}</p>
+    </div>
+  `).join('');
+}
+
+/* --------------------------------------------------------------------------
+   5. Quiz Engine
+   -------------------------------------------------------------------------- */
+function initQuizEngine() {
+  currentQuizIndex = 0;
+  quizScore = 0;
+  renderQuizQuestion();
+}
+
+function renderQuizQuestion() {
+  const box = document.getElementById('quiz-content');
+  if (!box) return;
+
+  if (currentQuizIndex >= quizQuestions.length) {
+    box.innerHTML = `
+      <div style="text-align:center; padding:20px;">
+        <h3 style="font-size:1.8rem; color:#38bdf8; margin-bottom:12px;">Quiz Complete! 🎉</h3>
+        <p style="font-size:1.2rem; color:#fff; margin-bottom:20px;">Your Final Score: <strong>${quizScore} / ${quizQuestions.length}</strong></p>
+        <button class="tab-btn active" id="quiz-restart-btn">Restart Quiz 🔄</button>
+      </div>
+    `;
+    document.getElementById('quiz-restart-btn')?.addEventListener('click', initQuizEngine);
+    return;
+  }
+
+  const q = quizQuestions[currentQuizIndex];
+  box.innerHTML = `
+    <div style="font-size:0.9rem; color:#38bdf8; font-weight:700; margin-bottom:10px;">Question ${currentQuizIndex + 1} of ${quizQuestions.length}</div>
+    <h3 style="font-size:1.3rem; margin-bottom:20px; color:#fff; line-height:1.4;">${q.question}</h3>
+    
+    <div>
+      ${q.options.map((opt, i) => `
+        <button class="quiz-option" data-index="${i}">${opt}</button>
+      `).join('')}
+    </div>
+
+    <div id="quiz-explanation" style="margin-top:20px; display:none; padding:14px; border-radius:10px; background:rgba(2,132,199,0.1); border-left:3px solid #38bdf8; font-size:0.95rem;"></div>
+  `;
+
+  box.querySelectorAll('.quiz-option').forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      const idx = parseInt(btn.getAttribute('data-index'), 10);
+      handleQuizAnswer(idx, q.answer, q.explanation);
+    });
+  });
+}
+
+function handleQuizAnswer(selectedIdx, correctIdx, explanation) {
+  const options = document.querySelectorAll('.quiz-option');
+  options.forEach((opt, i) => {
+    opt.disabled = true;
+    if (i === correctIdx) opt.classList.add('correct');
+    if (i === selectedIdx && i !== correctIdx) opt.classList.add('incorrect');
+  });
+
+  if (selectedIdx === correctIdx) quizScore++;
+
+  const expBox = document.getElementById('quiz-explanation');
+  if (expBox) {
+    expBox.style.display = 'block';
+    expBox.innerHTML = `<strong>${selectedIdx === correctIdx ? '✅ Correct!' : '❌ Incorrect.'}</strong> ${explanation}`;
+  }
+
+  setTimeout(() => {
+    currentQuizIndex++;
+    renderQuizQuestion();
+  }, 3200);
+}
+
+/* --------------------------------------------------------------------------
+   6. Subnav Smooth Scrolling
+   -------------------------------------------------------------------------- */
+function initSubnav() {
+  const btns = document.querySelectorAll('.subnav-btn');
+  btns.forEach(btn => {
+    btn.addEventListener('click', () => {
+      btns.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+
+      const targetId = btn.getAttribute('data-target');
+      const section = document.getElementById(targetId);
+      if (section) {
+        section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    });
+  });
+}
+
+/* --------------------------------------------------------------------------
+   7. Theme Support
+   -------------------------------------------------------------------------- */
+function initThemeSupport() {
+  const menuToggle = document.getElementById('menu-toggle');
+  const navMenu = document.getElementById('nav-menu');
+
+  menuToggle?.addEventListener('click', () => {
+    navMenu?.classList.toggle('active');
+  });
+}

--- a/frontend/table-tennis-explorer/style.css
+++ b/frontend/table-tennis-explorer/style.css
@@ -1,0 +1,619 @@
+/* ==========================================================================
+   INCREDIBLE INDIA EXPLORER - INDIAN TABLE TENNIS EXPLORER STYLESHEET
+   ========================================================================== */
+
+@import url("../../styles.css");
+
+/* Container & Scope */
+.tt-explorer-page {
+  background-color: var(--bg-dark-deep, #090d16);
+  color: var(--text-light, #f8fafc);
+  font-family: var(--font-body, 'Outfit', sans-serif);
+  min-height: 100vh;
+  margin: 0;
+  padding: 0;
+  overflow-x: hidden;
+}
+
+/* Hero Section */
+.tt-hero {
+  position: relative;
+  padding: 100px 20px 60px;
+  background: radial-gradient(circle at 50% 20%, rgba(2, 132, 199, 0.15), transparent 70%),
+              linear-gradient(180deg, rgba(15, 23, 42, 0.95) 0%, rgba(9, 13, 22, 1) 100%);
+  border-bottom: 1px solid var(--glass-border, rgba(255, 255, 255, 0.1));
+  text-align: center;
+}
+
+.tt-hero-grid-bg {
+  position: absolute;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background-image: 
+    radial-gradient(rgba(2, 132, 199, 0.1) 1px, transparent 1px);
+  background-size: 30px 30px;
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 18px;
+  border-radius: 30px;
+  background: rgba(2, 132, 199, 0.15);
+  border: 1px solid rgba(2, 132, 199, 0.4);
+  color: #38bdf8;
+  font-weight: 600;
+  font-size: 0.9rem;
+  letter-spacing: 0.5px;
+  margin-bottom: 20px;
+  text-transform: uppercase;
+}
+
+.tt-hero h1 {
+  font-family: var(--font-heading, 'Playfair Display', serif);
+  font-size: 3.2rem;
+  font-weight: 800;
+  margin-bottom: 16px;
+  background: linear-gradient(135deg, #ffffff 0%, #38bdf8 50%, #0284c7 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  line-height: 1.2;
+}
+
+.tt-hero p.hero-subtitle {
+  max-width: 800px;
+  margin: 0 auto 40px;
+  font-size: 1.15rem;
+  color: var(--text-muted, #94a3b8);
+  line-height: 1.6;
+}
+
+/* Stat Counters Banner */
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 20px;
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.stat-card {
+  background: var(--bg-dark-card, rgba(30, 41, 59, 0.65));
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--border-radius-lg, 18px);
+  padding: 20px;
+  text-align: center;
+  transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.stat-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(2, 132, 199, 0.4);
+}
+
+.stat-number {
+  font-size: 2.2rem;
+  font-weight: 800;
+  color: #38bdf8;
+  font-family: var(--font-heading, serif);
+}
+
+.stat-label {
+  font-size: 0.9rem;
+  color: var(--text-muted, #94a3b8);
+  margin-top: 4px;
+}
+
+/* Sticky Navigation Bar */
+.subnav-bar {
+  position: sticky;
+  top: 70px;
+  z-index: 90;
+  background: rgba(15, 23, 42, 0.92);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 12px 20px;
+}
+
+.subnav-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  gap: 12px;
+  overflow-x: auto;
+  scrollbar-width: none;
+  padding-bottom: 4px;
+}
+
+.subnav-container::-webkit-scrollbar {
+  display: none;
+}
+
+.subnav-btn {
+  padding: 8px 18px;
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text-muted, #94a3b8);
+  font-size: 0.9rem;
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: all 0.25s ease;
+}
+
+.subnav-btn:hover,
+.subnav-btn.active {
+  background: #0284c7;
+  color: #fff;
+  border-color: #38bdf8;
+  font-weight: 600;
+  box-shadow: 0 0 15px rgba(2, 132, 199, 0.4);
+}
+
+/* Main Section Containers */
+.tt-section {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 60px 20px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.section-header {
+  margin-bottom: 40px;
+}
+
+.section-header .section-tag {
+  color: #38bdf8;
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  display: block;
+  margin-bottom: 6px;
+}
+
+.section-header h2 {
+  font-family: var(--font-heading, serif);
+  font-size: 2.2rem;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+
+.section-header p {
+  color: var(--text-muted, #94a3b8);
+  font-size: 1.05rem;
+  max-width: 700px;
+}
+
+/* Timeline Layout */
+.timeline-container {
+  position: relative;
+  padding-left: 30px;
+  border-left: 2px solid rgba(2, 132, 199, 0.3);
+}
+
+.timeline-item {
+  position: relative;
+  margin-bottom: 40px;
+}
+
+.timeline-marker {
+  position: absolute;
+  left: -41px;
+  top: 0;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #38bdf8;
+  border: 4px solid #090d16;
+  box-shadow: 0 0 10px rgba(56, 189, 248, 0.5);
+}
+
+.timeline-card {
+  background: var(--bg-dark-card, rgba(30, 41, 59, 0.65));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--border-radius-lg, 18px);
+  padding: 24px;
+  transition: transform 0.3s ease;
+}
+
+.timeline-card:hover {
+  transform: translateX(6px);
+  border-color: rgba(56, 189, 248, 0.4);
+}
+
+.timeline-period {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 12px;
+  background: rgba(2, 132, 199, 0.2);
+  color: #38bdf8;
+  font-size: 0.85rem;
+  font-weight: 700;
+  margin-bottom: 10px;
+}
+
+.timeline-card h3 {
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+
+.timeline-card .subtitle {
+  color: #38bdf8;
+  font-weight: 500;
+  font-size: 1rem;
+  margin-bottom: 12px;
+}
+
+.timeline-card p {
+  color: var(--text-muted, #94a3b8);
+  line-height: 1.6;
+}
+
+/* Tabs & Controls */
+.filter-tabs {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+}
+
+.tab-btn {
+  padding: 10px 20px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: var(--text-light, #f8fafc);
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.tab-btn.active,
+.tab-btn:hover {
+  background: #0284c7;
+  color: #fff;
+  border-color: #38bdf8;
+}
+
+.search-filter-box {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 30px;
+  flex-wrap: wrap;
+}
+
+.search-input, .select-filter {
+  padding: 12px 18px;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: #fff;
+  font-size: 0.95rem;
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+.search-input {
+  flex: 1;
+  min-width: 250px;
+}
+
+.search-input:focus, .select-filter:focus {
+  border-color: #38bdf8;
+  box-shadow: 0 0 10px rgba(56, 189, 248, 0.2);
+}
+
+/* Table Styling */
+.table-responsive {
+  width: 100%;
+  overflow-x: auto;
+  border-radius: var(--border-radius-lg, 18px);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: var(--bg-dark-card, rgba(30, 41, 59, 0.65));
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  text-align: left;
+  font-size: 0.95rem;
+}
+
+.data-table th {
+  background: rgba(15, 23, 42, 0.9);
+  color: #38bdf8;
+  padding: 16px;
+  font-weight: 700;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+  letter-spacing: 0.5px;
+  border-bottom: 2px solid rgba(255, 255, 255, 0.1);
+}
+
+.data-table td {
+  padding: 14px 16px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  color: var(--text-light, #f8fafc);
+}
+
+.data-table tbody tr:hover {
+  background: rgba(2, 132, 199, 0.08);
+}
+
+.badge-blue {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 12px;
+  background: rgba(2, 132, 199, 0.2);
+  color: #38bdf8;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+/* Champions Grid */
+.champions-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 24px;
+}
+
+.champion-card {
+  background: var(--bg-dark-card, rgba(30, 41, 59, 0.65));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--border-radius-lg, 18px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  transition: all 0.3s ease;
+  cursor: pointer;
+}
+
+.champion-card:hover {
+  transform: translateY(-6px);
+  border-color: #38bdf8;
+  box-shadow: 0 8px 30px rgba(0,0,0,0.4);
+}
+
+.card-header-banner {
+  padding: 24px;
+  color: #fff;
+}
+
+.card-header-banner .icon-avatar {
+  font-size: 2.5rem;
+  margin-bottom: 10px;
+}
+
+.card-header-banner h3 {
+  font-size: 1.4rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.card-header-banner .title-tag {
+  font-size: 0.85rem;
+  opacity: 0.9;
+  margin-top: 4px;
+}
+
+.champion-card-body {
+  padding: 20px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.champion-meta {
+  display: flex;
+  gap: 12px;
+  font-size: 0.85rem;
+  color: var(--text-muted, #94a3b8);
+  margin-bottom: 12px;
+}
+
+.champion-summary {
+  font-size: 0.95rem;
+  color: #cbd5e1;
+  line-height: 1.5;
+  margin-bottom: 16px;
+}
+
+.view-profile-btn {
+  align-self: flex-start;
+  padding: 8px 16px;
+  border-radius: 8px;
+  background: rgba(2, 132, 199, 0.15);
+  color: #38bdf8;
+  border: 1px solid rgba(2, 132, 199, 0.3);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.champion-card:hover .view-profile-btn {
+  background: #0284c7;
+  color: #fff;
+}
+
+/* Tactics Showcase */
+.tactics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+}
+
+.tactic-card {
+  background: var(--bg-dark-card, rgba(30, 41, 59, 0.65));
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: var(--border-radius-lg, 18px);
+  padding: 24px;
+  text-align: left;
+}
+
+.tactic-card .tactic-icon {
+  font-size: 2.5rem;
+  margin-bottom: 12px;
+}
+
+.tactic-card h3 {
+  font-size: 1.3rem;
+  color: #38bdf8;
+  margin-bottom: 8px;
+}
+
+.tactic-card p {
+  font-size: 0.95rem;
+  color: var(--text-muted, #94a3b8);
+  line-height: 1.6;
+}
+
+/* Quiz Section */
+.quiz-card {
+  background: var(--bg-dark-card, rgba(30, 41, 59, 0.65));
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: var(--border-radius-lg, 18px);
+  padding: 36px;
+  max-width: 750px;
+  margin: 0 auto;
+}
+
+.quiz-option {
+  display: block;
+  width: 100%;
+  padding: 14px 20px;
+  margin-bottom: 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #fff;
+  text-align: left;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.quiz-option:hover {
+  background: rgba(2, 132, 199, 0.15);
+  border-color: #38bdf8;
+}
+
+.quiz-option.correct {
+  background: rgba(16, 185, 129, 0.25) !important;
+  border-color: #10b981 !important;
+  color: #a7f3d0;
+}
+
+.quiz-option.incorrect {
+  background: rgba(239, 68, 68, 0.25) !important;
+  border-color: #ef4444 !important;
+  color: #fca5a5;
+}
+
+/* Modal Overlay */
+.modal-overlay {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(0, 0, 0, 0.8);
+  backdrop-filter: blur(8px);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+.modal-overlay.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.modal-content {
+  background: var(--bg-dark-modal, #0f172a);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 20px;
+  max-width: 650px;
+  width: 100%;
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: 30px;
+  position: relative;
+  box-shadow: 0 20px 50px rgba(0,0,0,0.5);
+}
+
+.close-modal-btn {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  background: rgba(255, 255, 255, 0.1);
+  border: none;
+  color: #fff;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  font-size: 1.2rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Light Theme Overrides */
+body.light-theme .tt-explorer-page {
+  background-color: #f8fafc;
+  color: #0f172a;
+}
+
+body.light-theme .tt-hero {
+  background: radial-gradient(circle at 50% 20%, rgba(2, 132, 199, 0.1), transparent 70%),
+              linear-gradient(180deg, #f1f5f9 0%, #e2e8f0 100%);
+}
+
+body.light-theme .tt-hero h1 {
+  background: linear-gradient(135deg, #0f172a 0%, #0369a1 50%, #0284c7 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+body.light-theme .stat-card,
+body.light-theme .timeline-card,
+body.light-theme .table-responsive,
+body.light-theme .champion-card,
+body.light-theme .tactic-card,
+body.light-theme .quiz-card {
+  background: #ffffff;
+  border-color: #cbd5e1;
+  color: #0f172a;
+}
+
+body.light-theme .data-table th {
+  background: #f1f5f9;
+  color: #0284c7;
+}
+
+body.light-theme .data-table td {
+  color: #1e293b;
+  border-bottom-color: #e2e8f0;
+}
+
+body.light-theme .search-input,
+body.light-theme .select-filter {
+  background: #ffffff;
+  color: #0f172a;
+  border-color: #cbd5e1;
+}
+
+body.light-theme .subnav-bar {
+  background: rgba(255, 255, 255, 0.92);
+}

--- a/frontend/table-tennis-explorer/tt-data.js
+++ b/frontend/table-tennis-explorer/tt-data.js
@@ -1,0 +1,372 @@
+/**
+ * Incredible India Explorer - Indian Table Tennis Heritage Data Repository
+ */
+
+export const ttEvolutionData = [
+  {
+    period: "1937 - 1938",
+    title: "Founding of TTFI & First National Championship",
+    subtitle: "Birth of Organized Table Tennis in India",
+    description: "The Table Tennis Federation of India (TTFI) was established in 1937 in Calcutta (Kolkata). In 1938, the inaugural Senior National Table Tennis Championship took place. M. Ayub won the inaugural Men's Singles title, while A. Rouf captured the first Women's Singles title, establishing the bedrock for table tennis across the nation.",
+    icon: "🏓",
+    tag: "Foundation Era"
+  },
+  {
+    period: "1952",
+    title: "19th World Championships Hosted in Bombay",
+    subtitle: "India Hosts the Global Table Tennis Elite",
+    description: "Bombay (now Mumbai) made global history by hosting the 19th World Table Tennis Championships in 1952. It was the first time the World Championships were held in Asia. The event popularized ping pong rapidly across Indian metros and witnessed historic performances by Indian legends like Uttam Chandarana and V. Sivaraman.",
+    icon: "🌍",
+    tag: "Global Milestone"
+  },
+  {
+    period: "1960s - 1970s",
+    title: "The Golden Eras of Farrokh Khodaiji & Usha Sundarraj",
+    subtitle: "Domination of Early Masters",
+    description: "Farrokh Khodaiji and V. Sivaraman dominated Indian men's table tennis in the 1960s. Khodaiji was awarded the prestigious Arjuna Award in 1965. In the women's section, Usha Sundarraj and Kaity Chargeman claimed multiple national titles, paving the path for female table tennis pioneers.",
+    icon: "🏆",
+    tag: "Pioneer Era"
+  },
+  {
+    period: "1979 - 1985",
+    title: "Indu Puri's 8 National Titles & Historic Defeat of World #1",
+    subtitle: "India's First International Women's Icon",
+    description: "Indu Puri achieved monumental national and international success. She won a record-equaling 8 Senior National Women's Singles titles between 1972 and 1985. In 1978, at the Asian Table Tennis Championships in Kuala Lumpur, Indu Puri defeated Pak Yung-Sun of North Korea—the reigning World Champion—marking one of India's greatest upsets in sport history.",
+    icon: "⭐",
+    tag: "Legendary Upset"
+  },
+  {
+    period: "1981 - 1995",
+    title: "The Kamlesh Mehta Empire",
+    subtitle: "Record 8 Men's National Titles",
+    description: "Kamlesh Mehta redefined consistency in Indian sport by reaching 11 National Singles finals and winning a record 8 Men's National Championships between 1981 and 1995. Known for his flawless Shakehand forehand drive, stamina, and tactical intelligence, Mehta represented India in two Olympic Games (1988 Seoul, 1992 Barcelona).",
+    icon: "🥇",
+    tag: "Mehta Era"
+  },
+  {
+    period: "1990s - 2000s",
+    title: "Chetan Baboor & The Rise of Achanta Sharath Kamal",
+    subtitle: "Transition to Modern Speed & Power",
+    description: "Chetan Baboor won 4 National Singles titles and claimed India's first Commonwealth Championship Gold in 1997. In 2004, a tall, powerful 22-year-old from Chennai named Achanta Sharath Kamal won his 1st National Title and captured Commonwealth Games Singles Gold in Melbourne 2006, igniting a new era of aggressive counter-looping table tennis.",
+    icon: "🚀",
+    tag: "Modern Transformation"
+  },
+  {
+    period: "2000 - 2017",
+    title: "Poulomi Ghatak & Mouma Das Dominance",
+    subtitle: "Bengal's Queens of the Table",
+    description: "West Bengal produced two titans of Indian table tennis: Poulomi Ghatak (7 National Singles titles) and Mouma Das (5 National Singles titles). Together, they anchored Team India in 5 Olympic Games and multiple Commonwealth Games, securing international doubles medals and inspiring the nation's female athletes.",
+    icon: "👸",
+    tag: "Bengal Queens"
+  },
+  {
+    period: "2018",
+    title: "Gold Coast Commonwealth Games & Jakarta Asian Games Miracles",
+    subtitle: "Historic 8 CWG Medals & 2 Asian Games Medals",
+    description: "2018 was Indian table tennis's golden year. At the Gold Coast CWG, India won 8 medals, including Gold in Men's Team, Women's Team, and Women's Singles (Manika Batra). Months later at the Jakarta Asian Games, India broke a 60-year drought by winning Bronze in Men's Team (Sharath, Sathiyan, Harmeet, Amalraj, Manav) and Mixed Doubles (Sharath & Manika).",
+    icon: "🥇🥇",
+    tag: "Golden Epoch"
+  },
+  {
+    period: "2019 - 2023",
+    title: "Sharath Kamal's 10th Record Title & Asian Cup Medals",
+    subtitle: "Breaking All National & Global Records",
+    description: "Sharath Kamal surpassed Kamlesh Mehta's record by winning his 10th Men's Senior National Singles Title in 2022. Manika Batra became the first Indian woman to win a medal at the Asian Cup (Bronze 2022 in Bangkok), while Ayhika Mukherjee and Sutirtha Mukherjee shocked the world by defeating World No. 1 Chinese pair Sun Yingsha & Wang Manyu to win Asian Games Silver in 2023.",
+    icon: "👑",
+    tag: "Record Breaker"
+  },
+  {
+    period: "2024",
+    title: "Paris Olympics Team Quarterfinals Historic Breakthrough",
+    subtitle: "India Elite Top 8 in the World",
+    description: "At the Paris 2024 Olympic Games, both the Indian Men's Team (Sharath Kamal, Harmeet Desai, Manav Thakkar) and Women's Team (Manika Batra, Sreeja Akula, Archana Kamath) qualified for the Olympics as a team for the first time in history and reached the Olympic Quarterfinals, establishing India among the world's elite table tennis powerhouses.",
+    icon: "🇫🇷",
+    tag: "Olympic Milestone"
+  }
+];
+
+export const mensSinglesHistory = [
+  { year: 1937, venue: "Calcutta", winner: "M. Ayub", runnerUp: "A.H. Batliwala", state: "Bengal", notes: "Inaugural Men's Senior National Singles Champion." },
+  { year: 1939, venue: "Bombay", winner: "P. Siva Rao", runnerUp: "M. Ayub", state: "Madras", notes: "Siva Rao won in 5 sets." },
+  { year: 1941, venue: "Calcutta", winner: "V. Sivaraman", runnerUp: "P. Siva Rao", state: "Madras", notes: "First title for defensive stalwart V. Sivaraman." },
+  { year: 1943, venue: "Madras", winner: "V. Sivaraman", runnerUp: "K.D. Gaekwad", state: "Madras", notes: "Retained national title." },
+  { year: 1945, venue: "Bombay", winner: "Uttam Chandarana", runnerUp: "V. Sivaraman", state: "Bombay", notes: "First of Uttam Chandarana's titles." },
+  { year: 1947, venue: "Delhi", winner: "Uttam Chandarana", runnerUp: "K. Jayant", state: "Bombay", notes: "Second national title." },
+  { year: 1949, venue: "Hyderabad", winner: "Uttam Chandarana", runnerUp: "V. Sivaraman", state: "Bombay", notes: "Third national crown." },
+  { year: 1952, venue: "Bombay", winner: "V. Sivaraman", runnerUp: "Uttam Chandarana", state: "Madras", notes: "Sivaraman reclaimed crown during World Championships year." },
+  { year: 1954, venue: "Jalandhar", winner: "Uttam Chandarana", runnerUp: "Yatin Vyas", state: "Bombay", notes: "Fourth title for Chandarana." },
+  { year: 1957, venue: "Madras", winner: "Sudhir Thackersey", runnerUp: "G. Ranganayaki", state: "Bombay", notes: "Thackersey's inaugural victory." },
+  { year: 1961, venue: "Calcutta", winner: "Farrokh Khodaiji", runnerUp: "P.P. Haldankar", state: "Maharashtra", notes: "First title for Arjuna Awardee Farrokh Khodaiji." },
+  { year: 1964, venue: "Jamshedpur", winner: "Farrokh Khodaiji", runnerUp: "G. Jagannath", state: "Maharashtra", notes: "Second national crown." },
+  { year: 1967, venue: "Indore", winner: "Mir Kaser Ali", runnerUp: "Farrokh Khodaiji", state: "Andhra Pradesh", notes: "Mir Kaser Ali won in a 5-set classic." },
+  { year: 1970, venue: "Hyderabad", winner: "G. Jagannath", runnerUp: "K. Jayant", state: "Tamil Nadu", notes: "Jagannath clinched title." },
+  { year: 1973, venue: "Ahmedabad", winner: "N.V. Ashok", runnerUp: "Manjit Dua", state: "Tamil Nadu", notes: "Ashok won national crown." },
+  { year: 1976, venue: "Cuttack", winner: "Manjit Dua", runnerUp: "N.V. Ashok", state: "Delhi", notes: "Manjit Dua's inaugural national title." },
+  { year: 1979, venue: "Calcutta", winner: "Manjit Dua", runnerUp: "V. Chandrasekar", state: "Delhi", notes: "Second title for Manjit Dua." },
+  { year: 1980, venue: "Bangalore", winner: "V. Chandrasekar", runnerUp: "Manjit Dua", state: "Tamil Nadu", notes: "First of Chandra's 3 national titles." },
+  { year: 1981, venue: "Jalandhar", winner: "Kamlesh Mehta", runnerUp: "V. Chandrasekar", state: "Maharashtra", notes: "Start of Kamlesh Mehta's legendary 8-title era." },
+  { year: 1982, venue: "Madras", winner: "V. Chandrasekar", runnerUp: "Kamlesh Mehta", state: "Tamil Nadu", notes: "Chandra regained the title." },
+  { year: 1983, venue: "Calcutta", winner: "Kamlesh Mehta", runnerUp: "Manmeet Singh", state: "Maharashtra", notes: "Second title for Kamlesh Mehta." },
+  { year: 1984, venue: "Pune", winner: "Kamlesh Mehta", runnerUp: "V. Chandrasekar", state: "Maharashtra", notes: "Third title." },
+  { year: 1985, venue: "New Delhi", winner: "Kamlesh Mehta", runnerUp: "S. Sriram", state: "Maharashtra", notes: "Fourth title." },
+  { year: 1987, venue: "Indore", winner: "Kamlesh Mehta", runnerUp: "Chetan Baboor", state: "Maharashtra", notes: "Fifth national crown." },
+  { year: 1988, venue: "Shillong", winner: "Kamlesh Mehta", runnerUp: "S. Raman", state: "Maharashtra", notes: "Sixth title." },
+  { year: 1990, venue: "Jaipur", winner: "Kamlesh Mehta", runnerUp: "Chetan Baboor", state: "Maharashtra", notes: "Seventh title." },
+  { year: 1992, venue: "Lucknow", winner: "Chetan Baboor", runnerUp: "Kamlesh Mehta", state: "Karnataka", notes: "Chetan Baboor won his 1st national crown." },
+  { year: 1994, venue: "Hyderabad", winner: "Kamlesh Mehta", runnerUp: "Chetan Baboor", state: "Maharashtra", notes: "Record 8th Senior National Title for Kamlesh Mehta." },
+  { year: 1995, venue: "Pondicherry", winner: "Chetan Baboor", runnerUp: "S. Raman", state: "Karnataka", notes: "Second title for Baboor." },
+  { year: 1997, venue: "Jammu", winner: "Chetan Baboor", runnerUp: "S. Raman", state: "Karnataka", notes: "Third title." },
+  { year: 1999, venue: "Chennai", winner: "S. Raman", runnerUp: "Chetan Baboor", state: "Tamil Nadu", notes: "S. Raman won his inaugural title." },
+  { year: 2000, venue: "Cuttack", winner: "Chetan Baboor", runnerUp: "A. Sharath Kamal", state: "Karnataka", notes: "Fourth and final national title for Baboor." },
+  { year: 2002, venue: "Lucknow", winner: "S. Raman", runnerUp: "Soumyadeep Roy", state: "Tamil Nadu", notes: "Second title for S. Raman." },
+  { year: 2003, venue: "Manesar", winner: "A. Sharath Kamal", runnerUp: "Subhajit Saha", state: "Tamil Nadu", notes: "First of Sharath Kamal's record 10 national titles." },
+  { year: 2004, venue: "Indore", winner: "A. Sharath Kamal", runnerUp: "Soumyadeep Roy", state: "Tamil Nadu", notes: "Retained title after CWG Melbourne preparation." },
+  { year: 2006, venue: "Jaipur", winner: "A. Sharath Kamal", runnerUp: "Subhajit Saha", state: "Tamil Nadu", notes: "Third national crown." },
+  { year: 2007, venue: "Siliguri", winner: "A. Sharath Kamal", runnerUp: "Pathik Bhate", state: "Tamil Nadu", notes: "Fourth title." },
+  { year: 2008, venue: "Patna", winner: "Subhajit Saha", runnerUp: "A. Sharath Kamal", state: "West Bengal", notes: "Subhajit Saha defeated Sharath in final." },
+  { year: 2009, venue: "Guwahati", winner: "A. Sharath Kamal", runnerUp: "Soumyadeep Roy", state: "Tamil Nadu", notes: "Fifth title." },
+  { year: 2010, venue: "Kolkata", winner: "A. Sharath Kamal", runnerUp: "Anirban Nandi", state: "Tamil Nadu", notes: "Sixth title." },
+  { year: 2011, venue: "Lucknow", winner: "A. Sharath Kamal", runnerUp: "Sanil Shetty", state: "Tamil Nadu", notes: "Seventh title." },
+  { year: 2013, venue: "Puducherry", winner: "Sanil Shetty", runnerUp: "A. Amalraj", state: "Maharashtra", notes: "Sanil Shetty won inaugural national crown." },
+  { year: 2014, venue: "Patna", winner: "Soumyadeep Roy", runnerUp: "G. Sathiyan", state: "West Bengal", notes: "Soumyadeep Roy won after 4 runner-up finishes." },
+  { year: 2015, venue: "Hyderabad", winner: "A. Amalraj", runnerUp: "G. Sathiyan", state: "Tamil Nadu", notes: "Anthony Amalraj claimed national title." },
+  { year: 2016, venue: "Manesar", winner: "A. Sharath Kamal", runnerUp: "Soumyajit Ghosh", state: "Tamil Nadu", notes: "Eighth title, equaling Kamlesh Mehta's record." },
+  { year: 2017, venue: "Ranchi", winner: "A. Sharath Kamal", runnerUp: "A. Amalraj", state: "Tamil Nadu", notes: "Record 9th Senior National Title." },
+  { year: 2018, venue: "Cuttack", winner: "Harmeet Desai", runnerUp: "Manav Thakkar", state: "Gujarat", notes: "Harmeet Desai won first national title." },
+  { year: 2019, venue: "Hyderabad", winner: "A. Sharath Kamal", runnerUp: "G. Sathiyan", state: "Tamil Nadu", notes: "Record 10th Senior National Title for Sharath Kamal." },
+  { year: 2021, venue: "Panchkula", winner: "G. Sathiyan", runnerUp: "A. Sharath Kamal", state: "Tamil Nadu", notes: "Sathiyan defeated Sharath to win 1st National Title." },
+  { year: 2022, venue: "Shillong", winner: "A. Sharath Kamal", runnerUp: "G. Sathiyan", state: "Tamil Nadu", notes: "Extending record to 10th official Senior National Title." },
+  { year: 2023, venue: "Jammu", winner: "Harmeet Desai", runnerUp: "G. Sathiyan", state: "Gujarat", notes: "Harmeet won his second national championship." },
+  { year: 2024, venue: "Haryana", winner: "Manav Thakkar", runnerUp: "Harmeet Desai", state: "Gujarat", notes: "24-year-old Manav Thakkar won 2024 National Title." }
+];
+
+export const womensSinglesHistory = [
+  { year: 1937, venue: "Calcutta", winner: "A. Rouf", runnerUp: "M. Mhaiskar", state: "Bengal", notes: "Inaugural Women's National Singles Champion." },
+  { year: 1945, venue: "Bombay", winner: "Kaity Chargeman", runnerUp: "Enid Bocarro", state: "Bombay", notes: "First of Kaity Chargeman's titles." },
+  { year: 1950, venue: "Madras", winner: "Sayeed Sultana", runnerUp: "Usha Sundarraj", state: "Hyderabad", notes: "Sayeed Sultana won title." },
+  { year: 1955, venue: "Bangalore", winner: "Usha Sundarraj", runnerUp: "Kaity Chargeman", state: "Mysore", notes: "First of Usha Sundarraj's national crowns." },
+  { year: 1960, venue: "Bombay", winner: "Usha Sundarraj", runnerUp: "Rachel John", state: "Mysore", notes: "Retained crown." },
+  { year: 1966, venue: "Calcutta", winner: "Rachel John", runnerUp: "Kaity Chargeman", state: "Madras", notes: "Rachel John won national title." },
+  { year: 1970, venue: "Hyderabad", winner: "Kaity Chargeman", runnerUp: "Indu Puri", state: "Maharashtra", notes: "Kaity won final national title." },
+  { year: 1972, venue: "Ahmedabad", winner: "Indu Puri", runnerUp: "Rupa Mukherjee", state: "West Bengal", notes: "First of Indu Puri's 8 national championships." },
+  { year: 1975, venue: "Calcutta", winner: "Indu Puri", runnerUp: "Shailaja Salokhe", state: "West Bengal", notes: "Second title for Indu Puri." },
+  { year: 1977, venue: "Madras", winner: "Shailaja Salokhe", runnerUp: "Indu Puri", state: "Maharashtra", notes: "Shailaja won in tight 5-set final." },
+  { year: 1979, venue: "Calcutta", winner: "Indu Puri", runnerUp: "Vyoma Parikh", state: "West Bengal", notes: "Third title." },
+  { year: 1981, venue: "Jalandhar", winner: "Indu Puri", runnerUp: "Vyoma Shah", state: "West Bengal", notes: "Fourth title." },
+  { year: 1982, venue: "Madras", winner: "Indu Puri", runnerUp: "Monalisa Barua", state: "West Bengal", notes: "Fifth title." },
+  { year: 1983, venue: "Calcutta", winner: "Indu Puri", runnerUp: "Monalisa Barua", state: "West Bengal", notes: "Sixth title." },
+  { year: 1984, venue: "Pune", winner: "Indu Puri", runnerUp: "Vyoma Shah", state: "West Bengal", notes: "Seventh title." },
+  { year: 1985, venue: "New Delhi", winner: "Indu Puri", runnerUp: "Niyati Roy", state: "West Bengal", notes: "Record 8th Senior Women's National Title for Indu Puri." },
+  { year: 1987, venue: "Indore", winner: "Monalisa Barua (Mehta)", runnerUp: "Niyati Roy", state: "Assam / Maharashtra", notes: "First national title for Monalisa Barua." },
+  { year: 1989, venue: "Cuttack", winner: "Niyati Roy", runnerUp: "Monalisa Barua", state: "West Bengal", notes: "Niyati Roy won national title." },
+  { year: 1992, venue: "Lucknow", winner: "M.S. Myers", runnerUp: "Bhuvaneshwari", state: "Tamil Nadu", notes: "Myers won national title." },
+  { year: 1995, venue: "Pondicherry", winner: "Anindita Chakraborty", runnerUp: "Poulomi Ghatak", state: "West Bengal", notes: "Anindita won first title." },
+  { year: 1998, venue: "Chennai", winner: "Poulomi Ghatak", runnerUp: "Mouma Das", state: "West Bengal", notes: "16-year-old Poulomi won 1st of 7 national titles." },
+  { year: 1999, venue: "Cuttack", winner: "Mouma Das", runnerUp: "Poulomi Ghatak", state: "West Bengal", notes: "First of Mouma Das's 5 national titles." },
+  { year: 2000, venue: "Calcutta", winner: "Poulomi Ghatak", runnerUp: "Mouma Das", state: "West Bengal", notes: "Second title for Poulomi." },
+  { year: 2002, venue: "Lucknow", winner: "Poulomi Ghatak", runnerUp: "Mouma Das", state: "West Bengal", notes: "Third title." },
+  { year: 2004, venue: "Indore", winner: "Poulomi Ghatak", runnerUp: "Mouma Das", state: "West Bengal", notes: "Fourth title." },
+  { year: 2005, venue: "Jaipur", winner: "Mouma Das", runnerUp: "Poulomi Ghatak", state: "West Bengal", notes: "Second title for Mouma Das." },
+  { year: 2006, venue: "Jaipur", winner: "Poulomi Ghatak", runnerUp: "K. Shamini", state: "West Bengal", notes: "Fifth title." },
+  { year: 2007, venue: "Siliguri", winner: "Poulomi Ghatak", runnerUp: "Mouma Das", state: "West Bengal", notes: "Sixth title." },
+  { year: 2008, venue: "Patna", winner: "K. Shamini", runnerUp: "Mouma Das", state: "Tamil Nadu", notes: "K. Shamini won 1st national crown." },
+  { year: 2009, venue: "Guwahati", winner: "Poulomi Ghatak", runnerUp: "K. Shamini", state: "West Bengal", notes: "Record 7th National Title for Poulomi Ghatak." },
+  { year: 2010, venue: "Kolkata", winner: "K. Shamini", runnerUp: "Poulomi Ghatak", state: "Tamil Nadu", notes: "Second title for Shamini." },
+  { year: 2013, venue: "Puducherry", winner: "K. Shamini", runnerUp: "Mouma Das", state: "Tamil Nadu", notes: "Third title for Shamini." },
+  { year: 2014, venue: "Patna", winner: "Mouma Das", runnerUp: "Poulomi Ghatak", state: "West Bengal", notes: "Third title for Mouma Das." },
+  { year: 2015, venue: "Hyderabad", winner: "Manika Batra", runnerUp: "Mouma Das", state: "Delhi", notes: "First Senior National Title for 20-year-old Manika Batra." },
+  { year: 2016, venue: "Manesar", winner: "Manika Batra", runnerUp: "Mouma Das", state: "Delhi", notes: "Retained title back-to-back." },
+  { year: 2017, venue: "Ranchi", winner: "Sutirtha Mukherjee", runnerUp: "Manika Batra", state: "West Bengal", notes: "Sutirtha won 1st National Title." },
+  { year: 2018, venue: "Cuttack", winner: "Archana Kamath", runnerUp: "Nithya Mani", state: "Karnataka", notes: "18-year-old Archana won national title." },
+  { year: 2019, venue: "Hyderabad", winner: "Sutirtha Mukherjee", runnerUp: "Krittwika Sinha Roy", state: "West Bengal", notes: "Second title for Sutirtha." },
+  { year: 2021, venue: "Panchkula", winner: "Manika Batra", runnerUp: "Reeth Rishya", state: "Delhi", notes: "Third Senior National Title for Manika Batra." },
+  { year: 2022, venue: "Shillong", winner: "Sreeja Akula", runnerUp: "Mouma Das", state: "Telangana", notes: "First National Title for Sreeja Akula." },
+  { year: 2023, venue: "Jammu", winner: "Sreeja Akula", runnerUp: "Sutirtha Mukherjee", state: "Telangana", notes: "Back-to-back title defense for Sreeja." },
+  { year: 2024, venue: "Haryana", winner: "Poymantee Baisya", runnerUp: "Ayhika Mukherjee", state: "West Bengal", notes: "Poymantee won 2024 National Championship." }
+];
+
+export const doublesHistoryData = [
+  { event: "Men's Doubles 2023", champions: "G. Sathiyan & Harmeet Desai", runnerUp: "Manav Thakkar & Ishaan Hingorani", notes: "Sathiyan & Harmeet dominated with lightning counter-attacks." },
+  { event: "Women's Doubles 2023", champions: "Ayhika Mukherjee & Sutirtha Mukherjee", runnerUp: "Sreeja Akula & Diya Chitale", notes: "Asian Games Silver medalists clinched national doubles title." },
+  { event: "Mixed Doubles 2023", champions: "G. Sathiyan & Manika Batra", runnerUp: "Harmeet Desai & Krittwika Sinha Roy", notes: "World No. 5 mixed doubles pair captured national crown." },
+  { event: "Historic CWG Mixed Doubles 2018", champions: "Sharath Kamal & Manika Batra", runnerUp: "Sathiyan & Mouma Das", notes: "Won historic Bronze at 2018 Asian Games (Jakarta) and Gold at CWG." },
+  { event: "WTT Contender Tuniz 2023", champions: "Sutirtha Mukherjee & Ayhika Mukherjee", runnerUp: "Shin Yubin & Jeon Jihee (KOR)", notes: "First Indian Women's Doubles pair to win WTT Contender Title." }
+];
+
+export const majorChampionsData = [
+  {
+    name: "Achanta Sharath Kamal",
+    title: "10x Senior National Champion | Khel Ratna & Padma Shri",
+    state: "Tamil Nadu (Chennai)",
+    peakWorldRank: "15",
+    birthYear: 1982,
+    imageBg: "linear-gradient(135deg, #1e3a8a, #0284c7)",
+    summary: "Undisputed titan of Indian table tennis, record 10-time National Champion, 13 Commonwealth Games medals (7 Gold), and 5-time Olympian.",
+    achievements: [
+      "Record 10-time Senior National Men's Singles Champion",
+      "7 Commonwealth Games Gold Medals (Singles Gold 2006, 2022)",
+      "2 Asian Games Medals (Bronze 2018 Team & Mixed Doubles)",
+      "Major Dhyan Chand Khel Ratna Award recipient (2022)",
+      "India's Flagbearer at Paris 2024 Olympic Games"
+    ],
+    bio: "Born in Chennai, Sharath Kamal learned table tennis from his father A. Srinivasa Rao and uncle Muralidhara Rao. Standing 6ft 2in tall, his explosive forehand loop and longevity spanning over two decades revolutionized Indian table tennis. In 2022, at age 40, he won 3 Gold Medals at the Birmingham Commonwealth Games and captured his 10th national title."
+  },
+  {
+    name: "Manika Batra",
+    title: "3x National Champion | Asian Cup Medalist",
+    state: "Delhi",
+    peakWorldRank: "24",
+    birthYear: 1995,
+    imageBg: "linear-gradient(135deg, #831843, #ef4444)",
+    summary: "India's highest-ranked female player in history, 2018 CWG 4-medal superstar, and 1st Indian to win an Asian Cup medal.",
+    achievements: [
+      "Individual Gold Medalist at 2018 Commonwealth Games (Gold Coast)",
+      "First Indian woman to win Asian Cup Medal (Bronze 2022, Bangkok)",
+      "Reached Round of 16 at Paris 2024 Olympics (Individual & Team QF)",
+      "3-time Senior National Women's Singles Champion",
+      "Major Dhyan Chand Khel Ratna Award recipient (2020)"
+    ],
+    bio: "Manika Batra gained global fame with her unique playing style using long-pimple rubber on her backhand, twiddling her racket mid-rally to disrupt opponents' rhythm. She led India to historic Team Gold over Singapore at the 2018 CWG and defeated World No. 7 Chen Szu-yu to win Bronze at the 2022 Asian Cup."
+  },
+  {
+    name: "Kamlesh Mehta",
+    title: "8x Senior National Champion | Arjuna Awardee",
+    state: "Maharashtra (Mumbai)",
+    peakWorldRank: "Historical Top 50",
+    birthYear: 1960,
+    imageBg: "linear-gradient(135deg, #78350f, #d97706)",
+    summary: "Legendary table tennis icon who reached 11 National Finals, winning 8 titles between 1981 and 1995.",
+    achievements: [
+      "8-time Senior National Men's Singles Champion",
+      "Captain of Team India for 12 consecutive years",
+      "Represented India at 2 Olympics (1988 Seoul, 1992 Barcelona)",
+      "Arjuna Award recipient (1985)",
+      "Coached Team India at international championships"
+    ],
+    bio: "Kamlesh Mehta was the gold standard of consistency, sportsmanship, and mental fortitude. He dominated national table tennis for a decade and a half and carried India's flag across international events before serving as an elite coach and TTFI administrator."
+  },
+  {
+    name: "Sathiyan Gnanasekaran",
+    title: "World Top 25 | Olympians & National Champion",
+    state: "Tamil Nadu (Chennai)",
+    peakWorldRank: "24",
+    birthYear: 1993,
+    imageBg: "linear-gradient(135deg, #065f46, #10b981)",
+    summary: "First Indian player to win an ITTF World Tour title abroad (Czech Open 2016) and key member of India's top 8 Olympic team.",
+    achievements: [
+      "Winner of ITTF Czech Open (2016) & ITTF Spanish Open (2017)",
+      "Senior National Singles Champion (2021)",
+      "World Top 5 Mixed Doubles Pair with Manika Batra",
+      "Gold Coast & Birmingham CWG Multi-Medalist",
+      "Arjuna Award recipient (2018)"
+    ],
+    bio: "An engineer by education, Sathiyan is famous for his lightning-fast backhand counter-blocks, tactical preparation, and intense athletic speed. Coached by S. Raman, Sathiyan reached a career-high World Rank of 24 and scored key wins over World Top 10 players."
+  },
+  {
+    name: "Indu Puri",
+    title: "8x Senior National Champion | Arjuna Awardee",
+    state: "West Bengal / Kolkata",
+    peakWorldRank: "Asian Top 8",
+    birthYear: 1953,
+    imageBg: "linear-gradient(135deg, #701a75, #d946ef)",
+    summary: "Table tennis legend who won 8 National Women's Singles titles and defeated reigning World Champion Pak Yung-Sun in 1978.",
+    achievements: [
+      "8-time Senior National Women's Singles Champion",
+      "Defeated World No. 1 Pak Yung-Sun at 1978 Asian Championship",
+      "Arjuna Award recipient (1979-80)",
+      "First woman table tennis player to win 8 national crowns",
+      "Chairperson of National Sports Awards Selection Committee"
+    ],
+    bio: "Indu Puri overcame chronic asthma to become India's dominant female athlete of the 1970s and 1980s. Her fearless attacking game against Asian powerhouses established India as a competitive force in international table tennis."
+  },
+  {
+    name: "Sreeja Akula",
+    title: "2x National Champion | WTT Contender Winner",
+    state: "Telangana (Hyderabad)",
+    peakWorldRank: "22",
+    birthYear: 1998,
+    imageBg: "linear-gradient(135deg, #312e81, #6366f1)",
+    summary: "First Indian player to win a WTT Contender Singles Title (2024 Lagos) and back-to-back National Champion.",
+    achievements: [
+      "Winner of WTT Contender Lagos 2024 (Singles & Doubles)",
+      "2-time Senior National Women's Singles Champion (2022, 2023)",
+      "Commonwealth Games Gold Medalist in Mixed Doubles (2022)",
+      "Paris 2024 Olympic Round of 16 & Team Quarterfinalist",
+      "Arjuna Award recipient (2022)"
+    ],
+    bio: "Coached by Somnath Ghosh in Hyderabad, Sreeja is renowned for her cool demeanor under pressure, precise placement, and rapid pimple-block variation. She surged into the World Top 25 in 2024 after conquering consecutive WTT titles."
+  },
+  {
+    name: "Ayhika & Sutirtha Mukherjee",
+    title: "Asian Games Silver Medalists 2023",
+    state: "West Bengal (Naihati)",
+    peakWorldRank: "World Top 10 Doubles",
+    birthYear: 1997,
+    imageBg: "linear-gradient(135deg, #0f766e, #14b8a6)",
+    summary: "Dynamic Bengali doubles duo who shocked the world by defeating World No. 1 China to win historic Asian Games Silver.",
+    achievements: [
+      "Asian Games Silver Medalists (Hangzhou 2023)",
+      "Defeated World Champions Sun Yingsha & Wang Manyu (China)",
+      "WTT Contender Tunis Champions (2023)",
+      "Senior National Champions in Singles & Doubles",
+      "Paris 2024 Olympic Team Members"
+    ],
+    bio: "Hailing from Naihati, West Bengal, childhood friends Ayhika and Sutirtha combined anti-spin and pimple rubber variations to script one of Indian sport's greatest triumphs by knocking off China's top pair in their home arena at the Hangzhou Asian Games."
+  }
+];
+
+export const tacticsGuideData = [
+  {
+    title: "Shakehand vs Penhold Grip",
+    description: "The Shakehand grip (similar to shaking hands with the handle) is used by 95% of Indian players including Sharath Kamal and Sathiyan, offering equal power on forehand and backhand loops. The Penhold grip (holding handle like a pen) offers superior wrist movement and serve variation.",
+    icon: "🤝"
+  },
+  {
+    title: "Spin Mechanics: Topspin, Underspin & Sidespin",
+    description: "Table tennis balls travel at speeds over 120 km/h with rotation up to 9,000 RPM. Topspin causes the ball to dip rapidly onto the table and kick upward. Underspin (Chop) causes the ball to float and drop into the net if not lifted properly.",
+    icon: "🌀"
+  },
+  {
+    title: "Pimple & Anti-Spin Rubber Variations",
+    description: "Indian stars like Manika Batra (long pimples) and Ayhika Mukherjee (anti-spin) use special rubbers that reverse or absorb opponent spin, confusing attackers and creating high-floating pop-ups for decisive forehand smashes.",
+    icon: "🏓"
+  }
+];
+
+export const quizQuestions = [
+  {
+    id: 1,
+    question: "Who holds the national record for the most Senior Men's National Singles Titles with 10 championships?",
+    options: ["Kamlesh Mehta", "Achanta Sharath Kamal", "Chetan Baboor", "G. Sathiyan"],
+    answer: 1,
+    explanation: "Achanta Sharath Kamal won his record 10th Senior National Title in 2022, surpassing Kamlesh Mehta's longstanding record of 8 titles."
+  },
+  {
+    id: 2,
+    question: "In which year did Bombay host the 19th World Table Tennis Championships, marking the first time the event came to Asia?",
+    options: ["1937", "1952", "1971", "1982"],
+    answer: 1,
+    explanation: "In 1952, Bombay (Mumbai) hosted the 19th World Championships, bringing global table tennis to Asian soil for the first time."
+  },
+  {
+    id: 3,
+    question: "Which female table tennis star won historic Individual Gold at the 2018 Gold Coast Commonwealth Games?",
+    options: ["Poulomi Ghatak", "Mouma Das", "Manika Batra", "Sreeja Akula"],
+    answer: 2,
+    explanation: "Manika Batra won 4 total medals at the 2018 CWG, including Women's Team Gold and Women's Singles Gold."
+  },
+  {
+    id: 4,
+    question: "Which Indian Women's Doubles pair shocked World No. 1 China to win Asian Games Silver in 2023?",
+    options: ["Manika Batra & Archana Kamath", "Ayhika Mukherjee & Sutirtha Mukherjee", "Mouma Das & Poulomi Ghatak", "Sreeja Akula & Diya Chitale"],
+    answer: 1,
+    explanation: "Ayhika & Sutirtha Mukherjee defeated World No. 1 Sun Yingsha & Wang Manyu of China to win historic Asian Games Silver in 2023."
+  },
+  {
+    id: 5,
+    question: "At which Olympic Games did both Indian Men's & Women's Table Tennis teams reach the Olympic Quarterfinals for the first time?",
+    options: ["Tokyo 2020", "Rio 2016", "Paris 2024", "London 2012"],
+    answer: 2,
+    explanation: "At the Paris 2024 Olympics, India qualified as a team for the first time and reached the Team Quarterfinals in both Men's and Women's divisions."
+  }
+];


### PR DESCRIPTION
What Was Built
Evolution & Historic Milestones Timeline (index.html
):

Interactive timeline tracing Indian table tennis from the founding of TTFI in 1937 and the historic 1952 World Championships in Bombay (first in Asia), through the Farrokh Khodaiji & Usha Sundarraj eras, Indu Puri's historic 1978 win over the reigning World Champion, Kamlesh Mehta's 8 titles, Achanta Sharath Kamal's record 10 titles & Commonwealth Games golds, to the historic 2018 CWG & Asian Games double haul, Manika Batra's 2022 Asian Cup Bronze, and Paris 2024 Olympic Team Quarterfinals.
National Championships Archive (1937–2024) (tt-data.js
):

Interactive searchable database with filter tabs for:
Men's Singles: 1937 to 2024 (featuring M. Ayub, V. Sivaraman, Uttam Chandarana, Kamlesh Mehta, Chetan Baboor, Sharath Kamal's record 10 titles, Sathiyan Gnanasekaran, Harmeet Desai, Manav Thakkar).
Women's Singles: 1937 to 2024 (featuring A. Rouf, Kaity Chargeman, Indu Puri's 8 titles, Poulomi Ghatak's 7 titles, Mouma Das's 5 titles, Manika Batra, Sreeja Akula).
Doubles & Mixed Doubles: Major national doubles titles and international medal pairs (e.g. Sharath & Sathiyan, Manika & Archana, Sharath & Manika, Ayhika & Sutirtha Mukherjee).
Major Champions & Women's Heritage:

Detailed champion profile cards and modal dialogs for Achanta Sharath Kamal, Manika Batra, Kamlesh Mehta, Sathiyan Gnanasekaran, Indu Puri, Sreeja Akula, and Ayhika & Sutirtha Mukherjee.
Interactive Rally & Tactics Showcase (index.html
):

Breakdown of Shakehand vs Penhold grips, 9,000 RPM topspin & underspin physics, and long-pimple / anti-spin rubber strategy.


closes #2551