### PR TITLE
hareable trail links + Trail Badges achievements

### DIFF
--- a/frontend/indian-national-army-explorer/index.html
+++ b/frontend/indian-national-army-explorer/index.html
@@ -1,626 +1,590 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description"
-        content="Explore the Indian National Army (INA) - from Indian POWs in Southeast Asia and Mohan Singh's First INA, through Subhas Chandra Bose's Azad Hind Government, the Rani of Jhansi Regiment, the Northeast India campaign, to the Red Fort Trials.">
+        content="Explore the Indian National Army (INA) - from POW camps in Singapore to the jungles of Imphal, under Subhas Chandra Bose's Azad Hind Government.">
     <title>Indian National Army (INA) Explorer | Incredible India</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link
-        href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,400&display=swap"
-        rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,500;0,600;0,700;0,800;1,400&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../../styles.css">
-    <link rel="stylesheet" href="style.css?v=1.0">
+    <link rel="stylesheet" href="style.css?v=2.0">
     <link rel="stylesheet" href="../js-modules/page-progress/page-progress.css">
 
-    <!-- Open Graph / Social Media Tags -->
     <meta property="og:title" content="Indian National Army (INA) Explorer | Incredible India Explorer">
     <meta property="og:description"
-        content="From POW camps in Singapore to the jungles of Imphal - trace the Indian National Army's formation, Azad Hind Government, campaigns, and the Red Fort Trials.">
+        content="From POW camps in Singapore to the jungles of Imphal - trace the INA's formation, Azad Hind Government, campaigns, and Red Fort Trials.">
     <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/frontend/assets/ina_explorer_banner.png">
-    <meta property="og:image:width" content="1200">
-    <meta property="og:image:height" content="630">
-    <meta property="og:url"
-        content="https://incredibleindiaexplorer.gov.in/frontend/indian-national-army-explorer/index.html">
+    <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/indian-national-army-explorer/index.html">
     <meta property="og:type" content="website">
-    <meta property="og:site_name" content="Incredible India Explorer">
-    <meta property="og:locale" content="en_IN">
-
-    <!-- Canonical URL -->
-    <link rel="canonical"
-        href="https://incredibleindiaexplorer.gov.in/frontend/indian-national-army-explorer/index.html">
+    <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/indian-national-army-explorer/index.html">
 </head>
 
 <body>
