### PR TITLE
Davis Cup: India's Tennis Journey — interactive timeline, players & finals archive

### DIFF
--- a/frontend/davis-cup-explorer/davis-cup-explorer.css
+++ b/frontend/davis-cup-explorer/davis-cup-explorer.css
@@ -1,0 +1,254 @@
+/* davis-cup-explorer.css
+   Styling for Davis Cup: India's Tennis Journey. Mirrors the site's design language. */
+
+:root {
+  --dc-saffron: #FF9933;
+  --dc-green: #138808;
+  --dc-navy: #0B1F3A;
+  --dc-gold: #D4AF37;
+  --dc-bg: #FAFAF7;
+  --dc-card-bg: #FFFFFF;
+  --dc-text: #1C1C1C;
+  --dc-muted: #6B7280;
+  --dc-border: #E5E7EB;
+  --dc-radius: 14px;
+  --dc-shadow: 0 4px 14px rgba(11, 31, 58, 0.08);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", Roboto, -apple-system, sans-serif;
+  background: var(--dc-bg);
+  color: var(--dc-text);
+}
+
+.hidden { display: none !important; }
+
+/* Hero */
+.dc-hero {
+  background: linear-gradient(135deg, var(--dc-saffron), var(--dc-navy) 70%, var(--dc-green));
+  color: #fff;
+  padding: 3rem 1.5rem 2.5rem;
+  text-align: center;
+}
+.dc-hero h1 { margin: 0 0 0.5rem; font-size: clamp(1.8rem, 4vw, 2.6rem); }
+.dc-hero p { margin: 0 auto; max-width: 640px; opacity: 0.92; }
+
+.dc-main-container {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 3rem;
+}
+
+/* Overview strip */
+.dc-overview-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.75rem;
+}
+.dc-overview-stat {
+  background: var(--dc-card-bg);
+  border: 1px solid var(--dc-border);
+  border-radius: var(--dc-radius);
+  box-shadow: var(--dc-shadow);
+  padding: 1rem;
+  text-align: center;
+}
+.dc-stat-value {
+  display: block;
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--dc-navy);
+}
+.dc-stat-label {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--dc-muted);
+  margin-top: 0.2rem;
+}
+
+/* View Tabs */
+.dc-view-tabs-nav {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+}
+.btn-dc-view-tab {
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  border: 2px solid var(--dc-border);
+  background: var(--dc-card-bg);
+  cursor: pointer;
+  font-weight: 600;
+  transition: all 0.2s ease;
+}
+.btn-dc-view-tab:hover { border-color: var(--dc-saffron); }
+.btn-dc-view-tab.active {
+  background: var(--dc-navy);
+  border-color: var(--dc-navy);
+  color: #fff;
+}
+
+/* Controls */
+.dc-controls-bar { margin-bottom: 1rem; }
+.dc-search-input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: var(--dc-radius);
+  border: 2px solid var(--dc-border);
+  font-size: 1rem;
+}
+.dc-search-input:focus { outline: none; border-color: var(--dc-saffron); }
+
+.dc-type-filter-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.25rem;
+}
+.btn-dc-type-filter {
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--dc-border);
+  background: #fff;
+  font-size: 0.85rem;
+  cursor: pointer;
+  color: var(--dc-muted);
+}
+.btn-dc-type-filter.active {
+  background: var(--dc-saffron);
+  border-color: var(--dc-saffron);
+  color: #fff;
+}
+
+/* Timeline */
+.dc-timeline-container {
+  position: relative;
+  padding-left: 2rem;
+  border-left: 3px solid var(--dc-saffron);
+}
+.dc-timeline-node { position: relative; margin-bottom: 1.75rem; }
+.dc-timeline-node::before {
+  content: "";
+  position: absolute;
+  left: -2.42rem;
+  top: 0.3rem;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--dc-gold);
+  border: 3px solid var(--dc-card-bg);
+  box-shadow: 0 0 0 2px var(--dc-saffron);
+}
+.dc-year-pill {
+  display: inline-block;
+  background: var(--dc-navy);
+  color: #fff;
+  padding: 0.2rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+}
+.dc-timeline-card {
+  background: var(--dc-card-bg);
+  border: 1px solid var(--dc-border);
+  border-radius: var(--dc-radius);
+  padding: 1rem 1.15rem;
+  box-shadow: var(--dc-shadow);
+}
+.dc-timeline-card h3 { margin: 0.4rem 0; font-size: 1rem; }
+.dc-timeline-card p { margin: 0.4rem 0 0; font-size: 0.9rem; }
+
+.dc-type-tag {
+  display: inline-block;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.dc-type-milestone { background: rgba(19,136,8,0.12); color: var(--dc-green); }
+.dc-type-historic-tie { background: rgba(212,175,55,0.18); color: #8a6d1c; }
+.dc-type-final { background: rgba(255,153,51,0.18); color: #b5651d; }
+
+.dc-source { font-style: italic; font-size: 0.75rem; color: var(--dc-muted); }
+
+/* Players */
+.dc-players-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.25rem;
+}
+.dc-player-card {
+  background: var(--dc-card-bg);
+  border: 1px solid var(--dc-border);
+  border-radius: var(--dc-radius);
+  box-shadow: var(--dc-shadow);
+  padding: 1.25rem;
+  transition: transform 0.15s ease;
+}
+.dc-player-card:hover { transform: translateY(-3px); }
+.dc-player-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
+.dc-player-icon { font-size: 1.8rem; }
+.dc-player-era {
+  background: var(--dc-navy);
+  color: #fff;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+.dc-player-card h3 { margin: 0.2rem 0 0.3rem; font-size: 1.05rem; }
+.dc-player-record {
+  font-weight: 600;
+  color: var(--dc-saffron);
+  font-size: 0.9rem;
+  margin: 0 0 0.5rem;
+}
+.dc-player-desc { font-size: 0.9rem; margin: 0 0 0.5rem; }
+
+/* Finals */
+.dc-finals-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.25rem;
+}
+.dc-final-card {
+  background: var(--dc-card-bg);
+  border: 1px solid var(--dc-border);
+  border-radius: var(--dc-radius);
+  box-shadow: var(--dc-shadow);
+  padding: 1.25rem;
+}
+.dc-final-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
+.dc-final-year { font-size: 1.3rem; font-weight: 800; color: var(--dc-navy); }
+.dc-final-result {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #fff;
+}
+.dc-result-lost { background: #B91C1C; }
+.dc-result-forfeited { background: #6B7280; }
+
+.dc-final-card h3 { margin: 0.3rem 0; }
+.dc-final-venue { font-style: italic; color: var(--dc-muted); font-size: 0.88rem; margin: 0.2rem 0; }
+.dc-final-players, .dc-final-summary { font-size: 0.9rem; margin: 0.4rem 0; }
+
+.dc-empty-msg { text-align: center; padding: 2.5rem 1rem; color: var(--dc-muted); }
+
+/* Footer */
+.dc-footer {
+  text-align: center;
+  padding: 1.5rem;
+  color: var(--dc-muted);
+  font-size: 0.82rem;
+}

--- a/frontend/davis-cup-explorer/davis-cup-explorer.html
+++ b/frontend/davis-cup-explorer/davis-cup-explorer.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Davis Cup: Explore India's Tennis Journey — an interactive archive of India's Davis Cup history since 1921, featuring 3 finals appearances (1966, 1974, 1987), famous players like Leander Paes and the Amritraj brothers, and a searchable chronological timeline.">
+  <title>Davis Cup: India's Tennis Journey | Incredible India Explorer</title>
+  <link rel="stylesheet" href="davis-cup-explorer.min.css">
+</head>
+<body>
+
+  <header class="dc-hero">
+    <h1>🎾 Davis Cup: India's Tennis Journey</h1>
+    <p>From India's 1921 debut to three Davis Cup finals — a chronological archive of India's biggest tennis moments, players, and historic ties.</p>
+  </header>
+
+  <main class="dc-main-container">
+
+    <!-- Trophy / Overview strip -->
+    <section class="dc-overview-strip">
+      <div class="dc-overview-stat">
+        <span class="dc-stat-value">1921</span>
+        <span class="dc-stat-label">First participation</span>
+      </div>
+      <div class="dc-overview-stat">
+        <span class="dc-stat-value">3</span>
+        <span class="dc-stat-label">Finals reached (1966, 1974, 1987)</span>
+      </div>
+      <div class="dc-overview-stat">
+        <span class="dc-stat-value">89</span>
+        <span class="dc-stat-label">Years played</span>
+      </div>
+      <div class="dc-overview-stat">
+        <span class="dc-stat-value">🏆 Never won</span>
+        <span class="dc-stat-label">Trophy still awaited</span>
+      </div>
+    </section>
+
+    <nav class="dc-view-tabs-nav" aria-label="View mode">
+      <button type="button" class="btn-dc-view-tab active" data-view="timeline">📅 Timeline</button>
+      <button type="button" class="btn-dc-view-tab" data-view="players">🎾 Players</button>
+      <button type="button" class="btn-dc-view-tab" data-view="finals">🏆 Finals</button>
+    </nav>
+
+    <div class="dc-controls-bar">
+      <input
+        type="search"
+        id="dc-search"
+        class="dc-search-input"
+        placeholder="Search by player, year, opponent, or event..."
+        aria-label="Search Davis Cup history"
+      >
+    </div>
+
+    <!-- TIMELINE VIEW -->
+    <section id="dc-view-timeline" class="dc-view-panel">
+      <div class="dc-type-filter-row">
+        <button type="button" class="btn-dc-type-filter active" data-type="all">All</button>
+        <button type="button" class="btn-dc-type-filter" data-type="Milestone">Milestones</button>
+        <button type="button" class="btn-dc-type-filter" data-type="Historic Tie">Historic Ties</button>
+        <button type="button" class="btn-dc-type-filter" data-type="Final">Finals</button>
+      </div>
+      <div id="dc-timeline-container" class="dc-timeline-container" aria-live="polite"></div>
+    </section>
+
+    <!-- PLAYERS VIEW -->
+    <section id="dc-view-players" class="dc-view-panel hidden">
+      <div id="dc-players-grid" class="dc-players-grid" aria-live="polite"></div>
+    </section>
+
+    <!-- FINALS VIEW -->
+    <section id="dc-view-finals" class="dc-view-panel hidden">
+      <div id="dc-finals-grid" class="dc-finals-grid"></div>
+    </section>
+
+  </main>
+
+  <footer class="dc-footer">
+    <p>History fact-checked against ITF/Wikipedia Davis Cup records, The Federal, and Tennis Majors. See in-card sources for each entry.</p>
+  </footer>
+
+  <script src="davis-cup-explorer.min.js" type="module"></script>
+</body>
+</html>

--- a/frontend/davis-cup-explorer/davis-cup-explorer.js
+++ b/frontend/davis-cup-explorer/davis-cup-explorer.js
@@ -1,0 +1,362 @@
+/**
+ * davis-cup-explorer.js
+ * India's Davis Cup Journey - Timeline, Players, and Finals Archive
+ * Pure Vanilla JavaScript with ESM export support for Vitest unit testing.
+ */
+
+// Chronological timeline of India's major Davis Cup milestones (fact-checked)
+export const davisCupTimeline = [
+  {
+    id: "debut-1921",
+    year: 1921,
+    title: "India's Davis Cup Debut",
+    type: "Milestone",
+    description: "India competed in its first Davis Cup, entering the International Lawn Tennis Challenge as British India, decades before independence.",
+    source: "ITF / Wikipedia — India Davis Cup team"
+  },
+  {
+    id: "first-win-1938",
+    year: 1938,
+    title: "First Tie Win",
+    type: "Milestone",
+    description: "India won its first recorded Davis Cup tie, advancing past Austria in the Europe Zone second round.",
+    source: "ITF Davis Cup archives"
+  },
+  {
+    id: "independence-1947",
+    year: 1947,
+    title: "Post-Independence Team",
+    type: "Milestone",
+    description: "Following independence, the Davis Cup team transitioned to representing the sovereign Republic of India, with the All India Tennis Association overseeing the program.",
+    source: "Grokipedia — India Davis Cup team"
+  },
+  {
+    id: "first-interzone-1956",
+    year: 1956,
+    title: "First Inter-Zone Final",
+    type: "Milestone",
+    description: "Under captain Naresh Kumar, India reached its first Inter-Zone final, losing to the United States after a decade of building depth in the Eastern Zone.",
+    source: "Grokipedia — India Davis Cup team"
+  },
+  {
+    id: "krishnan-laver-1959",
+    year: 1959,
+    title: "Krishnan Defeats Laver",
+    type: "Historic Tie",
+    description: "India reached the Inter-Zone final against Australia. A young Ramanathan Krishnan defeated future Grand Slam champion Rod Laver in singles, though India lost the tie.",
+    source: "Grokipedia — India Davis Cup team"
+  },
+  {
+    id: "final-1966",
+    year: 1966,
+    title: "First Davis Cup Final",
+    type: "Final",
+    description: "India reached its first Davis Cup final (then the Challenge Round), led by Ramanathan Krishnan and Jaideep Mukerjea, after defeating Brazil and West Germany. India lost the final to Australia.",
+    source: "Wikipedia — India Davis Cup team"
+  },
+  {
+    id: "final-1974-forfeit",
+    year: 1974,
+    title: "The Forfeited Final",
+    type: "Final",
+    description: "India reached the final again after upsetting defending champion Australia in the quarterfinals (Jasjit Singh beat Bob Giltinan; Vijay Amritraj's team excelled). India then forfeited the final against apartheid-era South Africa on the Indian government's orders — the only Davis Cup final in history never played.",
+    source: "The Federal — '1974 Davis Cup final: When India forfeited the tie'"
+  },
+  {
+    id: "final-1987",
+    year: 1987,
+    title: "Third Davis Cup Final",
+    type: "Final",
+    description: "Led by Vijay and Anand Amritraj plus Ramesh Krishnan, India upset Australia in the semifinal to reach a third final — but lost 5-0 to Sweden (Mats Wilander, Joakim Nystrom) in Gothenburg.",
+    source: "Wikipedia — 1987 Davis Cup; Tennis Majors"
+  },
+  {
+    id: "paes-bhupathi-2004",
+    year: 2004,
+    title: "Paes-Bhupathi Doubles Pairing",
+    type: "Historic Tie",
+    description: "Leander Paes and Mahesh Bhupathi paired up in Davis Cup doubles for India, going on to become the nation's most successful doubles team (25-2 win/loss record together).",
+    source: "iloveindia.com — India in Davis Cup"
+  },
+  {
+    id: "world-group-2011",
+    year: 2011,
+    title: "Last World Group Appearance",
+    type: "Milestone",
+    description: "India's most recent appearance in the elite 16-nation World Group ended in a 4-1 defeat to Serbia; India has not qualified for the World Group since.",
+    source: "Wikipedia — India Davis Cup team"
+  }
+];
+
+// Famous Indian Davis Cup players (fact-checked career records)
+export const davisCupPlayers = [
+  {
+    id: "ramanathan-krishnan",
+    name: "Ramanathan Krishnan",
+    era: "1953–1975",
+    icon: "🎾",
+    record: "Most singles wins: 50–19",
+    description: "India's most successful Davis Cup singles player, he led India to its first Davis Cup final in 1966 and famously defeated future champion Rod Laver in 1959.",
+    source: "Wikipedia — India Davis Cup team"
+  },
+  {
+    id: "leander-paes",
+    name: "Leander Paes",
+    era: "1990–2016",
+    icon: "🏆",
+    record: "Most total wins: 93–35 · Most doubles wins: 45–13 · Most ties played: 58 · Most years played: 30",
+    description: "India's most decorated Davis Cup player by every major career metric — wins, ties played, and years of service to the team.",
+    source: "Wikipedia — India Davis Cup team"
+  },
+  {
+    id: "mahesh-bhupathi",
+    name: "Mahesh Bhupathi",
+    era: "1995–2011",
+    icon: "🎾",
+    record: "Best doubles team with Paes: 25–2",
+    description: "Paired with Leander Paes to form India's most successful Davis Cup doubles partnership, and later served as India's Davis Cup captain.",
+    source: "Wikipedia — India Davis Cup team"
+  },
+  {
+    id: "vijay-amritraj",
+    name: "Vijay Amritraj",
+    era: "1970–1987",
+    icon: "🎾",
+    record: "Led India to the 1974 and 1987 finals",
+    description: "The face of Indian tennis through the 1970s and 80s, Vijay Amritraj anchored India's Davis Cup team through two of its three final appearances.",
+    source: "The Federal; Tennis Majors"
+  },
+  {
+    id: "anand-amritraj",
+    name: "Anand Amritraj",
+    era: "1968–1987",
+    icon: "🎾",
+    record: "Doubles partner in the 1974 and 1987 finals",
+    description: "Vijay's elder brother and long-time doubles partner, Anand played alongside him in India's Davis Cup campaigns of the 1970s and 80s.",
+    source: "Tennis Majors"
+  },
+  {
+    id: "ramesh-krishnan",
+    name: "Ramesh Krishnan",
+    era: "1979–1993",
+    icon: "🎾",
+    record: "India's top-ranked singles player in the 1987 run",
+    description: "Son of Ramanathan Krishnan, he was India's only top-100-ranked singles player during the improbable 1987 run to the final.",
+    source: "Tennis Majors"
+  }
+];
+
+// The three Davis Cup finals India has reached (India has never won)
+export const davisCupFinals = [
+  {
+    id: "final-1966",
+    year: 1966,
+    opponent: "Australia",
+    result: "Lost",
+    venue: "Challenge Round",
+    keyPlayers: "Ramanathan Krishnan, Jaideep Mukerjea",
+    summary: "India's first Davis Cup final. India defeated Brazil and West Germany en route before losing the Challenge Round to Australia.",
+    source: "Wikipedia — India Davis Cup team"
+  },
+  {
+    id: "final-1974",
+    year: 1974,
+    opponent: "South Africa",
+    result: "Forfeited",
+    venue: "Never played",
+    keyPlayers: "Vijay Amritraj, Anand Amritraj, Jasjit Singh",
+    summary: "India upset defending champion Australia in the quarterfinals to reach the final, then forfeited on government orders in protest of South African apartheid — the only Davis Cup final in history never played.",
+    source: "The Federal — '1974 Davis Cup final'"
+  },
+  {
+    id: "final-1987",
+    year: 1987,
+    opponent: "Sweden",
+    result: "Lost 5–0",
+    venue: "Gothenburg, Sweden (indoor clay)",
+    keyPlayers: "Vijay Amritraj, Anand Amritraj, Ramesh Krishnan",
+    summary: "With only one top-100 player (Ramesh Krishnan), India upset Australia in the semifinal for one of the tournament's most unlikely final runs, before being swept 5-0 by Mats Wilander's Sweden.",
+    source: "Wikipedia — 1987 Davis Cup; Tennis Majors"
+  }
+];
+
+/**
+ * Get timeline entries sorted chronologically.
+ */
+export function getSortedTimeline(list = davisCupTimeline) {
+  if (!Array.isArray(list)) return [];
+  return [...list].sort((a, b) => a.year - b.year);
+}
+
+/**
+ * Filter timeline entries by type ("all" | "Milestone" | "Historic Tie" | "Final").
+ */
+export function filterTimelineByType(typeFilter = "all", list = davisCupTimeline) {
+  if (!Array.isArray(list)) return [];
+  if (!typeFilter || typeFilter.toLowerCase() === "all") return getSortedTimeline(list);
+  return getSortedTimeline(list).filter(
+    item => item.type.toLowerCase() === typeFilter.toLowerCase()
+  );
+}
+
+/**
+ * Search timeline, players, or finals by free-text query.
+ */
+export function searchDavisCup(query = "") {
+  const q = query.trim().toLowerCase();
+  if (!q) {
+    return { timeline: davisCupTimeline, players: davisCupPlayers, finals: davisCupFinals };
+  }
+  const matches = (obj, fields) =>
+    fields.some(f => obj[f] && obj[f].toString().toLowerCase().includes(q));
+
+  return {
+    timeline: davisCupTimeline.filter(item =>
+      matches(item, ["title", "type", "description", "year"])
+    ),
+    players: davisCupPlayers.filter(item =>
+      matches(item, ["name", "era", "record", "description"])
+    ),
+    finals: davisCupFinals.filter(item =>
+      matches(item, ["opponent", "result", "keyPlayers", "summary", "year"])
+    )
+  };
+}
+
+/* ==========================================================================
+   BROWSER DOM ENGINE
+   ========================================================================== */
+
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  window.davisCupTimeline = davisCupTimeline;
+  window.davisCupPlayers = davisCupPlayers;
+  window.davisCupFinals = davisCupFinals;
+  window.getSortedTimeline = getSortedTimeline;
+  window.filterTimelineByType = filterTimelineByType;
+  window.searchDavisCup = searchDavisCup;
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const timelineContainer = document.getElementById("dc-timeline-container");
+    const playersGrid = document.getElementById("dc-players-grid");
+    const finalsGrid = document.getElementById("dc-finals-grid");
+    const searchInput = document.getElementById("dc-search");
+    const typeBtns = document.querySelectorAll(".btn-dc-type-filter");
+    const viewTabs = document.querySelectorAll(".btn-dc-view-tab");
+
+    let currentType = "all";
+
+    function renderTimeline() {
+      if (!timelineContainer) return;
+      timelineContainer.innerHTML = "";
+
+      const query = searchInput ? searchInput.value : "";
+      let items = query ? searchDavisCup(query).timeline : davisCupTimeline;
+      items = filterTimelineByType(currentType, items);
+
+      if (items.length === 0) {
+        timelineContainer.innerHTML = `<div class="dc-empty-msg"><h3>No results</h3><p>Try a different search term or filter.</p></div>`;
+        return;
+      }
+
+      items.forEach(item => {
+        const node = document.createElement("div");
+        node.className = "dc-timeline-node";
+        node.innerHTML = `
+          <div class="dc-year-pill">📅 ${item.year}</div>
+          <div class="dc-timeline-card">
+            <span class="dc-type-tag dc-type-${item.type.replace(/\s+/g, "-").toLowerCase()}">${item.type}</span>
+            <h3>${item.title}</h3>
+            <p>${item.description}</p>
+            <p class="dc-source">Source: ${item.source}</p>
+          </div>
+        `;
+        timelineContainer.appendChild(node);
+      });
+    }
+
+    function renderPlayers() {
+      if (!playersGrid) return;
+      playersGrid.innerHTML = "";
+
+      const query = searchInput ? searchInput.value : "";
+      const items = query ? searchDavisCup(query).players : davisCupPlayers;
+
+      if (items.length === 0) {
+        playersGrid.innerHTML = `<div class="dc-empty-msg"><h3>No players found</h3></div>`;
+        return;
+      }
+
+      items.forEach(p => {
+        const card = document.createElement("article");
+        card.className = "dc-player-card";
+        card.innerHTML = `
+          <div class="dc-player-header">
+            <span class="dc-player-icon">${p.icon}</span>
+            <span class="dc-player-era">${p.era}</span>
+          </div>
+          <h3>${p.name}</h3>
+          <p class="dc-player-record">${p.record}</p>
+          <p class="dc-player-desc">${p.description}</p>
+          <p class="dc-source">Source: ${p.source}</p>
+        `;
+        playersGrid.appendChild(card);
+      });
+    }
+
+    function renderFinals() {
+      if (!finalsGrid) return;
+      finalsGrid.innerHTML = "";
+
+      davisCupFinals.forEach(f => {
+        const card = document.createElement("article");
+        card.className = "dc-final-card";
+        card.innerHTML = `
+          <div class="dc-final-header">
+            <span class="dc-final-year">${f.year}</span>
+            <span class="dc-final-result dc-result-${f.result.split(" ")[0].toLowerCase()}">${f.result}</span>
+          </div>
+          <h3>India vs. ${f.opponent}</h3>
+          <p class="dc-final-venue">${f.venue}</p>
+          <p class="dc-final-players"><strong>Key players:</strong> ${f.keyPlayers}</p>
+          <p class="dc-final-summary">${f.summary}</p>
+          <p class="dc-source">Source: ${f.source}</p>
+        `;
+        finalsGrid.appendChild(card);
+      });
+    }
+
+    // View tab switching
+    viewTabs.forEach(tab => {
+      tab.addEventListener("click", () => {
+        viewTabs.forEach(t => t.classList.remove("active"));
+        tab.classList.add("active");
+        const target = tab.dataset.view;
+        document.querySelectorAll(".dc-view-panel").forEach(p => p.classList.add("hidden"));
+        document.getElementById(`dc-view-${target}`)?.classList.remove("hidden");
+      });
+    });
+
+    // Type filter (timeline only)
+    typeBtns.forEach(btn => {
+      btn.addEventListener("click", () => {
+        typeBtns.forEach(b => b.classList.remove("active"));
+        btn.classList.add("active");
+        currentType = btn.dataset.type || "all";
+        renderTimeline();
+      });
+    });
+
+    // Search (applies to timeline + players)
+    if (searchInput) {
+      searchInput.addEventListener("input", () => {
+        renderTimeline();
+        renderPlayers();
+      });
+    }
+
+    // Initial render
+    renderTimeline();
+    renderPlayers();
+    renderFinals();
+  });
+}

--- a/frontend/davis-cup-explorer/davis-cup-explorer.min.css
+++ b/frontend/davis-cup-explorer/davis-cup-explorer.min.css
@@ -1,0 +1,254 @@
+/* davis-cup-explorer.css
+   Styling for Davis Cup: India's Tennis Journey. Mirrors the site's design language. */
+
+:root {
+  --dc-saffron: #FF9933;
+  --dc-green: #138808;
+  --dc-navy: #0B1F3A;
+  --dc-gold: #D4AF37;
+  --dc-bg: #FAFAF7;
+  --dc-card-bg: #FFFFFF;
+  --dc-text: #1C1C1C;
+  --dc-muted: #6B7280;
+  --dc-border: #E5E7EB;
+  --dc-radius: 14px;
+  --dc-shadow: 0 4px 14px rgba(11, 31, 58, 0.08);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", Roboto, -apple-system, sans-serif;
+  background: var(--dc-bg);
+  color: var(--dc-text);
+}
+
+.hidden { display: none !important; }
+
+/* Hero */
+.dc-hero {
+  background: linear-gradient(135deg, var(--dc-saffron), var(--dc-navy) 70%, var(--dc-green));
+  color: #fff;
+  padding: 3rem 1.5rem 2.5rem;
+  text-align: center;
+}
+.dc-hero h1 { margin: 0 0 0.5rem; font-size: clamp(1.8rem, 4vw, 2.6rem); }
+.dc-hero p { margin: 0 auto; max-width: 640px; opacity: 0.92; }
+
+.dc-main-container {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 3rem;
+}
+
+/* Overview strip */
+.dc-overview-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.75rem;
+}
+.dc-overview-stat {
+  background: var(--dc-card-bg);
+  border: 1px solid var(--dc-border);
+  border-radius: var(--dc-radius);
+  box-shadow: var(--dc-shadow);
+  padding: 1rem;
+  text-align: center;
+}
+.dc-stat-value {
+  display: block;
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--dc-navy);
+}
+.dc-stat-label {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--dc-muted);
+  margin-top: 0.2rem;
+}
+
+/* View Tabs */
+.dc-view-tabs-nav {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+}
+.btn-dc-view-tab {
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  border: 2px solid var(--dc-border);
+  background: var(--dc-card-bg);
+  cursor: pointer;
+  font-weight: 600;
+  transition: all 0.2s ease;
+}
+.btn-dc-view-tab:hover { border-color: var(--dc-saffron); }
+.btn-dc-view-tab.active {
+  background: var(--dc-navy);
+  border-color: var(--dc-navy);
+  color: #fff;
+}
+
+/* Controls */
+.dc-controls-bar { margin-bottom: 1rem; }
+.dc-search-input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: var(--dc-radius);
+  border: 2px solid var(--dc-border);
+  font-size: 1rem;
+}
+.dc-search-input:focus { outline: none; border-color: var(--dc-saffron); }
+
+.dc-type-filter-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.25rem;
+}
+.btn-dc-type-filter {
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--dc-border);
+  background: #fff;
+  font-size: 0.85rem;
+  cursor: pointer;
+  color: var(--dc-muted);
+}
+.btn-dc-type-filter.active {
+  background: var(--dc-saffron);
+  border-color: var(--dc-saffron);
+  color: #fff;
+}
+
+/* Timeline */
+.dc-timeline-container {
+  position: relative;
+  padding-left: 2rem;
+  border-left: 3px solid var(--dc-saffron);
+}
+.dc-timeline-node { position: relative; margin-bottom: 1.75rem; }
+.dc-timeline-node::before {
+  content: "";
+  position: absolute;
+  left: -2.42rem;
+  top: 0.3rem;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--dc-gold);
+  border: 3px solid var(--dc-card-bg);
+  box-shadow: 0 0 0 2px var(--dc-saffron);
+}
+.dc-year-pill {
+  display: inline-block;
+  background: var(--dc-navy);
+  color: #fff;
+  padding: 0.2rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+}
+.dc-timeline-card {
+  background: var(--dc-card-bg);
+  border: 1px solid var(--dc-border);
+  border-radius: var(--dc-radius);
+  padding: 1rem 1.15rem;
+  box-shadow: var(--dc-shadow);
+}
+.dc-timeline-card h3 { margin: 0.4rem 0; font-size: 1rem; }
+.dc-timeline-card p { margin: 0.4rem 0 0; font-size: 0.9rem; }
+
+.dc-type-tag {
+  display: inline-block;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.dc-type-milestone { background: rgba(19,136,8,0.12); color: var(--dc-green); }
+.dc-type-historic-tie { background: rgba(212,175,55,0.18); color: #8a6d1c; }
+.dc-type-final { background: rgba(255,153,51,0.18); color: #b5651d; }
+
+.dc-source { font-style: italic; font-size: 0.75rem; color: var(--dc-muted); }
+
+/* Players */
+.dc-players-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.25rem;
+}
+.dc-player-card {
+  background: var(--dc-card-bg);
+  border: 1px solid var(--dc-border);
+  border-radius: var(--dc-radius);
+  box-shadow: var(--dc-shadow);
+  padding: 1.25rem;
+  transition: transform 0.15s ease;
+}
+.dc-player-card:hover { transform: translateY(-3px); }
+.dc-player-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
+.dc-player-icon { font-size: 1.8rem; }
+.dc-player-era {
+  background: var(--dc-navy);
+  color: #fff;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+.dc-player-card h3 { margin: 0.2rem 0 0.3rem; font-size: 1.05rem; }
+.dc-player-record {
+  font-weight: 600;
+  color: var(--dc-saffron);
+  font-size: 0.9rem;
+  margin: 0 0 0.5rem;
+}
+.dc-player-desc { font-size: 0.9rem; margin: 0 0 0.5rem; }
+
+/* Finals */
+.dc-finals-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.25rem;
+}
+.dc-final-card {
+  background: var(--dc-card-bg);
+  border: 1px solid var(--dc-border);
+  border-radius: var(--dc-radius);
+  box-shadow: var(--dc-shadow);
+  padding: 1.25rem;
+}
+.dc-final-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
+.dc-final-year { font-size: 1.3rem; font-weight: 800; color: var(--dc-navy); }
+.dc-final-result {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #fff;
+}
+.dc-result-lost { background: #B91C1C; }
+.dc-result-forfeited { background: #6B7280; }
+
+.dc-final-card h3 { margin: 0.3rem 0; }
+.dc-final-venue { font-style: italic; color: var(--dc-muted); font-size: 0.88rem; margin: 0.2rem 0; }
+.dc-final-players, .dc-final-summary { font-size: 0.9rem; margin: 0.4rem 0; }
+
+.dc-empty-msg { text-align: center; padding: 2.5rem 1rem; color: var(--dc-muted); }
+
+/* Footer */
+.dc-footer {
+  text-align: center;
+  padding: 1.5rem;
+  color: var(--dc-muted);
+  font-size: 0.82rem;
+}

--- a/frontend/davis-cup-explorer/davis-cup-explorer.min.js
+++ b/frontend/davis-cup-explorer/davis-cup-explorer.min.js
@@ -1,0 +1,362 @@
+/**
+ * davis-cup-explorer.js
+ * India's Davis Cup Journey - Timeline, Players, and Finals Archive
+ * Pure Vanilla JavaScript with ESM export support for Vitest unit testing.
+ */
+
+// Chronological timeline of India's major Davis Cup milestones (fact-checked)
+export const davisCupTimeline = [
+  {
+    id: "debut-1921",
+    year: 1921,
+    title: "India's Davis Cup Debut",
+    type: "Milestone",
+    description: "India competed in its first Davis Cup, entering the International Lawn Tennis Challenge as British India, decades before independence.",
+    source: "ITF / Wikipedia — India Davis Cup team"
+  },
+  {
+    id: "first-win-1938",
+    year: 1938,
+    title: "First Tie Win",
+    type: "Milestone",
+    description: "India won its first recorded Davis Cup tie, advancing past Austria in the Europe Zone second round.",
+    source: "ITF Davis Cup archives"
+  },
+  {
+    id: "independence-1947",
+    year: 1947,
+    title: "Post-Independence Team",
+    type: "Milestone",
+    description: "Following independence, the Davis Cup team transitioned to representing the sovereign Republic of India, with the All India Tennis Association overseeing the program.",
+    source: "Grokipedia — India Davis Cup team"
+  },
+  {
+    id: "first-interzone-1956",
+    year: 1956,
+    title: "First Inter-Zone Final",
+    type: "Milestone",
+    description: "Under captain Naresh Kumar, India reached its first Inter-Zone final, losing to the United States after a decade of building depth in the Eastern Zone.",
+    source: "Grokipedia — India Davis Cup team"
+  },
+  {
+    id: "krishnan-laver-1959",
+    year: 1959,
+    title: "Krishnan Defeats Laver",
+    type: "Historic Tie",
+    description: "India reached the Inter-Zone final against Australia. A young Ramanathan Krishnan defeated future Grand Slam champion Rod Laver in singles, though India lost the tie.",
+    source: "Grokipedia — India Davis Cup team"
+  },
+  {
+    id: "final-1966",
+    year: 1966,
+    title: "First Davis Cup Final",
+    type: "Final",
+    description: "India reached its first Davis Cup final (then the Challenge Round), led by Ramanathan Krishnan and Jaideep Mukerjea, after defeating Brazil and West Germany. India lost the final to Australia.",
+    source: "Wikipedia — India Davis Cup team"
+  },
+  {
+    id: "final-1974-forfeit",
+    year: 1974,
+    title: "The Forfeited Final",
+    type: "Final",
+    description: "India reached the final again after upsetting defending champion Australia in the quarterfinals (Jasjit Singh beat Bob Giltinan; Vijay Amritraj's team excelled). India then forfeited the final against apartheid-era South Africa on the Indian government's orders — the only Davis Cup final in history never played.",
+    source: "The Federal — '1974 Davis Cup final: When India forfeited the tie'"
+  },
+  {
+    id: "final-1987",
+    year: 1987,
+    title: "Third Davis Cup Final",
+    type: "Final",
+    description: "Led by Vijay and Anand Amritraj plus Ramesh Krishnan, India upset Australia in the semifinal to reach a third final — but lost 5-0 to Sweden (Mats Wilander, Joakim Nystrom) in Gothenburg.",
+    source: "Wikipedia — 1987 Davis Cup; Tennis Majors"
+  },
+  {
+    id: "paes-bhupathi-2004",
+    year: 2004,
+    title: "Paes-Bhupathi Doubles Pairing",
+    type: "Historic Tie",
+    description: "Leander Paes and Mahesh Bhupathi paired up in Davis Cup doubles for India, going on to become the nation's most successful doubles team (25-2 win/loss record together).",
+    source: "iloveindia.com — India in Davis Cup"
+  },
+  {
+    id: "world-group-2011",
+    year: 2011,
+    title: "Last World Group Appearance",
+    type: "Milestone",
+    description: "India's most recent appearance in the elite 16-nation World Group ended in a 4-1 defeat to Serbia; India has not qualified for the World Group since.",
+    source: "Wikipedia — India Davis Cup team"
+  }
+];
+
+// Famous Indian Davis Cup players (fact-checked career records)
+export const davisCupPlayers = [
+  {
+    id: "ramanathan-krishnan",
+    name: "Ramanathan Krishnan",
+    era: "1953–1975",
+    icon: "🎾",
+    record: "Most singles wins: 50–19",
+    description: "India's most successful Davis Cup singles player, he led India to its first Davis Cup final in 1966 and famously defeated future champion Rod Laver in 1959.",
+    source: "Wikipedia — India Davis Cup team"
+  },
+  {
+    id: "leander-paes",
+    name: "Leander Paes",
+    era: "1990–2016",
+    icon: "🏆",
+    record: "Most total wins: 93–35 · Most doubles wins: 45–13 · Most ties played: 58 · Most years played: 30",
+    description: "India's most decorated Davis Cup player by every major career metric — wins, ties played, and years of service to the team.",
+    source: "Wikipedia — India Davis Cup team"
+  },
+  {
+    id: "mahesh-bhupathi",
+    name: "Mahesh Bhupathi",
+    era: "1995–2011",
+    icon: "🎾",
+    record: "Best doubles team with Paes: 25–2",
+    description: "Paired with Leander Paes to form India's most successful Davis Cup doubles partnership, and later served as India's Davis Cup captain.",
+    source: "Wikipedia — India Davis Cup team"
+  },
+  {
+    id: "vijay-amritraj",
+    name: "Vijay Amritraj",
+    era: "1970–1987",
+    icon: "🎾",
+    record: "Led India to the 1974 and 1987 finals",
+    description: "The face of Indian tennis through the 1970s and 80s, Vijay Amritraj anchored India's Davis Cup team through two of its three final appearances.",
+    source: "The Federal; Tennis Majors"
+  },
+  {
+    id: "anand-amritraj",
+    name: "Anand Amritraj",
+    era: "1968–1987",
+    icon: "🎾",
+    record: "Doubles partner in the 1974 and 1987 finals",
+    description: "Vijay's elder brother and long-time doubles partner, Anand played alongside him in India's Davis Cup campaigns of the 1970s and 80s.",
+    source: "Tennis Majors"
+  },
+  {
+    id: "ramesh-krishnan",
+    name: "Ramesh Krishnan",
+    era: "1979–1993",
+    icon: "🎾",
+    record: "India's top-ranked singles player in the 1987 run",
+    description: "Son of Ramanathan Krishnan, he was India's only top-100-ranked singles player during the improbable 1987 run to the final.",
+    source: "Tennis Majors"
+  }
+];
+
+// The three Davis Cup finals India has reached (India has never won)
+export const davisCupFinals = [
+  {
+    id: "final-1966",
+    year: 1966,
+    opponent: "Australia",
+    result: "Lost",
+    venue: "Challenge Round",
+    keyPlayers: "Ramanathan Krishnan, Jaideep Mukerjea",
+    summary: "India's first Davis Cup final. India defeated Brazil and West Germany en route before losing the Challenge Round to Australia.",
+    source: "Wikipedia — India Davis Cup team"
+  },
+  {
+    id: "final-1974",
+    year: 1974,
+    opponent: "South Africa",
+    result: "Forfeited",
+    venue: "Never played",
+    keyPlayers: "Vijay Amritraj, Anand Amritraj, Jasjit Singh",
+    summary: "India upset defending champion Australia in the quarterfinals to reach the final, then forfeited on government orders in protest of South African apartheid — the only Davis Cup final in history never played.",
+    source: "The Federal — '1974 Davis Cup final'"
+  },
+  {
+    id: "final-1987",
+    year: 1987,
+    opponent: "Sweden",
+    result: "Lost 5–0",
+    venue: "Gothenburg, Sweden (indoor clay)",
+    keyPlayers: "Vijay Amritraj, Anand Amritraj, Ramesh Krishnan",
+    summary: "With only one top-100 player (Ramesh Krishnan), India upset Australia in the semifinal for one of the tournament's most unlikely final runs, before being swept 5-0 by Mats Wilander's Sweden.",
+    source: "Wikipedia — 1987 Davis Cup; Tennis Majors"
+  }
+];
+
+/**
+ * Get timeline entries sorted chronologically.
+ */
+export function getSortedTimeline(list = davisCupTimeline) {
+  if (!Array.isArray(list)) return [];
+  return [...list].sort((a, b) => a.year - b.year);
+}
+
+/**
+ * Filter timeline entries by type ("all" | "Milestone" | "Historic Tie" | "Final").
+ */
+export function filterTimelineByType(typeFilter = "all", list = davisCupTimeline) {
+  if (!Array.isArray(list)) return [];
+  if (!typeFilter || typeFilter.toLowerCase() === "all") return getSortedTimeline(list);
+  return getSortedTimeline(list).filter(
+    item => item.type.toLowerCase() === typeFilter.toLowerCase()
+  );
+}
+
+/**
+ * Search timeline, players, or finals by free-text query.
+ */
+export function searchDavisCup(query = "") {
+  const q = query.trim().toLowerCase();
+  if (!q) {
+    return { timeline: davisCupTimeline, players: davisCupPlayers, finals: davisCupFinals };
+  }
+  const matches = (obj, fields) =>
+    fields.some(f => obj[f] && obj[f].toString().toLowerCase().includes(q));
+
+  return {
+    timeline: davisCupTimeline.filter(item =>
+      matches(item, ["title", "type", "description", "year"])
+    ),
+    players: davisCupPlayers.filter(item =>
+      matches(item, ["name", "era", "record", "description"])
+    ),
+    finals: davisCupFinals.filter(item =>
+      matches(item, ["opponent", "result", "keyPlayers", "summary", "year"])
+    )
+  };
+}
+
+/* ==========================================================================
+   BROWSER DOM ENGINE
+   ========================================================================== */
+
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  window.davisCupTimeline = davisCupTimeline;
+  window.davisCupPlayers = davisCupPlayers;
+  window.davisCupFinals = davisCupFinals;
+  window.getSortedTimeline = getSortedTimeline;
+  window.filterTimelineByType = filterTimelineByType;
+  window.searchDavisCup = searchDavisCup;
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const timelineContainer = document.getElementById("dc-timeline-container");
+    const playersGrid = document.getElementById("dc-players-grid");
+    const finalsGrid = document.getElementById("dc-finals-grid");
+    const searchInput = document.getElementById("dc-search");
+    const typeBtns = document.querySelectorAll(".btn-dc-type-filter");
+    const viewTabs = document.querySelectorAll(".btn-dc-view-tab");
+
+    let currentType = "all";
+
+    function renderTimeline() {
+      if (!timelineContainer) return;
+      timelineContainer.innerHTML = "";
+
+      const query = searchInput ? searchInput.value : "";
+      let items = query ? searchDavisCup(query).timeline : davisCupTimeline;
+      items = filterTimelineByType(currentType, items);
+
+      if (items.length === 0) {
+        timelineContainer.innerHTML = `<div class="dc-empty-msg"><h3>No results</h3><p>Try a different search term or filter.</p></div>`;
+        return;
+      }
+
+      items.forEach(item => {
+        const node = document.createElement("div");
+        node.className = "dc-timeline-node";
+        node.innerHTML = `
+          <div class="dc-year-pill">📅 ${item.year}</div>
+          <div class="dc-timeline-card">
+            <span class="dc-type-tag dc-type-${item.type.replace(/\s+/g, "-").toLowerCase()}">${item.type}</span>
+            <h3>${item.title}</h3>
+            <p>${item.description}</p>
+            <p class="dc-source">Source: ${item.source}</p>
+          </div>
+        `;
+        timelineContainer.appendChild(node);
+      });
+    }
+
+    function renderPlayers() {
+      if (!playersGrid) return;
+      playersGrid.innerHTML = "";
+
+      const query = searchInput ? searchInput.value : "";
+      const items = query ? searchDavisCup(query).players : davisCupPlayers;
+
+      if (items.length === 0) {
+        playersGrid.innerHTML = `<div class="dc-empty-msg"><h3>No players found</h3></div>`;
+        return;
+      }
+
+      items.forEach(p => {
+        const card = document.createElement("article");
+        card.className = "dc-player-card";
+        card.innerHTML = `
+          <div class="dc-player-header">
+            <span class="dc-player-icon">${p.icon}</span>
+            <span class="dc-player-era">${p.era}</span>
+          </div>
+          <h3>${p.name}</h3>
+          <p class="dc-player-record">${p.record}</p>
+          <p class="dc-player-desc">${p.description}</p>
+          <p class="dc-source">Source: ${p.source}</p>
+        `;
+        playersGrid.appendChild(card);
+      });
+    }
+
+    function renderFinals() {
+      if (!finalsGrid) return;
+      finalsGrid.innerHTML = "";
+
+      davisCupFinals.forEach(f => {
+        const card = document.createElement("article");
+        card.className = "dc-final-card";
+        card.innerHTML = `
+          <div class="dc-final-header">
+            <span class="dc-final-year">${f.year}</span>
+            <span class="dc-final-result dc-result-${f.result.split(" ")[0].toLowerCase()}">${f.result}</span>
+          </div>
+          <h3>India vs. ${f.opponent}</h3>
+          <p class="dc-final-venue">${f.venue}</p>
+          <p class="dc-final-players"><strong>Key players:</strong> ${f.keyPlayers}</p>
+          <p class="dc-final-summary">${f.summary}</p>
+          <p class="dc-source">Source: ${f.source}</p>
+        `;
+        finalsGrid.appendChild(card);
+      });
+    }
+
+    // View tab switching
+    viewTabs.forEach(tab => {
+      tab.addEventListener("click", () => {
+        viewTabs.forEach(t => t.classList.remove("active"));
+        tab.classList.add("active");
+        const target = tab.dataset.view;
+        document.querySelectorAll(".dc-view-panel").forEach(p => p.classList.add("hidden"));
+        document.getElementById(`dc-view-${target}`)?.classList.remove("hidden");
+      });
+    });
+
+    // Type filter (timeline only)
+    typeBtns.forEach(btn => {
+      btn.addEventListener("click", () => {
+        typeBtns.forEach(b => b.classList.remove("active"));
+        btn.classList.add("active");
+        currentType = btn.dataset.type || "all";
+        renderTimeline();
+      });
+    });
+
+    // Search (applies to timeline + players)
+    if (searchInput) {
+      searchInput.addEventListener("input", () => {
+        renderTimeline();
+        renderPlayers();
+      });
+    }
+
+    // Initial render
+    renderTimeline();
+    renderPlayers();
+    renderFinals();
+  });
+}

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -3807,17 +3807,27 @@ window.indiaSearchIndex = [
     {
         title: 'Swargarohini Mountain Explorer',
         category: 'Mountains & Geography',
-        description:
-            'Dedicated explorer for Swargarohini, a 6,252 m high massif in the Garhwal Himalayas of Uttarakhand, featuring mythological history, trekking routes, map locations, image gallery, and FAQs.',
+        description: 'Dedicated explorer for Swargarohini, a 6,252 m high massif in the Garhwal Himalayas of Uttarakhand, featuring mythological history, trekking routes, map locations, image gallery, and FAQs.',
         url: 'frontend/swargarohini/swargarohini.html'
     },
     // --- Bandarpoonch Mountain ---
     {
         title: 'Bandarpoonch Mountain Explorer',
         category: 'Mountains & Geography',
-        description:
-            'Dedicated explorer for Bandarpoonch, a 6,316 m high peak in the Garhwal Himalayas of Uttarakhand, featuring facts, map locations, image gallery, trekking details, and FAQs.',
+        description:'Dedicated explorer for Bandarpoonch, a 6,316 m high peak in the Garhwal Himalayas of Uttarakhand, featuring facts, map locations, image gallery, trekking details, and FAQs.',
         url: 'frontend/bandarpoonch/bandarpoonch.html'
+    },
+    {
+        title: "Davis Cup: Explore India's Tennis Journey",
+        category: "Sports & Culture",
+        description: "Interactive archive of India's Davis Cup history since 1921 — 3 finals (1966, 1974 forfeit, 1987), key players (Leander Paes, Amritraj brothers), and a searchable, filterable timeline with sources.",
+        url: "frontend/davis-cup-explorer/davis-cup-explorer.html"
+    },
+    {
+        title: "Thomas Cup: India's Badminton Journey",
+        category: "Sports & Culture",
+        description: "Interactive archive of India's Thomas Cup history since 1952 — maiden 2022 title over Indonesia, top-4 finishes (1952, 1955, 1979), key players (Prakash Padukone, Lakshya Sen, Satwik-Chirag), and a searchable timeline with sources.",
+        url: "frontend/thomas-cup-explorer/thomas-cup-explorer.html"
     },
     // --- India's Firsts Encyclopedia ---
     {


### PR DESCRIPTION
Closes #2542

Interactive archive of India's Davis Cup history since 1921.

**Includes:**
- Timeline (10 milestones, 1921–2011) — filterable by Milestone/Historic Tie/Final
- Players (6 cards) — Ramanathan Krishnan, Leander Paes, Mahesh Bhupathi, Vijay & Anand Amritraj, Ramesh Krishnan, with verified career records
- Finals (all 3 India has reached) — 1966 vs Australia, 1974 forfeit vs South Africa, 1987 vs Sweden
- Search across timeline + players

Sources: Wikipedia/ITF Davis Cup records, The Federal, Tennis Majors — cited per card.

Tested locally via `python -m http.server 8080`.
<img width="1440" height="852" alt="Screenshot 2026-08-16 173348" src="https://github.com/user-attachments/assets/5f028fa8-4076-4b68-9f33-f2ac463fbd7e" />
<img width="1440" height="852" alt="Screenshot 2026-08-16 173353" src="https://github.com/user-attachments/assets/b36def6a-ceb8-403a-989a-e4d2bf2550bf" />
<img width="1440" height="852" alt="Screenshot 2026-08-16 173358" src="https://github.com/user-attachments/assets/cc98e3f7-6743-4858-be21-99ac1848d5d1" />
