### PR TITLE
Thomas Cup: India's Badminton Journey — interactive timeline, players & campaigns archive

### DIFF
--- a/frontend/thomas-cup-explorer/thomas-cup-explorer.css
+++ b/frontend/thomas-cup-explorer/thomas-cup-explorer.css
@@ -1,0 +1,253 @@
+/* thomas-cup-explorer.css
+   Styling for Thomas Cup: India's Badminton Journey. Mirrors the site's design language. */
+
+:root {
+  --tc-saffron: #FF9933;
+  --tc-green: #138808;
+  --tc-navy: #0B1F3A;
+  --tc-gold: #D4AF37;
+  --tc-bg: #FAFAF7;
+  --tc-card-bg: #FFFFFF;
+  --tc-text: #1C1C1C;
+  --tc-muted: #6B7280;
+  --tc-border: #E5E7EB;
+  --tc-radius: 14px;
+  --tc-shadow: 0 4px 14px rgba(11, 31, 58, 0.08);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", Roboto, -apple-system, sans-serif;
+  background: var(--tc-bg);
+  color: var(--tc-text);
+}
+
+.hidden { display: none !important; }
+
+/* Hero */
+.tc-hero {
+  background: linear-gradient(135deg, var(--tc-saffron), var(--tc-navy) 70%, var(--tc-green));
+  color: #fff;
+  padding: 3rem 1.5rem 2.5rem;
+  text-align: center;
+}
+.tc-hero h1 { margin: 0 0 0.5rem; font-size: clamp(1.8rem, 4vw, 2.6rem); }
+.tc-hero p { margin: 0 auto; max-width: 640px; opacity: 0.92; }
+
+.tc-main-container {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 3rem;
+}
+
+/* Overview strip */
+.tc-overview-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.75rem;
+}
+.tc-overview-stat {
+  background: var(--tc-card-bg);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius);
+  box-shadow: var(--tc-shadow);
+  padding: 1rem;
+  text-align: center;
+}
+.tc-stat-value {
+  display: block;
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--tc-navy);
+}
+.tc-stat-label {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--tc-muted);
+  margin-top: 0.2rem;
+}
+
+/* View Tabs */
+.tc-view-tabs-nav {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+}
+.btn-tc-view-tab {
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  border: 2px solid var(--tc-border);
+  background: var(--tc-card-bg);
+  cursor: pointer;
+  font-weight: 600;
+  transition: all 0.2s ease;
+}
+.btn-tc-view-tab:hover { border-color: var(--tc-saffron); }
+.btn-tc-view-tab.active {
+  background: var(--tc-navy);
+  border-color: var(--tc-navy);
+  color: #fff;
+}
+
+/* Controls */
+.tc-controls-bar { margin-bottom: 1rem; }
+.tc-search-input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: var(--tc-radius);
+  border: 2px solid var(--tc-border);
+  font-size: 1rem;
+}
+.tc-search-input:focus { outline: none; border-color: var(--tc-saffron); }
+
+.tc-type-filter-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.25rem;
+}
+.btn-tc-type-filter {
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--tc-border);
+  background: #fff;
+  font-size: 0.85rem;
+  cursor: pointer;
+  color: var(--tc-muted);
+}
+.btn-tc-type-filter.active {
+  background: var(--tc-saffron);
+  border-color: var(--tc-saffron);
+  color: #fff;
+}
+
+/* Timeline */
+.tc-timeline-container {
+  position: relative;
+  padding-left: 2rem;
+  border-left: 3px solid var(--tc-saffron);
+}
+.tc-timeline-node { position: relative; margin-bottom: 1.75rem; }
+.tc-timeline-node::before {
+  content: "";
+  position: absolute;
+  left: -2.42rem;
+  top: 0.3rem;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--tc-gold);
+  border: 3px solid var(--tc-card-bg);
+  box-shadow: 0 0 0 2px var(--tc-saffron);
+}
+.tc-year-pill {
+  display: inline-block;
+  background: var(--tc-navy);
+  color: #fff;
+  padding: 0.2rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+}
+.tc-timeline-card {
+  background: var(--tc-card-bg);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius);
+  padding: 1rem 1.15rem;
+  box-shadow: var(--tc-shadow);
+}
+.tc-timeline-card h3 { margin: 0.4rem 0; font-size: 1rem; }
+.tc-timeline-card p { margin: 0.4rem 0 0; font-size: 0.9rem; }
+
+.tc-type-tag {
+  display: inline-block;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.tc-type-milestone { background: rgba(19,136,8,0.12); color: var(--tc-green); }
+.tc-type-historic-tie { background: rgba(212,175,55,0.18); color: #8a6d1c; }
+.tc-type-final { background: rgba(255,153,51,0.18); color: #b5651d; }
+
+.tc-source { font-style: italic; font-size: 0.75rem; color: var(--tc-muted); }
+
+/* Players */
+.tc-players-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.25rem;
+}
+.tc-player-card {
+  background: var(--tc-card-bg);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius);
+  box-shadow: var(--tc-shadow);
+  padding: 1.25rem;
+  transition: transform 0.15s ease;
+}
+.tc-player-card:hover { transform: translateY(-3px); }
+.tc-player-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
+.tc-player-icon { font-size: 1.8rem; }
+.tc-player-era {
+  background: var(--tc-navy);
+  color: #fff;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+.tc-player-card h3 { margin: 0.2rem 0 0.3rem; font-size: 1.05rem; }
+.tc-player-role {
+  font-weight: 600;
+  color: var(--tc-saffron);
+  font-size: 0.9rem;
+  margin: 0 0 0.5rem;
+}
+.tc-player-desc { font-size: 0.9rem; margin: 0 0 0.5rem; }
+
+/* Campaigns */
+.tc-campaigns-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.25rem;
+}
+.tc-campaign-card {
+  background: var(--tc-card-bg);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius);
+  box-shadow: var(--tc-shadow);
+  padding: 1.25rem;
+}
+.tc-campaign-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
+.tc-campaign-year { font-size: 1.3rem; font-weight: 800; color: var(--tc-navy); }
+.tc-campaign-result {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #fff;
+}
+.tc-result-champion { background: var(--tc-green); }
+.tc-result-qf { background: #6B7280; }
+.tc-result-top4 { background: var(--tc-gold); color: #3a2f0a; }
+
+.tc-campaign-summary { font-size: 0.9rem; margin: 0.4rem 0; }
+
+.tc-empty-msg { text-align: center; padding: 2.5rem 1rem; color: var(--tc-muted); }
+
+/* Footer */
+.tc-footer {
+  text-align: center;
+  padding: 1.5rem;
+  color: var(--tc-muted);
+  font-size: 0.82rem;
+}

--- a/frontend/thomas-cup-explorer/thomas-cup-explorer.html
+++ b/frontend/thomas-cup-explorer/thomas-cup-explorer.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Thomas Cup: India's Badminton Journey — an interactive archive of India's Thomas Cup history since 1952, including India's historic maiden title in 2022, top-4 finishes in 1952/1955/1979, key players like Prakash Padukone, Lakshya Sen, and Satwiksairaj Rankireddy & Chirag Shetty, and a searchable performance timeline.">
+  <title>Thomas Cup: India's Badminton Journey | Incredible India Explorer</title>
+  <link rel="stylesheet" href="thomas-cup-explorer.min.css">
+</head>
+<body>
+
+  <header class="tc-hero">
+    <h1>🏸 Thomas Cup: India's Badminton Journey</h1>
+    <p>From India's 1952 debut to a historic maiden title in 2022 — the story of India's rise in world men's team badminton.</p>
+  </header>
+
+  <main class="tc-main-container">
+
+    <!-- Trophy / Overview strip -->
+    <section class="tc-overview-strip">
+      <div class="tc-overview-stat">
+        <span class="tc-stat-value">1952</span>
+        <span class="tc-stat-label">India's debut</span>
+      </div>
+      <div class="tc-overview-stat">
+        <span class="tc-stat-value">2022</span>
+        <span class="tc-stat-label">Maiden title 🏆</span>
+      </div>
+      <div class="tc-overview-stat">
+        <span class="tc-stat-value">3</span>
+        <span class="tc-stat-label">Top-4 finishes before 2022 (1952, 1955, 1979)</span>
+      </div>
+      <div class="tc-overview-stat">
+        <span class="tc-stat-value">73</span>
+        <span class="tc-stat-label">Years to first title (est. 1949)</span>
+      </div>
+    </section>
+
+    <nav class="tc-view-tabs-nav" aria-label="View mode">
+      <button type="button" class="btn-tc-view-tab active" data-view="timeline">📅 Timeline</button>
+      <button type="button" class="btn-tc-view-tab" data-view="players">🏸 Players</button>
+      <button type="button" class="btn-tc-view-tab" data-view="campaigns">🏆 Campaigns</button>
+    </nav>
+
+    <div class="tc-controls-bar">
+      <input
+        type="search"
+        id="tc-search"
+        class="tc-search-input"
+        placeholder="Search by player, year, or event..."
+        aria-label="Search Thomas Cup history"
+      >
+    </div>
+
+    <!-- TIMELINE VIEW -->
+    <section id="tc-view-timeline" class="tc-view-panel">
+      <div class="tc-type-filter-row">
+        <button type="button" class="btn-tc-type-filter active" data-type="all">All</button>
+        <button type="button" class="btn-tc-type-filter" data-type="Milestone">Milestones</button>
+        <button type="button" class="btn-tc-type-filter" data-type="Historic Tie">Historic Ties</button>
+        <button type="button" class="btn-tc-type-filter" data-type="Final">Finals</button>
+      </div>
+      <div id="tc-timeline-container" class="tc-timeline-container" aria-live="polite"></div>
+    </section>
+
+    <!-- PLAYERS VIEW -->
+    <section id="tc-view-players" class="tc-view-panel hidden">
+      <div id="tc-players-grid" class="tc-players-grid" aria-live="polite"></div>
+    </section>
+
+    <!-- CAMPAIGNS VIEW -->
+    <section id="tc-view-campaigns" class="tc-view-panel hidden">
+      <div id="tc-campaigns-grid" class="tc-campaigns-grid"></div>
+    </section>
+
+  </main>
+
+  <footer class="tc-footer">
+    <p>History fact-checked against BWF Thomas Cup records, Wikipedia, Olympics.com, and contemporary match reports. See in-card sources for each entry.</p>
+  </footer>
+
+  <script src="thomas-cup-explorer.min.js" type="module"></script>
+</body>
+</html>

--- a/frontend/thomas-cup-explorer/thomas-cup-explorer.js
+++ b/frontend/thomas-cup-explorer/thomas-cup-explorer.js
@@ -1,0 +1,344 @@
+/**
+ * thomas-cup-explorer.js
+ * Thomas Cup: India's Badminton Journey - Timeline, Players, and Campaign Archive
+ * Pure Vanilla JavaScript with ESM export support for Vitest unit testing.
+ */
+
+// Chronological timeline of India's major Thomas Cup milestones (fact-checked)
+export const thomasCupTimeline = [
+  {
+    id: "trophy-founded-1939",
+    year: 1939,
+    title: "The Thomas Cup Is Conceived",
+    type: "Milestone",
+    description: "Sir George Alan Thomas, founder-president of the International Badminton Federation, proposed a world men's team championship and commissioned the silver-gilt trophy — delayed a decade by World War II.",
+    source: "BWF Thomas & Uber Cup History"
+  },
+  {
+    id: "inaugural-1949",
+    year: 1949,
+    title: "Inaugural Thomas Cup",
+    type: "Milestone",
+    description: "The first Thomas Cup was held in England; Malaya (now Malaysia) defeated Denmark 8-1 in the final to become the first name on the trophy. India did not compete in this edition.",
+    source: "Wikipedia — 1949 Thomas Cup"
+  },
+  {
+    id: "india-debut-1952",
+    year: 1952,
+    title: "India's Thomas Cup Debut",
+    type: "Milestone",
+    description: "India made its Thomas Cup debut and reached the top four under the tournament's early format, where only finalists (the last four teams) earned medals — India's first bronze-equivalent finish.",
+    source: "The Bridge — 'India's history at Thomas Cup'"
+  },
+  {
+    id: "second-top4-1955",
+    year: 1955,
+    title: "Second Top-Four Finish",
+    type: "Milestone",
+    description: "India repeated its strong debut form, again reaching the top four before losing 3-6 to Denmark.",
+    source: "The Bridge — 'India's history at Thomas Cup'"
+  },
+  {
+    id: "padukone-1979",
+    year: 1979,
+    title: "Padukone-Led Campaign",
+    type: "Historic Tie",
+    description: "Led by a young Prakash Padukone, India again reached the top four — one of its best pre-2022 campaigns — before losing to Denmark. India would not match this run for over four decades.",
+    source: "The Bridge; Wikipedia — 1979 Thomas Cup squads"
+  },
+  {
+    id: "semifinal-2022",
+    year: 2022,
+    title: "Return to the Semifinals",
+    type: "Historic Tie",
+    description: "India reached the Thomas Cup semifinals for the first time in 43 years, beating Malaysia 3-2 in the quarterfinal before advancing.",
+    source: "Sportskeeda — Thomas Cup 2022 preview"
+  },
+  {
+    id: "final-champions-2022",
+    year: 2022,
+    title: "Maiden Title",
+    type: "Final",
+    description: "India beat Denmark 3-2 in the semifinal to reach its first-ever final, then stunned 14-time champions Indonesia 3-0 in Bangkok to win the Thomas Cup for the first time in the tournament's 73-year history.",
+    source: "Olympics.com; Gulf News — Thomas Cup 2022"
+  },
+  {
+    id: "title-defense-2024",
+    year: 2024,
+    title: "Title Defense Ends in Quarterfinals",
+    type: "Milestone",
+    description: "As defending champions in Chengdu, China, India reached the quarterfinals after group-stage wins over Thailand and England, but lost 1-3 to host nation China, ending their title defense.",
+    source: "Khel Now; ESPN — Thomas & Uber Cup 2024"
+  }
+];
+
+// Key Indian players across Thomas Cup history (fact-checked)
+export const thomasCupPlayers = [
+  {
+    id: "prakash-padukone",
+    name: "Prakash Padukone",
+    era: "1970s–1991",
+    icon: "🏸",
+    role: "Singles legend",
+    description: "Led India's standout 1979 Thomas Cup campaign to the top four. He went on to become India's first World No. 1 and the first Indian to win the All England Championships (1980).",
+    source: "Britannica — Prakash Padukone"
+  },
+  {
+    id: "kidambi-srikanth",
+    name: "Kidambi Srikanth",
+    era: "2013–present",
+    icon: "🏸",
+    role: "Singles, 2022 title-winning shot",
+    description: "Sealed India's historic 2022 final win, defeating higher-ranked Jonatan Christie in straight games to complete the 3-0 sweep of Indonesia.",
+    source: "Sportskeeda — Thomas Cup 2022"
+  },
+  {
+    id: "lakshya-sen",
+    name: "Lakshya Sen",
+    era: "2018–present",
+    icon: "🏸",
+    role: "Singles, opened the 2022 final",
+    description: "Then 20 years old, Sen opened India's 2022 final by beating world No. 4 Anthony Ginting after dropping the first game — setting the tone for India's title run.",
+    source: "Sportsunfold — Thomas Cup 2022"
+  },
+  {
+    id: "satwik-chirag",
+    name: "Satwiksairaj Rankireddy & Chirag Shetty",
+    era: "2016–present",
+    icon: "🏸",
+    role: "Doubles pair",
+    description: "India's premier doubles pairing sealed the second point of the 2022 final over Indonesia's Ahsan/Sukamuljo, and remain central to India's Thomas Cup campaigns since.",
+    source: "Gulf News — Thomas Cup 2022"
+  },
+  {
+    id: "hs-prannoy",
+    name: "H. S. Prannoy",
+    era: "2010–present",
+    icon: "🏸",
+    role: "Singles, 2024 campaign",
+    description: "India's senior singles player during the 2024 title defense, winning key group-stage and quarterfinal rubbers in Chengdu before India's run ended against China.",
+    source: "Khel Now — Thomas & Uber Cup 2024"
+  }
+];
+
+// India's notable Thomas Cup campaigns/results
+export const thomasCupCampaigns = [
+  {
+    id: "campaign-1952",
+    year: 1952,
+    result: "Top 4 (bronze-equivalent)",
+    summary: "India's Thomas Cup debut. Under the pre-1984 format, only the last four teams earned medals — India reached that stage in its first appearance.",
+    source: "The Bridge — 'India's history at Thomas Cup'"
+  },
+  {
+    id: "campaign-1955",
+    year: 1955,
+    result: "Top 4 (bronze-equivalent)",
+    summary: "India again reached the top four before losing 3-6 to Denmark.",
+    source: "The Bridge — 'India's history at Thomas Cup'"
+  },
+  {
+    id: "campaign-1979",
+    year: 1979,
+    result: "Top 4 (bronze-equivalent)",
+    summary: "Led by Prakash Padukone, India reached the top four again before losing to Denmark — a campaign India would not equal for 43 years.",
+    source: "The Bridge; Wikipedia — 1979 Thomas Cup squads"
+  },
+  {
+    id: "campaign-2022",
+    year: 2022,
+    result: "Champions 🏆",
+    summary: "India's maiden Thomas Cup title. Group stage: beat Germany 5-0 and Canada 5-0, lost 2-3 to Chinese Taipei. Knockouts: beat Malaysia 3-2 (QF), Denmark 3-2 (SF), and Indonesia 3-0 in the final.",
+    source: "Sportsunfold; Olympics.com — Thomas Cup 2022"
+  },
+  {
+    id: "campaign-2024",
+    year: 2024,
+    result: "Quarterfinals",
+    summary: "As defending champions, India beat Thailand 4-1 and England 5-0 in the group stage before losing 1-3 to host China in the quarterfinals.",
+    source: "Khel Now; ESPN — Thomas & Uber Cup 2024"
+  }
+];
+
+/**
+ * Get timeline entries sorted chronologically.
+ */
+export function getSortedTimeline(list = thomasCupTimeline) {
+  if (!Array.isArray(list)) return [];
+  return [...list].sort((a, b) => a.year - b.year);
+}
+
+/**
+ * Filter timeline entries by type ("all" | "Milestone" | "Historic Tie" | "Final").
+ */
+export function filterTimelineByType(typeFilter = "all", list = thomasCupTimeline) {
+  if (!Array.isArray(list)) return [];
+  if (!typeFilter || typeFilter.toLowerCase() === "all") return getSortedTimeline(list);
+  return getSortedTimeline(list).filter(
+    item => item.type.toLowerCase() === typeFilter.toLowerCase()
+  );
+}
+
+/**
+ * Search timeline, players, or campaigns by free-text query.
+ */
+export function searchThomasCup(query = "") {
+  const q = query.trim().toLowerCase();
+  if (!q) {
+    return { timeline: thomasCupTimeline, players: thomasCupPlayers, campaigns: thomasCupCampaigns };
+  }
+  const matches = (obj, fields) =>
+    fields.some(f => obj[f] && obj[f].toString().toLowerCase().includes(q));
+
+  return {
+    timeline: thomasCupTimeline.filter(item =>
+      matches(item, ["title", "type", "description", "year"])
+    ),
+    players: thomasCupPlayers.filter(item =>
+      matches(item, ["name", "era", "role", "description"])
+    ),
+    campaigns: thomasCupCampaigns.filter(item =>
+      matches(item, ["result", "summary", "year"])
+    )
+  };
+}
+
+/* ==========================================================================
+   BROWSER DOM ENGINE
+   ========================================================================== */
+
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  window.thomasCupTimeline = thomasCupTimeline;
+  window.thomasCupPlayers = thomasCupPlayers;
+  window.thomasCupCampaigns = thomasCupCampaigns;
+  window.getSortedTimeline = getSortedTimeline;
+  window.filterTimelineByType = filterTimelineByType;
+  window.searchThomasCup = searchThomasCup;
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const timelineContainer = document.getElementById("tc-timeline-container");
+    const playersGrid = document.getElementById("tc-players-grid");
+    const campaignsGrid = document.getElementById("tc-campaigns-grid");
+    const searchInput = document.getElementById("tc-search");
+    const typeBtns = document.querySelectorAll(".btn-tc-type-filter");
+    const viewTabs = document.querySelectorAll(".btn-tc-view-tab");
+
+    let currentType = "all";
+
+    function renderTimeline() {
+      if (!timelineContainer) return;
+      timelineContainer.innerHTML = "";
+
+      const query = searchInput ? searchInput.value : "";
+      let items = query ? searchThomasCup(query).timeline : thomasCupTimeline;
+      items = filterTimelineByType(currentType, items);
+
+      if (items.length === 0) {
+        timelineContainer.innerHTML = `<div class="tc-empty-msg"><h3>No results</h3><p>Try a different search term or filter.</p></div>`;
+        return;
+      }
+
+      items.forEach(item => {
+        const node = document.createElement("div");
+        node.className = "tc-timeline-node";
+        node.innerHTML = `
+          <div class="tc-year-pill">📅 ${item.year}</div>
+          <div class="tc-timeline-card">
+            <span class="tc-type-tag tc-type-${item.type.replace(/\s+/g, "-").toLowerCase()}">${item.type}</span>
+            <h3>${item.title}</h3>
+            <p>${item.description}</p>
+            <p class="tc-source">Source: ${item.source}</p>
+          </div>
+        `;
+        timelineContainer.appendChild(node);
+      });
+    }
+
+    function renderPlayers() {
+      if (!playersGrid) return;
+      playersGrid.innerHTML = "";
+
+      const query = searchInput ? searchInput.value : "";
+      const items = query ? searchThomasCup(query).players : thomasCupPlayers;
+
+      if (items.length === 0) {
+        playersGrid.innerHTML = `<div class="tc-empty-msg"><h3>No players found</h3></div>`;
+        return;
+      }
+
+      items.forEach(p => {
+        const card = document.createElement("article");
+        card.className = "tc-player-card";
+        card.innerHTML = `
+          <div class="tc-player-header">
+            <span class="tc-player-icon">${p.icon}</span>
+            <span class="tc-player-era">${p.era}</span>
+          </div>
+          <h3>${p.name}</h3>
+          <p class="tc-player-role">${p.role}</p>
+          <p class="tc-player-desc">${p.description}</p>
+          <p class="tc-source">Source: ${p.source}</p>
+        `;
+        playersGrid.appendChild(card);
+      });
+    }
+
+    function renderCampaigns() {
+      if (!campaignsGrid) return;
+      campaignsGrid.innerHTML = "";
+
+      thomasCupCampaigns.forEach(c => {
+        const card = document.createElement("article");
+        card.className = "tc-campaign-card";
+        const resultClass = c.result.toLowerCase().includes("champion")
+          ? "tc-result-champion"
+          : c.result.toLowerCase().includes("quarterfinal")
+          ? "tc-result-qf"
+          : "tc-result-top4";
+        card.innerHTML = `
+          <div class="tc-campaign-header">
+            <span class="tc-campaign-year">${c.year}</span>
+            <span class="tc-campaign-result ${resultClass}">${c.result}</span>
+          </div>
+          <p class="tc-campaign-summary">${c.summary}</p>
+          <p class="tc-source">Source: ${c.source}</p>
+        `;
+        campaignsGrid.appendChild(card);
+      });
+    }
+
+    // View tab switching
+    viewTabs.forEach(tab => {
+      tab.addEventListener("click", () => {
+        viewTabs.forEach(t => t.classList.remove("active"));
+        tab.classList.add("active");
+        const target = tab.dataset.view;
+        document.querySelectorAll(".tc-view-panel").forEach(p => p.classList.add("hidden"));
+        document.getElementById(`tc-view-${target}`)?.classList.remove("hidden");
+      });
+    });
+
+    // Type filter (timeline only)
+    typeBtns.forEach(btn => {
+      btn.addEventListener("click", () => {
+        typeBtns.forEach(b => b.classList.remove("active"));
+        btn.classList.add("active");
+        currentType = btn.dataset.type || "all";
+        renderTimeline();
+      });
+    });
+
+    // Search (applies to timeline + players)
+    if (searchInput) {
+      searchInput.addEventListener("input", () => {
+        renderTimeline();
+        renderPlayers();
+      });
+    }
+
+    // Initial render
+    renderTimeline();
+    renderPlayers();
+    renderCampaigns();
+  });
+}