-    <script>
-        (function () {
-            const theme = localStorage.getItem('theme') || 'dark';
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
+<script>
+  (function () {
+    const theme = localStorage.getItem('theme') || 'dark';
+    if (theme === 'light') document.body.classList.add('light-theme');
+  })();
+</script>
 
-    <!-- Sticky Navigation Bar -->
-    <header class="navbar" id="navbar">
-    <div class="nav-container">
-        <a href="../../index.html#home" class="nav-logo" id="nav-logo">
-            <span class="saffron">Incredible</span>
-            <span class="gold">India</span>
-            <span class="green">Explorer</span>
-        </a>
-        <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
-            <span class="bar"></span>
-            <span class="bar"></span>
-            <span class="bar"></span>
-        </button>
-        <nav class="nav-menu" id="nav-menu">
-            <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
-
-            <div class="nav-dropdown">
-                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
-                <div class="dropdown-menu">
-                    <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
-                    <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
-                    <a href="../../frontend/ancient-ports-explorer/index.html" class="dropdown-item">Ancient Ports of India</a>
-                    <a href="../../frontend/islands/islands.html" class="dropdown-item">Islands of India</a>
-                    <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
-                    <a href="../../frontend/forts/forts.html" class="dropdown-item">Forts of India</a>
-                    <a href="../../frontend/route-planner/route-planner.html" class="dropdown-item">Route Planner</a>
-                </div>
-            </div>
-
-            <div class="nav-dropdown">
-                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
-                <div class="dropdown-menu">
-                    <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
-                    <a href="../../frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
-                    <a href="../../frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
-                    <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
-                    <a href="../../frontend/national-symbols-gallery/national-symbols-gallery.html" class="dropdown-item">National Symbols</a>
-                    <a href="../../frontend/cuisine-discovery-hub/index.html" class="dropdown-item">UP Cuisine</a>
-                    <a href="../../frontend/handicrafts-showcase/index.html" class="dropdown-item">UP Handicrafts</a>
-                    <a href="../../frontend/national-days-calendar/index.html" class="dropdown-item">National Days</a>
-                    <a href="../../frontend/ganga-ghats-experience/index.html" class="dropdown-item">Ganga Ghats</a>
-                </div>
-            </div>
-
-            <div class="nav-dropdown">
-                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Nature ▾</button>
-                <div class="dropdown-menu">
-                    <a href="../../frontend/national-parks-explorer/index.html" class="dropdown-item">National Parks</a>
-                    <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
-                    <a href="../../frontend/wildlife-rescue/wildlife-rescue.html" class="dropdown-item">Wildlife Rescue</a>
-                    <a href="../../frontend/endemic-flora-fauna-explorer/index.html" class="dropdown-item">Endemic Flora & Fauna</a>
-                    <a href="../../frontend/harike-wetland/harike-wetland.html" class="dropdown-item">Harike Wetland</a>
-                    <a href="../../frontend/wular-lake/wular-lake.html" class="dropdown-item">Wular Lake</a>
-                    <a href="../../frontend/crowd-density/index.html" class="dropdown-item">Crowd Density Predictor</a>
-                </div>
-            </div>
-
-            <div class="nav-dropdown">
-                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Games ▾</button>
-                <div class="dropdown-menu">
-                    <a href="../../frontend/passport-quest/passport-quest.html" class="dropdown-item">Passport Quest</a>
-                    <a href="../../frontend/culinary-game/culinary-game.html" class="dropdown-item">Culinary Challenge</a>
-                    <a href="../../frontend/monsoon-game/monsoon-game.html" class="dropdown-item">Monsoon Game</a>
-                    <a href="../../frontend/river-game/river-game.html" class="dropdown-item">River Explorer</a>
-                    <a href="../../frontend/geo-guesser-india/index.html" class="dropdown-item">GeoGuesser</a>
-                </div>
-            </div>
-
-            <div class="nav-dropdown">
-                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Community ▾</button>
-                <div class="dropdown-menu">
-                    <a href="../../frontend/contributors/contributors.html" class="dropdown-item">Contributors</a>
-                    <a href="../../frontend/world-records-india/index.html" class="dropdown-item">World Records</a>
-                </div>
-            </div>
-            
-            <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
-        </nav>
-    </div>
+<header class="navbar" id="navbar">
+  <div class="nav-container">
+    <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+      <span class="saffron">Incredible</span><span class="gold">India</span><span class="green">Explorer</span>
+    </a>
+    <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+      <span class="bar"></span><span class="bar"></span><span class="bar"></span>
+    </button>
+    <nav class="nav-menu" id="nav-menu">
+      <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+      <div class="nav-dropdown"><button class="nav-link dropdown-toggle">Destinations ▾</button><div class="dropdown-menu"><a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a><a href="../../frontend/forts/forts.html" class="dropdown-item">Forts of India</a></div></div>
+      <div class="nav-dropdown"><button class="nav-link dropdown-toggle">Culture ▾</button><div class="dropdown-menu"><a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a><a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a></div></div>
+      <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+    </nav>
+  </div>
 </header>
 
-    <!-- SPA Router Target Container -->
-    <main id="app-root" class="ina-main">
+<main id="app-root" class="ina-main">
 
-        <!-- Hero Banner -->
-        <section class="ina-hero">
-            <div class="ina-hero-content">
-                <span class="ina-kicker">🪖 Singapore to Imphal · 1942-1945</span>
-                <h1>Indian National Army <span>Explorer</span></h1>
-                <p>"Give me blood, and I shall give you freedom!" From prisoner-of-war camps in Singapore to the
-                    monsoon-soaked hills of Imphal and Kohima, the Indian National Army carried the fight for
-                    independence beyond India's borders - raising an army, a government, and a women's regiment in exile
-                    under the Azad Hind tricolour.</p>
-                <div class="ina-bookmark-container">
-                    <button class="ina-bookmark-btn journey-bookmark-btn" type="button" data-bookmark-id="ina-main"
-                        aria-pressed="false" aria-label="Bookmark Indian National Army Explorer">
-                        ♡ Save to Journey
-                    </button>
-                </div>
-            </div>
-        </section>
-
-        <!-- Section: Origins - Indian POWs in Southeast Asia -->
-        <section class="ina-section" id="origins">
-            <div class="ina-container ina-grid-2col">
-                <div class="ina-text-block">
-                    <span class="ina-eyebrow">Where It Began</span>
-                    <h2>Indian Prisoners of War in Southeast Asia</h2>
-                    <p>The INA's origins lie in catastrophe. When Japanese forces swept through Malaya and captured
-                        Singapore in February 1942, over 60,000 Indian soldiers of the British Indian Army - who had
-                        fought and lost - became prisoners of war almost overnight.</p>
-                    <p>Held in camps across Malaya and Singapore, these soldiers were approached by Japanese
-                        intelligence officers and by Indian nationalists already active in the region, who argued that
-                        their captivity could be turned into an opportunity: an army raised from among themselves,
-                        fighting not for Britain but for India's freedom.</p>
-                </div>
-                <div class="ina-stat-block">
-                    <div class="ina-stat-card">
-                        <span class="ina-stat-number">60,000+</span>
-                        <span class="ina-stat-label">Indian soldiers captured after the fall of Singapore</span>
-                    </div>
-                    <div class="ina-stat-card">
-                        <span class="ina-stat-number">Feb 1942</span>
-                        <span class="ina-stat-label">Fall of Singapore triggers mass Indian POW captures</span>
-                    </div>
-                    <div class="ina-stat-card">
-                        <span class="ina-stat-number">2</span>
-                        <span class="ina-stat-label">Distinct INAs - Mohan Singh's First INA and Bose's reorganized
-                            force</span>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- Section: First INA under Mohan Singh -->
-        <section class="ina-section ina-section-alt" id="first-ina">
-            <div class="ina-container">
-                <div class="ina-section-header">
-                    <span class="ina-eyebrow">The First Attempt</span>
-                    <h2>The First INA under Mohan Singh</h2>
-                    <p>Captain Mohan Singh, an Indian Army officer captured at the fall of Malaya, became the founding
-                        commander of the first Indian National Army in 1942.</p>
-                </div>
-                <div class="ina-cards-grid">
-                    <div class="ina-info-card">
-                        <span class="ina-info-icon">🤝</span>
-                        <h3>F Kikan Contact</h3>
-                        <p>Japanese intelligence officer Major Fujiwara Iwaichi persuaded Mohan Singh to organise
-                            willing POWs into an independence army rather than remain passive captives.</p>
-                    </div>
-                    <div class="ina-info-card">
-                        <span class="ina-info-icon">🏛️</span>
-                        <h3>Bangkok & Tokyo Conferences</h3>
-                        <p>The Indian Independence League, led by Rash Behari Bose, formally endorsed the plan at
-                            conferences in Bangkok and Tokyo in mid-1942, giving the new army political backing.</p>
-                    </div>
-                    <div class="ina-info-card">
-                        <span class="ina-info-icon">⚠️</span>
-                        <h3>Growing Distrust</h3>
-                        <p>Mohan Singh increasingly suspected Japan intended to use the INA merely as a token force
-                            under its own control, rather than as a genuine ally in India's liberation.</p>
-                    </div>
-                    <div class="ina-info-card">
-                        <span class="ina-info-icon">🛑</span>
-                        <h3>Dissolution</h3>
-                        <p>In December 1942, Mohan Singh ordered the First INA disbanded rather than see it used against
-                            Indian interests. He was arrested by the Japanese, and the force fragmented.</p>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- Section: Rash Behari Bose -->
-        <section class="ina-section" id="rash-behari">
-            <div class="ina-container ina-grid-2col ina-grid-reverse">
-                <div class="ina-text-block">
-                    <span class="ina-eyebrow">The Bridge Between Two Bounds</span>
-                    <h2>Rash Behari Bose's Role</h2>
-                    <p>A veteran revolutionary who had lived in exile in Japan since 1915, Rash Behari Bose led the
-                        Indian Independence League in East Asia and was instrumental in giving the fledgling INA
-                        political legitimacy and Japanese government backing.</p>
-                    <p>After the First INA's collapse, it was Rash Behari Bose who, in 1943, formally handed over
-                        leadership of the Indian Independence League and the INA project to a new arrival from Germany -
-                        Subhas Chandra Bose - recognising that the movement needed a leader who could command mass
-                        Indian loyalty.</p>
-                    <a href="../rash-behari-bose-explorer/index.html" class="ina-crosslink-btn">Explore Rash Behari Bose
-                        in Depth →</a>
-                </div>
-                <div class="ina-text-block">
-                    <span class="ina-eyebrow">Handover</span>
-                    <h2>July 1943, Singapore</h2>
-                    <p>At a ceremony in Singapore, Rash Behari Bose transferred leadership of the Indian Independence
-                        League to Subhas Chandra Bose, who had journeyed by German and Japanese submarine from Europe to
-                        Southeast Asia earlier that year - a handover that marked the true beginning of the INA as
-                        history remembers it.</p>
-                </div>
-            </div>
-        </section>
-
-        <!-- Section: Reorganization under Subhas Chandra Bose -->
-        <section class="ina-section ina-section-alt" id="reorganization">
-            <div class="ina-container">
-                <div class="ina-section-header">
-                    <span class="ina-eyebrow">A New Commander</span>
-                    <h2>Reorganization under Subhas Chandra Bose</h2>
-                    <p>Subhas Chandra Bose - known to his troops as Netaji - relaunched the INA in 1943 as a genuinely
-                        mass movement, drawing not just former POWs but civilian volunteers from the large Indian
-                        expatriate communities of Malaya, Singapore, and Burma.</p>
-                </div>
-                <div class="ina-cards-grid">
-                    <div class="ina-info-card">
-                        <span class="ina-info-icon">🎖️</span>
-                        <h3>Supreme Commander</h3>
-                        <p>Bose assumed direct command of the INA, rebuilding morale and expanding recruitment to
-                            roughly 40,000-45,000 personnel at its peak strength.</p>
-                    </div>
-                    <div class="ina-info-card">
-                        <span class="ina-info-icon">🗣️</span>
-                        <h3>"Give Me Blood"</h3>
-                        <p>His speech in Burma in July 1944, urging supporters to give him blood in exchange for
-                            freedom, became the movement's defining rallying cry.</p>
-                    </div>
-                    <div class="ina-info-card">
-                        <span class="ina-info-icon">🕊️</span>
-                        <h3>Jai Hind</h3>
-                        <p>Bose popularised "Jai Hind" as a greeting and slogan across the INA and the wider
-                            independence movement, a usage that endures in India today.</p>
-                    </div>
-                    <div class="ina-info-card">
-                        <span class="ina-info-icon">🇩🇪</span>
-                        <h3>From Europe to Asia</h3>
-                        <p>Before reaching Singapore, Bose had spent years in Germany seeking Axis support for Indian
-                            independence, travelling onward to Southeast Asia by submarine in early 1943.</p>
-                    </div>
-                </div>
-                <a href="../subhas-chandra-bose-explorer/index.html" class="ina-crosslink-btn">Explore Subhas Chandra
-                    Bose in Depth →</a>
-            </div>
-        </section>
-
-        <!-- Section: Azad Hind Government -->
-        <section class="ina-section" id="azad-hind">
-            <div class="ina-container ina-grid-2col">
-                <div class="ina-text-block">
-                    <span class="ina-eyebrow">A Government in Exile</span>
-                    <h2>The Azad Hind Government</h2>
-                    <p>On 21 October 1943, Bose proclaimed the Provisional Government of Free India - Azad Hind - in
-                        Singapore, with himself as Head of State, Prime Minister, and Minister of War. It was recognised
-                        diplomatically by Japan, Germany, Italy, and several Axis-aligned states.</p>
-                    <p>Azad Hind issued its own currency, postage stamps, and even claimed sovereignty over the Andaman
-                        and Nicobar Islands after Japan formally transferred nominal control of the islands in December
-                        1943, renaming them Shaheed and Swaraj Islands.</p>
-                </div>
-                <div class="ina-stat-block">
-                    <div class="ina-stat-card">
-                        <span class="ina-stat-number">21 Oct 1943</span>
-                        <span class="ina-stat-label">Azad Hind proclaimed in Singapore</span>
-                    </div>
-                    <div class="ina-stat-card">
-                        <span class="ina-stat-number">9</span>
-                        <span class="ina-stat-label">Nations that formally recognised the Provisional Government</span>
-                    </div>
-                    <div class="ina-stat-card">
-                        <span class="ina-stat-number">Andaman &amp; Nicobar</span>
-                        <span class="ina-stat-label">Only Indian territory nominally under Azad Hind control</span>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- Section: INA Structure & Rani of Jhansi Regiment -->
-        <section class="ina-section ina-section-alt" id="structure">
-            <div class="ina-container">
-                <div class="ina-section-header">
-                    <span class="ina-eyebrow">Order of Battle</span>
-                    <h2>INA Structure & Regiments</h2>
-                    <p>The reorganized INA was built around named divisions and brigades, alongside a pioneering
-                        all-women combat regiment.</p>
-                </div>
-                <div class="ina-regiment-grid">
-                    <div class="ina-regiment-card" data-title="1st Division"
-                        data-desc="The main combat force of the INA, comprising several brigades formed largely from former British Indian Army POWs, including the Subhas Brigade, Gandhi Brigade, Nehru Brigade, and Azad Brigade.">
-                        <span class="ina-regiment-icon">🎗️</span>
-                        <h3>1st Division</h3>
-                        <p>Core combat divisions named after national leaders: Subhas, Gandhi, Nehru, and Azad Brigades.
-                        </p>
-                    </div>
-                    <div class="ina-regiment-card" data-title="2nd Division"
-                        data-desc="A reserve and training division that fed reinforcements into the 1st Division as campaigns in Burma and the Northeast intensified.">
-                        <span class="ina-regiment-icon">🛡️</span>
-                        <h3>2nd Division</h3>
-                        <p>Reserve and reinforcement division supporting front-line INA brigades.</p>
-                    </div>
-                    <div class="ina-regiment-card" data-title="Rani of Jhansi Regiment"
-                        data-desc="An all-women combat regiment named for the warrior-queen Lakshmibai, raised chiefly from Indian civilian women in Malaya and Singapore and commanded by Captain Lakshmi Sahgal. It trained for combat roles and nursing duties, a rare instance of a women's fighting unit in this era.">
-                        <span class="ina-regiment-icon">⚔️</span>
-                        <h3>Rani of Jhansi Regiment</h3>
-                        <p>All-women unit led by Captain Lakshmi Sahgal, named after the Rani of Jhansi.</p>
-                    </div>
-                    <div class="ina-regiment-card" data-title="Intelligence & Special Forces"
-                        data-desc="Smaller specialist units handled intelligence gathering, sabotage, and liaison with Japanese command, operating alongside the main combat divisions.">
-                        <span class="ina-regiment-icon">🕵️</span>
-                        <h3>Intelligence Units</h3>
-                        <p>Specialist detachments for reconnaissance, sabotage, and liaison with Japanese forces.</p>
-                    </div>
-                </div>
-                <a href="../captain-lakshmi-sahgal-explorer/index.html" class="ina-crosslink-btn">Explore the Rani of
-                    Jhansi Regiment in Depth →</a>
-            </div>
-        </section>
-
-        <!-- Section: India + Southeast Asia Map -->
-        <section class="ina-section" id="map">
-            <div class="ina-container">
-                <div class="ina-section-header">
-                    <span class="ina-eyebrow">Interactive Regional Map</span>
-                    <h2>Southeast Asian Bases & the Northeast India Campaign</h2>
-                    <p>Click a location to see its role in the INA's story - from training bases to front-line
-                        battlefields.</p>
-                </div>
-                <div class="ina-region-map">
-                    <div class="ina-region-pin" data-title="Singapore" data-role="Headquarters & Azad Hind capital"
-                        data-desc="Home to the Indian Independence League headquarters and the site where Bose proclaimed the Azad Hind Provisional Government on 21 October 1943.">
-                        <span class="ina-pin-dot"></span>
-                        <span class="ina-pin-label">Singapore</span>
-                    </div>
-                    <div class="ina-region-pin" data-title="Malaya (Kuala Lumpur & Camps)"
-                        data-role="POW camps & recruitment"
-                        data-desc="Site of major POW camps where the First INA was raised, and home to a large ethnic Indian population that supplied civilian volunteers to the reorganized INA.">
-                        <span class="ina-pin-dot"></span>
-                        <span class="ina-pin-label">Malaya</span>
-                    </div>
-                    <div class="ina-region-pin" data-title="Rangoon, Burma" data-role="Forward command base"
-                        data-desc="Bose relocated Azad Hind's forward headquarters to Rangoon in early 1944 to be closer to the front as the INA prepared to advance into India.">
-                        <span class="ina-pin-dot"></span>
-                        <span class="ina-pin-label">Rangoon</span>
-                    </div>
-                    <div class="ina-region-pin ina-pin-battle" data-title="Imphal, Manipur"
-                        data-role="Major campaign battlefield"
-                        data-desc="The INA's 1st Division advanced alongside Japanese forces toward Imphal in early 1944, aiming to plant the tricolour on Indian soil - but was halted by fierce Allied resistance and crippling supply shortages.">
-                        <span class="ina-pin-dot"></span>
-                        <span class="ina-pin-label">Imphal</span>
-                    </div>
-                    <div class="ina-region-pin ina-pin-battle" data-title="Kohima, Nagaland"
-                        data-role="Turning point of the campaign"
-                        data-desc="The Battle of Kohima, fought alongside the Imphal campaign in mid-1944, became one of the bloodiest reversals for Japanese and INA forces, marking the campaign's turning point.">
-                        <span class="ina-pin-dot"></span>
-                        <span class="ina-pin-label">Kohima</span>
-                    </div>
-                    <div class="ina-region-pin" data-title="Andaman & Nicobar Islands"
-                        data-role="Nominal Azad Hind territory"
-                        data-desc="Renamed Shaheed and Swaraj Islands after Japan transferred nominal sovereignty to Azad Hind in December 1943 - the only Indian territory ever nominally under the Provisional Government's flag.">
-                        <span class="ina-pin-dot"></span>
-                        <span class="ina-pin-label">Andaman &amp; Nicobar</span>
-                    </div>
-                    <div class="ina-region-pin" data-title="Bangkok, Thailand" data-role="Early political conferences"
-                        data-desc="Hosted the 1942 Indian Independence League conference that first endorsed raising an Indian National Army from POWs.">
-                        <span class="ina-pin-dot"></span>
-                        <span class="ina-pin-label">Bangkok</span>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- Section: Timeline -->
-        <section class="ina-section ina-section-alt" id="timeline">
-            <div class="ina-container">
-                <div class="ina-section-header">
-                    <span class="ina-eyebrow">From Capture to Collapse</span>
-                    <h2>Timeline of the INA</h2>
-                </div>
-                <div class="timeline-flow">
-                    <div class="timeline-step">
-                        <div class="timeline-step-marker"></div>
-                        <div class="timeline-step-card">
-                            <span class="timeline-step-year">February 1942</span>
-                            <h3>Fall of Singapore</h3>
-                            <p>Over 60,000 Indian soldiers become Japanese prisoners of war after Singapore's surrender,
-                                providing the manpower for the future INA.</p>
-                        </div>
-                    </div>
-                    <div class="timeline-step">
-                        <div class="timeline-step-marker"></div>
-                        <div class="timeline-step-card">
-                            <span class="timeline-step-year">September 1942</span>
-                            <h3>First INA Formed</h3>
-                            <p>Mohan Singh formally raises the first Indian National Army from willing POWs, backed by
-                                Rash Behari Bose's Indian Independence League.</p>
-                        </div>
-                    </div>
-                    <div class="timeline-step">
-                        <div class="timeline-step-marker"></div>
-                        <div class="timeline-step-card">
-                            <span class="timeline-step-year">December 1942</span>
-                            <h3>First INA Dissolved</h3>
-                            <p>Distrustful of Japanese intentions, Mohan Singh disbands the force; he is arrested and
-                                the movement fragments.</p>
-                        </div>
-                    </div>
-                    <div class="timeline-step">
-                        <div class="timeline-step-marker"></div>
-                        <div class="timeline-step-card">
-                            <span class="timeline-step-year">July 1943</span>
-                            <h3>Bose Takes Command</h3>
-                            <p>Subhas Chandra Bose arrives in Singapore and receives leadership of the Indian
-                                Independence League and INA from Rash Behari Bose.</p>
-                        </div>
-                    </div>
-                    <div class="timeline-step">
-                        <div class="timeline-step-marker"></div>
-                        <div class="timeline-step-card">
-                            <span class="timeline-step-year">21 October 1943</span>
-                            <h3>Azad Hind Proclaimed</h3>
-                            <p>Bose declares the Provisional Government of Free India in Singapore, formally declaring
-                                war on Britain and the United States.</p>
-                        </div>
-                    </div>
-                    <div class="timeline-step">
-                        <div class="timeline-step-marker"></div>
-                        <div class="timeline-step-card">
-                            <span class="timeline-step-year">Early 1944</span>
-                            <h3>Advance Toward India</h3>
-                            <p>INA units advance with Japan's Burma-based forces toward Manipur, aiming to raise the
-                                tricolour on Indian soil for the first time.</p>
-                        </div>
-                    </div>
-                    <div class="timeline-step">
-                        <div class="timeline-step-marker"></div>
-                        <div class="timeline-step-card">
-                            <span class="timeline-step-year">April-July 1944</span>
-                            <h3>Battles of Imphal & Kohima</h3>
-                            <p>Fierce Allied resistance, monsoon rains, and collapsed supply lines force a disastrous
-                                retreat, effectively ending the INA's campaign to reach India.</p>
-                        </div>
-                    </div>
-                    <div class="timeline-step">
-                        <div class="timeline-step-marker"></div>
-                        <div class="timeline-step-card">
-                            <span class="timeline-step-year">August 1945</span>
-                            <h3>Japan Surrenders, INA Collapses</h3>
-                            <p>With Japan's surrender, the INA disintegrates as a fighting force. Bose dies in a plane
-                                crash in Taiwan on 18 August 1945 while attempting to reach the Soviet Union.</p>
-                        </div>
-                    </div>
-                    <div class="timeline-step">
-                        <div class="timeline-step-marker"></div>
-                        <div class="timeline-step-card">
-                            <span class="timeline-step-year">November 1945 - May 1946</span>
-                            <h3>Red Fort Trials</h3>
-                            <p>Captured INA officers - including Shah Nawaz Khan, Prem Sahgal, and Gurbaksh Singh
-                                Dhillon - are court-martialled for treason at Delhi's Red Fort, triggering nationwide
-                                protests.</p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- Section: British Response & Collapse -->
-        <section class="ina-section" id="collapse">
-            <div class="ina-container ina-grid-2col">
-                <div class="ina-text-block">
-                    <span class="ina-eyebrow">Facing the Empire</span>
-                    <h2>British Response</h2>
-                    <p>British and Allied commanders initially treated the INA as a minor irregular threat, but its
-                        advance toward Imphal in 1944 forced a serious military response. After the campaign's collapse,
-                        Britain treated captured INA officers as traitors under military law rather than prisoners of
-                        war, leading directly to the Red Fort Trials.</p>
-                    <p>The trials, intended to make an example of INA leadership, instead backfired: public sympathy for
-                        the accused officers - who were defended by a legal team including Bhulabhai Desai and a young
-                        Jawaharlal Nehru - grew so intense that Britain was forced to commute the death sentences and
-                        release the convicted officers.</p>
-                </div>
-                <div class="ina-text-block">
-                    <span class="ina-eyebrow">The Final Retreat</span>
-                    <h2>Collapse of the Campaign</h2>
-                    <p>The failure at Imphal and Kohima, combined with the wider collapse of Japanese forces in Burma
-                        through 1944-45, left the INA cut off from supplies and reinforcements. Many units surrendered
-                        or were captured as Allied forces retook Burma; others made a fighting retreat alongside
-                        remaining Japanese troops before the general Japanese surrender in August 1945 ended organised
-                        resistance entirely.</p>
-                </div>
-            </div>
-        </section>
-
-        <!-- Section: Post-War Trials & Historical Impact -->
-        <section class="ina-section ina-section-alt" id="impact">
-            <div class="ina-container">
-                <div class="ina-section-header">
-                    <span class="ina-eyebrow">Beyond the Battlefield</span>
-                    <h2>Post-War Trials and Historical Impact</h2>
-                </div>
-                <div class="ina-cards-grid">
-                    <div class="ina-info-card">
-                        <span class="ina-info-icon">⚖️</span>
-                        <h3>Red Fort Trials</h3>
-                        <p>The court-martial of INA officers at the Red Fort became a rallying point that united
-                            political opinion across India as never before, regardless of party lines.</p>
-                    </div>
-                    <div class="ina-info-card">
-                        <span class="ina-info-icon">📣</span>
-                        <h3>Nationwide Protests</h3>
-                        <p>Mass demonstrations, strikes, and clashes with police broke out in cities across India in
-                            support of the accused officers through late 1945 and early 1946.</p>
-                    </div>
-                    <div class="ina-info-card">
-                        <span class="ina-info-icon">⚓</span>
-                        <h3>Fueling Wider Unrest</h3>
-                        <p>Sympathy for the INA fed directly into the atmosphere of post-war military unrest, including
-                            the RIAF revolt and the Royal Indian Navy Mutiny of early 1946.</p>
-                    </div>
-                    <div class="ina-info-card">
-                        <span class="ina-info-icon">🏛️</span>
-                        <h3>A Shaken Empire</h3>
-                        <p>The episode convinced many British officials that the loyalty of India's own armed forces
-                            could no longer be assumed, accelerating the political timetable toward independence in
-                            1947.</p>
-                    </div>
-                </div>
-            </div>
-        </section>
-
-        <!-- Section: References -->
-        <section class="ina-section" id="references">
-            <div class="ina-container">
-                <div class="ina-references">
-                    <h3>📚 Sources &amp; Further Reading</h3>
-                    <ul>
-                        <li><strong>Fay, Peter Ward (1993)</strong>. <em>The Forgotten Army: India's Armed Struggle for
-                                Independence, 1942-1945</em>. University of Michigan Press.</li>
-                        <li><strong>Toye, Hugh (1959)</strong>. <em>The Springing Tiger: A Study of a
-                                Revolutionary</em>. Cassell.</li>
-                        <li><strong>Lebra, Joyce C. (1971)</strong>. <em>Jungle Alliance: Japan and the Indian National
-                                Army</em>. Asia Pacific Press.</li>
-                        <li><strong>Sarkar, Sumit (1983)</strong>. <em>Modern India, 1885-1947</em>. Macmillan. (Covers
-                            the Red Fort Trials and their political impact.)</li>
-                        <li><strong>Netaji Research Bureau, Kolkata</strong>. Archival records and papers relating to
-                            Subhas Chandra Bose and the Azad Hind Government.</li>
-                    </ul>
-                </div>
-            </div>
-        </section>
-
-    </main>
-
-    <!-- Interactive Detail Modal -->
-    <div class="museum-modal" id="port-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title"
-        aria-hidden="true">
-        <div class="museum-modal-card">
-            <button class="museum-modal-close" id="port-modal-close" type="button" aria-label="Close details">✕</button>
-            <span class="modal-category" id="modal-category">INA Location</span>
-            <h2 id="modal-title"></h2>
-            <p class="modal-location" style="color: var(--ina-gold-light);" id="modal-heading"></p>
-            <div style="border-top: 1px solid rgba(255,255,255,0.1); margin-top: 15px; padding-top: 15px;">
-                <p class="modal-description" id="modal-description"></p>
-            </div>
+  <!-- ============ HERO ============ -->
+  <section class="ina-hero">
+    <div class="ina-tricolor" aria-hidden="true"><i></i><i></i><i></i></div>
+    <div class="hero-grain" aria-hidden="true"></div>
+    <div class="ina-hero-inner">
+      <div class="hero-copy">
+        <span class="ina-kicker">
+          <span class="kicker-dot"></span>
+          Singapore · Malaya · Burma · Imphal · Kohima · 1942–1945
+        </span>
+        <h1>Indian National Army<br><em>Explorer</em></h1>
+        <p class="hero-lede">A volunteer army raised in exile. A provisional government proclaimed on foreign soil. A women's regiment decades ahead of its time. The INA carried the fight for Indian independence far beyond India's borders — and left a legacy that shook an empire.</p>
+        <div class="hero-quote" role="region" aria-label="Netaji quote">
+          <span class="quote-mark">"</span>
+          <p id="typewriter-quote">Give me blood, and I shall give you freedom!</p>
+          <cite>— Subhas Chandra Bose, Burma, 1944</cite>
         </div>
+        <div class="hero-ctas">
+          <a href="#origins" class="btn-ina btn-primary">Begin the journey ↓</a>
+          <a href="#map" class="btn-ina btn-ghost">View the theatre of war</a>
+        </div>
+      </div>
+      <aside class="hero-emblem" aria-hidden="true">
+        <svg viewBox="0 0 240 240" class="emblem-svg">
+          <defs>
+            <radialGradient id="emb-glow" cx="50%" cy="50%">
+              <stop offset="0%" stop-color="#ffb347" stop-opacity="0.8"/>
+              <stop offset="100%" stop-color="#ff6a00" stop-opacity="0"/>
+            </radialGradient>
+            <linearGradient id="emb-ring" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stop-color="#f6c453"/><stop offset="100%" stop-color="#c9923b"/>
+            </linearGradient>
+          </defs>
+          <circle cx="120" cy="120" r="115" fill="url(#emb-glow)"/>
+          <circle cx="120" cy="120" r="90" fill="none" stroke="url(#emb-ring)" stroke-width="1.5"/>
+          <circle cx="120" cy="120" r="70" fill="none" stroke="url(#emb-ring)" stroke-width="0.6" stroke-dasharray="2 4"/>
+          <g class="spinning-spring" style="transform-origin:120px 120px">
+            <circle cx="120" cy="120" r="50" fill="none" stroke="#f6c453" stroke-width="0.8"/>
+            <text x="120" y="80" text-anchor="middle" font-family="Playfair Display" font-size="9" fill="#f6c453" font-weight="700">JAI HIND</text>
+            <text x="120" y="168" text-anchor="middle" font-family="Playfair Display" font-size="9" fill="#f6c453" font-weight="700">آزاد ہند</text>
+          </g>
+          <text x="120" y="128" text-anchor="middle" font-family="Playfair Display" font-style="italic" font-size="22" fill="#fff8e7" font-weight="600">Azad</text>
+          <text x="120" y="148" text-anchor="middle" font-family="Playfair Display" font-size="14" fill="#f6c453" letter-spacing="2">HIND</text>
+        </svg>
+      </aside>
     </div>
+    <div class="hero-bottom">
+      <div class="hero-stat-mini"><b id="counter-1">0</b><span>POWs captured, 1942</span></div>
+      <div class="hero-stat-mini"><b id="counter-2">0</b><span>Troops at peak strength</span></div>
+      <div class="hero-stat-mini"><b id="counter-3">0</b><span>Nations recognised Azad Hind</span></div>
+      <button class="ina-bookmark-btn journey-bookmark-btn" type="button" data-bookmark-id="ina-main" aria-pressed="false">♡ Save to Journey</button>
+    </div>
+  </section>
 
-    <!-- Footer -->
-    <footer class="ina-footer">
-        <div class="ina-container">
-            <p>Part of <a href="../../index.html">Incredible India Explorer</a> · Discover the army that carried India's
-                fight for freedom across Southeast Asia.</p>
+  <!-- ============ ORIGINS ============ -->
+  <section class="ina-section reveal" id="origins">
+    <div class="ina-container ina-grid-2col">
+      <div class="ina-text-block">
+        <span class="ina-eyebrow">Where It Began</span>
+        <h2>Indian Prisoners of War in Southeast Asia</h2>
+        <p>The INA's origins lie in catastrophe. When Japanese forces swept through Malaya and captured Singapore in February 1942, over <mark>60,000 Indian soldiers</mark> of the British Indian Army became prisoners of war almost overnight.</p>
+        <p>Held in camps across Malaya and Singapore, these soldiers were approached by Japanese intelligence officers and by Indian nationalists already active in the region, who argued that their captivity could be turned into an opportunity: an army raised from among themselves, fighting not for Britain but for India's freedom.</p>
+      </div>
+      <div class="ina-stat-block">
+        <div class="ina-stat-card"><span class="ina-stat-number" data-count="60000" data-suffix="+">0</span><span class="ina-stat-label">Indian soldiers captured after Singapore's fall</span></div>
+        <div class="ina-stat-card"><span class="ina-stat-number">Feb 1942</span><span class="ina-stat-label">Fall of Singapore triggers mass POW captures</span></div>
+        <div class="ina-stat-card"><span class="ina-stat-number">2</span><span class="ina-stat-label">Distinct INAs — Mohan Singh's first, then Bose's</span></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ FIRST INA ============ -->
+  <section class="ina-section ina-section-alt reveal" id="first-ina">
+    <div class="ina-container">
+      <div class="ina-section-header">
+        <span class="ina-eyebrow">The First Attempt · 1942</span>
+        <h2>The First INA under Mohan Singh</h2>
+        <p>Captain Mohan Singh, captured at the fall of Malaya, became the founding commander of the first Indian National Army — a force that would dissolve within months over distrust of Japanese intentions.</p>
+      </div>
+      <div class="ina-cards-grid">
+        <div class="ina-info-card"><span class="ina-info-icon">🤝</span><h3>F Kikan Contact</h3><p>Major Fujiwara Iwaichi persuaded Mohan Singh to organise willing POWs into an independence army.</p></div>
+        <div class="ina-info-card"><span class="ina-info-icon">🏛️</span><h3>Bangkok & Tokyo</h3><p>The Indian Independence League, led by Rash Behari Bose, formally endorsed the plan in mid-1942.</p></div>
+        <div class="ina-info-card"><span class="ina-info-icon">⚠️</span><h3>Growing Distrust</h3><p>Mohan Singh suspected Japan intended to use the INA as a token force under its own command.</p></div>
+        <div class="ina-info-card"><span class="ina-info-icon">🛑</span><h3>Dissolution</h3><p>In December 1942, he ordered the First INA disbanded. He was arrested by the Japanese.</p></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ RASH BEHARI BOSE ============ -->
+  <section class="ina-section reveal" id="rash-behari">
+    <div class="ina-container ina-grid-2col ina-grid-reverse">
+      <div class="ina-text-block">
+        <span class="ina-eyebrow">The Bridge Between Two Bounds</span>
+        <h2>Rash Behari Bose's Role</h2>
+        <p>A veteran revolutionary who had lived in exile in Japan since 1915, Rash Behari Bose led the Indian Independence League and gave the fledgling INA political legitimacy. After the First INA's collapse, he formally handed over leadership in 1943 — to a new arrival from Germany named <b>Subhas Chandra Bose</b>.</p>
+        <a href="../rash-behari-bose-explorer/index.html" class="ina-crosslink-btn">
+          <span class="cl-icon">📖</span>
+          <span class="cl-body"><b>Explore Rash Behari Bose</b><small>Revolutionary · Exile · Mentor</small></span>
+          <span class="cl-arrow">→</span>
+        </a>
+      </div>
+      <div class="ina-handover-card">
+        <span class="handover-label">THE HANDOVER · July 1943 · Singapore</span>
+        <h3>"I hand over to you the leadership of this League."</h3>
+        <p>At a ceremony in Singapore, the baton passed from the veteran exile to the firebrand returning from Europe — a moment that marks the true beginning of the INA as history remembers it.</p>
+        <div class="handover-meta">
+          <span>🇯🇵 Empire of Japan (host)</span>
+          <span>🇮🇳 Indian Independence League</span>
         </div>
-    </footer>
+      </div>
+    </div>
+  </section>
 
-    <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+  <!-- ============ REORGANIZATION ============ -->
+  <section class="ina-section ina-section-alt reveal" id="reorganization">
+    <div class="ina-container">
+      <div class="ina-section-header">
+        <span class="ina-eyebrow">A New Commander · 1943</span>
+        <h2>Reorganization under Subhas Chandra Bose</h2>
+        <p>Known to his troops as <mark>Netaji</mark> ("Respected Leader"), Bose relaunched the INA as a genuinely mass movement — drawing not just POWs but civilian volunteers from Malaya, Singapore, and Burma.</p>
+      </div>
+      <div class="ina-cards-grid">
+        <div class="ina-info-card"><span class="ina-info-icon">🎖️</span><h3>Supreme Commander</h3><p>Peak strength: 40,000–45,000 personnel, including civilians and a women's regiment.</p></div>
+        <div class="ina-info-card"><span class="ina-info-icon">🗣️</span><h3>"Give Me Blood"</h3><p>His July 1944 Burma speech became the movement's defining rallying cry.</p></div>
+        <div class="ina-info-card"><span class="ina-info-icon">🕊️</span><h3>Jai Hind</h3><p>Popularised as a greeting across the INA and the wider independence movement.</p></div>
+        <div class="ina-info-card"><span class="ina-info-icon">🇩🇪</span><h3>From Europe to Asia</h3><p>Traveled by German and Japanese submarine from Europe to Southeast Asia in early 1943.</p></div>
+      </div>
+      <a href="../subhas-chandra-bose-explorer/index.html" class="ina-crosslink-btn">
+        <span class="cl-icon">⭐</span>
+        <span class="cl-body"><b>Explore Subhas Chandra Bose</b><small>Netaji · Commander · Patriot</small></span>
+        <span class="cl-arrow">→</span>
+      </a>
+    </div>
+  </section>
 
-    <!-- JS Dependencies -->
-    <script src="../app.js" defer></script>
-    <script src="../../frontend/journey/journey.js" defer></script>
-    <script src="script.js" defer></script>
-    <script type="module" src="../firebase-config.js"></script>
-    <script type="module" src="../auth.js"></script>
-    <script src="../router.js" defer></script>
-    <script src="../js-modules/page-progress/page-progress.js"></script>
+  <!-- ============ AZAD HIND ============ -->
+  <section class="ina-section reveal" id="azad-hind">
+    <div class="ina-container ina-grid-2col">
+      <div class="ina-text-block">
+        <span class="ina-eyebrow">A Government in Exile</span>
+        <h2>The Azad Hind Government</h2>
+        <p>On <b>21 October 1943</b>, Bose proclaimed the Provisional Government of Free India in Singapore — with himself as Head of State, Prime Minister, and Minister of War. It was recognised diplomatically by Japan, Germany, Italy, and several Axis-aligned states.</p>
+        <p>Azad Hind issued its own currency, postage stamps, and even claimed sovereignty over the Andaman and Nicobar Islands after Japan transferred nominal control in December 1943, renaming them <mark>Shaheed</mark> and <mark>Swaraj</mark> Islands.</p>
+      </div>
+      <div class="ina-azad-card">
+        <div class="azad-flag">
+          <span class="flag-saffron"></span>
+          <span class="flag-white"></span>
+          <span class="flag-green"></span>
+          <span class="flag-spring">☸</span>
+        </div>
+        <h3>Provisional Government of Free India</h3>
+        <p class="azad-slogan">इत्तेहाद, एतमाद, क़ुरबानी<br><small>Ittehad, Etamad, Qurbani · Unity, Faith, Sacrifice</small></p>
+        <ul class="azad-facts">
+          <li><b>Capital</b><span>Port Blair (Shaheed)</span></li>
+          <li><b>Recognised by</b><span>9 nations</span></li>
+          <li><b>Currency</b><span>Rupee, Anna, Pie</span></li>
+          <li><b>War declared on</b><span>Britain &amp; USA</span></li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ REGIMENTS (TABS) ============ -->
+  <section class="ina-section ina-section-alt reveal" id="structure">
+    <div class="ina-container">
+      <div class="ina-section-header">
+        <span class="ina-eyebrow">Order of Battle</span>
+        <h2>INA Structure &amp; Regiments</h2>
+        <p>The reorganised INA was built around named brigades and a pioneering all-women combat regiment decades ahead of its time.</p>
+      </div>
+      <div class="regiment-tabs">
+        <div class="regiment-nav" role="tablist">
+          <button role="tab" data-tab="first" aria-selected="true">1st Division</button>
+          <button role="tab" data-tab="second" aria-selected="false">2nd Division</button>
+          <button role="tab" data-tab="rani" aria-selected="false">Rani of Jhansi Regiment</button>
+          <button role="tab" data-tab="intel" aria-selected="false">Intelligence Units</button>
+        </div>
+        <div class="regiment-panels">
+          <article class="regiment-panel active" data-panel="first">
+            <div class="rp-head"><span class="rp-icon">🎗️</span><div><h3>1st Division</h3><small>Main combat force · Front-line brigades</small></div></div>
+            <p>Core combat divisions named after national leaders — <b>Subhas Brigade</b>, <b>Gandhi Brigade</b>, <b>Nehru Brigade</b>, and <b>Azad Brigade</b>. Formed largely from former British Indian Army POWs, these brigades bore the brunt of fighting at Imphal and Kohima.</p>
+            <div class="rp-stats">
+              <div><b>~25,000</b><span>Personnel</span></div>
+              <div><b>4</b><span>Named brigades</span></div>
+              <div><b>1944</b><span>Imphal campaign</span></div>
+            </div>
+          </article>
+          <article class="regiment-panel" data-panel="second">
+            <div class="rp-head"><span class="rp-icon">🛡️</span><div><h3>2nd Division</h3><small>Reserve &amp; reinforcement</small></div></div>
+            <p>A reserve and training division that fed reinforcements into the 1st Division as campaigns in Burma and the Northeast intensified. Less engaged in direct combat but critical to the INA's operational sustainability.</p>
+            <div class="rp-stats">
+              <div><b>~12,000</b><span>Personnel</span></div>
+              <div><b>Reserve</b><span>Role</span></div>
+              <div><b>Rangoon</b><span>Base</span></div>
+            </div>
+          </article>
+          <article class="regiment-panel" data-panel="rani">
+            <div class="rp-head"><span class="rp-icon">⚔️</span><div><h3>Rani of Jhansi Regiment</h3><small>All-women combat regiment · Pioneer of its era</small></div></div>
+            <p>Named for the warrior-queen Lakshmibai and commanded by <b>Captain Lakshmi Sahgal</b>, the regiment was raised chiefly from Indian civilian women in Malaya and Singapore. Trained for both combat roles and nursing duties — a rare instance of a women's fighting unit in this era.</p>
+            <div class="rp-stats">
+              <div><b>~500</b><span>Personnel</span></div>
+              <div><b>1943</b><span>Raised</span></div>
+              <div><b>Cpt. Lakshmi Sahgal</b><span>Commander</span></div>
+            </div>
+            <a href="../captain-lakshmi-sahgal-explorer/index.html" class="ina-crosslink-btn small">
+              <span class="cl-icon">👑</span>
+              <span class="cl-body"><b>Explore Captain Lakshmi Sahgal</b><small>Commander of the regiment</small></span>
+              <span class="cl-arrow">→</span>
+            </a>
+          </article>
+          <article class="regiment-panel" data-panel="intel">
+            <div class="rp-head"><span class="rp-icon">🕵️</span><div><h3>Intelligence &amp; Special Forces</h3><small>Reconnaissance, sabotage, liaison</small></div></div>
+            <p>Smaller specialist detachments handled intelligence gathering, sabotage behind Allied lines, and liaison with Japanese command, operating alongside the main combat divisions.</p>
+            <div class="rp-stats">
+              <div><b>Classified</b><span>Exact strength</span></div>
+              <div><b>Forward</b><span>Deployment</span></div>
+              <div><b>1943–45</b><span>Active</span></div>
+            </div>
+          </article>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ INTERACTIVE MAP ============ -->
+  <section class="ina-section reveal" id="map">
+    <div class="ina-container">
+      <div class="ina-section-header">
+        <span class="ina-eyebrow">Interactive Regional Map</span>
+        <h2>The Theatre of War</h2>
+        <p>From Singapore's headquarters to the jungles of Imphal — click any location to see its role in the INA's story.</p>
+      </div>
+      <div class="ina-region-map">
+        <svg class="map-svg" viewBox="0 0 800 500" preserveAspectRatio="xMidYMid meet">
+          <defs>
+            <linearGradient id="sea-grad" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="0%" stop-color="#0b1a2e"/><stop offset="100%" stop-color="#102947"/>
+            </linearGradient>
+            <linearGradient id="land-grad" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0%" stop-color="#2d3f2a"/><stop offset="100%" stop-color="#1f2d1c"/>
+            </linearGradient>
+            <pattern id="map-grid" width="40" height="40" patternUnits="userSpaceOnUse">
+              <path d="M 40 0 L 0 0 0 40" fill="none" stroke="rgba(246,196,83,0.08)" stroke-width="0.5"/>
+            </pattern>
+            <marker id="route-arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="3" markerHeight="3" orient="auto">
+              <path d="M0 0 L10 5 L0 10 z" fill="#ff9933"/>
+            </marker>
+          </defs>
+
+          <rect width="800" height="500" fill="url(#sea-grad)"/>
+          <rect width="800" height="500" fill="url(#map-grid)"/>
+
+          <!-- India subcontinent -->
+          <path class="land" d="M 80,120 Q 130,100 180,110 Q 240,115 270,140 L 295,180 Q 305,210 295,245 L 275,295 Q 260,330 235,360 Q 205,390 175,410 Q 150,415 135,400 Q 115,370 100,340 Q 85,300 75,255 Q 70,205 75,165 Z" fill="url(#land-grad)" stroke="rgba(246,196,83,0.4)" stroke-width="1"/>
+
+          <!-- Burma -->
+          <path class="land" d="M 320,175 Q 355,180 375,215 L 385,265 Q 390,305 375,335 Q 355,360 335,355 Q 320,335 315,300 L 310,240 Q 310,205 320,175 Z" fill="url(#land-grad)" stroke="rgba(246,196,83,0.4)" stroke-width="1"/>
+
+          <!-- Malaya -->
+          <path class="land" d="M 410,290 Q 430,295 440,330 L 445,385 Q 440,420 425,430 Q 410,425 405,395 L 400,345 Q 402,310 410,290 Z" fill="url(#land-grad)" stroke="rgba(246,196,83,0.4)" stroke-width="1"/>
+
+          <!-- Thailand -->
+          <path class="land" d="M 385,220 Q 415,225 430,260 L 430,285 Q 420,290 405,285 Q 385,265 380,240 Z" fill="url(#land-grad)" stroke="rgba(246,196,83,0.3)" stroke-width="0.7"/>
+
+          <!-- Andaman & Nicobar -->
+          <ellipse class="land" cx="330" cy="380" rx="8" ry="20" fill="url(#land-grad)" stroke="rgba(246,196,83,0.4)" stroke-width="0.8"/>
+          <ellipse class="land" cx="335" cy="420" rx="6" ry="14" fill="url(#land-grad)" stroke="rgba(246,196,83,0.4)" stroke-width="0.8"/>
+
+          <!-- Sumatra (background) -->
+          <path class="land far" d="M 420,445 Q 470,460 510,485 Q 510,495 470,490 Q 430,475 420,460 Z" fill="rgba(45,63,42,0.45)" stroke="rgba(246,196,83,0.2)" stroke-width="0.5"/>
+
+          <!-- Animated INA route -->
+          <path class="ina-route" d="M 430,400 Q 415,370 385,300 Q 360,245 355,225 Q 340,200 310,200" fill="none" stroke="#ff9933" stroke-width="2.5" stroke-dasharray="6 6" stroke-linecap="round" marker-end="url(#route-arrow)"/>
+
+          <!-- Sea labels -->
+          <text x="215" y="340" class="sea-label" fill="rgba(246,196,83,0.5)" font-size="10" letter-spacing="3">BAY OF BENGAL</text>
+          <text x="490" y="440" class="sea-label" fill="rgba(246,196,83,0.5)" font-size="10" letter-spacing="3">STRAIT OF MALACCA</text>
+
+          <!-- Compass -->
+          <g transform="translate(720,60)" class="compass">
+            <circle r="26" fill="rgba(0,0,0,0.35)" stroke="rgba(246,196,83,0.5)" stroke-width="1"/>
+            <path d="M0 -20 L4 0 L0 20 L-4 0 Z" fill="#f6c453" opacity="0.85"/>
+            <text y="-30" text-anchor="middle" font-family="Playfair Display" font-size="10" fill="#f6c453" font-weight="700">N</text>
+          </g>
+        </svg>
+
+        <div class="map-pin-layer">
+          <button class="map-pin" data-id="singapore" style="--x:86%; --y:80%;">
+            <span class="pin-pulse"></span><span class="pin-core">🏛️</span><span class="pin-label">Singapore</span>
+          </button>
+          <button class="map-pin" data-id="malaya" style="--x:82%; --y:68%;">
+            <span class="pin-pulse"></span><span class="pin-core">⛓️</span><span class="pin-label">Malaya</span>
+          </button>
+          <button class="map-pin" data-id="rangoon" style="--x:70%; --y:48%;">
+            <span class="pin-pulse"></span><span class="pin-core">🎯</span><span class="pin-label">Rangoon</span>
+          </button>
+          <button class="map-pin map-pin-battle" data-id="imphal" style="--x:60%; --y:38%;">
+            <span class="pin-pulse"></span><span class="pin-core">⚔️</span><span class="pin-label">Imphal</span>
+          </button>
+          <button class="map-pin map-pin-battle" data-id="kohima" style="--x:63%; --y:30%;">
+            <span class="pin-pulse"></span><span class="pin-core">⚔️</span><span class="pin-label">Kohima</span>
+          </button>
+          <button class="map-pin" data-id="andaman" style="--x:64%; --y:76%;">
+            <span class="pin-pulse"></span><span class="pin-core">🏝️</span><span class="pin-label">Andaman</span>
+          </button>
+          <button class="map-pin" data-id="bangkok" style="--x:78%; --y:50%;">
+            <span class="pin-pulse"></span><span class="pin-core">📜</span><span class="pin-label">Bangkok</span>
+          </button>
+        </div>
+
+        <div class="map-legend">
+          <span class="leg-chip"><i class="leg-dot"></i>Political base</span>
+          <span class="leg-chip"><i class="leg-dot battle"></i>Battlefield</span>
+          <span class="leg-chip"><i class="leg-line"></i>INA advance route, 1944</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ TIMELINE ============ -->
+  <section class="ina-section ina-section-alt reveal" id="timeline">
+    <div class="ina-container">
+      <div class="ina-section-header">
+        <span class="ina-eyebrow">From Capture to Collapse · 1942–1946</span>
+        <h2>Timeline of the INA</h2>
+      </div>
+      <div class="timeline-flow">
+        <div class="timeline-line"></div>
+        <div class="timeline-step" data-year="1942">
+          <div class="timeline-marker"><span>1942</span></div>
+          <article class="timeline-card"><span class="tc-date">February 1942</span><h3>Fall of Singapore</h3><p>Over 60,000 Indian soldiers become Japanese prisoners of war, providing the manpower for the future INA.</p></article>
+        </div>
+        <div class="timeline-step" data-year="1942">
+          <div class="timeline-marker"><span>Sep</span></div>
+          <article class="timeline-card"><span class="tc-date">September 1942</span><h3>First INA Formed</h3><p>Mohan Singh raises the first INA from willing POWs, backed by Rash Behari Bose's Indian Independence League.</p></article>
+        </div>
+        <div class="timeline-step" data-year="1942">
+          <div class="timeline-marker"><span>Dec</span></div>
+          <article class="timeline-card"><span class="tc-date">December 1942</span><h3>First INA Dissolved</h3><p>Mohan Singh disbands the force over distrust of Japanese intentions; he is arrested.</p></article>
+        </div>
+        <div class="timeline-step" data-year="1943">
+          <div class="timeline-marker"><span>Jul</span></div>
+          <article class="timeline-card"><span class="tc-date">July 1943</span><h3>Bose Takes Command</h3><p>Subhas Chandra Bose arrives in Singapore and receives leadership from Rash Behari Bose.</p></article>
+        </div>
+        <div class="timeline-step" data-year="1943">
+          <div class="timeline-marker"><span>21</span></div>
+          <article class="timeline-card"><span class="tc-date">21 October 1943</span><h3>Azad Hind Proclaimed</h3><p>Bose declares the Provisional Government of Free India in Singapore, declaring war on Britain and the USA.</p></article>
+        </div>
+        <div class="timeline-step" data-year="1944">
+          <div class="timeline-marker"><span>Q1</span></div>
+          <article class="timeline-card"><span class="tc-date">Early 1944</span><h3>Advance Toward India</h3><p>INA units advance alongside Japanese forces toward Manipur, aiming to raise the tricolour on Indian soil.</p></article>
+        </div>
+        <div class="timeline-step" data-year="1944">
+          <div class="timeline-marker"><span>⚔️</span></div>
+          <article class="timeline-card tc-battle"><span class="tc-date">Apr–Jul 1944</span><h3>Imphal &amp; Kohima</h3><p>Allied resistance, monsoon rains, and collapsed supply lines force a disastrous retreat — ending the campaign to reach India.</p></article>
+        </div>
+        <div class="timeline-step" data-year="1945">
+          <div class="timeline-marker"><span>Aug</span></div>
+          <article class="timeline-card"><span class="tc-date">August 1945</span><h3>Japan Surrenders</h3><p>The INA disintegrates. Bose dies in a plane crash in Taiwan on 18 August while trying to reach the USSR.</p></article>
+        </div>
+        <div class="timeline-step" data-year="1945">
+          <div class="timeline-marker"><span>⚖️</span></div>
+          <article class="timeline-card tc-trial"><span class="tc-date">Nov 1945 – May 1946</span><h3>Red Fort Trials</h3><p>Captured INA officers — Shah Nawaz Khan, Prem Sahgal, and Gurbaksh Singh Dhillon — are court-martialled at Delhi's Red Fort, triggering nationwide protests.</p></article>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ COMMANDERS GALLERY ============ -->
+  <section class="ina-section reveal" id="commanders">
+    <div class="ina-container">
+      <div class="ina-section-header">
+        <span class="ina-eyebrow">The People Behind the Army</span>
+        <h2>Key Commanders &amp; Figures</h2>
+      </div>
+      <div class="commanders-grid">
+        <a class="commander-card" href="../subhas-chandra-bose-explorer/index.html">
+          <span class="cc-badge">Netaji</span>
+          <div class="cc-portrait" data-initials="SCB">
+            <svg viewBox="0 0 120 120" preserveAspectRatio="xMidYMid slice">
+              <defs><radialGradient id="p1" cx="50%" cy="40%"><stop offset="0%" stop-color="#ff9933"/><stop offset="100%" stop-color="#6b2d05"/></radialGradient></defs>
+              <rect width="120" height="120" fill="url(#p1)"/>
+              <text x="60" y="72" text-anchor="middle" font-family="Playfair Display" font-size="36" font-weight="700" fill="#fff8e7">SCB</text>
+            </svg>
+          </div>
+          <div class="cc-body"><h3>Subhas Chandra Bose</h3><p>Supreme Commander · 1897–1945</p><small>Explore in depth →</small></div>
+        </a>
+        <a class="commander-card" href="../rash-behari-bose-explorer/index.html">
+          <span class="cc-badge">Veteran</span>
+          <div class="cc-portrait" data-initials="RBB">
+            <svg viewBox="0 0 120 120"><defs><radialGradient id="p2" cx="50%" cy="40%"><stop offset="0%" stop-color="#f6c453"/><stop offset="100%" stop-color="#6e4a12"/></radialGradient></defs><rect width="120" height="120" fill="url(#p2)"/><text x="60" y="72" text-anchor="middle" font-family="Playfair Display" font-size="36" font-weight="700" fill="#fff8e7">RBB</text></svg>
+          </div>
+          <div class="cc-body"><h3>Rash Behari Bose</h3><p>President, Indian Independence League · 1886–1945</p><small>Explore in depth →</small></div>
+        </a>
+        <a class="commander-card" href="../captain-lakshmi-sahgal-explorer/index.html">
+          <span class="cc-badge">Captain</span>
+          <div class="cc-portrait" data-initials="LS">
+            <svg viewBox="0 0 120 120"><defs><radialGradient id="p3" cx="50%" cy="40%"><stop offset="0%" stop-color="#37a45d"/><stop offset="100%" stop-color="#0d3c1a"/></radialGradient></defs><rect width="120" height="120" fill="url(#p3)"/><text x="60" y="72" text-anchor="middle" font-family="Playfair Display" font-size="36" font-weight="700" fill="#fff8e7">LS</text></svg>
+          </div>
+          <div class="cc-body"><h3>Captain Lakshmi Sahgal</h3><p>Commander, Rani of Jhansi Regiment · 1914–2012</p><small>Explore in depth →</small></div>
+        </a>
+        <div class="commander-card">
+          <span class="cc-badge">Founder</span>
+          <div class="cc-portrait" data-initials="MS">
+            <svg viewBox="0 0 120 120"><defs><radialGradient id="p4" cx="50%" cy="40%"><stop offset="0%" stop-color="#8b7355"/><stop offset="100%" stop-color="#3a2f1e"/></radialGradient></defs><rect width="120" height="120" fill="url(#p4)"/><text x="60" y="72" text-anchor="middle" font-family="Playfair Display" font-size="36" font-weight="700" fill="#fff8e7">MS</text></svg>
+          </div>
+          <div class="cc-body"><h3>Captain Mohan Singh</h3><p>Founder, First INA · 1909–1989</p><small>Raised the first army in 1942</small></div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ QUOTES CAROUSEL ============ -->
+  <section class="ina-section ina-section-alt reveal" id="quotes">
+    <div class="ina-container">
+      <div class="ina-section-header">
+        <span class="ina-eyebrow">Voices of the Movement</span>
+        <h2>Words That Rallied an Army</h2>
+      </div>
+      <div class="quotes-carousel">
+        <div class="quote-track" id="quote-track">
+          <blockquote class="quote-card"><p>"Give me blood, and I shall give you freedom!"</p><cite>— Subhas Chandra Bose, Burma, 1944</cite></blockquote>
+          <blockquote class="quote-card"><p>"Ittehad, Etamad, Qurbani — Unity, Faith, Sacrifice."</p><cite>— Motto of the Azad Hind Government</cite></blockquote>
+          <blockquote class="quote-card"><p>"One individual should die for a great leader to emerge — but a leader should never die without leaving behind his message."</p><cite>— Subhas Chandra Bose</cite></blockquote>
+          <blockquote class="quote-card"><p>"The road to Delhi is through Imphal."</p><cite>— INA rallying call, 1944</cite></blockquote>
+          <blockquote class="quote-card"><p>"Forget not that the greatest enemies of our cause are greed and apathy."</p><cite>— Subhas Chandra Bose</cite></blockquote>
+        </div>
+        <div class="quote-controls">
+          <button class="q-btn" id="q-prev" aria-label="Previous quote">←</button>
+          <div class="q-dots" id="q-dots"></div>
+          <button class="q-btn" id="q-next" aria-label="Next quote">→</button>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ BRITISH RESPONSE & IMPACT ============ -->
+  <section class="ina-section reveal" id="collapse">
+    <div class="ina-container ina-grid-2col">
+      <div class="ina-text-block">
+        <span class="ina-eyebrow">Facing the Empire</span>
+        <h2>British Response &amp; the Final Retreat</h2>
+        <p>The failure at Imphal and Kohima left the INA cut off from supplies. Many units surrendered as Allied forces retook Burma; others made a fighting retreat before Japan's August 1945 surrender ended organised resistance.</p>
+        <p>Britain treated captured INA officers as <mark>traitors</mark> under military law — leading directly to the Red Fort Trials. Intended as an example, the trials backfired catastrophically: public sympathy for the accused grew so intense that Britain was forced to commute death sentences and release the convicted officers.</p>
+      </div>
+      <div class="ina-text-block">
+        <span class="ina-eyebrow">Beyond the Battlefield</span>
+        <h2>A Shaken Empire</h2>
+        <ul class="impact-list">
+          <li><b>⚖️ Red Fort Trials</b><span>United political opinion across party lines like never before.</span></li>
+          <li><b>📣 Nationwide protests</b><span>Mass demonstrations and strikes through late 1945 and early 1946.</span></li>
+          <li><b>⚓ Military unrest</b><span>Fed the atmosphere that produced the RIN Mutiny of February 1946.</span></li>
+          <li><b>🏛️ Accelerated independence</b><span>Convinced Britain that Indian armed forces could no longer be relied upon to maintain the Raj.</span></li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ DID YOU KNOW ============ -->
+  <section class="ina-section ina-section-alt reveal" id="trivia">
+    <div class="ina-container">
+      <div class="ina-section-header">
+        <span class="ina-eyebrow">Lesser-Known Facts</span>
+        <h2>Did You Know?</h2>
+      </div>
+      <div class="accordion" id="trivia-accordion">
+        <details class="acc-item" open>
+          <summary><span class="acc-icon">🏝️</span>The INA briefly "governed" Indian territory</summary>
+          <div class="acc-body">After Japan transferred nominal sovereignty over the Andaman and Nicobar Islands in December 1943, Azad Hind renamed them <b>Shaheed</b> (Martyr) and <b>Swaraj</b> (Self-Rule) Islands — the only Indian soil ever under the INA flag.</div>
+        </details>
+        <details class="acc-item">
+          <summary><span class="acc-icon">⚔️</span>A women's combat regiment, decades early</summary>
+          <div class="acc-body">The Rani of Jhansi Regiment, raised in 1943 and commanded by Captain Lakshmi Sahgal, was one of the earliest all-women combat units in Asia — formed a full generation before most modern militaries opened combat roles to women.</div>
+        </details>
+        <details class="acc-item">
+          <summary><span class="acc-icon">🚢</span>Bose reached Asia by submarine</summary>
+          <div class="acc-body">After years in Germany seeking Axis support, Bose transferred from a German U-boat to a Japanese submarine in the Indian Ocean in early 1943 — one of the only wartime transfers between Axis submarines — before arriving in Singapore.</div>
+        </details>
+        <details class="acc-item">
+          <summary><span class="acc-icon">🎬</span>The Red Fort Trials united political rivals</summary>
+          <div class="acc-body">Congress, the Muslim League, Hindu Mahasabha, and Communists — normally fierce rivals — all demanded the release of the accused officers. Defence counsel included Bhulabhai Desai and a young Jawaharlal Nehru.</div>
+        </details>
+        <details class="acc-item">
+          <summary><span class="acc-icon">🌊</span>A currency and postage of their own</summary>
+          <div class="acc-body">Azad Hind issued its own postage stamps and currency (rupees, annas, pies) — symbolic but real state apparatus — that circulated in the territories it nominally controlled.</div>
+        </details>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ REFERENCES ============ -->
+  <section class="ina-section reveal" id="references">
+    <div class="ina-container">
+      <div class="ina-references">
+        <h3>📚 Sources &amp; Further Reading</h3>
+        <ul>
+          <li><strong>Fay, Peter Ward (1993)</strong>. <em>The Forgotten Army: India's Armed Struggle for Independence, 1942–1945</em>. University of Michigan Press.</li>
+          <li><strong>Toye, Hugh (1959)</strong>. <em>The Springing Tiger: A Study of a Revolutionary</em>. Cassell.</li>
+          <li><strong>Lebra, Joyce C. (1971)</strong>. <em>Jungle Alliance: Japan and the Indian National Army</em>. Asia Pacific Press.</li>
+          <li><strong>Sarkar, Sumit (1983)</strong>. <em>Modern India, 1885–1947</em>. Macmillan.</li>
+          <li><strong>Netaji Research Bureau, Kolkata</strong>. Archival records and papers relating to Subhas Chandra Bose and the Azad Hind Government.</li>
+        </ul>
+      </div>
+    </div>
+  </section>
+
+</main>
+
+<!-- ============ MODAL ============ -->
+<div class="museum-modal" id="port-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-hidden="true">
+  <div class="museum-modal-card">
+    <button class="museum-modal-close" id="port-modal-close" type="button" aria-label="Close details">✕</button>
+    <span class="modal-category" id="modal-category">INA Location</span>
+    <h2 id="modal-title"></h2>
+    <p class="modal-location" id="modal-heading"></p>
+    <div class="modal-body">
+      <p class="modal-description" id="modal-description"></p>
+    </div>
+  </div>
+</div>
+
+<footer class="ina-footer">
+  <div class="ina-container">
+    <p>Part of <a href="../../index.html">Incredible India Explorer</a> · Discover the army that carried India's fight for freedom across Southeast Asia.</p>
+  </div>
+</footer>
+
+<button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+
+<script src="../app.js" defer></script>
+<script src="../../frontend/journey/journey.js" defer></script>
+<script src="script.js" defer></script>
+<script type="module" src="../firebase-config.js"></script>
+<script type="module" src="../auth.js"></script>
+<script src="../router.js" defer></script>
+<script src="../js-modules/page-progress/page-progress.js"></script>
 </body>
-
 </html>


### PR DESCRIPTION
Closes #2736

🧾 Summary
Adds two retention features to the Heritage Trail game: URL-encoded shareable routes (challenge a friend with your exact trail) and a persistent Trail Badges achievement system with unlock toasts.


🧪 How to test
Build a route → watch URL hash update live
Copy the URL, open in a new/incognito tab → route restores + toast appears
Tamper with hash (#trail=foo.delhi&diff=hacker) → invalid parts ignored, no errors
Complete a 3-stop trail → 🥾 First Steps unlocks with toast + glow
Cover all 5 zones → 🗺️ Zone Master unlocks
Refresh page → badges persist; "Clear saved" does not wipe badges
Toggle light theme + enable reduced-motion → both behave

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the INA Explorer page with an enhanced hero section, animated statistics, historical quotes, emblem artwork, and journey bookmarking.
  * Added interactive regiment tabs, campaign map pins, timeline markers, quote carousel controls, trivia accordions, and informational modals.
  * Expanded historical content covering INA origins, leadership, Azad Hind, regiments, campaigns, commanders, British response, and references.
* **Style**
  * Updated navigation, layouts, cards, descriptions, footer, and visual theme behavior for a more cohesive experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->