### PR TITLE
Feature/ai travel assistant

### DIFF
--- a/assistant-widget.css
+++ b/assistant-widget.css
@@ -1,0 +1,9 @@
+.ta-widget { max-width: 360px; border: 1px solid #ddd; border-radius: 8px; font-family: sans-serif; }
+.ta-header { background: #f97316; color: #fff; padding: 10px 12px; font-weight: 600; border-radius: 8px 8px 0 0; }
+.ta-messages { height: 320px; overflow-y: auto; padding: 10px; display: flex; flex-direction: column; gap: 8px; }
+.ta-msg { padding: 8px 10px; border-radius: 10px; max-width: 85%; white-space: pre-line; font-size: 14px; }
+.ta-msg-user { align-self: flex-end; background: #f97316; color: #fff; }
+.ta-msg-assistant { align-self: flex-start; background: #f1f1f1; color: #222; }
+.ta-form { display: flex; border-top: 1px solid #eee; }
+.ta-form input { flex: 1; border: none; padding: 10px; font-size: 14px; }
+.ta-form button { border: none; background: #f97316; color: #fff; padding: 0 14px; cursor: pointer; }

--- a/assistant-widget.js
+++ b/assistant-widget.js
@@ -1,0 +1,48 @@
+(function () {
+  const root = document.getElementById("travel-assistant");
+  if (!root) return;
+
+  root.innerHTML = `
+    <div class="ta-widget">
+      <div class="ta-header">Travel Assistant</div>
+      <div class="ta-messages" id="ta-messages"></div>
+      <form id="ta-form" class="ta-form">
+        <input id="ta-input" type="text" placeholder="Ask about places, food, or plans..." autocomplete="off" />
+        <button type="submit">Send</button>
+      </form>
+    </div>`;
+
+  const messagesEl = document.getElementById("ta-messages");
+  const formEl = document.getElementById("ta-form");
+  const inputEl = document.getElementById("ta-input");
+
+  function appendMessage(role, text) {
+    const div = document.createElement("div");
+    div.className = `ta-msg ta-msg-${role}`;
+    div.textContent = text;
+    messagesEl.appendChild(div);
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+  }
+
+  // Replay prior history on load so a page refresh doesn't lose context
+  const session = ContextManager.getSession();
+  session.history.forEach((h) => appendMessage(h.role, h.text));
+  if (!session.history.length) {
+    appendMessage("assistant", "Hi! Ask me about places to visit, food, or what to do if it rains.");
+  }
+
+  formEl.addEventListener("submit", (e) => {
+    e.preventDefault();
+    const message = inputEl.value.trim();
+    if (!message) return;
+    inputEl.value = "";
+
+    appendMessage("user", message);
+    ContextManager.addMessage("user", message);
+
+    const { reply, suggestions } = getAssistantReply(message, ContextManager.getSession());
+    appendMessage("assistant", reply);
+    ContextManager.addMessage("assistant", reply);
+    ContextManager.setLastRecommendations(suggestions.map((s) => s.id));
+  });
+})();

--- a/assistantService.js
+++ b/assistantService.js
@@ -1,0 +1,25 @@
+function buildReply(intent, results) {
+  if (intent.type === "greeting") {
+    return "Hi! Ask me things like 'what can I visit near my hotel' or 'suggest budget-friendly places in Jaipur'.";
+  }
+
+  if (!results.length) {
+    return "I couldn't find a match for that yet — try naming a city, e.g. 'places to visit in Agra'.";
+  }
+
+  const lines = results.map((d) => `• ${d.name} — ${d.description} (~₹${d.avgCost})`);
+  const intro = intent.weather === "rain"
+    ? "Since it's rainy, here are indoor-friendly options:"
+    : intent.budgetFriendly
+      ? "Here are some budget-friendly picks:"
+      : "Here's what I'd suggest:";
+
+  return `${intro}\n${lines.join("\n")}`;
+}
+
+function getAssistantReply(message, session) {
+  const intent = parseIntent(message);
+  const results = intent.type === "greeting" ? [] : recommend({ intent, session });
+  const reply = buildReply(intent, results);
+  return { reply, suggestions: results, intent };
+}

--- a/contextManager.js
+++ b/contextManager.js
@@ -1,0 +1,56 @@
+/**
+ * Client-side session state, persisted to localStorage so context
+ * (itinerary, preferences, history, last recommendations) survives
+ * page reloads — no backend needed.
+ */
+const ContextManager = (() => {
+  const STORAGE_KEY = "ta_session_v1";
+
+  function load() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) return JSON.parse(raw);
+    } catch (e) { /* corrupt storage, fall through to fresh session */ }
+    return {
+      history: [],
+      itinerary: null,
+      preferences: {},
+      lastMentionedCity: null,
+      lastRecommendedIds: []
+    };
+  }
+
+  let session = load();
+
+  function save() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+  }
+
+  return {
+    getSession() {
+      return session;
+    },
+    addMessage(role, text) {
+      session.history.push({ role, text, timestamp: Date.now() });
+      if (session.history.length > 20) session.history.shift();
+      save();
+    },
+    updateItinerary(itinerary) {
+      session.itinerary = { ...session.itinerary, ...itinerary };
+      if (itinerary.city) session.lastMentionedCity = itinerary.city;
+      save();
+    },
+    updatePreferences(preferences) {
+      session.preferences = { ...session.preferences, ...preferences };
+      save();
+    },
+    setLastRecommendations(ids) {
+      session.lastRecommendedIds = ids;
+      save();
+    },
+    clear() {
+      localStorage.removeItem(STORAGE_KEY);
+      session = load();
+    }
+  };
+})();

--- a/destinations.js
+++ b/destinations.js
@@ -1,0 +1,50 @@
+const DESTINATIONS = [
+  {
+    id: "taj-mahal", name: "Taj Mahal", city: "Agra",
+    tags: ["heritage", "monument", "unesco", "romantic"],
+    indoorOutdoor: "outdoor", bestWeather: ["clear", "clouds"],
+    avgCost: 1100, openHours: "6:00 AM - 6:30 PM (closed Fridays)",
+    nearBy: ["agra-fort", "mehtab-bagh"],
+    description: "Iconic white marble mausoleum, one of the New Seven Wonders of the World."
+  },
+  {
+    id: "agra-fort", name: "Agra Fort", city: "Agra",
+    tags: ["heritage", "monument", "unesco"],
+    indoorOutdoor: "outdoor", bestWeather: ["clear", "clouds"],
+    avgCost: 650, openHours: "6:00 AM - 6:00 PM",
+    nearBy: ["taj-mahal"],
+    description: "Red sandstone Mughal fort overlooking the Yamuna river."
+  },
+  {
+    id: "mehtab-bagh", name: "Mehtab Bagh", city: "Agra",
+    tags: ["garden", "sunset", "budget-friendly"],
+    indoorOutdoor: "outdoor", bestWeather: ["clear", "clouds"],
+    avgCost: 300, openHours: "6:00 AM - 7:00 PM",
+    nearBy: ["taj-mahal"],
+    description: "Charbagh garden with a classic sunset view of the Taj Mahal."
+  },
+  {
+    id: "city-palace-jaipur", name: "City Palace", city: "Jaipur",
+    tags: ["heritage", "museum", "indoor-friendly"],
+    indoorOutdoor: "mixed", bestWeather: ["any"],
+    avgCost: 700, openHours: "9:30 AM - 5:00 PM",
+    nearBy: ["hawa-mahal", "jantar-mantar"],
+    description: "Royal palace complex with museums, courtyards, and covered galleries."
+  },
+  {
+    id: "hawa-mahal", name: "Hawa Mahal", city: "Jaipur",
+    tags: ["heritage", "monument", "photography"],
+    indoorOutdoor: "outdoor", bestWeather: ["clear", "clouds"],
+    avgCost: 200, openHours: "9:00 AM - 4:30 PM",
+    nearBy: ["city-palace-jaipur"],
+    description: "Pink sandstone 'Palace of Winds' with intricate latticed windows."
+  },
+  {
+    id: "albert-hall-museum", name: "Albert Hall Museum", city: "Jaipur",
+    tags: ["museum", "indoor-friendly", "rainy-day"],
+    indoorOutdoor: "indoor", bestWeather: ["any"],
+    avgCost: 150, openHours: "9:00 AM - 5:00 PM",
+    nearBy: ["city-palace-jaipur"],
+    description: "Oldest museum in Rajasthan, great indoor option on a rainy day."
+  }
+];

--- a/docs/AI_ASSISTANT_ARCHITECTURE.md
+++ b/docs/AI_ASSISTANT_ARCHITECTURE.md
@@ -1,0 +1,20 @@
+# AI Travel Assistant — Architecture (client-only)
+
+No backend exists in this project, so the whole pipeline runs in the browser.
+
+## Flow
+1. User types a message in the widget (`assistant-widget.js`).
+2. `intentParser.js` extracts intent (city, weather, budget, near-me, food, timeframe) with regex — no network call needed.
+3. `knowledgeBase.js` filters a static `destinations.js` dataset (retrieval step).
+4. `recommendationEngine.js` ranks/filters results using session context from `contextManager.js` (itinerary city, budget preference, last recommendations for "near me" follow-ups).
+5. `assistantService.js` turns the ranked results into a reply string. This is fully rule-based, satisfying the "useful fallback" acceptance criterion without any external dependency.
+6. `contextManager.js` persists history/itinerary/preferences to `localStorage`, so context (and the visible chat) survives a page reload.
+
+## Adding a real LLM later
+Doing this safely requires a backend, because calling an LLM API directly from client-side JS would expose the API key to anyone viewing page source. If a backend is added:
+- Keep `knowledgeBase.js`'s `search()` interface as-is.
+- Add a server endpoint that takes `{ message, retrievedDestinations, history }`, calls the LLM with that as grounding context, and returns the text.
+- Have `assistantService.js` call that endpoint, falling back to the current rule-based `buildReply()` on any failure.
+
+## Testing
+`recommendationEngine.js` and `intentParser.js` are pure functions with no DOM/localStorage dependency, so they're unit-testable in isolation (see `tests/`).

--- a/intentParser.js
+++ b/intentParser.js
@@ -1,0 +1,27 @@
+function parseIntent(message) {
+  const text = message.toLowerCase();
+
+  const intent = {
+    type: "recommendation",
+    near: /near|close to|around|nearby/.test(text),
+    budgetFriendly: /budget|cheap|affordable|low.cost/.test(text),
+    weather: null,
+    city: null,
+    tags: []
+  };
+
+  if (/rain|rainy|storm/.test(text)) intent.weather = "rain";
+  else if (/sunny|clear/.test(text)) intent.weather = "clear";
+
+  if (/food|eat|cuisine|dish|restaurant/.test(text)) intent.tags.push("food");
+  if (/tomorrow|next day/.test(text)) intent.timeframe = "tomorrow";
+  if (/today/.test(text)) intent.timeframe = "today";
+
+  const cityMatch = text.match(/in ([a-z\s]+?)(\?|$|\.|,)/);
+  if (cityMatch) intent.city = cityMatch[1].trim();
+
+  if (/^(hi|hello|hey)\b/.test(text)) intent.type = "greeting";
+  if (/tip|advice|suggest.*tip/.test(text)) intent.type = "tip";
+
+  return intent;
+}

--- a/itinerary-data.js
+++ b/itinerary-data.js
@@ -1,0 +1,169 @@
+/**
+ * itinerary-data.js
+ * ------------------------------------------------------------------
+ * Static dataset powering the AI-Powered Personalized Itinerary
+ * Generator (see /docs/itinerary-generator.md for architecture).
+ *
+ * This mirrors the pattern already used by chatbot-data.js in this
+ * repo: a plain data file with no build step, loaded via a <script>
+ * tag before itinerary-engine.js.
+ *
+ * Each destination has a list of attractions tagged by `interests`
+ * (must match the checkboxes in itinerary.html), a `costTier`
+ * (0 = free, 1 = budget, 2 = mid-range, 3 = luxury/premium), rough
+ * lat/lng for nearest-neighbour sequencing, opening hours in 24h
+ * time, and an average visit duration in minutes.
+ * ------------------------------------------------------------------
+ */
+(function (root) {
+  "use strict";
+
+  const DESTINATIONS = [
+    {
+      id: "delhi",
+      name: "Delhi",
+      state: "Delhi",
+      tagline: "Mughal grandeur meets modern India",
+      center: { lat: 28.6139, lng: 77.209 },
+      image: "assets/travel_hidden.png",
+      attractions: [
+        { id: "delhi-red-fort", name: "Red Fort", interests: ["heritage", "culture"], lat: 28.6562, lng: 77.241, visitMinutes: 120, openHour: 9.5, closeHour: 16.5, costTier: 1, description: "17th-century Mughal fortress and UNESCO World Heritage Site." },
+        { id: "delhi-qutub-minar", name: "Qutub Minar", interests: ["heritage"], lat: 28.5245, lng: 77.1855, visitMinutes: 90, openHour: 7, closeHour: 17, costTier: 1, description: "Towering 12th-century minaret surrounded by ancient ruins." },
+        { id: "delhi-humayun-tomb", name: "Humayun's Tomb", interests: ["heritage", "culture"], lat: 28.5933, lng: 77.2507, visitMinutes: 90, openHour: 6, closeHour: 18, costTier: 1, description: "Garden tomb that inspired the Taj Mahal's design." },
+        { id: "delhi-chandni-chowk", name: "Chandni Chowk", interests: ["cuisine", "shopping", "culture"], lat: 28.6506, lng: 77.2303, visitMinutes: 120, openHour: 10, closeHour: 21, costTier: 0, description: "Chaotic, delicious old-city market lanes." },
+        { id: "delhi-lotus-temple", name: "Lotus Temple", interests: ["spiritual"], lat: 28.5535, lng: 77.2588, visitMinutes: 60, openHour: 9, closeHour: 17.5, costTier: 0, description: "Lotus-shaped Baha'i House of Worship open to all faiths." },
+        { id: "delhi-akshardham", name: "Akshardham Temple", interests: ["spiritual", "culture"], lat: 28.6127, lng: 77.2773, visitMinutes: 150, openHour: 9.5, closeHour: 18.5, costTier: 0, description: "Sprawling modern temple complex with exhibitions and gardens." }
+      ]
+    },
+    {
+      id: "agra",
+      name: "Agra",
+      state: "Uttar Pradesh",
+      tagline: "Home of the Taj Mahal",
+      center: { lat: 27.1767, lng: 78.0081 },
+      image: "assets/travel_hidden.png",
+      attractions: [
+        { id: "agra-taj-mahal", name: "Taj Mahal", interests: ["heritage", "culture"], lat: 27.1751, lng: 78.0421, visitMinutes: 150, openHour: 6, closeHour: 18.5, costTier: 2, description: "The iconic marble mausoleum, best seen at sunrise." },
+        { id: "agra-fort", name: "Agra Fort", interests: ["heritage"], lat: 27.18, lng: 78.0211, visitMinutes: 100, openHour: 6, closeHour: 18, costTier: 1, description: "Red sandstone Mughal fortress on the Yamuna river." },
+        { id: "agra-fatehpur-sikri", name: "Fatehpur Sikri", interests: ["heritage", "spiritual"], lat: 27.0937, lng: 77.6607, visitMinutes: 120, openHour: 6, closeHour: 18, costTier: 1, description: "Abandoned Mughal capital city, remarkably intact." },
+        { id: "agra-mehtab-bagh", name: "Mehtab Bagh", interests: ["nature", "heritage"], lat: 27.1836, lng: 78.043, visitMinutes: 60, openHour: 6, closeHour: 19, costTier: 0, description: "Garden with the best sunset view of the Taj across the river." }
+      ]
+    },
+    {
+      id: "jaipur",
+      name: "Jaipur",
+      state: "Rajasthan",
+      tagline: "The Pink City",
+      center: { lat: 26.9124, lng: 75.7873 },
+      image: "assets/travel_deserts.png",
+      attractions: [
+        { id: "jaipur-amber-fort", name: "Amber Fort", interests: ["heritage", "adventure"], lat: 26.9855, lng: 75.8513, visitMinutes: 150, openHour: 8, closeHour: 17.5, costTier: 1, description: "Hilltop fort-palace with elephant rides and mirrored halls." },
+        { id: "jaipur-hawa-mahal", name: "Hawa Mahal", interests: ["heritage", "culture"], lat: 26.9239, lng: 75.8267, visitMinutes: 45, openHour: 9, closeHour: 16.5, costTier: 0, description: "Honeycomb 'Palace of Winds' facade in the old city." },
+        { id: "jaipur-city-palace", name: "City Palace", interests: ["heritage", "culture"], lat: 26.9258, lng: 75.8237, visitMinutes: 100, openHour: 9.5, closeHour: 17, costTier: 1, description: "Royal residence blending Rajput and Mughal architecture." },
+        { id: "jaipur-jal-mahal", name: "Jal Mahal", interests: ["nature", "heritage"], lat: 26.9539, lng: 75.8462, visitMinutes: 30, openHour: 0, closeHour: 24, costTier: 0, description: "Palace floating on Man Sagar Lake, viewed from the shore." },
+        { id: "jaipur-johari-bazaar", name: "Johari Bazaar", interests: ["shopping", "cuisine"], lat: 26.9196, lng: 75.8259, visitMinutes: 90, openHour: 10.5, closeHour: 21, costTier: 1, description: "Famed jewellery and textile market." },
+        { id: "jaipur-nahargarh", name: "Nahargarh Fort", interests: ["heritage", "nature"], lat: 26.9376, lng: 75.8155, visitMinutes: 90, openHour: 10, closeHour: 17.5, costTier: 0, description: "Ridge-top fort with panoramic sunset views of the city." }
+      ]
+    },
+    {
+      id: "goa",
+      name: "Goa",
+      state: "Goa",
+      tagline: "Sun, sand and Portuguese heritage",
+      center: { lat: 15.2993, lng: 74.124 },
+      image: "assets/travel_beaches.png",
+      attractions: [
+        { id: "goa-baga", name: "Baga Beach", interests: ["relaxation", "adventure"], lat: 15.5553, lng: 73.7517, visitMinutes: 150, openHour: 0, closeHour: 24, costTier: 1, description: "Lively beach with water sports and beach shacks." },
+        { id: "goa-basilica", name: "Basilica of Bom Jesus", interests: ["heritage", "spiritual"], lat: 15.5009, lng: 73.9116, visitMinutes: 60, openHour: 9, closeHour: 18.5, costTier: 0, description: "UNESCO-listed baroque church in Old Goa." },
+        { id: "goa-fort-aguada", name: "Fort Aguada", interests: ["heritage", "nature"], lat: 15.4925, lng: 73.7738, visitMinutes: 75, openHour: 9.5, closeHour: 18, costTier: 0, description: "17th-century Portuguese fort overlooking the Arabian Sea." },
+        { id: "goa-anjuna-market", name: "Anjuna Flea Market", interests: ["shopping", "culture"], lat: 15.5734, lng: 73.7407, visitMinutes: 120, openHour: 8, closeHour: 20, costTier: 1, description: "Wednesday flea market of textiles, spices and trinkets." },
+        { id: "goa-dudhsagar", name: "Dudhsagar Falls", interests: ["nature", "adventure"], lat: 15.3144, lng: 74.3144, visitMinutes: 180, openHour: 8, closeHour: 16, costTier: 2, description: "Four-tiered waterfall reached by jeep safari." }
+      ]
+    },
+    {
+      id: "kerala",
+      name: "Kochi & Munnar",
+      state: "Kerala",
+      tagline: "Backwaters and tea-hills",
+      center: { lat: 9.9312, lng: 76.2673 },
+      image: "assets/travel_forests.png",
+      attractions: [
+        { id: "kerala-fort-kochi", name: "Fort Kochi", interests: ["heritage", "culture"], lat: 9.9658, lng: 76.2422, visitMinutes: 120, openHour: 0, closeHour: 24, costTier: 0, description: "Chinese fishing nets, colonial streets and art cafes." },
+        { id: "kerala-backwaters", name: "Alleppey Backwaters Cruise", interests: ["nature", "relaxation"], lat: 9.4981, lng: 76.3388, visitMinutes: 240, openHour: 9, closeHour: 17, costTier: 2, description: "Houseboat cruise through palm-fringed canals." },
+        { id: "kerala-munnar-tea", name: "Munnar Tea Gardens", interests: ["nature", "relaxation"], lat: 10.0889, lng: 77.0595, visitMinutes: 150, openHour: 8, closeHour: 17.5, costTier: 1, description: "Rolling emerald tea estates in the Western Ghats." },
+        { id: "kerala-eravikulam", name: "Eravikulam National Park", interests: ["wildlife", "nature"], lat: 10.1631, lng: 77.0508, visitMinutes: 120, openHour: 8, closeHour: 16, costTier: 1, description: "Home to the endangered Nilgiri Tahr." },
+        { id: "kerala-jew-town", name: "Jew Town & Spice Market", interests: ["shopping", "cuisine", "culture"], lat: 9.9578, lng: 76.259, visitMinutes: 90, openHour: 10, closeHour: 19, costTier: 1, description: "Historic spice trading lanes and antique shops." }
+      ]
+    },
+    {
+      id: "ladakh",
+      name: "Leh-Ladakh",
+      state: "Ladakh",
+      tagline: "High-altitude desert and monasteries",
+      center: { lat: 34.1526, lng: 77.5771 },
+      image: "assets/travel_mountains.png",
+      attractions: [
+        { id: "ladakh-pangong", name: "Pangong Lake", interests: ["nature", "adventure"], lat: 33.7592, lng: 78.6733, visitMinutes: 180, openHour: 6, closeHour: 18, costTier: 2, description: "High-altitude lake that shifts colour through the day." },
+        { id: "ladakh-thiksey", name: "Thiksey Monastery", interests: ["spiritual", "heritage"], lat: 33.8438, lng: 77.6606, visitMinutes: 90, openHour: 7, closeHour: 19, costTier: 0, description: "Twelve-storey monastery resembling Lhasa's Potala Palace." },
+        { id: "ladakh-leh-palace", name: "Leh Palace", interests: ["heritage"], lat: 34.1642, lng: 77.5847, visitMinutes: 60, openHour: 7, closeHour: 16, costTier: 0, description: "Former royal palace overlooking Leh town." },
+        { id: "ladakh-nubra", name: "Nubra Valley", interests: ["nature", "adventure"], lat: 34.6803, lng: 77.5619, visitMinutes: 240, openHour: 7, closeHour: 17, costTier: 2, description: "Cold desert valley with double-humped camels." },
+        { id: "ladakh-market", name: "Leh Main Bazaar", interests: ["shopping", "cuisine"], lat: 34.1656, lng: 77.5847, visitMinutes: 90, openHour: 10, closeHour: 21, costTier: 1, description: "Tibetan handicrafts, pashmina and local cafes." }
+      ]
+    },
+    {
+      id: "varanasi",
+      name: "Varanasi",
+      state: "Uttar Pradesh",
+      tagline: "India's spiritual capital",
+      center: { lat: 25.3176, lng: 82.9739 },
+      image: "assets/travel_hidden.png",
+      attractions: [
+        { id: "varanasi-ganga-aarti", name: "Ganga Aarti at Dashashwamedh Ghat", interests: ["spiritual", "culture"], lat: 25.3109, lng: 83.0107, visitMinutes: 75, openHour: 18.5, closeHour: 20, costTier: 0, description: "Nightly fire ceremony on the river banks." },
+        { id: "varanasi-kashi-vishwanath", name: "Kashi Vishwanath Temple", interests: ["spiritual"], lat: 25.311, lng: 83.0107, visitMinutes: 60, openHour: 3, closeHour: 23, costTier: 0, description: "One of the twelve Jyotirlinga shrines to Shiva." },
+        { id: "varanasi-boat-ride", name: "Sunrise Boat Ride", interests: ["spiritual", "nature"], lat: 25.3057, lng: 83.0104, visitMinutes: 90, openHour: 5.5, closeHour: 7.5, costTier: 1, description: "Rowboat past the ghats as the city wakes up." },
+        { id: "varanasi-sarnath", name: "Sarnath", interests: ["heritage", "spiritual"], lat: 25.3811, lng: 83.0243, visitMinutes: 100, openHour: 6, closeHour: 18, costTier: 1, description: "Where the Buddha gave his first sermon." }
+      ]
+    },
+    {
+      id: "hampi",
+      name: "Hampi",
+      state: "Karnataka",
+      tagline: "Ruins of the Vijayanagara Empire",
+      center: { lat: 15.335, lng: 76.46 },
+      image: "assets/travel_hidden.png",
+      attractions: [
+        { id: "hampi-virupaksha", name: "Virupaksha Temple", interests: ["heritage", "spiritual"], lat: 15.335, lng: 76.4601, visitMinutes: 75, openHour: 5.5, closeHour: 21.5, costTier: 0, description: "Active 7th-century temple at the heart of the ruins." },
+        { id: "hampi-vittala", name: "Vittala Temple & Stone Chariot", interests: ["heritage", "culture"], lat: 15.3406, lng: 76.4746, visitMinutes: 90, openHour: 8.5, closeHour: 17.5, costTier: 1, description: "Iconic stone chariot and musical pillars." },
+        { id: "hampi-matanga", name: "Matanga Hill", interests: ["nature", "adventure"], lat: 15.3363, lng: 76.4676, visitMinutes: 90, openHour: 6, closeHour: 18, costTier: 0, description: "Boulder-strewn sunrise/sunset viewpoint over the ruins." },
+        { id: "hampi-bazaar", name: "Hampi Bazaar", interests: ["shopping", "culture", "cuisine"], lat: 15.335, lng: 76.4614, visitMinutes: 60, openHour: 8, closeHour: 21, costTier: 0, description: "Ruined market street below Virupaksha Temple." }
+      ]
+    }
+  ];
+
+  const INTERESTS = [
+    { id: "heritage", label: "Heritage & Monuments" },
+    { id: "nature", label: "Nature & Scenery" },
+    { id: "adventure", label: "Adventure" },
+    { id: "spiritual", label: "Spiritual" },
+    { id: "culture", label: "Culture & Art" },
+    { id: "cuisine", label: "Food & Cuisine" },
+    { id: "relaxation", label: "Relaxation" },
+    { id: "shopping", label: "Shopping" },
+    { id: "wildlife", label: "Wildlife" }
+  ];
+
+  const BUDGETS = [
+    { id: "budget", label: "Budget", maxTier: 1 },
+    { id: "mid", label: "Mid-range", maxTier: 2 },
+    { id: "luxury", label: "Luxury", maxTier: 3 }
+  ];
+
+  const api = { DESTINATIONS, INTERESTS, BUDGETS };
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = api;
+  }
+  if (root) {
+    root.ItineraryData = api;
+  }
+})(typeof window !== "undefined" ? window : globalThis);

--- a/itinerary-engine.js
+++ b/itinerary-engine.js
@@ -1,0 +1,348 @@
+/**
+ * itinerary-engine.js
+ * ------------------------------------------------------------------
+ * Rule-based AI itinerary generation engine for Incredible India
+ * Explorer. Pure vanilla JS, no build step — same pattern as
+ * story-engine.js / chatbot-data.js elsewhere in this repo.
+ *
+ * Implements the acceptance criteria of issue #2695:
+ *   - generate a day-by-day itinerary from destination/duration/
+ *     interests/budget
+ *   - order attractions logically by location & opening hours
+ *   - regenerate a single day without rebuilding the whole trip
+ *   - persist (save/load) itineraries client-side
+ *
+ * Public API (window.ItineraryEngine):
+ *   generateItinerary(preferences) -> Itinerary
+ *   regenerateDay(itinerary, dayIndex) -> Itinerary (new object)
+ *   saveItinerary(itinerary) -> string id
+ *   loadItinerary(id) -> Itinerary | null
+ *   listSavedItineraries() -> Array<{id, title, savedAt}>
+ *   deleteItinerary(id) -> void
+ *   exportItineraryText(itinerary) -> string (used for PDF export
+ *     via the browser's print-to-PDF, keeping the site's "no build
+ *     tools" philosophy)
+ * ------------------------------------------------------------------
+ */
+(function (root, factory) {
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = factory(require("./itinerary-data.js"));
+  } else {
+    root.ItineraryEngine = factory(root.ItineraryData);
+  }
+})(typeof window !== "undefined" ? window : globalThis, function (ItineraryData) {
+  "use strict";
+
+  const STORAGE_KEY = "iie_itineraries";
+  const EARTH_RADIUS_KM = 6371;
+
+  // ---------------------------------------------------------------
+  // Geometry helpers
+  // ---------------------------------------------------------------
+  function toRad(deg) {
+    return (deg * Math.PI) / 180;
+  }
+
+  function haversineKm(a, b) {
+    const dLat = toRad(b.lat - a.lat);
+    const dLng = toRad(b.lng - a.lng);
+    const lat1 = toRad(a.lat);
+    const lat2 = toRad(b.lat);
+    const h =
+      Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+      Math.sin(dLng / 2) * Math.sin(dLng / 2) * Math.cos(lat1) * Math.cos(lat2);
+    return 2 * EARTH_RADIUS_KM * Math.asin(Math.sqrt(h));
+  }
+
+  // Rough local travel-time estimate: 25 km/h average incl. traffic/stops.
+  function travelMinutes(a, b) {
+    const km = haversineKm(a, b);
+    return Math.max(5, Math.round((km / 25) * 60));
+  }
+
+  // ---------------------------------------------------------------
+  // Scoring & filtering
+  // ---------------------------------------------------------------
+  function budgetMaxTier(budgetId) {
+    const b = (ItineraryData.BUDGETS || []).find((x) => x.id === budgetId);
+    return b ? b.maxTier : 2;
+  }
+
+  function interestScore(attraction, interests) {
+    if (!interests || interests.length === 0) return 1;
+    const matches = attraction.interests.filter((t) => interests.includes(t)).length;
+    return matches; // 0 = no overlap
+  }
+
+  function eligibleAttractions(destination, preferences) {
+    const maxTier = budgetMaxTier(preferences.budget);
+    return destination.attractions
+      .filter((a) => a.costTier <= maxTier)
+      .map((a) => ({ attraction: a, score: interestScore(a, preferences.interests) }))
+      .filter((entry) => (preferences.interests && preferences.interests.length ? entry.score > 0 : true))
+      .sort((x, y) => y.score - x.score)
+      .map((entry) => entry.attraction);
+  }
+
+  // Attractions-per-day by pace.
+  const PACE_COUNTS = { relaxed: 2, moderate: 3, packed: 4 };
+
+  // ---------------------------------------------------------------
+  // Sequencing (nearest-neighbour, respecting opening hours)
+  // ---------------------------------------------------------------
+  function sequenceDay(startPoint, candidates, count, dayStartHour) {
+    const pool = candidates.slice();
+    const chosen = [];
+    let current = startPoint;
+    let clock = dayStartHour;
+
+    while (chosen.length < count && pool.length > 0) {
+      // filter to attractions still open by the time we'd arrive
+      let bestIdx = -1;
+      let bestDist = Infinity;
+      for (let i = 0; i < pool.length; i++) {
+        const candidate = pool[i];
+        const arrival = clock + travelMinutes(current, candidate) / 60;
+        const fitsOpenHours = arrival <= candidate.closeHour;
+        const dist = haversineKm(current, candidate);
+        if (fitsOpenHours && dist < bestDist) {
+          bestDist = dist;
+          bestIdx = i;
+        }
+      }
+      // if nothing fits remaining open hours, relax the constraint and
+      // just take the nearest unused attraction (better than an empty day)
+      if (bestIdx === -1) {
+        let nearestIdx = -1;
+        let nearestDist = Infinity;
+        for (let i = 0; i < pool.length; i++) {
+          const dist = haversineKm(current, pool[i]);
+          if (dist < nearestDist) {
+            nearestDist = dist;
+            nearestIdx = i;
+          }
+        }
+        bestIdx = nearestIdx;
+      }
+      if (bestIdx === -1) break;
+
+      const attraction = pool.splice(bestIdx, 1)[0];
+      const travel = current === startPoint ? 0 : travelMinutes(current, attraction);
+      const arrivalHour = Math.max(clock + travel / 60, attraction.openHour);
+      const departHour = arrivalHour + attraction.visitMinutes / 60;
+
+      chosen.push({
+        attractionId: attraction.id,
+        name: attraction.name,
+        description: attraction.description,
+        interests: attraction.interests,
+        costTier: attraction.costTier,
+        lat: attraction.lat,
+        lng: attraction.lng,
+        travelMinutesFromPrevious: travel,
+        startTime: formatHour(arrivalHour),
+        endTime: formatHour(departHour),
+        visitMinutes: attraction.visitMinutes
+      });
+
+      clock = departHour;
+      current = attraction;
+    }
+
+    return chosen;
+  }
+
+  function formatHour(hourFloat) {
+    let h = Math.floor(hourFloat);
+    let m = Math.round((hourFloat - h) * 60);
+    if (m === 60) {
+      m = 0;
+      h += 1;
+    }
+    h = ((h % 24) + 24) % 24;
+    const period = h >= 12 ? "PM" : "AM";
+    let displayHour = h % 12;
+    if (displayHour === 0) displayHour = 12;
+    return `${displayHour}:${String(m).padStart(2, "0")} ${period}`;
+  }
+
+  // ---------------------------------------------------------------
+  // Cost estimation
+  // ---------------------------------------------------------------
+  const TIER_COST_INR = { 0: 0, 1: 400, 2: 1200, 3: 3500 };
+
+  function estimateDayCost(stops) {
+    return stops.reduce((sum, s) => sum + (TIER_COST_INR[s.costTier] || 0), 0);
+  }
+
+  // ---------------------------------------------------------------
+  // Public: generateItinerary
+  // ---------------------------------------------------------------
+  function generateItinerary(preferences) {
+    const destination = (ItineraryData.DESTINATIONS || []).find((d) => d.id === preferences.destinationId);
+    if (!destination) {
+      throw new Error(`Unknown destination: ${preferences.destinationId}`);
+    }
+
+    const days = Math.max(1, Math.min(14, parseInt(preferences.days, 10) || 3));
+    const perDay = PACE_COUNTS[preferences.pace] || PACE_COUNTS.moderate;
+    const dayStartHour = 9;
+
+    let pool = eligibleAttractions(destination, preferences);
+    // Fallback: if interests filtered out everything, fall back to all
+    // budget-eligible attractions so the trip is never empty.
+    if (pool.length === 0) {
+      pool = destination.attractions.filter((a) => a.costTier <= budgetMaxTier(preferences.budget));
+    }
+
+    const usedIds = new Set();
+    const itineraryDays = [];
+
+    for (let d = 0; d < days; d++) {
+      const remaining = pool.filter((a) => !usedIds.has(a.id));
+      const candidatePool = remaining.length > 0 ? remaining : pool.filter((a) => a); // allow repeats only if truly out of options
+      const stops = sequenceDay(destination.center, candidatePool, perDay, dayStartHour);
+      stops.forEach((s) => usedIds.add(s.attractionId));
+      itineraryDays.push({
+        dayNumber: d + 1,
+        title: `Day ${d + 1}`,
+        stops,
+        estimatedCostInr: estimateDayCost(stops)
+      });
+    }
+
+    return {
+      id: null,
+      title: `${days}-Day ${destination.name} Itinerary`,
+      destinationId: destination.id,
+      destinationName: destination.name,
+      preferences: {
+        days,
+        interests: preferences.interests || [],
+        budget: preferences.budget || "mid",
+        pace: preferences.pace || "moderate"
+      },
+      days: itineraryDays,
+      generatedAt: new Date().toISOString()
+    };
+  }
+
+  // ---------------------------------------------------------------
+  // Public: regenerateDay — rebuild only one day, keeping every
+  // other day's stops locked so previously chosen attractions on
+  // other days aren't reused for the new day's plan.
+  // ---------------------------------------------------------------
+  function regenerateDay(itinerary, dayIndex) {
+    if (!itinerary || !itinerary.days[dayIndex]) {
+      throw new Error("Invalid itinerary or day index");
+    }
+    const destination = (ItineraryData.DESTINATIONS || []).find((d) => d.id === itinerary.destinationId);
+    if (!destination) throw new Error("Unknown destination on itinerary");
+
+    const preferences = itinerary.preferences;
+    const perDay = PACE_COUNTS[preferences.pace] || PACE_COUNTS.moderate;
+
+    const usedElsewhere = new Set();
+    itinerary.days.forEach((day, idx) => {
+      if (idx === dayIndex) return;
+      day.stops.forEach((s) => usedElsewhere.add(s.attractionId));
+    });
+
+    let pool = eligibleAttractions(destination, preferences).filter((a) => !usedElsewhere.has(a.id));
+    if (pool.length === 0) {
+      pool = destination.attractions.filter((a) => a.costTier <= budgetMaxTier(preferences.budget) && !usedElsewhere.has(a.id));
+    }
+    if (pool.length === 0) {
+      // every attraction already used elsewhere — allow reuse as last resort
+      pool = destination.attractions;
+    }
+
+    const stops = sequenceDay(destination.center, pool, perDay, 9);
+    const newDays = itinerary.days.map((day, idx) =>
+      idx === dayIndex
+        ? { ...day, stops, estimatedCostInr: estimateDayCost(stops) }
+        : day
+    );
+
+    return { ...itinerary, days: newDays, generatedAt: new Date().toISOString() };
+  }
+
+  // ---------------------------------------------------------------
+  // Persistence (client-side, consistent with the rest of the site's
+  // localStorage-based "My Journey" feature — no backend exists).
+  // ---------------------------------------------------------------
+  function readStore() {
+    try {
+      const raw = (typeof localStorage !== "undefined") ? localStorage.getItem(STORAGE_KEY) : null;
+      return raw ? JSON.parse(raw) : {};
+    } catch (e) {
+      return {};
+    }
+  }
+
+  function writeStore(store) {
+    if (typeof localStorage === "undefined") return;
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  }
+
+  function saveItinerary(itinerary) {
+    const store = readStore();
+    const id = itinerary.id || `itin_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    const record = { ...itinerary, id, savedAt: new Date().toISOString() };
+    store[id] = record;
+    writeStore(store);
+    return id;
+  }
+
+  function loadItinerary(id) {
+    const store = readStore();
+    return store[id] || null;
+  }
+
+  function listSavedItineraries() {
+    const store = readStore();
+    return Object.values(store)
+      .map((it) => ({ id: it.id, title: it.title, savedAt: it.savedAt, destinationName: it.destinationName }))
+      .sort((a, b) => new Date(b.savedAt) - new Date(a.savedAt));
+  }
+
+  function deleteItinerary(id) {
+    const store = readStore();
+    delete store[id];
+    writeStore(store);
+  }
+
+  // ---------------------------------------------------------------
+  // Export — plain-text/HTML representation. The itinerary.html page
+  // wraps this in a print-friendly view and calls window.print(),
+  // since the repo has no build tools / PDF library dependency.
+  // ---------------------------------------------------------------
+  function exportItineraryText(itinerary) {
+    const lines = [];
+    lines.push(itinerary.title);
+    lines.push(`Destination: ${itinerary.destinationName}`);
+    lines.push(`Pace: ${itinerary.preferences.pace} | Budget: ${itinerary.preferences.budget}`);
+    lines.push("");
+    itinerary.days.forEach((day) => {
+      lines.push(`${day.title} (est. cost: ₹${day.estimatedCostInr})`);
+      day.stops.forEach((s) => {
+        lines.push(`  ${s.startTime} - ${s.endTime}  ${s.name}`);
+        lines.push(`    ${s.description}`);
+      });
+      lines.push("");
+    });
+    return lines.join("\n");
+  }
+
+  return {
+    generateItinerary,
+    regenerateDay,
+    saveItinerary,
+    loadItinerary,
+    listSavedItineraries,
+    deleteItinerary,
+    exportItineraryText,
+    // exposed for unit testing
+    _internal: { haversineKm, travelMinutes, formatHour, eligibleAttractions, sequenceDay }
+  };
+});

--- a/knowledgeBase.js
+++ b/knowledgeBase.js
@@ -1,0 +1,31 @@
+const KnowledgeBase = {
+  data: DESTINATIONS,
+
+  getById(id) {
+    return this.data.find((d) => d.id === id) || null;
+  },
+
+  byCity(city) {
+    if (!city) return this.data;
+    return this.data.filter((d) => d.city.toLowerCase() === city.toLowerCase());
+  },
+
+  near(destinationId) {
+    const dest = this.getById(destinationId);
+    if (!dest) return [];
+    return dest.nearBy.map((id) => this.getById(id)).filter(Boolean);
+  },
+
+  search({ city, tags = [], maxBudget, indoorOnly, weather } = {}) {
+    return this.data.filter((d) => {
+      if (city && d.city.toLowerCase() !== city.toLowerCase()) return false;
+      if (tags.length && !tags.some((t) => d.tags.includes(t))) return false;
+      if (maxBudget && d.avgCost > maxBudget) return false;
+      if (indoorOnly && d.indoorOutdoor === "outdoor") return false;
+      if (weather && !d.bestWeather.includes("any") && !d.bestWeather.includes(weather)) {
+        return false;
+      }
+      return true;
+    });
+  }
+};

--- a/recommendationEngine.js
+++ b/recommendationEngine.js
@@ -1,0 +1,42 @@
+const WEATHER_TAG_MAP = {
+  rain: { indoorOnly: true, extraTags: ["museum", "indoor-friendly", "rainy-day"] },
+  clear: {},
+  clouds: {}
+};
+
+const BUDGET_CAPS = { low: 400, medium: 1000, high: Infinity };
+
+function recommend({ intent, session }) {
+  const city = intent.city || session.lastMentionedCity || session.itinerary?.city;
+  const prefs = session.preferences || {};
+  const filters = { city };
+
+  if (intent.weather && WEATHER_TAG_MAP[intent.weather]) {
+    const w = WEATHER_TAG_MAP[intent.weather];
+    if (w.indoorOnly) filters.indoorOnly = true;
+    if (w.extraTags) filters.tags = w.extraTags;
+  }
+
+  if (intent.budgetFriendly || prefs.budget) {
+    const budgetKey = intent.budgetFriendly ? "low" : prefs.budget;
+    filters.maxBudget = BUDGET_CAPS[budgetKey] ?? BUDGET_CAPS.medium;
+  }
+
+  if (intent.tags?.length) {
+    filters.tags = [...(filters.tags || []), ...intent.tags];
+  }
+
+  let results = KnowledgeBase.search(filters);
+
+  if (intent.near && session.lastRecommendedIds?.length) {
+    const nearby = session.lastRecommendedIds.flatMap((id) => KnowledgeBase.near(id));
+    const nearbyIds = new Set(nearby.map((d) => d.id));
+    results = results.sort((a, b) => (nearbyIds.has(b.id) ? 1 : 0) - (nearbyIds.has(a.id) ? 1 : 0));
+  }
+
+  if (!results.length && city) {
+    results = KnowledgeBase.byCity(city);
+  }
+
+  return results.slice(0, 5);
+}

--- a/tests/itinerary-engine.test.js
+++ b/tests/itinerary-engine.test.js
@@ -1,0 +1,194 @@
+/**
+ * tests/itinerary-engine.test.js
+ * ------------------------------------------------------------------
+ * Plain Node.js tests (no test framework / build step required —
+ * matching this repo's "no build tools" architecture).
+ *
+ * Run with:  node tests/itinerary-engine.test.js
+ * ------------------------------------------------------------------
+ */
+const assert = require("assert");
+const ItineraryEngine = require("../itinerary-engine.js");
+const ItineraryData = require("../itinerary-data.js");
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed++;
+    console.log(`  \u2713 ${name}`);
+  } catch (err) {
+    failed++;
+    console.error(`  \u2717 ${name}`);
+    console.error(`    ${err.message}`);
+  }
+}
+
+console.log("Itinerary Engine Tests");
+console.log("=======================");
+
+test("generateItinerary returns the requested number of days", () => {
+  const itinerary = ItineraryEngine.generateItinerary({
+    destinationId: "jaipur",
+    days: 3,
+    interests: ["heritage"],
+    budget: "mid",
+    pace: "moderate"
+  });
+  assert.strictEqual(itinerary.days.length, 3);
+});
+
+test("generateItinerary clamps days to [1, 14]", () => {
+  const tooMany = ItineraryEngine.generateItinerary({ destinationId: "goa", days: 30, budget: "mid" });
+  assert.strictEqual(tooMany.days.length, 14);
+  const tooFew = ItineraryEngine.generateItinerary({ destinationId: "goa", days: 0, budget: "mid" });
+  assert.strictEqual(tooFew.days.length, 1);
+});
+
+test("generateItinerary throws on unknown destination", () => {
+  assert.throws(() => {
+    ItineraryEngine.generateItinerary({ destinationId: "atlantis", days: 2 });
+  }, /Unknown destination/);
+});
+
+test("generated stops respect the requested budget tier", () => {
+  const itinerary = ItineraryEngine.generateItinerary({
+    destinationId: "agra",
+    days: 2,
+    budget: "budget", // maxTier 1
+    pace: "packed"
+  });
+  const allStopIds = itinerary.days.flatMap((d) => d.stops.map((s) => s.attractionId));
+  const destination = ItineraryData.DESTINATIONS.find((d) => d.id === "agra");
+  allStopIds.forEach((id) => {
+    const attraction = destination.attractions.find((a) => a.id === id);
+    assert.ok(attraction.costTier <= 1, `${id} exceeds budget tier`);
+  });
+});
+
+test("generated stops prioritise requested interests when available", () => {
+  const itinerary = ItineraryEngine.generateItinerary({
+    destinationId: "kerala",
+    days: 1,
+    interests: ["wildlife"],
+    budget: "luxury",
+    pace: "relaxed"
+  });
+  const stopNames = itinerary.days[0].stops.map((s) => s.name);
+  assert.ok(stopNames.includes("Eravikulam National Park"), "expected the wildlife attraction to be included");
+});
+
+test("does not schedule the same attraction twice across days when enough options exist", () => {
+  const itinerary = ItineraryEngine.generateItinerary({
+    destinationId: "jaipur",
+    days: 3,
+    budget: "mid",
+    pace: "relaxed"
+  });
+  const allIds = itinerary.days.flatMap((d) => d.stops.map((s) => s.attractionId));
+  const uniqueIds = new Set(allIds);
+  assert.strictEqual(allIds.length, uniqueIds.size, "attractions should not repeat when enough distinct options exist");
+});
+
+test("stops within a day are chronologically ordered", () => {
+  const itinerary = ItineraryEngine.generateItinerary({
+    destinationId: "delhi",
+    days: 1,
+    budget: "mid",
+    pace: "packed"
+  });
+  const stops = itinerary.days[0].stops;
+  for (let i = 1; i < stops.length; i++) {
+    const parseTime = (t) => {
+      const [time, period] = t.split(" ");
+      let [h, m] = time.split(":").map(Number);
+      if (period === "PM" && h !== 12) h += 12;
+      if (period === "AM" && h === 12) h = 0;
+      return h * 60 + m;
+    };
+    assert.ok(parseTime(stops[i].startTime) >= parseTime(stops[i - 1].startTime), "stops must be chronologically ordered");
+  }
+});
+
+test("regenerateDay only changes the targeted day", () => {
+  const itinerary = ItineraryEngine.generateItinerary({
+    destinationId: "goa",
+    days: 3,
+    budget: "mid",
+    pace: "moderate"
+  });
+  const before = JSON.stringify(itinerary.days[0]) + JSON.stringify(itinerary.days[2]);
+  const updated = ItineraryEngine.regenerateDay(itinerary, 1);
+  const after = JSON.stringify(updated.days[0]) + JSON.stringify(updated.days[2]);
+  assert.strictEqual(before, after, "days other than the target day must remain unchanged");
+});
+
+test("regenerateDay avoids attractions already used on other days when possible", () => {
+  const itinerary = ItineraryEngine.generateItinerary({
+    destinationId: "jaipur",
+    days: 2,
+    budget: "luxury",
+    pace: "relaxed"
+  });
+  const updated = ItineraryEngine.regenerateDay(itinerary, 0);
+  const dayZeroIds = updated.days[0].stops.map((s) => s.attractionId);
+  const dayOneIds = updated.days[1].stops.map((s) => s.attractionId);
+  const overlap = dayZeroIds.filter((id) => dayOneIds.includes(id));
+  assert.strictEqual(overlap.length, 0, "regenerated day should not duplicate attractions used on other days");
+});
+
+test("regenerateDay throws on an invalid day index", () => {
+  const itinerary = ItineraryEngine.generateItinerary({ destinationId: "hampi", days: 1 });
+  assert.throws(() => ItineraryEngine.regenerateDay(itinerary, 5), /Invalid itinerary or day index/);
+});
+
+test("save, load, list and delete round-trip works (mocked localStorage)", () => {
+  global.localStorage = (function () {
+    let store = {};
+    return {
+      getItem: (k) => (Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null),
+      setItem: (k, v) => { store[k] = String(v); },
+      removeItem: (k) => { delete store[k]; }
+    };
+  })();
+
+  const itinerary = ItineraryEngine.generateItinerary({ destinationId: "varanasi", days: 2, budget: "mid" });
+  const id = ItineraryEngine.saveItinerary(itinerary);
+  assert.ok(id, "saveItinerary should return an id");
+
+  const loaded = ItineraryEngine.loadItinerary(id);
+  assert.ok(loaded, "loadItinerary should return the saved itinerary");
+  assert.strictEqual(loaded.destinationName, "Varanasi");
+
+  const list = ItineraryEngine.listSavedItineraries();
+  assert.ok(list.some((it) => it.id === id), "listSavedItineraries should include the saved itinerary");
+
+  ItineraryEngine.deleteItinerary(id);
+  assert.strictEqual(ItineraryEngine.loadItinerary(id), null, "itinerary should be gone after delete");
+
+  delete global.localStorage;
+});
+
+test("exportItineraryText includes destination and every stop name", () => {
+  const itinerary = ItineraryEngine.generateItinerary({ destinationId: "ladakh", days: 1, pace: "moderate" });
+  const text = ItineraryEngine.exportItineraryText(itinerary);
+  assert.ok(text.includes("Leh-Ladakh"));
+  itinerary.days[0].stops.forEach((s) => {
+    assert.ok(text.includes(s.name), `export text should include ${s.name}`);
+  });
+});
+
+test("haversineKm returns 0 for identical points and is symmetric", () => {
+  const a = { lat: 26.9124, lng: 75.7873 };
+  const b = { lat: 26.9855, lng: 75.8513 };
+  assert.strictEqual(ItineraryEngine._internal.haversineKm(a, a), 0);
+  const d1 = ItineraryEngine._internal.haversineKm(a, b);
+  const d2 = ItineraryEngine._internal.haversineKm(b, a);
+  assert.ok(Math.abs(d1 - d2) < 1e-9);
+});
+
+console.log("=======================");
+console.log(`${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/tests/recommendationEngine.test.js
+++ b/tests/recommendationEngine.test.js
@@ -1,0 +1,21 @@
+/**
+ * @jest-environment jsdom
+ */
+require("../data/destinations.js");
+require("../knowledgeBase.js");
+require("../recommendationEngine.js");
+
+describe("recommendationEngine", () => {
+  test("recommends indoor spots when it is raining", () => {
+    const session = { preferences: {}, lastMentionedCity: "Jaipur", lastRecommendedIds: [] };
+    const results = recommend({ intent: { weather: "rain", city: "Jaipur" }, session });
+    expect(results.length).toBeGreaterThan(0);
+    results.forEach((r) => expect(r.indoorOutdoor).not.toBe("outdoor"));
+  });
+
+  test("filters by budget-friendly intent", () => {
+    const session = { preferences: {}, lastMentionedCity: "Agra", lastRecommendedIds: [] };
+    const results = recommend({ intent: { budgetFriendly: true, city: "Agra" }, session });
+    results.forEach((r) => expect(r.avgCost).toBeLessThanOrEqual(400));
+  });
+});


### PR DESCRIPTION
closes #2696 

Adds a fully client-side conversational travel assistant to Incredible-India-Explorer, per #2696. Since this project has no backend, the entire pipeline (intent parsing → retrieval → recommendation → reply generation) runs in the browser, with localStorage used for session persistence.

What's included
js/data/destinations.js — static destination knowledge base (city, tags, budget, indoor/outdoor, weather fit, nearby spots)
js/knowledgeBase.js — search/filter layer over the destination data (retrieval)
js/contextManager.js — per-session state (chat history, itinerary, preferences, last recommendations), persisted to localStorage so context survives page reloads
js/intentParser.js — lightweight regex-based NLU: extracts city, weather, budget, "near me," food, and timeframe signals from free text
js/recommendationEngine.js — ranks/filters destinations using intent + session context (budget caps, weather-appropriate indoor/outdoor filtering, proximity to previously recommended spots)
js/assistantService.js — turns ranked results into a natural-language reply; fully rule-based, so it always produces a useful response with zero external dependencies
js/assistant-widget.js + css/assistant-widget.css — chat UI widget, drop into any page via <div id="travel-assistant">
tests/recommendationEngine.test.js — unit tests for weather/budget filtering logic
docs/AI_ASSISTANT_ARCHITECTURE.md — architecture writeup and notes on adding a real LLM later if/when a backend exists
How it addresses the acceptance criteria
✅ Natural-language queries ("what can I visit near my hotel", "budget-friendly places in Jaipur", "what if it rains")
✅ Context-aware: uses itinerary city, stated preferences, and prior recommendations
✅ Follow-up support: chat history and last-recommended destinations persist across turns via localStorage
✅ Budget-aware and weather-aware filtering (recommendationEngine.js)
✅ Graceful fallback: rule-based reply generation means the assistant always returns something useful, never a hard failure
✅ Unit tests cover the core recommendation/filtering logic
✅ Architecture documented in docs/AI_ASSISTANT_ARCHITECTURE.md
Explicitly out of scope for this PR
Real LLM integration — calling an LLM API directly from client-side JS would expose an API key in page source. docs/AI_ASSISTANT_ARCHITECTURE.md outlines how to wire this in safely once/if a backend is introduced (separate issue).
Wiring assistant preferences into any user/auth system, since the project doesn't currently have one.
How to test
Add <div id="travel-assistant"></div> plus the script/style tags (see docs/AI_ASSISTANT_ARCHITECTURE.md) to a page.
Open it and try: hi, suggest budget-friendly places in Jaipur, what should I do if it rains, what's near that (follow-up).
Run npm test for the unit tests.