--- a/frontend/thomas-cup-explorer/thomas-cup-explorer.min.css
+++ b/frontend/thomas-cup-explorer/thomas-cup-explorer.min.css
@@ -1,0 +1,253 @@
+/* thomas-cup-explorer.css
+   Styling for Thomas Cup: India's Badminton Journey. Mirrors the site's design language. */
+
+:root {
+  --tc-saffron: #FF9933;
+  --tc-green: #138808;
+  --tc-navy: #0B1F3A;
+  --tc-gold: #D4AF37;
+  --tc-bg: #FAFAF7;
+  --tc-card-bg: #FFFFFF;
+  --tc-text: #1C1C1C;
+  --tc-muted: #6B7280;
+  --tc-border: #E5E7EB;
+  --tc-radius: 14px;
+  --tc-shadow: 0 4px 14px rgba(11, 31, 58, 0.08);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", Roboto, -apple-system, sans-serif;
+  background: var(--tc-bg);
+  color: var(--tc-text);
+}
+
+.hidden { display: none !important; }
+
+/* Hero */
+.tc-hero {
+  background: linear-gradient(135deg, var(--tc-saffron), var(--tc-navy) 70%, var(--tc-green));
+  color: #fff;
+  padding: 3rem 1.5rem 2.5rem;
+  text-align: center;
+}
+.tc-hero h1 { margin: 0 0 0.5rem; font-size: clamp(1.8rem, 4vw, 2.6rem); }
+.tc-hero p { margin: 0 auto; max-width: 640px; opacity: 0.92; }
+
+.tc-main-container {
+  max-width: 1080px;
+  margin: 0 auto;
+  padding: 2rem 1.25rem 3rem;
+}
+
+/* Overview strip */
+.tc-overview-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.75rem;
+}
+.tc-overview-stat {
+  background: var(--tc-card-bg);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius);
+  box-shadow: var(--tc-shadow);
+  padding: 1rem;
+  text-align: center;
+}
+.tc-stat-value {
+  display: block;
+  font-size: 1.5rem;
+  font-weight: 800;
+  color: var(--tc-navy);
+}
+.tc-stat-label {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--tc-muted);
+  margin-top: 0.2rem;
+}
+
+/* View Tabs */
+.tc-view-tabs-nav {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+}
+.btn-tc-view-tab {
+  padding: 0.6rem 1.4rem;
+  border-radius: 999px;
+  border: 2px solid var(--tc-border);
+  background: var(--tc-card-bg);
+  cursor: pointer;
+  font-weight: 600;
+  transition: all 0.2s ease;
+}
+.btn-tc-view-tab:hover { border-color: var(--tc-saffron); }
+.btn-tc-view-tab.active {
+  background: var(--tc-navy);
+  border-color: var(--tc-navy);
+  color: #fff;
+}
+
+/* Controls */
+.tc-controls-bar { margin-bottom: 1rem; }
+.tc-search-input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: var(--tc-radius);
+  border: 2px solid var(--tc-border);
+  font-size: 1rem;
+}
+.tc-search-input:focus { outline: none; border-color: var(--tc-saffron); }
+
+.tc-type-filter-row {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.25rem;
+}
+.btn-tc-type-filter {
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--tc-border);
+  background: #fff;
+  font-size: 0.85rem;
+  cursor: pointer;
+  color: var(--tc-muted);
+}
+.btn-tc-type-filter.active {
+  background: var(--tc-saffron);
+  border-color: var(--tc-saffron);
+  color: #fff;
+}
+
+/* Timeline */
+.tc-timeline-container {
+  position: relative;
+  padding-left: 2rem;
+  border-left: 3px solid var(--tc-saffron);
+}
+.tc-timeline-node { position: relative; margin-bottom: 1.75rem; }
+.tc-timeline-node::before {
+  content: "";
+  position: absolute;
+  left: -2.42rem;
+  top: 0.3rem;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--tc-gold);
+  border: 3px solid var(--tc-card-bg);
+  box-shadow: 0 0 0 2px var(--tc-saffron);
+}
+.tc-year-pill {
+  display: inline-block;
+  background: var(--tc-navy);
+  color: #fff;
+  padding: 0.2rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+}
+.tc-timeline-card {
+  background: var(--tc-card-bg);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius);
+  padding: 1rem 1.15rem;
+  box-shadow: var(--tc-shadow);
+}
+.tc-timeline-card h3 { margin: 0.4rem 0; font-size: 1rem; }
+.tc-timeline-card p { margin: 0.4rem 0 0; font-size: 0.9rem; }
+
+.tc-type-tag {
+  display: inline-block;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+.tc-type-milestone { background: rgba(19,136,8,0.12); color: var(--tc-green); }
+.tc-type-historic-tie { background: rgba(212,175,55,0.18); color: #8a6d1c; }
+.tc-type-final { background: rgba(255,153,51,0.18); color: #b5651d; }
+
+.tc-source { font-style: italic; font-size: 0.75rem; color: var(--tc-muted); }
+
+/* Players */
+.tc-players-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 1.25rem;
+}
+.tc-player-card {
+  background: var(--tc-card-bg);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius);
+  box-shadow: var(--tc-shadow);
+  padding: 1.25rem;
+  transition: transform 0.15s ease;
+}
+.tc-player-card:hover { transform: translateY(-3px); }
+.tc-player-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
+.tc-player-icon { font-size: 1.8rem; }
+.tc-player-era {
+  background: var(--tc-navy);
+  color: #fff;
+  padding: 0.2rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+.tc-player-card h3 { margin: 0.2rem 0 0.3rem; font-size: 1.05rem; }
+.tc-player-role {
+  font-weight: 600;
+  color: var(--tc-saffron);
+  font-size: 0.9rem;
+  margin: 0 0 0.5rem;
+}
+.tc-player-desc { font-size: 0.9rem; margin: 0 0 0.5rem; }
+
+/* Campaigns */
+.tc-campaigns-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.25rem;
+}
+.tc-campaign-card {
+  background: var(--tc-card-bg);
+  border: 1px solid var(--tc-border);
+  border-radius: var(--tc-radius);
+  box-shadow: var(--tc-shadow);
+  padding: 1.25rem;
+}
+.tc-campaign-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.5rem; }
+.tc-campaign-year { font-size: 1.3rem; font-weight: 800; color: var(--tc-navy); }
+.tc-campaign-result {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: #fff;
+}
+.tc-result-champion { background: var(--tc-green); }
+.tc-result-qf { background: #6B7280; }
+.tc-result-top4 { background: var(--tc-gold); color: #3a2f0a; }
+
+.tc-campaign-summary { font-size: 0.9rem; margin: 0.4rem 0; }
+
+.tc-empty-msg { text-align: center; padding: 2.5rem 1rem; color: var(--tc-muted); }
+
+/* Footer */
+.tc-footer {
+  text-align: center;
+  padding: 1.5rem;
+  color: var(--tc-muted);
+  font-size: 0.82rem;
+}

--- a/frontend/thomas-cup-explorer/thomas-cup-explorer.min.js
+++ b/frontend/thomas-cup-explorer/thomas-cup-explorer.min.js
@@ -1,0 +1,344 @@
+/**
+ * thomas-cup-explorer.js
+ * Thomas Cup: India's Badminton Journey - Timeline, Players, and Campaign Archive
+ * Pure Vanilla JavaScript with ESM export support for Vitest unit testing.
+ */
+
+// Chronological timeline of India's major Thomas Cup milestones (fact-checked)
+export const thomasCupTimeline = [
+  {
+    id: "trophy-founded-1939",
+    year: 1939,
+    title: "The Thomas Cup Is Conceived",
+    type: "Milestone",
+    description: "Sir George Alan Thomas, founder-president of the International Badminton Federation, proposed a world men's team championship and commissioned the silver-gilt trophy — delayed a decade by World War II.",
+    source: "BWF Thomas & Uber Cup History"
+  },
+  {
+    id: "inaugural-1949",
+    year: 1949,
+    title: "Inaugural Thomas Cup",
+    type: "Milestone",
+    description: "The first Thomas Cup was held in England; Malaya (now Malaysia) defeated Denmark 8-1 in the final to become the first name on the trophy. India did not compete in this edition.",
+    source: "Wikipedia — 1949 Thomas Cup"
+  },
+  {
+    id: "india-debut-1952",
+    year: 1952,
+    title: "India's Thomas Cup Debut",
+    type: "Milestone",
+    description: "India made its Thomas Cup debut and reached the top four under the tournament's early format, where only finalists (the last four teams) earned medals — India's first bronze-equivalent finish.",
+    source: "The Bridge — 'India's history at Thomas Cup'"
+  },
+  {
+    id: "second-top4-1955",
+    year: 1955,
+    title: "Second Top-Four Finish",
+    type: "Milestone",
+    description: "India repeated its strong debut form, again reaching the top four before losing 3-6 to Denmark.",
+    source: "The Bridge — 'India's history at Thomas Cup'"
+  },
+  {
+    id: "padukone-1979",
+    year: 1979,
+    title: "Padukone-Led Campaign",
+    type: "Historic Tie",
+    description: "Led by a young Prakash Padukone, India again reached the top four — one of its best pre-2022 campaigns — before losing to Denmark. India would not match this run for over four decades.",
+    source: "The Bridge; Wikipedia — 1979 Thomas Cup squads"
+  },
+  {
+    id: "semifinal-2022",
+    year: 2022,
+    title: "Return to the Semifinals",
+    type: "Historic Tie",
+    description: "India reached the Thomas Cup semifinals for the first time in 43 years, beating Malaysia 3-2 in the quarterfinal before advancing.",
+    source: "Sportskeeda — Thomas Cup 2022 preview"
+  },
+  {
+    id: "final-champions-2022",
+    year: 2022,
+    title: "Maiden Title",
+    type: "Final",
+    description: "India beat Denmark 3-2 in the semifinal to reach its first-ever final, then stunned 14-time champions Indonesia 3-0 in Bangkok to win the Thomas Cup for the first time in the tournament's 73-year history.",
+    source: "Olympics.com; Gulf News — Thomas Cup 2022"
+  },
+  {
+    id: "title-defense-2024",
+    year: 2024,
+    title: "Title Defense Ends in Quarterfinals",
+    type: "Milestone",
+    description: "As defending champions in Chengdu, China, India reached the quarterfinals after group-stage wins over Thailand and England, but lost 1-3 to host nation China, ending their title defense.",
+    source: "Khel Now; ESPN — Thomas & Uber Cup 2024"
+  }
+];
+
+// Key Indian players across Thomas Cup history (fact-checked)
+export const thomasCupPlayers = [
+  {
+    id: "prakash-padukone",
+    name: "Prakash Padukone",
+    era: "1970s–1991",
+    icon: "🏸",
+    role: "Singles legend",
+    description: "Led India's standout 1979 Thomas Cup campaign to the top four. He went on to become India's first World No. 1 and the first Indian to win the All England Championships (1980).",
+    source: "Britannica — Prakash Padukone"
+  },
+  {
+    id: "kidambi-srikanth",
+    name: "Kidambi Srikanth",
+    era: "2013–present",
+    icon: "🏸",
+    role: "Singles, 2022 title-winning shot",
+    description: "Sealed India's historic 2022 final win, defeating higher-ranked Jonatan Christie in straight games to complete the 3-0 sweep of Indonesia.",
+    source: "Sportskeeda — Thomas Cup 2022"
+  },
+  {
+    id: "lakshya-sen",
+    name: "Lakshya Sen",
+    era: "2018–present",
+    icon: "🏸",
+    role: "Singles, opened the 2022 final",
+    description: "Then 20 years old, Sen opened India's 2022 final by beating world No. 4 Anthony Ginting after dropping the first game — setting the tone for India's title run.",
+    source: "Sportsunfold — Thomas Cup 2022"
+  },
+  {
+    id: "satwik-chirag",
+    name: "Satwiksairaj Rankireddy & Chirag Shetty",
+    era: "2016–present",
+    icon: "🏸",
+    role: "Doubles pair",
+    description: "India's premier doubles pairing sealed the second point of the 2022 final over Indonesia's Ahsan/Sukamuljo, and remain central to India's Thomas Cup campaigns since.",
+    source: "Gulf News — Thomas Cup 2022"
+  },
+  {
+    id: "hs-prannoy",
+    name: "H. S. Prannoy",
+    era: "2010–present",
+    icon: "🏸",
+    role: "Singles, 2024 campaign",
+    description: "India's senior singles player during the 2024 title defense, winning key group-stage and quarterfinal rubbers in Chengdu before India's run ended against China.",
+    source: "Khel Now — Thomas & Uber Cup 2024"
+  }
+];
+
+// India's notable Thomas Cup campaigns/results
+export const thomasCupCampaigns = [
+  {
+    id: "campaign-1952",
+    year: 1952,
+    result: "Top 4 (bronze-equivalent)",
+    summary: "India's Thomas Cup debut. Under the pre-1984 format, only the last four teams earned medals — India reached that stage in its first appearance.",
+    source: "The Bridge — 'India's history at Thomas Cup'"
+  },
+  {
+    id: "campaign-1955",
+    year: 1955,
+    result: "Top 4 (bronze-equivalent)",
+    summary: "India again reached the top four before losing 3-6 to Denmark.",
+    source: "The Bridge — 'India's history at Thomas Cup'"
+  },
+  {
+    id: "campaign-1979",
+    year: 1979,
+    result: "Top 4 (bronze-equivalent)",
+    summary: "Led by Prakash Padukone, India reached the top four again before losing to Denmark — a campaign India would not equal for 43 years.",
+    source: "The Bridge; Wikipedia — 1979 Thomas Cup squads"
+  },
+  {
+    id: "campaign-2022",
+    year: 2022,
+    result: "Champions 🏆",
+    summary: "India's maiden Thomas Cup title. Group stage: beat Germany 5-0 and Canada 5-0, lost 2-3 to Chinese Taipei. Knockouts: beat Malaysia 3-2 (QF), Denmark 3-2 (SF), and Indonesia 3-0 in the final.",
+    source: "Sportsunfold; Olympics.com — Thomas Cup 2022"
+  },
+  {
+    id: "campaign-2024",
+    year: 2024,
+    result: "Quarterfinals",
+    summary: "As defending champions, India beat Thailand 4-1 and England 5-0 in the group stage before losing 1-3 to host China in the quarterfinals.",
+    source: "Khel Now; ESPN — Thomas & Uber Cup 2024"
+  }
+];
+
+/**
+ * Get timeline entries sorted chronologically.
+ */
+export function getSortedTimeline(list = thomasCupTimeline) {
+  if (!Array.isArray(list)) return [];
+  return [...list].sort((a, b) => a.year - b.year);
+}
+
+/**
+ * Filter timeline entries by type ("all" | "Milestone" | "Historic Tie" | "Final").
+ */
+export function filterTimelineByType(typeFilter = "all", list = thomasCupTimeline) {
+  if (!Array.isArray(list)) return [];
+  if (!typeFilter || typeFilter.toLowerCase() === "all") return getSortedTimeline(list);
+  return getSortedTimeline(list).filter(
+    item => item.type.toLowerCase() === typeFilter.toLowerCase()
+  );
+}
+
+/**
+ * Search timeline, players, or campaigns by free-text query.
+ */
+export function searchThomasCup(query = "") {
+  const q = query.trim().toLowerCase();
+  if (!q) {
+    return { timeline: thomasCupTimeline, players: thomasCupPlayers, campaigns: thomasCupCampaigns };
+  }
+  const matches = (obj, fields) =>
+    fields.some(f => obj[f] && obj[f].toString().toLowerCase().includes(q));
+
+  return {
+    timeline: thomasCupTimeline.filter(item =>
+      matches(item, ["title", "type", "description", "year"])
+    ),
+    players: thomasCupPlayers.filter(item =>
+      matches(item, ["name", "era", "role", "description"])
+    ),
+    campaigns: thomasCupCampaigns.filter(item =>
+      matches(item, ["result", "summary", "year"])
+    )
+  };
+}
+
+/* ==========================================================================
+   BROWSER DOM ENGINE
+   ========================================================================== */
+
+if (typeof window !== "undefined" && typeof document !== "undefined") {
+  window.thomasCupTimeline = thomasCupTimeline;
+  window.thomasCupPlayers = thomasCupPlayers;
+  window.thomasCupCampaigns = thomasCupCampaigns;
+  window.getSortedTimeline = getSortedTimeline;
+  window.filterTimelineByType = filterTimelineByType;
+  window.searchThomasCup = searchThomasCup;
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const timelineContainer = document.getElementById("tc-timeline-container");
+    const playersGrid = document.getElementById("tc-players-grid");
+    const campaignsGrid = document.getElementById("tc-campaigns-grid");
+    const searchInput = document.getElementById("tc-search");
+    const typeBtns = document.querySelectorAll(".btn-tc-type-filter");
+    const viewTabs = document.querySelectorAll(".btn-tc-view-tab");
+
+    let currentType = "all";
+
+    function renderTimeline() {
+      if (!timelineContainer) return;
+      timelineContainer.innerHTML = "";
+
+      const query = searchInput ? searchInput.value : "";
+      let items = query ? searchThomasCup(query).timeline : thomasCupTimeline;
+      items = filterTimelineByType(currentType, items);
+
+      if (items.length === 0) {
+        timelineContainer.innerHTML = `<div class="tc-empty-msg"><h3>No results</h3><p>Try a different search term or filter.</p></div>`;
+        return;
+      }
+
+      items.forEach(item => {
+        const node = document.createElement("div");
+        node.className = "tc-timeline-node";
+        node.innerHTML = `
+          <div class="tc-year-pill">📅 ${item.year}</div>
+          <div class="tc-timeline-card">
+            <span class="tc-type-tag tc-type-${item.type.replace(/\s+/g, "-").toLowerCase()}">${item.type}</span>
+            <h3>${item.title}</h3>
+            <p>${item.description}</p>
+            <p class="tc-source">Source: ${item.source}</p>
+          </div>
+        `;
+        timelineContainer.appendChild(node);
+      });
+    }
+
+    function renderPlayers() {
+      if (!playersGrid) return;
+      playersGrid.innerHTML = "";
+
+      const query = searchInput ? searchInput.value : "";
+      const items = query ? searchThomasCup(query).players : thomasCupPlayers;
+
+      if (items.length === 0) {
+        playersGrid.innerHTML = `<div class="tc-empty-msg"><h3>No players found</h3></div>`;
+        return;
+      }
+
+      items.forEach(p => {
+        const card = document.createElement("article");
+        card.className = "tc-player-card";
+        card.innerHTML = `
+          <div class="tc-player-header">
+            <span class="tc-player-icon">${p.icon}</span>
+            <span class="tc-player-era">${p.era}</span>
+          </div>
+          <h3>${p.name}</h3>
+          <p class="tc-player-role">${p.role}</p>
+          <p class="tc-player-desc">${p.description}</p>
+          <p class="tc-source">Source: ${p.source}</p>
+        `;
+        playersGrid.appendChild(card);
+      });
+    }
+
+    function renderCampaigns() {
+      if (!campaignsGrid) return;
+      campaignsGrid.innerHTML = "";
+
+      thomasCupCampaigns.forEach(c => {
+        const card = document.createElement("article");
+        card.className = "tc-campaign-card";
+        const resultClass = c.result.toLowerCase().includes("champion")
+          ? "tc-result-champion"
+          : c.result.toLowerCase().includes("quarterfinal")
+          ? "tc-result-qf"
+          : "tc-result-top4";
+        card.innerHTML = `
+          <div class="tc-campaign-header">
+            <span class="tc-campaign-year">${c.year}</span>
+            <span class="tc-campaign-result ${resultClass}">${c.result}</span>
+          </div>
+          <p class="tc-campaign-summary">${c.summary}</p>
+          <p class="tc-source">Source: ${c.source}</p>
+        `;
+        campaignsGrid.appendChild(card);
+      });
+    }
+
+    // View tab switching
+    viewTabs.forEach(tab => {
+      tab.addEventListener("click", () => {
+        viewTabs.forEach(t => t.classList.remove("active"));
+        tab.classList.add("active");
+        const target = tab.dataset.view;
+        document.querySelectorAll(".tc-view-panel").forEach(p => p.classList.add("hidden"));
+        document.getElementById(`tc-view-${target}`)?.classList.remove("hidden");
+      });
+    });
+
+    // Type filter (timeline only)
+    typeBtns.forEach(btn => {
+      btn.addEventListener("click", () => {
+        typeBtns.forEach(b => b.classList.remove("active"));
+        btn.classList.add("active");
+        currentType = btn.dataset.type || "all";
+        renderTimeline();
+      });
+    });
+
+    // Search (applies to timeline + players)
+    if (searchInput) {
+      searchInput.addEventListener("input", () => {
+        renderTimeline();
+        renderPlayers();
+      });
+    }
+
+    // Initial render
+    renderTimeline();
+    renderPlayers();
+    renderCampaigns();
+  });
+}


### PR DESCRIPTION
Closes #2539

Interactive archive of India's Thomas Cup history since 1952.

**Includes:**
- Timeline (1939–2024) — filterable by Milestone/Historic Tie/Final
- Players (5 cards) — Prakash Padukone, Kidambi Srikanth, Lakshya Sen, Satwiksairaj Rankireddy & Chirag Shetty, HS Prannoy
- Campaigns — 1952/1955/1979 top-4 finishes, 2022 maiden title (beat Indonesia 3-0), 2024 title defense (QF exit to China)
- Search across timeline + players
- Added to site-wide search index

Sources: BWF, Wikipedia, Olympics.com, Sportskeeda, Khel Now, ESPN — cited per card.

Tested locally via `python -m http.server 8080`.
<img width="1440" height="852" alt="Screenshot 2026-08-16 174640" src="https://github.com/user-attachments/assets/083f4a7b-b12c-48c9-ae84-d6ebe96ae160" />
<img width="1440" height="852" alt="Screenshot 2026-08-16 174648" src="https://github.com/user-attachments/assets/f548c5e3-caa1-4232-99f2-ca8396241035" />
<img width="1440" height="852" alt="Screenshot 2026-08-16 174651" src="https://github.com/user-attachments/assets/491f2e30-1341-4119-8899-59835d6d02b7" />
