### PR TITLE
Kodungallur@1

### DIFF
--- a/frontend/kingdoms/index.html
+++ b/frontend/kingdoms/index.html
@@ -3,176 +3,243 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Explore India's major ancient kingdoms and empires through an animated timeline and interactive cards.">
+  <meta name="description" content="Explore India's greatest kingdoms — from the Mauryas and Guptas to the Cholas, Vijayanagara, Mughals and Marathas — through an interactive timeline, maps and dynasty profiles.">
   <title>Ancient Kingdoms Explorer | Incredible India</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,500;0,600;0,700;1,500&family=Inter:wght@400;500;600;700;800&family=Noto+Sans+Devanagari:wght@500;700&display=swap" rel="stylesheet">
+
   <link rel="stylesheet" href="../../styles.css">
-  <link rel="stylesheet" href="../traditional-games/style.css">
+  <link rel="stylesheet" href="kingdoms.css">
 </head>
-<body>
-    <script>
-        (function() {
-            let theme = 'dark'; try { theme = JSON.parse(localStorage.getItem('iie_storage') || '{}').theme || 'dark'; } catch(e) {}
-            if (theme === 'light') {
-                document.body.classList.add('light-theme');
-            }
-        })();
-    </script>
+<body class="kingdoms-body">
+  <script>
+    (function() {
+      let theme = 'dark';
+      try { theme = JSON.parse(localStorage.getItem('iie_storage') || '{}').theme || 'dark'; } catch(e) {}
+      if (theme === 'light') document.body.classList.add('light-theme');
+    })();
+  </script>
+
   <header class="navbar" id="navbar">
     <div class="nav-container">
-        <a href="../../index.html#home" class="nav-logo" id="nav-logo">
-            <span class="saffron">Incredible</span>
-            <span class="gold">India</span>
-            <span class="green">Explorer</span>
-        </a>
-        <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
-            <span class="bar"></span>
-            <span class="bar"></span>
-            <span class="bar"></span>
-        </button>
-        <nav class="nav-menu" id="nav-menu">
-            <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
-
-            <div class="nav-dropdown">
-                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
-                <div class="dropdown-menu">
-                    <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
-                    <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
-                    <a href="../../frontend/ancient-ports-explorer/index.html" class="dropdown-item">Ancient Ports of India</a>
-                    <a href="../../frontend/islands/islands.html" class="dropdown-item">Islands of India</a>
-                    <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
-                    <a href="../../frontend/forts/forts.html" class="dropdown-item">Forts of India</a>
-                    <a href="../../frontend/route-planner/route-planner.html" class="dropdown-item">Route Planner</a>
-                </div>
-            </div>
-
-            <div class="nav-dropdown">
-                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
-                <div class="dropdown-menu">
-                    <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
-                    <a href="../../frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
-                    <a href="../../frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
-                    <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
-                    <a href="../../frontend/national-symbols-gallery/national-symbols-gallery.html" class="dropdown-item">National Symbols</a>
-                    <a href="../../frontend/cuisine-discovery-hub/index.html" class="dropdown-item">UP Cuisine</a>
-                    <a href="../../frontend/handicrafts-showcase/index.html" class="dropdown-item">UP Handicrafts</a>
-                    <a href="../../frontend/national-days-calendar/index.html" class="dropdown-item">National Days</a>
-                    <a href="../../frontend/ganga-ghats-experience/index.html" class="dropdown-item">Ganga Ghats</a>
-                </div>
-            </div>
-
-            <div class="nav-dropdown">
-                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Nature ▾</button>
-                <div class="dropdown-menu">
-                    <a href="../../frontend/national-parks-explorer/index.html" class="dropdown-item">National Parks</a>
-                    <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
-                    <a href="../../frontend/wildlife-rescue/wildlife-rescue.html" class="dropdown-item">Wildlife Rescue</a>
-                    <a href="../../frontend/endemic-flora-fauna-explorer/index.html" class="dropdown-item">Endemic Flora & Fauna</a>
-                    <a href="../../frontend/harike-wetland/harike-wetland.html" class="dropdown-item">Harike Wetland</a>
-                    <a href="../../frontend/wular-lake/wular-lake.html" class="dropdown-item">Wular Lake</a>
-                    <a href="../../frontend/crowd-density/index.html" class="dropdown-item">Crowd Density Predictor</a>
-                </div>
-            </div>
-
-            <div class="nav-dropdown">
-                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Games ▾</button>
-                <div class="dropdown-menu">
-                    <a href="../../frontend/passport-quest/passport-quest.html" class="dropdown-item">Passport Quest</a>
-                    <a href="../../frontend/culinary-game/culinary-game.html" class="dropdown-item">Culinary Challenge</a>
-                    <a href="../../frontend/monsoon-game/monsoon-game.html" class="dropdown-item">Monsoon Game</a>
-                    <a href="../../frontend/river-game/river-game.html" class="dropdown-item">River Explorer</a>
-                    <a href="../../frontend/geo-guesser-india/index.html" class="dropdown-item">GeoGuesser</a>
-                </div>
-            </div>
-
-            <div class="nav-dropdown">
-                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Community ▾</button>
-                <div class="dropdown-menu">
-                    <a href="../../frontend/contributors/contributors.html" class="dropdown-item">Contributors</a>
-                    <a href="../../frontend/world-records-india/index.html" class="dropdown-item">World Records</a>
-                </div>
-            </div>
-            
-            <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
-        </nav>
+      <a href="../../index.html#home" class="nav-logo"><span class="saffron">Incredible</span><span class="gold">India</span><span class="green">Explorer</span></a>
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu"><span class="bar"></span><span class="bar"></span><span class="bar"></span></button>
+      <nav class="nav-menu" id="nav-menu">
+        <a href="../../index.html#home" class="nav-link active">Home</a>
+        <div class="nav-dropdown">
+          <button class="nav-link dropdown-toggle">Culture ▾</button>
+          <div class="dropdown-menu">
+            <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
+            <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+            <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+          </div>
+        </div>
+        <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Theme">☀️</button>
+      </nav>
     </div>
-</header>
+  </header>
 
   <main class="kingdoms-page">
-    <section class="kingdoms-hero">
-      <div class="kingdoms-hero-content">
-        <span class="hero-kicker">Journey Through Time</span>
-        <h1>Ancient Kingdoms <span>of India</span></h1>
-        <p>Discover the majesty of India's greatest empires, from the Mauryan conquests to the Maratha confederacy.</p>
+
+    <!-- ============ HERO ============ -->
+    <section class="hero">
+      <div class="hero-ornament" aria-hidden="true">
+        <svg viewBox="0 0 400 400" class="wheel-svg">
+          <g class="wheel-group">
+            <circle class="wheel-outer" cx="200" cy="200" r="180"/>
+            <circle class="wheel-inner" cx="200" cy="200" r="140"/>
+            <circle class="wheel-core" cx="200" cy="200" r="50"/>
+            <g class="wheel-spokes" id="wheel-spokes"></g>
+          </g>
+        </svg>
+      </div>
+
+      <div class="hero-inner">
+        <span class="hero-stamp">इतिहास · Chronicle of Empires</span>
+        <h1>Ancient Kingdoms <em>of India</em></h1>
+        <p class="hero-lede">From the brick-laid cities of the Indus Valley to the golden ships of the Cholas, the mountain forts of the Marathas and the marble courts of the Mughals — 4,000 years of kingdoms, conquerors and ideas that shaped a civilisation.</p>
+
         <div class="hero-stats">
-          <div><strong id="hero-total">6</strong><span>Major Empires</span></div>
-          <div><strong>3000+</strong><span>Years of History</span></div>
-          <div><strong>∞</strong><span>Stories to explore</span></div>
+          <div class="stat-pill"><strong data-count="18">0</strong><span>Major Empires</span></div>
+          <div class="stat-pill"><strong data-count="4000">0</strong><span>Years of History</span></div>
+          <div class="stat-pill"><strong data-count="60">0</strong><span>Legendary Rulers</span></div>
         </div>
-        <a href="#explorer" class="hero-cta">Explore the empires ↓</a>
+
+        <div class="hero-year">
+          <span>From</span><strong id="year-from">2600 BCE</strong>
+          <span class="dash">—</span>
+          <span>to</span><strong id="year-to">1849 CE</strong>
+        </div>
+
+        <div class="hero-ctas">
+          <a href="#timeline" class="btn-primary">Walk the timeline ↓</a>
+          <a href="#explorer" class="btn-ghost">Browse empires</a>
+          <a href="#quiz" class="btn-ghost">🏛️ Which empire are you?</a>
+        </div>
       </div>
     </section>
 
-    <section class="timeline-section" id="timeline">
-      <div class="timeline-container">
+    <!-- ============ TIMELINE ============ -->
+    <section class="section timeline-section" id="timeline">
+      <div class="container">
         <div class="section-heading">
-          <span class="section-badge">Rise and Fall</span>
-          <h2>Interactive Timeline</h2>
-          <p>Trace the chronological journey of India's ancient kingdoms.</p>
+          <span class="section-badge">Rise &amp; fall</span>
+          <h2>An Interactive Chronicle</h2>
+          <p>Scroll horizontally — or tap any era to filter the empire gallery below. Each bar's length reflects the dynasty's duration.</p>
         </div>
-        <div class="timeline" id="timeline-track"></div>
+
+        <div class="timeline-wrap">
+          <div class="timeline-axis">
+            <div class="axis-ruler" id="axis-ruler"></div>
+            <div class="axis-bars" id="axis-bars"></div>
+          </div>
+          <div class="timeline-controls">
+            <button id="tl-reset" class="tl-ctrl">Reset view</button>
+            <span class="tl-hint" id="tl-hint">All eras shown</span>
+          </div>
+        </div>
       </div>
     </section>
 
-    <section class="kingdoms-section" id="explorer">
-      <div class="kingdoms-container">
+    <!-- ============ EXPLORER ============ -->
+    <section class="section" id="explorer">
+      <div class="container">
         <div class="section-heading">
-          <span class="section-badge">Empire Profiles</span>
+          <span class="section-badge">Empire profiles</span>
           <h2>Explore the Kingdoms</h2>
-          <p>Click on any card to discover detailed information about each empire.</p>
+          <p>Filter by era or region, search by name or ruler, and tick up to two to compare.</p>
         </div>
 
-        <div class="kingdom-grid" id="kingdom-grid"></div>
+        <div class="explorer-controls">
+          <div class="search-box">
+            <span aria-hidden="true">🔍</span>
+            <input type="search" id="search-input" placeholder="Search Maurya, Ashoka, Chola, Taj Mahal..." autocomplete="off">
+          </div>
+          <div class="filter-chips" id="era-chips"></div>
+        </div>
+
+        <div class="region-filters" id="region-filters"></div>
+
+        <div class="results-bar">
+          <p id="result-status" aria-live="polite">Showing all kingdoms</p>
+          <span class="compare-indicator" id="compare-ind" hidden>
+            <b id="compare-count">0</b>/2 selected · <button id="open-compare">Compare →</button>
+          </span>
+        </div>
+
+        <div class="grid" id="kingdom-grid"></div>
+        <div class="empty-state" id="empty-state" hidden>
+          <span class="empty-icon">🏛️</span>
+          <h3>No kingdoms match</h3>
+          <p>Try a different era, region or keyword.</p>
+        </div>
       </div>
     </section>
+
+    <!-- ============ COMPARE ============ -->
+    <section class="section compare-section" id="compare-section">
+      <div class="container">
+        <div class="section-heading">
+          <span class="section-badge">Side by side</span>
+          <h2>Compare Empires</h2>
+          <p>Pick any two kingdoms from the gallery above — or use the selectors here.</p>
+        </div>
+        <div class="compare-pickers">
+          <label><span>Kingdom A</span><select id="pick-a"></select></label>
+          <span class="vs">vs</span>
+          <label><span>Kingdom B</span><select id="pick-b"></select></label>
+        </div>
+        <div class="compare-wrap">
+          <table class="compare-table" id="compare-table">
+            <thead><tr><th>Aspect</th><th id="ca-name">—</th><th id="cb-name">—</th></tr></thead>
+            <tbody id="compare-body"></tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ RULERS SPOTLIGHT ============ -->
+    <section class="section rulers-section">
+      <div class="container">
+        <div class="section-heading">
+          <span class="section-badge">Who shaped an era</span>
+          <h2>Rulers Worth Remembering</h2>
+          <p>A handful of sovereigns whose names echo through the centuries.</p>
+        </div>
+        <div class="rulers-track" id="rulers-track"></div>
+      </div>
+    </section>
+
+    <!-- ============ QUIZ ============ -->
+    <section class="section quiz-section" id="quiz">
+      <div class="container">
+        <div class="section-heading">
+          <span class="section-badge">Interactive</span>
+          <h2>Which Empire Matches Your Values?</h2>
+          <p>Six questions — we'll pair you with the dynasty whose ideals most closely match yours.</p>
+        </div>
+        <div class="quiz-panel" id="quiz-panel">
+          <div class="quiz-progress"><i id="quiz-bar"></i></div>
+          <div class="quiz-stage" id="quiz-stage"></div>
+          <div class="quiz-result" id="quiz-result" hidden></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ FACTS ============ -->
+    <section class="section facts-section">
+      <div class="container">
+        <div class="section-heading">
+          <span class="section-badge">Did you know?</span>
+          <h2>Facts From the Archives</h2>
+        </div>
+        <div class="facts-carousel" id="facts-carousel">
+          <button class="facts-nav prev" aria-label="Previous">‹</button>
+          <div class="fact-card"><span class="fact-icon">📜</span><p id="fact-text"></p><span class="fact-source" id="fact-source"></span></div>
+          <button class="facts-nav next" aria-label="Next">›</button>
+        </div>
+        <div class="facts-dots" id="facts-dots"></div>
+      </div>
+    </section>
+
   </main>
 
-  <div class="kingdom-modal" id="kingdom-modal" hidden role="dialog" aria-modal="true" aria-labelledby="modal-title">
-    <div class="modal-backdrop" data-close-modal></div>
-    <div class="modal-dialog">
-      <button class="modal-close" id="modal-close" type="button" aria-label="Close details">×</button>
-      <div class="modal-content">
-        <span class="modal-kicker" id="modal-period"></span>
-        <h2 id="modal-title"></h2>
-        <div class="modal-image">
-          <img id="modal-img" src="" alt="">
-        </div>
-        <p id="modal-description"></p>
-        <div class="modal-details">
-          <div class="detail-item">
-            <span>Capital City</span>
-            <strong id="modal-capital"></strong>
-          </div>
-          <div class="detail-item">
-            <span>Famous Rulers</span>
-            <strong id="modal-rulers"></strong>
-          </div>
-          <div class="detail-item">
-            <span>Major Achievements</span>
-            <strong id="modal-achievements"></strong>
-          </div>
+  <!-- ============ MODAL ============ -->
+  <div class="modal-overlay" id="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" hidden>
+    <div class="modal-backdrop" data-close></div>
+    <article class="modal-card">
+      <button class="modal-close" data-close aria-label="Close">✕</button>
+      <div class="modal-hero">
+        <div class="modal-hero-img" id="modal-img"></div>
+        <div class="modal-hero-content">
+          <span class="modal-era" id="modal-era"></span>
+          <h2 id="modal-title"></h2>
+          <p class="modal-period" id="modal-period"></p>
+          <p class="modal-tagline" id="modal-tagline"></p>
         </div>
       </div>
-    </div>
+      <nav class="modal-tabs">
+        <button class="tab active" data-tab="overview">Overview</button>
+        <button class="tab" data-tab="rulers">Rulers</button>
+        <button class="tab" data-tab="legacy">Legacy</button>
+        <button class="tab" data-tab="architecture">Architecture</button>
+      </nav>
+      <div class="modal-pane" id="tab-overview"></div>
+      <div class="modal-pane" id="tab-rulers" hidden></div>
+      <div class="modal-pane" id="tab-legacy" hidden></div>
+      <div class="modal-pane" id="tab-architecture" hidden></div>
+    </article>
   </div>
 
-  <footer class="kingdoms-footer">
-    <p>Part of <a href="../../index.html">Incredible India Explorer</a> · Explore the rich tapestry of Indian history.</p>
+  <footer class="site-footer">
+    <p>Part of <a href="../../index.html">Incredible India Explorer</a> · Exploring the rich tapestry of Indian history.</p>
   </footer>
 
-  <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
-  <script src="../js-modules/storage.js" defer></script>
-    <script src="../app.js" defer></script>
-  <script src="../traditional-games/script.js" defer></script>
-    <script type="module" src="../auth.js"></script>
+  <button id="btn-top" class="btn-top" aria-label="Back to top">↑</button>
+
+  <script type="module" src="kingdoms.js"></script>
+  <script src="../pages-common.js"></script>
 </body>
 </html>

--- a/frontend/kingdoms/kingdoms.css
+++ b/frontend/kingdoms/kingdoms.css
@@ -1,0 +1,456 @@
+/* ============================================================
+   Ancient Kingdoms Explorer
+   Palette: aged parchment · terracotta · indigo · gold leaf
+   Type: Cormorant Garamond + Inter + Noto Devanagari
+   ============================================================ */
+
+:root {
+  --parchment: #f4ead5;
+  --parchment-deep: #e8d8b5;
+  --terracotta: #c65d3a;
+  --terracotta-deep: #8f3a1d;
+  --indigo: #2a3a6b;
+  --indigo-deep: #1a264a;
+  --gold: #d4a64a;
+  --gold-deep: #a77e2e;
+  --emerald: #3d7a5f;
+  --bg: #1a1410;
+  --bg-2: #221812;
+  --surface: rgba(255, 240, 210, 0.06);
+  --surface-2: rgba(28, 18, 10, 0.8);
+  --line: rgba(212, 166, 74, 0.2);
+  --text: #f1e7cf;
+  --muted: #a89878;
+  --shadow: 0 22px 55px rgba(0, 0, 0, 0.55);
+  --font-display: "Cormorant Garamond", "Noto Sans Devanagari", Georgia, serif;
+  --font-body: "Inter", system-ui, sans-serif;
+  --font-dev: "Noto Sans Devanagari", sans-serif;
+}
+
+body.light-theme.kingdoms-body {
+  --bg: #f5ecd4;
+  --bg-2: #ebe0c3;
+  --surface: rgba(255, 255, 255, 0.6);
+  --surface-2: rgba(255, 251, 240, 0.92);
+  --line: rgba(143, 58, 29, 0.22);
+  --text: #2a1f13;
+  --muted: #6b5a43;
+  --shadow: 0 18px 44px rgba(90, 50, 10, 0.18);
+}
+
+.kingdoms-body {
+  margin: 0;
+  font-family: var(--font-body);
+  color: var(--text);
+  background:
+    radial-gradient(circle at 14% 8%, rgba(198, 93, 58, 0.1), transparent 42%),
+    radial-gradient(circle at 88% 82%, rgba(212, 166, 74, 0.09), transparent 40%),
+    linear-gradient(180deg, var(--bg), var(--bg-2));
+  min-height: 100vh;
+  position: relative;
+}
+
+/* subtle parchment grain */
+.kingdoms-body::before {
+  content: "";
+  position: fixed; inset: 0; pointer-events: none; z-index: 0; opacity: 0.06;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='200' height='200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+}
+
+.kingdoms-page h1, .kingdoms-page h2, .kingdoms-page h3, .kingdoms-page h4 { font-family: var(--font-display); font-weight: 600; letter-spacing: 0.01em; }
+
+/* ========== HERO ========== */
+.hero {
+  position: relative; min-height: 92vh; padding: 140px 20px 100px;
+  display: grid; place-items: center; overflow: hidden; z-index: 1;
+}
+.hero-ornament {
+  position: absolute; inset: 0; display: grid; place-items: center;
+  pointer-events: none; z-index: 0; opacity: 0.55;
+}
+.wheel-svg { width: min(720px, 90vw); height: min(720px, 90vw); }
+.wheel-outer, .wheel-inner { fill: none; stroke: var(--gold); stroke-width: 0.6; opacity: 0.45; }
+.wheel-core { fill: none; stroke: var(--gold); stroke-width: 1.2; opacity: 0.7; }
+.wheel-spokes line { stroke: var(--gold); stroke-width: 0.4; opacity: 0.35; }
+.wheel-group { transform-origin: 200px 200px; animation: wheel-spin 120s linear infinite; }
+@keyframes wheel-spin { to { transform: rotate(360deg); } }
+
+.hero-inner {
+  position: relative; z-index: 1; text-align: center;
+  width: min(1060px, 92%);
+}
+.hero-stamp {
+  display: inline-block; padding: 8px 18px; border-radius: 4px;
+  border: 1.5px solid var(--gold); color: var(--gold);
+  font-family: var(--font-dev); font-weight: 700; font-size: 0.88rem;
+  letter-spacing: 0.12em; text-transform: uppercase;
+  transform: rotate(-1.4deg); background: rgba(0,0,0,0.22);
+  margin-bottom: 22px;
+}
+body.light-theme .hero-stamp { background: rgba(255,255,255,0.55); }
+
+.hero h1 {
+  font-size: clamp(2.8rem, 7vw, 5.8rem); line-height: 1;
+  margin: 0 0 18px; font-weight: 500; letter-spacing: 0.01em;
+}
+.hero h1 em {
+  display: block; font-style: italic; font-weight: 500;
+  background: linear-gradient(135deg, var(--gold), var(--terracotta), var(--gold-deep));
+  -webkit-background-clip: text; background-clip: text; color: transparent;
+}
+.hero-lede { max-width: 780px; margin: 0 auto; font-size: 1.08rem; line-height: 1.8; color: var(--muted); }
+
+.hero-stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; margin: 36px auto 20px; width: min(680px, 100%); }
+.stat-pill {
+  padding: 18px 10px; border-radius: 14px; text-align: center;
+  border: 1px solid var(--line); background: var(--surface); backdrop-filter: blur(6px);
+}
+.stat-pill strong { display: block; font-family: var(--font-display); font-size: 2.4rem; color: var(--gold); line-height: 1.1; font-variant-numeric: tabular-nums; }
+.stat-pill span { font-size: 0.68rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.14em; color: var(--muted); }
+
+.hero-year {
+  display: flex; justify-content: center; align-items: baseline; gap: 10px;
+  margin: 18px auto 28px; font-family: var(--font-display); font-size: 1.2rem;
+  color: var(--muted);
+}
+.hero-year strong { color: var(--gold); font-size: 1.5rem; font-weight: 700; font-variant-numeric: tabular-nums; }
+.hero-year .dash { color: var(--terracotta); }
+
+.hero-ctas { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; }
+.btn-primary, .btn-ghost {
+  display: inline-block; padding: 13px 28px; border-radius: 999px;
+  font-weight: 800; text-decoration: none; transition: all 0.3s; font-size: 0.9rem;
+}
+.btn-primary { background: linear-gradient(135deg, var(--terracotta), var(--terracotta-deep)); color: #fff; box-shadow: 0 14px 30px rgba(198, 93, 58, 0.35); }
+.btn-primary:hover { transform: translateY(-3px); box-shadow: 0 20px 40px rgba(198, 93, 58, 0.5); }
+.btn-ghost { border: 1.5px solid var(--gold); color: var(--gold); }
+.btn-ghost:hover { background: rgba(212, 166, 74, 0.12); }
+body.light-theme .btn-ghost { color: var(--terracotta-deep); border-color: var(--terracotta); }
+
+/* ========== SECTIONS ========== */
+.section { padding: 80px 0; position: relative; z-index: 1; }
+.container { width: min(1260px, 92%); margin: 0 auto; }
+.section-heading { max-width: 760px; margin-bottom: 34px; }
+.section-badge {
+  display: inline-block; padding: 6px 14px; border-radius: 999px;
+  background: rgba(212, 166, 74, 0.1); border: 1px solid var(--line);
+  color: var(--gold); font-size: 0.7rem; font-weight: 800;
+  letter-spacing: 0.18em; text-transform: uppercase; margin-bottom: 12px;
+}
+.section-heading h2 { font-size: clamp(2rem, 4.5vw, 3.2rem); margin: 0 0 10px; line-height: 1.1; font-weight: 500; }
+.section-heading p { margin: 0; color: var(--muted); line-height: 1.7; }
+
+/* ========== TIMELINE ========== */
+.timeline-wrap {
+  border: 1px solid var(--line); border-radius: 22px;
+  background: var(--surface); backdrop-filter: blur(8px);
+  padding: 26px 24px; box-shadow: var(--shadow);
+}
+.timeline-axis { position: relative; overflow-x: auto; padding-bottom: 14px; scrollbar-width: thin; }
+.timeline-axis::-webkit-scrollbar { height: 8px; }
+.timeline-axis::-webkit-scrollbar-thumb { background: var(--gold); border-radius: 8px; }
+
+.axis-ruler {
+  position: relative; height: 34px; border-bottom: 1px solid var(--line);
+  margin-bottom: 14px; min-width: 1400px;
+}
+.axis-ruler span {
+  position: absolute; bottom: 6px; transform: translateX(-50%);
+  font-family: var(--font-display); font-size: 0.82rem; font-weight: 600;
+  color: var(--muted); font-variant-numeric: tabular-nums;
+}
+.axis-ruler span::before {
+  content: ""; position: absolute; top: -12px; left: 50%; width: 1px; height: 8px;
+  background: var(--line);
+}
+
+.axis-bars { position: relative; min-width: 1400px; }
+.era-row {
+  position: absolute; left: 0; right: 0; height: 34px;
+  display: flex; align-items: center; cursor: pointer;
+  transition: transform 0.25s;
+}
+.era-row:hover { transform: translateX(3px); }
+.era-bar {
+  position: absolute; height: 26px; border-radius: 4px;
+  background: linear-gradient(135deg, var(--ec), color-mix(in srgb, var(--ec) 65%, black));
+  display: flex; align-items: center; padding: 0 12px;
+  font-family: var(--font-display); font-weight: 600; font-size: 0.86rem;
+  color: #fff; text-shadow: 0 1px 2px rgba(0,0,0,0.4);
+  border: 1px solid rgba(255,255,255,0.15); overflow: hidden;
+  transition: filter 0.25s, box-shadow 0.25s;
+}
+.era-bar:hover { filter: brightness(1.1); box-shadow: 0 6px 18px rgba(0,0,0,0.35); }
+.era-bar.dim { opacity: 0.25; }
+.era-bar small { margin-left: auto; font-size: 0.68rem; opacity: 0.85; font-weight: 500; }
+
+.timeline-controls {
+  display: flex; justify-content: space-between; align-items: center;
+  margin-top: 16px; gap: 14px; flex-wrap: wrap;
+}
+.tl-ctrl {
+  border: 1px solid var(--line); background: transparent; color: var(--text);
+  border-radius: 999px; padding: 7px 16px; font: inherit; font-weight: 700;
+  font-size: 0.82rem; cursor: pointer; transition: all 0.25s;
+}
+.tl-ctrl:hover { border-color: var(--gold); color: var(--gold); }
+.tl-hint { font-size: 0.82rem; color: var(--muted); font-style: italic; }
+
+/* ========== EXPLORER ========== */
+.explorer-controls { display: flex; gap: 14px; flex-wrap: wrap; margin-bottom: 18px; }
+.search-box {
+  flex: 1; min-width: 260px; display: flex; align-items: center; gap: 10px;
+  border: 1px solid var(--line); border-radius: 999px;
+  background: var(--surface); padding: 11px 18px;
+}
+.search-box:focus-within { border-color: var(--gold); }
+.search-box input { flex: 1; border: 0; background: transparent; color: var(--text); font: inherit; outline: none; }
+.search-box input::placeholder { color: var(--muted); }
+
+.filter-chips { display: flex; gap: 8px; flex-wrap: wrap; }
+.chip {
+  border: 1px solid var(--line); border-radius: 999px; padding: 8px 15px;
+  background: var(--surface); color: var(--muted);
+  font: inherit; font-weight: 700; font-size: 0.82rem; cursor: pointer;
+  transition: all 0.25s;
+}
+.chip:hover { color: var(--text); border-color: var(--gold); }
+.chip.active { background: linear-gradient(135deg, var(--gold), var(--gold-deep)); color: #2a1f13; border-color: transparent; box-shadow: 0 8px 18px rgba(212, 166, 74, 0.3); }
+
+.region-filters { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
+.region-btn {
+  border: 1px dashed var(--line); border-radius: 10px; padding: 6px 12px;
+  background: transparent; color: var(--muted); font: inherit; font-weight: 700;
+  font-size: 0.78rem; cursor: pointer; transition: all 0.25s;
+}
+.region-btn:hover { border-style: solid; border-color: var(--terracotta); color: var(--text); }
+.region-btn.active { border-style: solid; background: rgba(198, 93, 58, 0.15); color: var(--terracotta); border-color: var(--terracotta); }
+
+.results-bar { display: flex; justify-content: space-between; align-items: center; gap: 14px; margin-bottom: 22px; flex-wrap: wrap; }
+.results-bar p { margin: 0; color: var(--muted); font-size: 0.86rem; }
+.compare-indicator { display: inline-flex; gap: 10px; align-items: center; font-size: 0.85rem; color: var(--gold); font-weight: 700; }
+.compare-indicator button { border: 0; background: var(--gold); color: #2a1f13; border-radius: 999px; padding: 7px 14px; font: inherit; font-weight: 800; cursor: pointer; }
+
+/* ========== CARDS ========== */
+.grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 22px; }
+
+.k-card {
+  position: relative; border-radius: 18px; overflow: hidden;
+  background: var(--surface); border: 1px solid var(--line);
+  cursor: pointer; transition: all 0.35s;
+  display: flex; flex-direction: column;
+}
+.k-card:hover { transform: translateY(-6px); box-shadow: var(--shadow); border-color: color-mix(in srgb, var(--ec) 60%, transparent); }
+
+.k-card-top { position: relative; aspect-ratio: 4 / 3; overflow: hidden; }
+.k-card-img { width: 100%; height: 100%; background-size: cover; background-position: center; transition: transform 0.6s; }
+.k-card:hover .k-card-img { transform: scale(1.08); }
+.k-card-top::after { content: ""; position: absolute; inset: 0; background: linear-gradient(180deg, transparent 40%, rgba(0,0,0,0.65)); }
+
+.k-era {
+  position: absolute; top: 12px; left: 12px; z-index: 2;
+  padding: 5px 11px; border-radius: 999px; color: #fff;
+  font-size: 0.66rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase;
+  background: var(--ec); box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+}
+.k-cmp {
+  position: absolute; top: 12px; right: 12px; z-index: 2;
+  width: 36px; height: 36px; border-radius: 50%; border: 0;
+  background: rgba(0,0,0,0.55); color: #fff; backdrop-filter: blur(6px);
+  cursor: pointer; font-size: 0.95rem; transition: all 0.25s;
+  display: grid; place-items: center;
+}
+.k-cmp:hover { background: var(--gold); transform: scale(1.1); }
+.k-cmp.ticked { background: var(--gold); color: #2a1f13; }
+.k-cmp.ticked::before { content: "✓"; font-weight: 900; }
+
+.k-body { padding: 18px 20px 20px; flex: 1; display: flex; flex-direction: column; gap: 8px; }
+.k-body h3 { margin: 0; font-size: 1.35rem; font-weight: 600; line-height: 1.2; }
+.k-period { font-family: var(--font-display); font-style: italic; font-size: 0.92rem; color: var(--ec); margin: 0; font-weight: 500; }
+.k-region { font-size: 0.76rem; color: var(--muted); font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase; }
+.k-desc { font-size: 0.88rem; line-height: 1.55; color: var(--muted); margin: 6px 0 0; display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; }
+.k-foot { margin-top: auto; padding-top: 12px; border-top: 1px dashed var(--line); display: flex; gap: 8px; flex-wrap: wrap; }
+.k-tag { font-size: 0.7rem; font-weight: 700; padding: 3px 10px; border-radius: 999px; background: rgba(255,255,255,0.06); color: var(--text); }
+body.light-theme .k-tag { background: rgba(42, 31, 19, 0.08); }
+
+.empty-state { text-align: center; padding: 60px 20px; color: var(--muted); }
+.empty-icon { font-size: 3rem; display: block; margin-bottom: 10px; }
+
+/* ========== COMPARE ========== */
+.compare-section { background: linear-gradient(180deg, transparent, rgba(212, 166, 74, 0.05), transparent); }
+.compare-pickers { display: flex; gap: 16px; align-items: center; flex-wrap: wrap; margin-bottom: 24px; }
+.compare-pickers label { display: flex; flex-direction: column; gap: 6px; flex: 1; min-width: 220px; }
+.compare-pickers span { font-size: 0.72rem; font-weight: 800; text-transform: uppercase; letter-spacing: 0.1em; color: var(--muted); }
+.compare-pickers select {
+  padding: 12px 16px; border-radius: 12px; border: 1px solid var(--line);
+  background: var(--surface); color: var(--text); font: inherit; cursor: pointer;
+}
+.vs { font-family: var(--font-display); font-size: 1.6rem; font-style: italic; color: var(--terracotta); padding: 0 8px; }
+
+.compare-wrap { overflow-x: auto; border-radius: 18px; border: 1px solid var(--line); background: var(--surface); }
+.compare-table { width: 100%; border-collapse: collapse; min-width: 600px; }
+.compare-table th, .compare-table td { padding: 14px 18px; text-align: left; border-bottom: 1px solid var(--line); vertical-align: top; line-height: 1.55; }
+.compare-table thead th { background: var(--surface-2); font-family: var(--font-display); font-size: 1.1rem; font-weight: 600; }
+.compare-table tbody td:first-child { font-weight: 700; color: var(--muted); text-transform: uppercase; font-size: 0.76rem; letter-spacing: 0.08em; width: 160px; }
+.compare-table tbody tr:hover td { background: rgba(212, 166, 74, 0.05); }
+
+/* ========== RULERS ========== */
+.rulers-track {
+  display: grid; grid-template-columns: repeat(auto-fill, minmax(230px, 1fr)); gap: 18px;
+}
+.ruler-card {
+  padding: 22px 20px; border-radius: 18px;
+  border: 1px solid var(--line); background: var(--surface);
+  position: relative; transition: all 0.3s; overflow: hidden;
+}
+.ruler-card::before {
+  content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 4px;
+  background: var(--ec, var(--gold));
+}
+.ruler-card:hover { transform: translateY(-4px); box-shadow: var(--shadow); }
+.ruler-era { display: inline-block; padding: 3px 10px; border-radius: 999px; font-size: 0.68rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; background: var(--ec, var(--gold)); color: #fff; margin-bottom: 10px; }
+.ruler-card h3 { margin: 0 0 4px; font-size: 1.2rem; font-weight: 600; }
+.ruler-reign { font-family: var(--font-display); font-style: italic; color: var(--muted); font-size: 0.88rem; margin: 0 0 10px; }
+.ruler-card p { margin: 0; font-size: 0.86rem; color: var(--muted); line-height: 1.55; }
+
+/* ========== QUIZ ========== */
+.quiz-section { background: linear-gradient(180deg, transparent, rgba(198, 93, 58, 0.04), transparent); }
+.quiz-panel {
+  max-width: 780px; margin: 0 auto; padding: 30px;
+  border: 1px solid var(--line); border-radius: 22px;
+  background: var(--surface); backdrop-filter: blur(8px); box-shadow: var(--shadow);
+}
+.quiz-progress { height: 6px; border-radius: 999px; background: rgba(255,255,255,0.08); overflow: hidden; margin-bottom: 24px; }
+body.light-theme .quiz-progress { background: rgba(42, 31, 19, 0.08); }
+.quiz-progress i { display: block; height: 100%; width: 0; background: linear-gradient(90deg, var(--terracotta), var(--gold)); transition: width 0.4s; }
+
+.quiz-stage h3 { font-size: 1.5rem; margin: 0 0 20px; line-height: 1.3; font-weight: 600; }
+.quiz-options { display: grid; gap: 12px; }
+.quiz-option {
+  padding: 16px 20px; border-radius: 12px; border: 1.5px solid var(--line);
+  background: var(--surface-2); color: var(--text);
+  text-align: left; font: inherit; font-size: 0.96rem; cursor: pointer;
+  transition: all 0.25s;
+}
+.quiz-option:hover { border-color: var(--gold); transform: translateX(4px); background: rgba(212, 166, 74, 0.08); }
+
+.quiz-result { text-align: center; }
+.quiz-result .match-emoji { font-size: 4rem; margin-bottom: 10px; }
+.quiz-result h3 { font-size: 2rem; margin: 0 0 8px; font-weight: 500; }
+.quiz-result .match-name { font-family: var(--font-display); font-size: 1.8rem; font-style: italic; color: var(--terracotta); margin: 6px 0 18px; }
+.quiz-result p { color: var(--muted); line-height: 1.65; max-width: 560px; margin: 0 auto 22px; }
+.quiz-result button { margin: 6px; }
+
+/* ========== FACTS ========== */
+.facts-carousel { display: flex; align-items: center; gap: 16px; max-width: 860px; margin: 0 auto; }
+.fact-card {
+  flex: 1; padding: 36px 30px; text-align: center;
+  border: 1px solid var(--line); border-radius: 22px;
+  background: var(--surface); backdrop-filter: blur(8px); min-height: 180px;
+  display: grid; gap: 10px; place-items: center;
+  animation: fade 0.4s;
+}
+@keyframes fade { from { opacity: 0; transform: translateY(10px); } }
+.fact-icon { font-size: 2.4rem; }
+.fact-card p { margin: 0; font-family: var(--font-display); font-size: 1.35rem; line-height: 1.5; font-style: italic; max-width: 600px; font-weight: 500; }
+.fact-source { font-size: 0.76rem; color: var(--muted); font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; }
+
+.facts-nav {
+  width: 48px; height: 48px; border-radius: 50%; border: 1px solid var(--line);
+  background: var(--surface); color: var(--text); font-size: 1.4rem; cursor: pointer;
+  transition: all 0.25s; flex-shrink: 0;
+}
+.facts-nav:hover { border-color: var(--gold); color: var(--gold); transform: scale(1.08); }
+
+.facts-dots { display: flex; gap: 8px; justify-content: center; margin-top: 22px; }
+.facts-dots i { width: 8px; height: 8px; border-radius: 50%; background: rgba(255,255,255,0.2); cursor: pointer; transition: all 0.25s; }
+body.light-theme .facts-dots i { background: rgba(42, 31, 19, 0.2); }
+.facts-dots i.active { background: var(--gold); width: 24px; border-radius: 999px; }
+
+/* ========== MODAL ========== */
+.modal-overlay { position: fixed; inset: 0; z-index: 100; display: grid; place-items: center; padding: 20px; }
+.modal-overlay[hidden] { display: none; }
+.modal-backdrop { position: absolute; inset: 0; background: rgba(5, 8, 16, 0.78); backdrop-filter: blur(6px); animation: mfade 0.25s; }
+@keyframes mfade { from { opacity: 0; } }
+.modal-card {
+  position: relative; width: min(860px, 100%); max-height: 90vh; overflow: auto;
+  background: var(--surface-2); border: 1px solid var(--line); border-radius: 24px;
+  box-shadow: var(--shadow); animation: mpop 0.3s cubic-bezier(0.2, 0.9, 0.3, 1.15);
+}
+@keyframes mpop { from { opacity: 0; transform: translateY(26px) scale(0.96); } }
+.modal-close {
+  position: absolute; top: 14px; right: 14px; z-index: 2;
+  width: 40px; height: 40px; border-radius: 50%;
+  border: 1px solid rgba(255,255,255,0.3); background: rgba(0,0,0,0.5); color: #fff;
+  cursor: pointer; font-size: 1rem; transition: all 0.25s;
+}
+.modal-close:hover { transform: rotate(90deg); background: var(--terracotta); }
+
+.modal-hero { display: grid; grid-template-columns: 0.9fr 1.1fr; min-height: 240px; }
+.modal-hero-img { background-size: cover; background-position: center; min-height: 240px; }
+.modal-hero-content { padding: 30px; display: flex; flex-direction: column; gap: 10px; }
+.modal-era { display: inline-block; width: fit-content; padding: 5px 12px; border-radius: 999px; color: #fff; font-size: 0.7rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; }
+.modal-hero h2 { margin: 0; font-size: 2.1rem; line-height: 1.1; font-weight: 600; }
+.modal-period { margin: 0; font-family: var(--font-display); font-style: italic; color: var(--muted); font-size: 1.05rem; font-weight: 500; }
+.modal-tagline { margin: auto 0 0 0; font-size: 0.9rem; color: var(--muted); line-height: 1.55; }
+
+.modal-tabs { display: flex; gap: 0; border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.tab {
+  flex: 1; padding: 14px; border: 0; background: transparent; color: var(--muted);
+  font: inherit; font-weight: 700; font-size: 0.84rem; letter-spacing: 0.04em;
+  text-transform: uppercase; cursor: pointer; transition: all 0.25s;
+  position: relative;
+}
+.tab:hover { color: var(--text); }
+.tab.active { color: var(--terracotta); }
+.tab.active::after { content: ""; position: absolute; left: 20%; right: 20%; bottom: -1px; height: 3px; background: var(--terracotta); border-radius: 3px; }
+
+.modal-pane { padding: 28px 30px; }
+.modal-pane p { line-height: 1.8; margin: 0 0 14px; font-size: 0.96rem; }
+.modal-pane h4 { font-family: var(--font-body); font-size: 0.8rem; font-weight: 800; letter-spacing: 0.2em; text-transform: uppercase; color: var(--muted); margin: 22px 0 10px; }
+.modal-pane ul { margin: 0; padding-left: 20px; display: grid; gap: 8px; }
+.modal-pane li { line-height: 1.6; font-size: 0.94rem; }
+.modal-pane li::marker { color: var(--terracotta); }
+
+.ruler-list { list-style: none; padding: 0; display: grid; gap: 12px; }
+.ruler-list li { padding: 14px 16px; border: 1px solid var(--line); border-radius: 12px; background: var(--surface); display: grid; grid-template-columns: auto 1fr; gap: 14px; align-items: center; }
+.ruler-list .rl-badge { width: 44px; height: 44px; border-radius: 50%; background: var(--ec, var(--gold)); color: #fff; display: grid; place-items: center; font-family: var(--font-display); font-weight: 700; font-size: 1.1rem; }
+.ruler-list b { font-family: var(--font-display); font-size: 1.1rem; font-weight: 600; display: block; margin-bottom: 2px; }
+.ruler-list small { color: var(--muted); font-size: 0.82rem; }
+
+/* ========== FOOTER & TOP ========== */
+.site-footer { border-top: 1px solid var(--line); padding: 36px 20px; text-align: center; color: var(--muted); position: relative; z-index: 1; }
+.site-footer a { color: var(--terracotta); font-weight: 700; text-decoration: none; }
+
+.btn-top {
+  position: fixed; right: 18px; bottom: 18px; z-index: 60;
+  width: 46px; height: 46px; border-radius: 50%;
+  border: 1px solid var(--line); background: var(--surface-2); color: var(--gold);
+  font-size: 1.1rem; cursor: pointer; opacity: 0; pointer-events: none;
+  transition: opacity 0.3s, transform 0.3s;
+}
+.btn-top.show { opacity: 1; pointer-events: auto; }
+.btn-top:hover { transform: translateY(-3px); border-color: var(--gold); }
+
+/* ========== RESPONSIVE ========== */
+@media (max-width: 900px) {
+  .hero-stats { grid-template-columns: 1fr; gap: 8px; }
+  .modal-hero { grid-template-columns: 1fr; }
+  .modal-hero-img { min-height: 180px; }
+}
+@media (max-width: 640px) {
+  .hero { padding: 120px 16px 80px; min-height: 80vh; }
+  .hero-stats { grid-template-columns: repeat(3, 1fr); gap: 8px; }
+  .stat-pill { padding: 12px 6px; }
+  .stat-pill strong { font-size: 1.5rem; }
+  .stat-pill span { font-size: 0.62rem; }
+  .hero-year { flex-wrap: wrap; }
+  .facts-carousel { flex-direction: column; }
+  .compare-pickers { flex-direction: column; }
+  .vs { align-self: center; }
+  .wheel-svg { opacity: 0.3; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .wheel-group, * { animation: none !important; transition-duration: 0.001s !important; }
+}

--- a/frontend/kingdoms/kingdoms.js
+++ b/frontend/kingdoms/kingdoms.js
@@ -222,15 +222,4 @@ const KINGDOMS = [
     ],
     legacy: ["Mughal miniature painting", "Urdu language synthesis", "Mansabdari administration", "Indo-Persian court culture"],
     architecture: ["Taj Mahal (UNESCO)", "Red Fort & Jama Masjid, Delhi", "Fatehpur Sikri", "Humayun's Tomb"],
-    tags: ["Taj Mahal", "Urdu", "Miniature"] },
-
-  { id: "maratha", name: "Maratha Empire", era: "earlymodern", region: "West",
-    period: "1674 – 1818 CE", tagline: "The saffron confederacy that challenged Mughal supremacy.",
-    image: "https://images.unsplash.com/photo-1587922546307-776227941871?w=900&q=70",
-    desc: "Shivaji's hill-forts grew into a confederacy that at its peak stretched from Attock to Cuttack — the last great indigenous empire before British rule.",
-    overview: "Shivaji carved out swarajya from the Deccan hills. His successors, especially the Peshwas, turned the Marathas into a pan-Indian power. The Third Battle of Panipat (1761) and Anglo-Maratha wars ended the confederacy.",
-    rulers: [
-      { n: "Shivaji Maharaj", r: "1674–1680 CE", d: "Founded swarajya; innovator of guerrilla warfare and naval strategy." },
-      { n: "Bajirao I", r: "1720–1740 CE", d: "Undefeated Peshwa; expanded Maratha power to Delhi." }
-    ],
-    legacy: ["Guerrilla warfare (ganimi kava)", "Naval forts (Sindhudurg, Vijayd
+    tags: ["Taj Mahal", "Urdu", "Miniature"] } ]

--- a/frontend/kingdoms/kingdoms.js
+++ b/frontend/kingdoms/kingdoms.js
@@ -1,0 +1,236 @@
+/* ================= DATA ================= */
+const ERAS = {
+  "ancient":   { label: "Ancient",   color: "#c65d3a", range: [-2600, 300] },
+  "classical": { label: "Classical", color: "#d4a64a", range: [300, 700] },
+  "medieval":  { label: "Medieval",  color: "#3d7a5f", range: [700, 1526] },
+  "earlymodern": { label: "Early Modern", color: "#2a3a6b", range: [1526, 1858] }
+};
+
+const KINGDOMS = [
+  { id: "ivc", name: "Indus Valley Civilisation", era: "ancient", region: "North-West",
+    period: "c. 2600 – 1900 BCE", tagline: "The cradle of urban India — cities of baked brick and planned drainage.",
+    image: "https://images.unsplash.com/photo-1609151941355-12a5309d6b61?w=900&q=70",
+    desc: "One of the world's three earliest urban civilisations, alongside Mesopotamia and Egypt. Spanned over a million square kilometres across what is now Pakistan and north-west India.",
+    overview: "Harappa and Mohenjo-daro were cities of extraordinary planning — grid streets, covered drains, standardised weights and bricks. Trade with Mesopotamia brought Indian goods to the Persian Gulf. The undeciphered Indus script remains one of archaeology's great puzzles.",
+    rulers: [{ n: "Unknown priest-kings", r: "—", d: "A famous steatite bust suggests ritual authority, but no royal inscriptions survive." }],
+    legacy: ["Standardised weights and measures", "Advanced urban sanitation", "Bead-making and metallurgy", "The undeciphered Indus script"],
+    architecture: ["The Great Bath of Mohenjo-daro", "Granaries and dockyards of Lothal", "Dholavira's water reservoirs and signboards"],
+    tags: ["Urban", "Trade", "Bronze Age"] },
+
+  { id: "mahajanapadas", name: "The Mahajanapadas", era: "ancient", region: "North",
+    period: "c. 600 – 345 BCE", tagline: "Sixteen great republics and kingdoms that shaped early Indian philosophy.",
+    image: "https://images.unsplash.com/photo-1599661046289-326574001573?w=900&q=70",
+    desc: "A constellation of sixteen major states — Magadha, Kosala, Vajji, Kuru and others — in which the Buddha and Mahavira preached, and republics coexisted with monarchies.",
+    overview: "The late Vedic period saw the rise of territorial states with standing armies, coinage and fortified capitals. This was also the age of the Upanishads, the Buddha and Mahavira — all reacting to the same social transformation.",
+    rulers: [
+      { n: "Bimbisara", r: "c. 558–491 BCE", d: "First great king of Magadha; patron of the Buddha." },
+      { n: "Ajatashatru", r: "c. 492–460 BCE", d: "Conquered the Vajji republic and fortified Pataliputra." }
+    ],
+    legacy: ["First Indian punch-marked coins", "Birth of Buddhism and Jainism", "Early republican governance (Vajji, Malla)"],
+    architecture: ["Rajgir's cyclopean walls", "Early stupas and monasteries", "Fortified capitals at Kaushambi, Shravasti"],
+    tags: ["Republics", "Philosophy", "Iron Age"] },
+
+  { id: "maurya", name: "Maurya Empire", era: "ancient", region: "Pan-Indian",
+    period: "322 – 185 BCE", tagline: "India's first great empire — unified from Afghanistan to the Deccan.",
+    image: "https://images.unsplash.com/photo-1564507592333-c6065734d399?w=900&q=70",
+    desc: "Founded by Chandragupta with Chanakya's strategy, and immortalised by Ashoka's edicts and the Sanchi and Sarnath stupas.",
+    overview: "The Mauryas unified most of the subcontinent for the first time. Chandragupta overthrew the Nandas and checked Seleucus Nicator; Bindusara held the empire; Ashoka, after the bloody Kalinga war, embraced dhamma and sent missions across Asia.",
+    rulers: [
+      { n: "Chandragupta Maurya", r: "322–298 BCE", d: "Founder — student of Chanakya; later became a Jain ascetic." },
+      { n: "Ashoka the Great", r: "268–232 BCE", d: "Conquered Kalinga, then renounced war and propagated dhamma across Asia." }
+    ],
+    legacy: ["Arthashastra — treatise on statecraft", "Edicts of Ashoka across the subcontinent", "Buddhism's spread to Sri Lanka and Central Asia", "The Lion Capital — now India's national emblem"],
+    architecture: ["Sanchi Stupa", "Sarnath Lion Capital", "Barabar rock-cut caves", "Polished sandstone pillars"],
+    tags: ["Empire", "Buddhism", "Statecraft"] },
+
+  { id: "shunga", name: "Shunga Dynasty", era: "ancient", region: "North",
+    period: "185 – 73 BCE", tagline: "A Brahmanical revival that nurtured early Indian art.",
+    image: "https://images.unsplash.com/photo-1609151941355-12a5309d6b61?w=900&q=70",
+    desc: "Founded when Pushyamitra Shunga assassinated the last Maurya king. A brief but artistically brilliant era.",
+    overview: "Though short-lived, the Shungas presided over some of India's finest early art. The Bharhut and Sanchi gateways, and Patanjali's Mahabhashya, belong to this period.",
+    rulers: [{ n: "Pushyamitra Shunga", r: "185–149 BCE", d: "General-turned-king; performed two ashvamedha sacrifices." }],
+    legacy: ["Bharhut stupa sculptures", "Patanjali's Mahabhashya (grammar)", "Revival of Vedic rituals"],
+    architecture: ["Bharhut toranas (gateways)", "Early Sanchi stupa renovations", "Rock-cut shrines at Udayagiri"],
+    tags: ["Art", "Brahmanical", "Grammar"] },
+
+  { id: "satavahana", name: "Satavahana Dynasty", era: "ancient", region: "Deccan",
+    period: "c. 230 BCE – 220 CE", tagline: "Lords of the Deccan — bridging north and south India.",
+    image: "https://images.unsplash.com/photo-1609151941355-12a5309d6b61?w=900&q=70",
+    desc: "A long-lived dynasty that controlled the Deccan, fostered Prakrit literature and opened Roman trade routes.",
+    overview: "The Satavahanas, also called Andhras, were great patrons of Buddhism and Prakrit. They minted lead and potin coins and maintained diplomatic and trade links with Rome.",
+    rulers: [{ n: "Gautamiputra Satakarni", r: "c. 103–127 CE", d: "Defeated the Shakas; his mother's Nashik inscription is a historical landmark." }],
+    legacy: ["Prakrit literature (Gaha Sattasai)", "Roman trade via western ports", "Land grants to Brahmins (early feudalism)"],
+    architecture: ["Amaravati stupa sculptures", "Karla and Bhaja rock-cut caves", "Nashik inscriptions"],
+    tags: ["Trade", "Prakrit", "Deccan"] },
+
+  { id: "kushan", name: "Kushan Empire", era: "ancient", region: "North-West",
+    period: "c. 30 – 375 CE", tagline: "The Silk Road empire that blended Greek, Persian and Indian cultures.",
+    image: "https://images.unsplash.com/photo-1564507592333-c6065734d399?w=900&q=70",
+    desc: "A Central Asian dynasty that ruled from Bactria to the Ganga, spreading Mahayana Buddhism along the Silk Road.",
+    overview: "The Kushans, of Yuezhi origin, created a cosmopolitan empire straddling the Silk Road. Their court used Greek, Bactrian and Sanskrit. Kanishka convened the great Buddhist council that shaped Mahayana.",
+    rulers: [{ n: "Kanishka the Great", r: "c. 127–150 CE", d: "Convened the 4th Buddhist council; his empire stretched to Central Asia." }],
+    legacy: ["Spread of Mahayana Buddhism to China", "Silk Road cultural synthesis", "Gandhara and Mathura art schools"],
+    architecture: ["Gandhara Buddha sculptures", "Kanishka's stupa at Peshawar", "Mathura school sculptures"],
+    tags: ["Silk Road", "Buddhism", "Cosmopolitan"] },
+
+  { id: "gupta", name: "Gupta Empire", era: "classical", region: "North",
+    period: "c. 320 – 550 CE", tagline: "India's Classical Age — the 'Golden Age' of art, science and literature.",
+    image: "https://images.unsplash.com/photo-1609151941355-12a5309d6b61?w=900&q=70",
+    desc: "The age of Kalidasa, Aryabhata, the Ajanta caves and the first iron pillar that has not rusted.",
+    overview: "Often called India's Golden Age. Sanskrit literature flowered under Kalidasa, astronomy advanced with Aryabhata and Varahamihira, and the Ajanta murals reached their peak. Hindu temple architecture began its classical evolution.",
+    rulers: [
+      { n: "Chandragupta I", r: "c. 320–335 CE", d: "Founded the Gupta era; married Licchavi princess." },
+      { n: "Samudragupta", r: "c. 335–375 CE", d: "The 'Napoleon of India' — conquered north, received southern homage." },
+      { n: "Chandragupta II (Vikramaditya)", r: "c. 375–415 CE", d: "Patron of Kalidasa and the 'nine gems' of his court." }
+    ],
+    legacy: ["Aryabhata's zero and heliocentric hints", "Kalidasa's plays (Abhijnanasakuntalam)", "Varahamihira's astronomy", "Iron Pillar of Delhi"],
+    architecture: ["Ajanta cave murals", "Dashavatara temple, Deogarh", "Brick temples at Bhitargaon"],
+    tags: ["Golden Age", "Sanskrit", "Science"] },
+
+  { id: "vakataka", name: "Vakataka Dynasty", era: "classical", region: "Deccan",
+    period: "c. 250 – 500 CE", tagline: "The patrons behind the Ajanta cave masterpieces.",
+    image: "https://images.unsplash.com/photo-1609151941355-12a5309d6b61?w=900&q=70",
+    desc: "Allies and contemporaries of the Guptas, their court funded the finest phase of Ajanta's paintings.",
+    overview: "The Vakatakas ruled the central Deccan and married into the Gupta family. Under Harishena, Ajanta's most celebrated caves (1, 2, 16, 17) were painted — now UNESCO World Heritage.",
+    rulers: [{ n: "Harishena", r: "c. 475–500 CE", d: "His minister Varahadeva commissioned Ajanta Cave 16." }],
+    legacy: ["Ajanta's finest murals", "Sanskrit patronage (Pravarasena II)", "Bridge between north and south traditions"],
+    architecture: ["Ajanta Caves 16, 17, 19, 26", "Rock-cut vihara complexes", "Nardeshwar temple"],
+    tags: ["Art", "Ajanta", "Patronage"] },
+
+  { id: "pallava", name: "Pallava Dynasty", era: "classical", region: "South",
+    period: "c. 275 – 897 CE", tagline: "Pioneers of Dravidian temple architecture and Tamil bhakti.",
+    image: "https://images.unsplash.com/photo-1587922546307-776227941871?w=900&q=70",
+    desc: "From their capital Kanchipuram, the Pallavas carved shore temples, birthed Dravidian architecture and fostered Tamil bhakti saints.",
+    overview: "The Pallavas transformed Mahabalipuram into a workshop of rock-cut architecture. The Nayanars and Alvars composed their devotional hymns under Pallava patronage, shaping Tamil Hinduism.",
+    rulers: [
+      { n: "Mahendravarman I", r: "c. 600–630 CE", d: "Started the rock-cut tradition; playwright and Jain-turned-Shaiva." },
+      { n: "Narasimhavarman I (Mamalla)", r: "c. 630–668 CE", d: "Defeated the Chalukyas; Mamallapuram is named after him." },
+      { n: "Narasimhavarman II (Rajasimha)", r: "c. 700–728 CE", d: "Built the Shore Temple and Kailasanathar at Kanchi." }
+    ],
+    legacy: ["Birth of Dravidian temple style", "Tamil bhakti movement (Nayanars, Alvars)", "Sanskrit-Tamil literary synthesis"],
+    architecture: ["Shore Temple, Mahabalipuram", "Pancha Rathas", "Kailasanathar Temple, Kanchipuram"],
+    tags: ["Temples", "Bhakti", "Tamil"] },
+
+  { id: "chalukya", name: "Chalukyas of Badami", era: "classical", region: "Deccan",
+    period: "c. 543 – 753 CE", tagline: "Rock-cut pioneers who fused Nagara and Dravida styles.",
+    image: "https://images.unsplash.com/photo-1564507592333-c6065734d399?w=900&q=70",
+    desc: "From the red sandstone cliffs of Badami, the Chalukyas created a hybrid temple style that shaped Deccan architecture.",
+    overview: "Pulakeshin II famously defeated Harshavardhana on the Narmada. Their cave temples at Badami, and structural temples at Aihole and Pattadakal, mark the birth of 'Vesara' (mixed) architecture.",
+    rulers: [{ n: "Pulakeshin II", r: "c. 610–642 CE", d: "Defeated Harsha; his Aihole inscription is a key historical source." }],
+    legacy: ["Vesara architectural style", "Aihole inscription (court poet Ravikirti)", "Defeat of Harshavardhana"],
+    architecture: ["Badami cave temples", "Aihole's 70+ experimental temples", "Pattadakal UNESCO complex"],
+    tags: ["Vesara", "Architecture", "Deccan"] },
+
+  { id: "rashtrakuta", name: "Rashtrakuta Empire", era: "medieval", region: "Deccan",
+    period: "c. 753 – 982 CE", tagline: "Builders of the world's largest monolithic monument.",
+    image: "https://images.unsplash.com/photo-1564507592333-c6065734d399?w=900&q=70",
+    desc: "A Deccan superpower that ruled from the Narmada to the Kaveri and carved the Kailasa temple at Ellora.",
+    overview: "The Rashtrakutas displaced the Chalukyas and became the dominant power of peninsular India. Their court was multilingual, their reach diplomatic (embassies to Baghdad).",
+    rulers: [
+      { n: "Dantidurga", r: "c. 735–756 CE", d: "Founder — overthrew Chalukya overlordship." },
+      { n: "Krishna I", r: "c. 756–774 CE", d: "Commissioned the Kailasa temple at Ellora." },
+      { n: "Amoghavarsha I", r: "c. 814–878 CE", d: "Author of Kavirajamarga, earliest Kannada literary work." }
+    ],
+    legacy: ["Kailasa temple (monolithic marvel)", "Kavirajamarga (Kannada literature)", "Embassies to the Abbasid Caliphate"],
+    architecture: ["Kailasa Temple, Ellora", "Elephanta cave sculptures", "Jain temples at Malkhed"],
+    tags: ["Monolith", "Kannada", "Ellora"] },
+
+  { id: "pala", name: "Pala Empire", era: "medieval", region: "East",
+    period: "c. 750 – 1174 CE", tagline: "Buddhist Bengal's last great imperial dynasty.",
+    image: "https://images.unsplash.com/photo-1609151941355-12a5309d6b61?w=900&q=70",
+    desc: "A Buddhist dynasty that ruled Bengal and Bihar for four centuries and built the great universities of Nalanda and Vikramashila.",
+    overview: "The Palas were elected by regional chiefs after a period of anarchy (matsyanyaya). They revived Nalanda and founded Vikramashila, sending Buddhist scholars to Tibet.",
+    rulers: [
+      { n: "Gopala I", r: "c. 750–770 CE", d: "Elected king; ended Bengal's anarchy." },
+      { n: "Dharmapala", r: "c. 770–810 CE", d: "Founded Vikramashila University." },
+      { n: "Devapala", r: "c. 810–850 CE", d: "Empire's zenith — defeated Pratiharas and Rashtrakutas." }
+    ],
+    legacy: ["Vikramashila University", "Buddhist transmission to Tibet (Atisha)", "Proto-Bengali language"],
+    architecture: ["Somapura Mahavihara (UNESCO)", "Vikramashila ruins", "Pala bronze sculptures"],
+    tags: ["Buddhist", "Universities", "Bengal"] },
+
+  { id: "pratihara", name: "Gurjara-Pratihara Empire", era: "medieval", region: "North",
+    period: "c. 730 – 1036 CE", tagline: "The doorkeepers of India — blocking Arab expansion eastward.",
+    image: "https://images.unsplash.com/photo-1564507592333-c6065734d399?w=900&q=70",
+    desc: "A tripartite struggle with the Palas and Rashtrakutas for Kannauj defined early medieval north India.",
+    overview: "The Pratiharas blocked Arab armies from Sindh for three centuries. Their court at Kannauj patronised the great Sanskrit poet Rajashekhara.",
+    rulers: [
+      { n: "Nagabhata I", r: "c. 730–760 CE", d: "Repelled Arab invasions." },
+      { n: "Mihira Bhoja", r: "c. 836–885 CE", d: "Empire's zenith; a great Vaishnava devotee." }
+    ],
+    legacy: ["Check on Arab expansion into India", "Kannauj as imperial capital", "Khajuraho temples (by feudatory Chandelas)"],
+    architecture: ["Teli-ka-Mandir, Gwalior", "Bateshwar temple complex", "Early Nagara-style temples"],
+    tags: ["Imperial", "Nagara", "Kannauj"] },
+
+  { id: "chola", name: "Chola Empire", era: "medieval", region: "South",
+    period: "c. 848 – 1279 CE", tagline: "India's greatest maritime empire — ships that reached Southeast Asia.",
+    image: "https://images.unsplash.com/photo-1587922546307-776227941871?w=900&q=70",
+    desc: "From Thanjavur, the Cholas ruled peninsular India, conquered Sri Lanka and sent naval expeditions to Srivijaya (Indonesia).",
+    overview: "The Imperial Cholas were master builders, administrators and sailors. They instituted village self-governance (the Uttiramerur inscriptions) and erected the tallest temple towers of their age.",
+    rulers: [
+      { n: "Rajaraja Chola I", r: "985–1014 CE", d: "Built the Brihadisvara Temple at Thanjavur." },
+      { n: "Rajendra Chola I", r: "1014–1044 CE", d: "Conquered Srivijaya; founded Gangaikondacholapuram." }
+    ],
+    legacy: ["Village self-governance (Uttiramerur)", "Naval expeditions to Southeast Asia", "Bronze Nataraja sculptures", "Spread of Hinduism to Southeast Asia"],
+    architecture: ["Brihadisvara Temple, Thanjavur (UNESCO)", "Gangaikondacholapuram temple", "Airavatesvara, Darasuram"],
+    tags: ["Maritime", "Naval", "Dravidian"] },
+
+  { id: "hoysala", name: "Hoysala Empire", era: "medieval", region: "South",
+    period: "c. 1026 – 1343 CE", tagline: "Soapstone sculptors whose temples read like carved encyclopaedias.",
+    image: "https://images.unsplash.com/photo-1564507592333-c6065734d399?w=900&q=70",
+    desc: "A Kannada dynasty whose star-shaped temples at Belur, Halebidu and Somnathpur are pinnacles of Indian sculpture.",
+    overview: "The Hoysalas ruled the Karnataka plateau and produced a uniquely ornate style of temple architecture. Every surface of their temples is carved with deities, musicians, dancers and animals.",
+    rulers: [{ n: "Vishnuvardhana", r: "c. 1108–1152 CE", d: "Commissioned the Chennakeshava Temple at Belur." }],
+    legacy: ["Star-shaped temple plans", "Pinnacle of soapstone carving", "Patronage to both Jainism and Vaishnavism"],
+    architecture: ["Chennakeshava Temple, Belur (UNESCO)", "Hoysaleswara Temple, Halebidu", "Kesava Temple, Somnathpur"],
+    tags: ["Sculpture", "Kannada", "Temples"] },
+
+  { id: "kakatiya", name: "Kakatiya Dynasty", era: "medieval", region: "South",
+    period: "c. 1163 – 1323 CE", tagline: "Telugu warrior-queens and engineers of tank-irrigation.",
+    image: "https://images.unsplash.com/photo-1564507592333-c6065734d399?w=900&q=70",
+    desc: "From Warangal, the Kakatiyas built irrigation tanks, diamond-trade networks and the Thousand-Pillar Temple.",
+    overview: "The Kakatiyas transformed the dry Telangana plateau with an extraordinary network of irrigation tanks. Rudrama Devi, one of India's rare ruling queens, defended the kingdom against the Yadavas and Pandyas.",
+    rulers: [
+      { n: "Ganapatideva", r: "1199–1262 CE", d: "Longest reign; expanded trade and irrigation." },
+      { n: "Rudrama Devi", r: "1262–1289 CE", d: "One of India's few reigning queens." }
+    ],
+    legacy: ["Tank-irrigation network (still in use)", "Koh-i-Noor diamond's earliest traces", "Rudrama Devi — rare female ruler"],
+    architecture: ["Thousand-Pillar Temple, Hanamkonda", "Ramappa Temple (UNESCO)", "Warangal Fort's kakatiya toranas"],
+    tags: ["Irrigation", "Telugu", "Warrior queens"] },
+
+  { id: "vijayanagara", name: "Vijayanagara Empire", era: "earlymodern", region: "South",
+    period: "1336 – 1646 CE", tagline: "The City of Victory — Hindu south's bulwark and jewel.",
+    image: "https://images.unsplash.com/photo-1564507592333-c6065734d399?w=900&q=70",
+    desc: "From Hampi's boulders, Vijayanagara ruled the Deccan and south — a cosmopolitan market city visited by travellers from Europe and Arabia.",
+    overview: "Founded by Harihara and Bukka, Vijayanagara became one of the largest cities in the world by the 1500s. Portuguese and Persian travellers described its wealth, markets and temple festivals. The 1565 Battle of Talikota ended its golden age.",
+    rulers: [
+      { n: "Krishnadevaraya", r: "1509–1529 CE", d: "The empire's greatest king; poet, conqueror and patron of Telugu literature." }
+    ],
+    legacy: ["Peak of south Indian temple architecture", "Telugu literary golden age", "International diamond and spice trade"],
+    architecture: ["Hampi (UNESCO city ruins)", "Vitthala Temple's musical pillars", "Virupaksha and Hazara Rama temples"],
+    tags: ["Hampi", "Trade", "Telugu"] },
+
+  { id: "mughal", name: "Mughal Empire", era: "earlymodern", region: "Pan-Indian",
+    period: "1526 – 1857 CE", tagline: "The empire that built the Taj, and the miniature painting.",
+    image: "https://images.unsplash.com/photo-1564507592333-c6065734d399?w=900&q=70",
+    desc: "From Babur's victory at Panipat to Shah Jahan's marble poetry, the Mughals unified much of India and created a syncretic court culture.",
+    overview: "Babur founded the dynasty; Akbar built its institutions (mansabdari, sulh-i-kul); Jahangir patronised painting; Shah Jahan built in marble; Aurangzeb expanded but strained. The empire fragmented after 1707, formally ending in 1857.",
+    rulers: [
+      { n: "Akbar the Great", r: "1556–1605 CE", d: "Instituted religious tolerance (sulh-i-kul) and the mansabdari system." },
+      { n: "Shah Jahan", r: "1628–1658 CE", d: "Builder of the Taj Mahal, Red Fort, Jama Masjid." },
+      { n: "Aurangzeb", r: "1658–1707 CE", d: "Expanded the empire to its greatest extent; orthodox policies strained it." }
+    ],
+    legacy: ["Mughal miniature painting", "Urdu language synthesis", "Mansabdari administration", "Indo-Persian court culture"],
+    architecture: ["Taj Mahal (UNESCO)", "Red Fort & Jama Masjid, Delhi", "Fatehpur Sikri", "Humayun's Tomb"],
+    tags: ["Taj Mahal", "Urdu", "Miniature"] },
+
+  { id: "maratha", name: "Maratha Empire", era: "earlymodern", region: "West",
+    period: "1674 – 1818 CE", tagline: "The saffron confederacy that challenged Mughal supremacy.",
+    image: "https://images.unsplash.com/photo-1587922546307-776227941871?w=900&q=70",
+    desc: "Shivaji's hill-forts grew into a confederacy that at its peak stretched from Attock to Cuttack — the last great indigenous empire before British rule.",
+    overview: "Shivaji carved out swarajya from the Deccan hills. His successors, especially the Peshwas, turned the Marathas into a pan-Indian power. The Third Battle of Panipat (1761) and Anglo-Maratha wars ended the confederacy.",
+    rulers: [
+      { n: "Shivaji Maharaj", r: "1674–1680 CE", d: "Founded swarajya; innovator of guerrilla warfare and naval strategy." },
+      { n: "Bajirao I", r: "1720–1740 CE", d: "Undefeated Peshwa; expanded Maratha power to Delhi." }
+    ],
+    legacy: ["Guerrilla warfare (ganimi kava)", "Naval forts (Sindhudurg, Vijayd

--- a/frontend/kingdoms/kingdoms.js
+++ b/frontend/kingdoms/kingdoms.js
@@ -73,6 +73,9 @@ const KINGDOMS = [
     architecture: ["Gandhara Buddha sculptures", "Kanishka's stupa at Peshawar", "Mathura school sculptures"],
     tags: ["Silk Road", "Buddhism", "Cosmopolitan"] },
 
+
+    
+
   { id: "gupta", name: "Gupta Empire", era: "classical", region: "North",
     period: "c. 320 – 550 CE", tagline: "India's Classical Age — the 'Golden Age' of art, science and literature.",
     image: "https://images.unsplash.com/photo-1609151941355-12a5309d6b61?w=900&q=70",

--- a/frontend/kodungallur-port-explorer/index.html
+++ b/frontend/kodungallur-port-explorer/index.html
@@ -3,394 +3,389 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="description" content="Explore Kodungallur Ancient Port in Kerala: legendary Muziris spice emporium, Greco-Roman trade routes, Pattanam excavations, and rich multi-religious heritage.">
+  <meta name="description" content="Explore Kodungallur Ancient Port (Muziris) in Kerala: legendary spice emporium, Roman trade routes, Pattanam excavations, and 2000 years of maritime heritage.">
   <title>Kodungallur Ancient Port Explorer | Incredible India</title>
-  <!-- Preload Critical Fonts -->
-    <link rel="preload" href="../../assets/fonts/Outfit-400.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="../../assets/fonts/Outfit-700.woff2" as="font" type="font/woff2" crossorigin>
-    <link rel="preload" href="../../assets/fonts/PlayfairDisplay-400.woff2" as="font" type="font/woff2" crossorigin>
-<link rel="stylesheet" href="../../styles.css">
+  
+  <link rel="preload" href="../../assets/fonts/Outfit-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="../../assets/fonts/Outfit-700.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="../../assets/fonts/PlayfairDisplay-400.woff2" as="font" type="font/woff2" crossorigin>
+  
+  <link rel="stylesheet" href="../../styles.css">
   <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="../js-modules/page-progress/page-progress.css">
 
-  <!-- Open Graph / Social Media Tags -->
-  <meta property="og:title" content="Kodungallur Ancient Port Explorer | Incredible India Explorer">
-  <meta property="og:description" content="Discover Kodungallur, the ancient port of Muziris in Kerala, its role as the global pepper emporium, Pattanam excavations, and syncretic culture.">
+  <meta property="og:title" content="Kodungallur Ancient Port Explorer">
+  <meta property="og:description" content="Discover Muziris — India's legendary ancient port, Roman gold trade, and 2000 years of maritime heritage.">
   <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/frontend/assets/kodungallur_port_banner.png">
-  <meta property="og:image:width" content="1200">
-  <meta property="og:image:height" content="630">
   <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/kodungallur-port-explorer/index.html">
-  <meta property="og:type" content="website">
-  <meta property="og:site_name" content="Incredible India Explorer">
-  <meta property="og:locale" content="en_IN">
-
-  <!-- Canonical URL -->
   <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/kodungallur-port-explorer/index.html">
 </head>
 <body>
   <script>
     (function() {
-      let theme = 'dark'; try { theme = JSON.parse(localStorage.getItem('iie_storage') || '{}').theme || 'dark'; } catch(e) {}
-      if (theme === 'light') {
-        document.body.classList.add('light-theme');
-      }
+      let theme = 'dark'; 
+      try { theme = JSON.parse(localStorage.getItem('iie_storage') || '{}').theme || 'dark'; } catch(e) {}
+      if (theme === 'light') document.body.classList.add('light-theme');
     })();
   </script>
 
-  <!-- Sticky Navigation Bar -->
   <header class="navbar" id="navbar">
     <div class="nav-container">
-        <a href="../../index.html#home" class="nav-logo" id="nav-logo">
-            <span class="saffron">Incredible</span>
-            <span class="gold">India</span>
-            <span class="green">Explorer</span>
-        </a>
-        <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
-            <span class="bar"></span>
-            <span class="bar"></span>
-            <span class="bar"></span>
-        </button>
-        <nav class="nav-menu" id="nav-menu">
-            <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
-
-            <div class="nav-dropdown">
-                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
-                <div class="dropdown-menu">
-                    <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
-                    <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
-                    <a href="../../frontend/ancient-ports-explorer/index.html" class="dropdown-item">Ancient Ports of India</a>
-                    <a href="../../frontend/islands/islands.html" class="dropdown-item">Islands of India</a>
-                    <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
-                    <a href="../../frontend/forts/forts.html" class="dropdown-item">Forts of India</a>
-                    <a href="../../frontend/route-planner/route-planner.html" class="dropdown-item">Route Planner</a>
-                </div>
-            </div>
-
-            <div class="nav-dropdown">
-                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
-                <div class="dropdown-menu">
-                    <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
-                    <a href="../../frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
-                    <a href="../../frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
-                    <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
-                    <a href="../../frontend/national-symbols-gallery/national-symbols-gallery.html" class="dropdown-item">National Symbols</a>
-                    <a href="../../frontend/cuisine-discovery-hub/index.html" class="dropdown-item">UP Cuisine</a>
-                    <a href="../../frontend/handicrafts-showcase/index.html" class="dropdown-item">UP Handicrafts</a>
-                    <a href="../../frontend/national-days-calendar/index.html" class="dropdown-item">National Days</a>
-                    <a href="../../frontend/ganga-ghats-experience/index.html" class="dropdown-item">Ganga Ghats</a>
-                </div>
-            </div>
-
-            <div class="nav-dropdown">
-                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Nature ▾</button>
-                <div class="dropdown-menu">
-                    <a href="../../frontend/national-parks-explorer/index.html" class="dropdown-item">National Parks</a>
-                    <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
-                    <a href="../../frontend/wildlife-rescue/wildlife-rescue.html" class="dropdown-item">Wildlife Rescue</a>
-                    <a href="../../frontend/endemic-flora-fauna-explorer/index.html" class="dropdown-item">Endemic Flora & Fauna</a>
-                    <a href="../../frontend/harike-wetland/harike-wetland.html" class="dropdown-item">Harike Wetland</a>
-                    <a href="../../frontend/wular-lake/wular-lake.html" class="dropdown-item">Wular Lake</a>
-                    <a href="../../frontend/crowd-density/index.html" class="dropdown-item">Crowd Density Predictor</a>
-                </div>
-            </div>
-
-            <div class="nav-dropdown">
-                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Games ▾</button>
-                <div class="dropdown-menu">
-                    <a href="../../frontend/passport-quest/passport-quest.html" class="dropdown-item">Passport Quest</a>
-                    <a href="../../frontend/culinary-game/culinary-game.html" class="dropdown-item">Culinary Challenge</a>
-                    <a href="../../frontend/monsoon-game/monsoon-game.html" class="dropdown-item">Monsoon Game</a>
-                    <a href="../../frontend/river-game/river-game.html" class="dropdown-item">River Explorer</a>
-                    <a href="../../frontend/geo-guesser-india/index.html" class="dropdown-item">GeoGuesser</a>
-                </div>
-            </div>
-
-            <div class="nav-dropdown">
-                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Community ▾</button>
-                <div class="dropdown-menu">
-                    <a href="../../frontend/contributors/contributors.html" class="dropdown-item">Contributors</a>
-                    <a href="../../frontend/world-records-india/index.html" class="dropdown-item">World Records</a>
-                </div>
-            </div>
-            
-            <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
-        </nav>
+      <a href="../../index.html#home" class="nav-logo">
+        <span class="saffron">Incredible</span><span class="gold">India</span><span class="green">Explorer</span>
+      </a>
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+        <span class="bar"></span><span class="bar"></span><span class="bar"></span>
+      </button>
+      <nav class="nav-menu" id="nav-menu">
+        <a href="../../index.html#home" class="nav-link active">Home</a>
+        <div class="nav-dropdown">
+          <button class="nav-link dropdown-toggle">Destinations ▾</button>
+          <div class="dropdown-menu">
+            <a href="../../frontend/ancient-ports-explorer/index.html" class="dropdown-item">Ancient Ports</a>
+            <a href="../../frontend/islands/islands.html" class="dropdown-item">Islands</a>
+            <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+          </div>
+        </div>
+        <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Theme">☀️</button>
+      </nav>
     </div>
-</header>
+  </header>
 
-  <!-- SPA Target Main Container -->
   <main id="app-root" class="port-main">
     
-    <!-- Hero Banner -->
+    <!-- ============ HERO ============ -->
     <section class="port-hero">
-      <div class="port-hero-content">
-        <span class="port-kicker">⚓ Malabar Coast · Legend of Muziris &amp; Black Gold</span>
-        <h1>Kodungallur Ancient Port <span>Explorer</span></h1>
-        <p>Step into Kodungallur (ancient Muziris), India's premier ancient maritime emporium. Discover the historic gateway of the Indian Ocean, Roman gold trade routes, groundbreaking Pattanam excavations, and centuries of syncretic spiritual heritage.</p>
-        <div class="port-bookmark-container">
-          <button class="port-bookmark-btn journey-bookmark-btn" type="button" data-bookmark-id="kodungallur-port-main" aria-pressed="false" aria-label="Bookmark Kodungallur Port">
+      <div class="hero-bg">
+        <div class="hero-gradient"></div>
+        <svg class="wave wave-back" viewBox="0 0 1440 200" preserveAspectRatio="none">
+          <path d="M0,120 C240,180 480,60 720,100 C960,140 1200,80 1440,120 L1440,200 L0,200 Z"/>
+        </svg>
+        <svg class="wave wave-mid" viewBox="0 0 1440 200" preserveAspectRatio="none">
+          <path d="M0,160 C320,80 560,200 800,140 C1040,80 1280,180 1440,100 L1440,200 L0,200 Z"/>
+        </svg>
+        <svg class="wave wave-front" viewBox="0 0 1440 200" preserveAspectRatio="none">
+          <path d="M0,180 C200,140 440,220 720,160 C1000,100 1240,200 1440,140 L1440,200 L0,200 Z"/>
+        </svg>
+        <div class="hero-ships" aria-hidden="true">
+          <div class="ship ship-1">⛵</div>
+          <div class="ship ship-2">🚢</div>
+          <div class="ship ship-3">⛵</div>
+        </div>
+      </div>
+
+      <div class="hero-content">
+        <span class="hero-stamp">⚓ Malabar Coast · 1st Century CE</span>
+        <h1>Kodungallur <em>Ancient Port</em></h1>
+        <p class="hero-lede">Step into <strong>Muziris</strong> — India's legendary gateway to the ancient world. Where Roman gold flowed for Malabar pepper, where St. Thomas first preached, and where three continents met on the Periyar delta.</p>
+
+        <div class="hero-stats">
+          <div class="stat-pill"><strong data-count="2000">0</strong><span>Years of trade</span></div>
+          <div class="stat-pill"><strong data-count="40">0</strong><span>Trade partners</span></div>
+          <div class="stat-pill"><strong data-count="629">0</strong><span>CE · First mosque</span></div>
+          <div class="stat-pill"><strong data-count="52">0</strong><span>CE · St. Thomas</span></div>
+        </div>
+
+        <div class="hero-ctas">
+          <a href="#trade-routes" class="btn-primary">Explore trade routes ↓</a>
+          <a href="#timeline" class="btn-ghost">Walk the timeline</a>
+          <button class="port-bookmark-btn journey-bookmark-btn" type="button" data-bookmark-id="kodungallur-port-main" aria-pressed="false">
             ♡ Save to Journey
           </button>
         </div>
       </div>
     </section>
 
-    <!-- Section 1: Historical Background -->
+    <!-- ============ OVERVIEW ============ -->
     <section class="port-section" id="overview">
-      <div class="port-container port-grid-2col">
-        <div class="port-text-block">
-          <span class="port-eyebrow">Ancient Emporium of the Cheras</span>
-          <h2>The Legendary Port of Muziris</h2>
-          <p>Kodungallur, situated at the mouth of the Periyar River in Thrissur district, Kerala, is historically and archaeologically identified as the core site of <strong>Muziris (Muciri)</strong> — the legendary ancient port city of South India.</p>
-          <p>Mentioned in Tamil Sangam literature as <em>Muciri</em> where "the beautiful vessels of the Yavanas (Greeks &amp; Romans) arrive with gold and leave laden with black pepper," Kodungallur served as the Royal Capital of the Second Chera Kingdom (Mahodayapuram / Makotai) between the 9th and 12th centuries CE.</p>
-          <p>In <strong>1341 CE</strong>, a catastrophic flood on the Periyar River permanently altered the geography of the Malabar coastline. The siltation choked the harbour of Muziris and gave birth to the natural port of Cochin, transforming Kodungallur into a silent keeper of ancient maritime memories.</p>
-        </div>
-        <div class="port-highlight-box">
-          <h3>📜 Classical References</h3>
-          <ul>
-            <li><strong>Periplus of the Erythraean Sea (1st c. CE)</strong>: Described Muziris as a leading emporium abounding in ships sent there with cargoes from Arabia and Rome.</li>
-            <li><strong>Pliny the Elder (77 CE)</strong>: Called Muziris <em>"Primum Inscriptionis Emporium Indiae"</em> (the first emporium of India), while cautioning about pirate threats nearby.</li>
-            <li><strong>Ptolemy's Geography (2nd c. CE)</strong>: Detailed Muziris as an inland port located 20 stadia from the mouth of the river.</li>
-            <li><strong>Tabula Peutingeriana</strong>: A Roman map showing a Temple of Augustus located at Muziris.</li>
-          </ul>
-        </div>
-      </div>
-    </section>
-
-    <!-- Section 2: Trade Significance -->
-    <section class="port-section" id="trade">
       <div class="port-container">
-        <div class="port-section-header">
-          <span class="port-eyebrow">Black Gold &amp; Monsoon Routes</span>
-          <h2>Maritime Significance &amp; Global Trade Hub</h2>
-          <p>Kodungallur connected the Indian subcontinent with Mediterranean, Middle Eastern, and East Asian trade networks for over two millennia.</p>
+        <div class="section-heading">
+          <span class="section-badge">The Legend</span>
+          <h2>Muziris — First Emporium of India</h2>
+          <p>Kodungallur, at the mouth of the Periyar River in Kerala, is archaeologically identified as <strong>Muziris (Muciri)</strong> — the legendary port that Pliny the Elder called <em>"Primum Inscriptionis Emporium Indiae"</em>.</p>
         </div>
 
-        <div class="port-card-grid">
-          <div class="port-card">
-            <span class="port-card-icon">🌶️</span>
-            <h3>"Black Gold" Emporium</h3>
-            <p>Malabar black pepper was coveted across the Roman Empire. Roman writers recorded immense sums of gold flowing into Muziris to secure spices, cardamom, cinnamon, beryl, and ivory.</p>
+        <div class="overview-grid">
+          <div class="overview-card">
+            <span class="oc-icon">📜</span>
+            <h3>Classical Sources</h3>
+            <p>Mentioned in the <strong>Periplus Maris Erythraei</strong> (1st c. CE), <strong>Pliny's Natural History</strong> (77 CE), and <strong>Ptolemy's Geography</strong> (2nd c. CE) as a thriving emporium where "Yavana ships arrive with gold and leave laden with pepper."</p>
           </div>
-          <div class="port-card">
-            <span class="port-card-icon">⛵</span>
-            <h3>Hippalus Monsoon Winds</h3>
-            <p>Following the discovery of the southwest monsoon winds by the Greek navigator Hippalus, merchant ships sailed directly from Berenike and Myos Hormos in Egypt across the Arabian Sea to Muziris in 40 days.</p>
+          <div class="overview-card">
+            <span class="oc-icon">🌊</span>
+            <h3>The Great Flood of 1341</h3>
+            <p>A catastrophic Periyar flood permanently altered the Malabar coast — silting Muziris harbour and giving birth to Cochin port. Kodungallur became a silent keeper of ancient maritime memories.</p>
           </div>
-          <div class="port-card">
-            <span class="port-card-icon">🪙</span>
-            <h3>Roman Hoards &amp; Papyrus Muziris</h3>
-            <p>Huge hoards of Roman gold (Aurei) and silver (Denarii) coins of Augustus, Tiberius, and Nero have been unearthed around Kodungallur (Eyyal, Valluvally), confirming staggering trade volumes documented in the 2nd-century *Muziris Papyrus* contract.</p>
-          </div>
-          <div class="port-card">
-            <span class="port-card-icon">🌏</span>
-            <h3>Multi-Continental Connections</h3>
-            <p>Beyond Rome and Greece, Kodungallur engaged in active maritime exchange with Phoenician, Persian, Arab, and Chinese merchants, who established trading guilds along the Periyar Delta.</p>
+          <div class="overview-card">
+            <span class="oc-icon">🏛️</span>
+            <h3>Chera Capital</h3>
+            <p>Between the 9th–12th centuries CE, Kodungallur (then <strong>Mahodayapuram</strong>) served as the royal capital of the Second Chera Kingdom under the Kulasekhara dynasty.</p>
           </div>
         </div>
       </div>
     </section>
 
-    <!-- Section 3: Cultural Heritage -->
+    <!-- ============ TRADE ROUTES MAP ============ -->
+    <section class="port-section" id="trade-routes">
+      <div class="port-container">
+        <div class="section-heading">
+          <span class="section-badge">Maritime Networks</span>
+          <h2>Global Trade Routes from Muziris</h2>
+          <p>Click any port to see what they traded. Hover routes to see monsoon wind patterns.</p>
+        </div>
+
+        <div class="trade-map-wrap">
+          <div class="trade-map" id="trade-map">
+            <svg viewBox="0 0 1000 600" class="map-svg">
+              <defs>
+                <radialGradient id="port-glow">
+                  <stop offset="0%" stop-color="#d4a64a" stop-opacity="0.8"/>
+                  <stop offset="100%" stop-color="#d4a64a" stop-opacity="0"/>
+                </radialGradient>
+              </defs>
+              <g id="map-routes"></g>
+              <g id="map-ports"></g>
+            </svg>
+            <div class="map-tooltip" id="map-tooltip" hidden></div>
+          </div>
+          <div class="map-legend">
+            <span class="legend-chip"><i class="dot dot-muziris"></i>Muziris (Home)</span>
+            <span class="legend-chip"><i class="dot dot-roman"></i>Roman Empire</span>
+            <span class="legend-chip"><i class="dot dot-arab"></i>Arabian Peninsula</span>
+            <span class="legend-chip"><i class="dot dot-china"></i>China & East Asia</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============ TRADE GOODS ============ -->
+    <section class="port-section" id="trade-goods">
+      <div class="port-container">
+        <div class="section-heading">
+          <span class="section-badge">Black Gold & Beyond</span>
+          <h2>What Flowed Through Muziris</h2>
+          <p>Filter by origin or era to explore the commodities that made Kodungallur a global emporium.</p>
+        </div>
+
+        <div class="goods-controls">
+          <div class="filter-chips" id="goods-origins">
+            <button class="chip active" data-origin="all">All Origins</button>
+            <button class="chip" data-origin="india">India (Exports)</button>
+            <button class="chip" data-origin="roman">Roman (Imports)</button>
+            <button class="chip" data-origin="arab">Arabian</button>
+            <button class="chip" data-origin="china">Chinese</button>
+          </div>
+          <div class="filter-chips" id="goods-eras">
+            <button class="chip active" data-era="all">All Eras</button>
+            <button class="chip" data-era="sangam">Sangam (300 BCE–300 CE)</button>
+            <button class="chip" data-era="roman">Roman Peak (1st–3rd c. CE)</button>
+            <button class="chip" data-era="medieval">Medieval (800–1300 CE)</button>
+          </div>
+        </div>
+
+        <div class="goods-grid" id="goods-grid"></div>
+      </div>
+    </section>
+
+    <!-- ============ CULTURAL HERITAGE ============ -->
     <section class="port-section" id="culture">
       <div class="port-container">
-        <div class="port-section-header">
-          <span class="port-eyebrow">Syncretic Sanctuary</span>
-          <h2>Cultural &amp; Spiritual Heritage of Kodungallur</h2>
-          <p>Kodungallur stands as India's premier cradle of interfaith harmony, welcoming world religions through its historic sea gates.</p>
+        <div class="section-heading">
+          <span class="section-badge">Syncretic Sanctuary</span>
+          <h2>Where World Faiths First Landed</h2>
+          <p>Kodungallur welcomed Christianity, Islam, and Judaism centuries before they reached most of India — all coexisting with ancient Hindu traditions.</p>
         </div>
 
-        <div class="port-card-grid">
-          <div class="port-card">
-            <span class="port-card-icon">🕌</span>
+        <div class="culture-map-wrap">
+          <div class="culture-map" id="culture-map">
+            <div class="culture-pin" data-site="cheraman" style="left: 45%; top: 35%;">
+              <span class="pin-icon">🕌</span>
+              <span class="pin-label">Cheraman Mosque</span>
+            </div>
+            <div class="culture-pin" data-site="thomas" style="left: 52%; top: 28%;">
+              <span class="pin-icon">⛪</span>
+              <span class="pin-label">St. Thomas</span>
+            </div>
+            <div class="culture-pin" data-site="bhagavathy" style="left: 38%; top: 52%;">
+              <span class="pin-icon">🛕</span>
+              <span class="pin-label">Bhagavathy</span>
+            </div>
+            <div class="culture-pin" data-site="shiva" style="left: 60%; top: 48%;">
+              <span class="pin-icon">🕉️</span>
+              <span class="pin-label">Thiruvanchikulam</span>
+            </div>
+            <div class="culture-pin" data-site="jewish" style="left: 48%; top: 65%;">
+              <span class="pin-icon">✡️</span>
+              <span class="pin-label">Jewish Quarter</span>
+            </div>
+          </div>
+          <div class="culture-info" id="culture-info">
+            <h3 id="culture-title">Click a site to explore</h3>
+            <p id="culture-desc">Kodungallur's heritage sites tell the story of India's earliest interfaith encounters.</p>
+          </div>
+        </div>
+
+        <div class="culture-cards">
+          <div class="culture-card">
+            <span class="cc-icon">🕌</span>
             <h3>Cheraman Juma Mosque (629 CE)</h3>
-            <p>Built by Malik Dinar during the lifetime of Prophet Muhammad, it is universally recognized as the first mosque in India. Constructed in traditional Kerala wood-and-tile architecture, it features an ancient brass oil lamp lit continuously for centuries.</p>
+            <p>India's first mosque, built by Malik Dinar during Prophet Muhammad's lifetime. Traditional Kerala architecture with a brass lamp lit continuously for 1,400 years.</p>
           </div>
-          <div class="port-card">
-            <span class="port-card-icon">⛪</span>
+          <div class="culture-card">
+            <span class="cc-icon">⛪</span>
             <h3>St. Thomas Church (52 CE)</h3>
-            <p>According to Christian tradition, St. Thomas the Apostle landed at Azhikode near Kodungallur in 52 CE, establishing seven original churches in Kerala and introducing Christianity to the subcontinent.</p>
+            <p>Tradition holds that St. Thomas the Apostle landed at Azhikode near Kodungallur, establishing Christianity in India 1,500 years before European missionaries.</p>
           </div>
-          <div class="port-card">
-            <span class="port-card-icon">🛕</span>
+          <div class="culture-card">
+            <span class="cc-icon">🛕</span>
             <h3>Kodungallur Bhagavathy Temple</h3>
-            <p>An ancient shrine dedicated to Goddess Bhadrakali/Kannaki, immortalized in the Tamil epic *Silappatikaram* written by Prince Ilango Adigal. Celebrated for its vibrant *Bharani* and *Thalappoli* festivals.</p>
+            <p>Ancient shrine to Goddess Kannaki/Bhadrakali, immortalized in the Tamil epic <em>Silappatikaram</em>. Famous for Bharani and Thalappoli festivals.</p>
           </div>
-          <div class="port-card">
-            <span class="port-card-icon">🪔</span>
+          <div class="culture-card">
+            <span class="cc-icon">🕉️</span>
             <h3>Thiruvanchikulam Shiva Temple</h3>
-            <p>The ancestral temple of the Chera emperors and the only Shaivite *Paadal Petra Sthalam* in Kerala, associated with Great Saints Sundarar and Cheraman Perumal Nayanar.</p>
-          </div>
-          <div class="port-card">
-            <span class="port-card-icon">📜</span>
-            <h3>Early Jewish &amp; Arab Heritage</h3>
-            <p>Tradition records Jewish merchants settling in Kodungallur after the destruction of the Second Temple in Jerusalem (70 CE), creating a thriving Judeo-Malayalam cultural legacy.</p>
+            <p>Ancestral temple of the Chera emperors. The only Shaivite <em>Paadal Petra Sthalam</em> in Kerala, associated with saints Sundarar and Cheraman Perumal.</p>
           </div>
         </div>
       </div>
     </section>
 
-    <!-- Section 4: Archaeological Findings -->
+    <!-- ============ ARCHAEOLOGY ============ -->
     <section class="port-section" id="archaeology">
-      <div class="port-container port-grid-2col">
-        <div class="port-highlight-box">
-          <h3>🏺 Key Excavation Discoveries</h3>
-          <ul>
-            <li><strong>2000-Year-Old Dugout Canoe</strong>: A 6-meter burnt-wood canoe unearthed in Pattanam, demonstrating ancient riverine navigation.</li>
-            <li><strong>Roman Amphorae &amp; Terra Sigillata</strong>: Hundreds of thousands of Mediterranean pottery sherds used for carrying wine and olive oil.</li>
-            <li><strong>Mesopotamian &amp; Chinese Ware</strong>: Turquoise glazed pottery from Parthia/Persia and celadon porcelain from China.</li>
-            <li><strong>Semiprecious Stone Beads</strong>: Carnelian, agate, jasper, and beryl production workshops detailing local craftsman guilds.</li>
-            <li><strong>Kottappuram Fort (1523 CE)</strong>: Portuguese fortress ruins defending the river mouth against rivals, later held by the Dutch and Tipu Sultan.</li>
-          </ul>
+      <div class="port-container">
+        <div class="section-heading">
+          <span class="section-badge">Unearthing Muziris</span>
+          <h2>Pattanam Excavations (2007–Present)</h2>
+          <p>Scientific excavations by the Kerala Council for Historical Research (KCHR) revealed concrete evidence of Muziris's global footprint.</p>
         </div>
-        <div class="port-text-block">
-          <span class="port-eyebrow">Unearthing Muziris</span>
-          <h2>Pattanam Excavations &amp; Kottappuram Fort</h2>
-          <p>Scientific multi-season excavations conducted at <strong>Pattanam</strong> (near Kodungallur) by the Kerala Council for Historical Research (KCHR) provided concrete empirical evidence of Muziris's extensive global footprint.</p>
-          <p>Layered soil strata revealed continuous human habitation from the Iron Age (c. 1000 BCE) through the Roman and Medieval periods. Artifacts from over 40 maritime regions confirmed that Pattanam was an active port of trade connected across three continents.</p>
-          <p>Nearby, the <strong>Kottappuram Fort (Cranganore Fort)</strong>, built by the Portuguese in 1523 CE, showcases the medieval military competition for control over the lucrative Malabar spice trade.</p>
+
+        <div class="archaeology-grid">
+          <div class="arch-card">
+            <span class="arch-icon">🛶</span>
+            <h3>2000-Year-Old Canoe</h3>
+            <p>A 6-meter burnt-wood dugout canoe demonstrating ancient riverine navigation techniques.</p>
+            <div class="arch-meta"><span>Iron Age</span><span>Pattanam</span></div>
+          </div>
+          <div class="arch-card">
+            <span class="arch-icon">🏺</span>
+            <h3>Roman Amphorae</h3>
+            <p>Hundreds of thousands of Mediterranean pottery sherds used for wine and olive oil transport.</p>
+            <div class="arch-meta"><span>1st–3rd c. CE</span><span>Italy</span></div>
+          </div>
+          <div class="arch-card">
+            <span class="arch-icon">🪙</span>
+            <h3>Roman Coin Hoards</h3>
+            <p>Gold aurei and silver denarii of Augustus, Tiberius, and Nero confirming massive trade volumes.</p>
+            <div class="arch-meta"><span>1st c. CE</span><span>Rome</span></div>
+          </div>
+          <div class="arch-card">
+            <span class="arch-icon">🫖</span>
+            <h3>Chinese Celadon</h3>
+            <p>Porcelain fragments from Song and Ming dynasties proving East Asian trade connections.</p>
+            <div class="arch-meta"><span>10th–15th c. CE</span><span>China</span></div>
+          </div>
+          <div class="arch-card">
+            <span class="arch-icon">💎</span>
+            <h3>Semiprecious Beads</h3>
+            <p>Carnelian, agate, and beryl workshops revealing local guild production for export.</p>
+            <div class="arch-meta"><span>Sangam Era</span><span>Local</span></div>
+          </div>
+          <div class="arch-card">
+            <span class="arch-icon">🏰</span>
+            <h3>Kottappuram Fort (1523)</h3>
+            <p>Portuguese fortress ruins defending the river mouth, later held by Dutch and Tipu Sultan.</p>
+            <div class="arch-meta"><span>16th c. CE</span><span>Portugal</span></div>
+          </div>
         </div>
       </div>
     </section>
 
-    <!-- Section 5: Timeline -->
+    <!-- ============ TIMELINE ============ -->
     <section class="port-section" id="timeline">
       <div class="port-container">
-        <div class="port-section-header">
-          <span class="port-eyebrow">Historical Chronology</span>
-          <h2>Milestones of Kodungallur &amp; Muziris</h2>
-          <p>Trace the evolution of Kodungallur from Sangam emporium to modern archaeological sanctuary.</p>
+        <div class="section-heading">
+          <span class="section-badge">Chronology</span>
+          <h2>2000 Years of Kodungallur</h2>
+          <p>Scroll to animate the timeline — from Sangam emporium to modern archaeological sanctuary.</p>
         </div>
 
-        <div class="timeline-flow">
-          <div class="timeline-step">
-            <div class="timeline-step-marker"></div>
-            <div class="timeline-step-card">
-              <span class="timeline-step-year">c. 300 BCE – 300 CE</span>
-              <h3>Sangam &amp; Greco-Roman Era</h3>
-              <p>Muziris flourishes as the primary spice port of the Chera dynasty. Roman ships exchange gold for pepper, beryl, and silks.</p>
-            </div>
-          </div>
-          <div class="timeline-step">
-            <div class="timeline-step-marker"></div>
-            <div class="timeline-step-card">
-              <span class="timeline-step-year">52 CE &amp; 629 CE</span>
-              <h3>Dawn of Faiths</h3>
-              <p>St. Thomas arrives in 52 CE; Cheraman Juma Mosque established in 629 CE, making Kodungallur an early interfaith haven.</p>
-            </div>
-          </div>
-          <div class="timeline-step">
-            <div class="timeline-step-marker"></div>
-            <div class="timeline-step-card">
-              <span class="timeline-step-year">800 – 1124 CE</span>
-              <h3>Kulasekhara Dynasty</h3>
-              <p>Kodungallur (Mahodayapuram) serves as the royal capital of the Second Chera Kingdom under great patron kings like Kulasekhara Alvar.</p>
-            </div>
-          </div>
-          <div class="timeline-step">
-            <div class="timeline-step-marker"></div>
-            <div class="timeline-step-card">
-              <span class="timeline-step-year">1341 CE</span>
-              <h3>Great Periyar Flood</h3>
-              <p>Cataclysmic flooding of the Periyar river silts the harbour of Muziris and creates Cochin port, altering regional trade geography forever.</p>
-            </div>
-          </div>
-          <div class="timeline-step">
-            <div class="timeline-step-marker"></div>
-            <div class="timeline-step-card">
-              <span class="timeline-step-year">2007 – Present</span>
-              <h3>Pattanam Discoveries &amp; Muziris Project</h3>
-              <p>Systematic KCHR excavations unearth ancient canoes and Roman relics, initiating India's largest heritage conservation project.</p>
-            </div>
-          </div>
+        <div class="timeline-wrap">
+          <div class="timeline-axis" id="timeline-axis"></div>
         </div>
       </div>
     </section>
 
-    <!-- Section 6: Gallery -->
+    <!-- ============ GALLERY ============ -->
     <section class="port-section" id="gallery">
       <div class="port-container">
-        <div class="port-section-header">
-          <span class="port-eyebrow">Visual Gallery</span>
-          <h2>Heritage Highlights of Kodungallur</h2>
-          <p>Explore the historic architectural monuments and archaeological relics of the ancient port region.</p>
+        <div class="section-heading">
+          <span class="section-badge">Visual Archive</span>
+          <h2>Heritage Highlights</h2>
+          <p>Click any image to explore the story behind it.</p>
         </div>
 
-        <div class="port-gallery-grid">
-          <div class="port-gallery-item" data-title="Kodungallur Ancient Port Banner" data-desc="Reconstruction illustration of Roman galleys and Indian dhows trading spices at the mouth of the Periyar river delta in Muziris.">
-            <img src="../../frontend/assets/kodungallur_port_banner.png" alt="Kodungallur Port illustration" loading="lazy">
-            <div class="port-gallery-overlay">
-              <h4>Kodungallur Port Delta</h4>
-              <p>Muziris Spice Emporium</p>
-            </div>
-          </div>
-          <div class="port-gallery-item" data-title="Cheraman Juma Mosque" data-desc="The historic Cheraman Juma Mosque in Kodungallur, built in traditional Kerala gabled timber architecture with an ancient brass oil lamp.">
-            <img src="../../frontend/assets/cheraman_juma_mosque.png" alt="Cheraman Juma Mosque" loading="lazy">
-            <div class="port-gallery-overlay">
-              <h4>Cheraman Juma Mosque</h4>
-              <p>India's First Mosque (629 CE)</p>
-            </div>
-          </div>
-          <div class="port-gallery-item" data-title="Pattanam Archaeological Canoe" data-desc="The 2000-year-old wooden dugout canoe and Roman amphorae excavated at Pattanam near Kodungallur by KCHR archaeologists.">
-            <img src="../../frontend/assets/pattanam_excavation_canoe.png" alt="Pattanam Excavation Canoe" loading="lazy">
-            <div class="port-gallery-overlay">
-              <h4>Pattanam Archaeological Artifacts</h4>
-              <p>2000-Year Dugout Canoe &amp; Amphorae</p>
-            </div>
-          </div>
-        </div>
+        <div class="gallery-grid" id="gallery-grid"></div>
       </div>
     </section>
 
-    <!-- Section 7: References -->
+    <!-- ============ REFERENCES ============ -->
     <section class="port-section" id="references">
       <div class="port-container">
-        <div class="port-references">
-          <h3>📚 Scholarly References &amp; Ancient Sources</h3>
-          <ul>
-            <li><strong>Anonymous (c. 40–70 CE)</strong>. <em>Periplus Maris Erythraei (Periplus of the Erythraean Sea)</em>. Translated by W.H. Schoff (1912).</li>
-            <li><strong>Pliny the Elder (77 CE)</strong>. <em>Naturalis Historia (Natural History)</em>. Book VI, Chapter 26.</li>
-            <li><strong>Gurukkal, Rajan (2013)</strong>. <em>Classical Indo-Roman Trade: Exaggeration and Reality</em>. Oxford University Press.</li>
-            <li><strong>Cherian, P. J. (Ed.) (2014)</strong>. <em>Unearthing Pattanam: Histories, Cultures, Crossing</em>. Kerala Council for Historical Research (KCHR), Thiruvananthapuram.</li>
-            <li><strong>Abraham, Shinu A. (2004)</strong>. <em>Chera, Chola, Pandya: Using Archaeological Evidence to Identify the Tamil Kingdoms of Early Historic South India</em>. Asian Perspectives.</li>
-            <li><strong>Ilango Adigal (c. 5th c. CE)</strong>. <em>Silappatikaram (The Tale of an Anklet)</em>. Epic account of Kannaki and Kodungallur.</li>
-          </ul>
+        <div class="section-heading">
+          <span class="section-badge">Scholarly Sources</span>
+          <h2>References & Further Reading</h2>
+        </div>
+
+        <div class="references-grid">
+          <div class="ref-card">
+            <h4>Ancient Sources</h4>
+            <ul>
+              <li><strong>Periplus Maris Erythraei</strong> (c. 40–70 CE) — Anonymous Greek merchant's guide</li>
+              <li><strong>Pliny the Elder</strong> — <em>Naturalis Historia</em> (77 CE), Book VI</li>
+              <li><strong>Ptolemy</strong> — <em>Geography</em> (2nd c. CE)</li>
+              <li><strong>Ilango Adigal</strong> — <em>Silappatikaram</em> (5th c. CE)</li>
+            </ul>
+          </div>
+          <div class="ref-card">
+            <h4>Modern Scholarship</h4>
+            <ul>
+              <li><strong>Cherian, P. J. (2014)</strong> — <em>Unearthing Pattanam</em>, KCHR</li>
+              <li><strong>Gurukkal, Rajan (2013)</strong> — <em>Classical Indo-Roman Trade</em>, OUP</li>
+              <li><strong>Abraham, Shinu A. (2004)</strong> — <em>Chera, Chola, Pandya</em>, Asian Perspectives</li>
+            </ul>
+          </div>
         </div>
       </div>
     </section>
 
   </main>
 
-  <!-- Interactive Lightbox Modal -->
-  <div class="museum-modal" id="port-modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" aria-hidden="true">
-    <div class="museum-modal-card">
-      <button class="museum-modal-close" id="port-modal-close" type="button" aria-label="Close details">✕</button>
-      <span class="modal-category" id="modal-category">Gallery Highlight</span>
-      <h2 id="modal-title"></h2>
-      <p class="modal-location" style="color: var(--port-emerald-light);" id="modal-heading"></p>
-      <div style="border-top: 1px solid rgba(255,255,255,0.1); margin-top: 15px; padding-top: 15px;">
-        <p class="modal-description" id="modal-description"></p>
+  <!-- Lightbox Modal -->
+  <div class="lightbox-modal" id="lightbox" role="dialog" aria-modal="true" hidden>
+    <div class="lightbox-backdrop" data-close></div>
+    <div class="lightbox-card">
+      <button class="lightbox-close" data-close aria-label="Close">✕</button>
+      <img id="lightbox-img" src="" alt="">
+      <div class="lightbox-content">
+        <span class="lightbox-category" id="lightbox-cat"></span>
+        <h2 id="lightbox-title"></h2>
+        <p id="lightbox-desc"></p>
       </div>
     </div>
   </div>
 
-  <!-- Footer -->
   <footer class="port-footer">
     <div class="port-container">
-      <p>Part of <a href="../../index.html">Incredible India Explorer</a> · Explore Malabar's ancient maritime trade and cultural heritage.</p>
+      <p>Part of <a href="../../index.html">Incredible India Explorer</a> · Preserving Malabar's ancient maritime heritage.</p>
     </div>
   </footer>
 
-  <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+  <button id="btn-top" class="btn-top" aria-label="Back to top">↑</button>
 
-  <!-- JS Dependencies -->
   <script src="../js-modules/storage.js" defer></script>
-    <script src="../app.js" defer></script>
+  <script src="../app.js" defer></script>
   <script src="../../frontend/journey/journey.js" defer></script>
-  <script src="script.js" defer></script>
-  <script type="module" src="../firebase-config.js"></script>
-  <script type="module" src="../auth.js"></script>
-  <script src="../router.js" defer></script>
+  <script type="module" src="script.js"></script>
   <script src="../js-modules/page-progress/page-progress.js"></script>
 </body>
 </html>

--- a/frontend/kodungallur-port-explorer/script.js
+++ b/frontend/kodungallur-port-explorer/script.js
@@ -1,132 +1,316 @@
-document.addEventListener("app:route-changed", () => {
-  const bookmarkButtons = [...document.querySelectorAll(".journey-bookmark-btn")];
-  const galleryItems = [...document.querySelectorAll(".port-gallery-item")];
+/* ================= DATA ================= */
+const TRADE_PORTS = [
+  { id: "muziris", name: "Muziris", x: 650, y: 420, type: "muziris", desc: "Legendary port of Kodungallur — gateway to ancient India's spice trade." },
+  { id: "berenike", name: "Berenike", x: 280, y: 340, type: "roman", desc: "Roman Red Sea port — ships sailed 40 days to Muziris on monsoon winds." },
+  { id: "alexandria", name: "Alexandria", x: 260, y: 280, type: "roman", desc: "Egyptian metropolis — redistributed Indian goods across the Roman Empire." },
+  { id: "rome", name: "Rome", x: 200, y: 200, type: "roman", desc: "Imperial capital — consumed vast quantities of Malabar pepper and spices." },
+  { id: "aden", name: "Aden", x: 380, y: 380, type: "arab", desc: "Arabian trading hub — intermediary between Rome and India." },
+  { id: "hormuz", name: "Hormuz", x: 480, y: 340, type: "arab", desc: "Persian Gulf port — connected Mesopotamia to Indian Ocean trade." },
+  { id: "guangzhou", name: "Guangzhou", x: 820, y: 280, type: "china", desc: "Chinese port — source of silk, porcelain, and tea traded westward." }
+];
 
-  const modal = document.getElementById("port-modal");
-  const modalClose = document.getElementById("port-modal-close");
-  const modalTitle = document.getElementById("modal-title");
-  const modalHeading = document.getElementById("modal-heading");
-  const modalDescription = document.getElementById("modal-description");
+const TRADE_ROUTES = [
+  { from: "muziris", to: "berenike", goods: "Pepper, ivory, beryl → Gold, wine, olive oil" },
+  { from: "muziris", to: "aden", goods: "Spices, textiles → Frankincense, dates" },
+  { from: "muziris", to: "hormuz", goods: "Pepper, gems → Horses, pearls" },
+  { from: "muziris", to: "guangzhou", goods: "Spices, cotton → Silk, porcelain" },
+  { from: "berenike", to: "alexandria", goods: "Indian goods transshipped" },
+  { from: "alexandria", to: "rome", goods: "Spices, gems → Imperial markets" }
+];
 
-  // --- Journey Integration (Bookmarks & Global Search) -------------
-  function initJourney() {
-    if (!window.Journey) return;
+const TRADE_GOODS = [
+  { name: "Black Pepper", icon: "🌶️", origin: "india", era: "sangam", desc: "Malabar's 'black gold' — Rome's most coveted import, worth its weight in silver." },
+  { name: "Roman Gold Coins", icon: "🪙", origin: "roman", era: "roman", desc: "Aurei and denarii of Augustus, Tiberius, Nero — thousands found in Kerala hoards." },
+  { name: "Cardamom", icon: "🌿", origin: "india", era: "sangam", desc: "Aromatic spice from the Western Ghats — prized in Roman cuisine and medicine." },
+  { name: "Amphorae", icon: "🏺", origin: "roman", era: "roman", desc: "Mediterranean pottery vessels for wine and olive oil — thousands of sherds at Pattanam." },
+  { name: "Silk", icon: "🧵", origin: "china", era: "medieval", desc: "Chinese luxury fabric transshipped through Muziris to Roman markets." },
+  { name: "Ivory", icon: "🦷", origin: "india", era: "sangam", desc: "Elephant tusks from Kerala forests — carved into Roman luxury objects." },
+  { name: "Frankincense", icon: "🌳", origin: "arab", era: "sangam", desc: "Arabian resin — burned in Roman temples and traded through Muziris." },
+  { name: "Beryl & Gems", icon: "💎", origin: "india", era: "sangam", desc: "Precious stones from South Indian mines — exported to Mediterranean jewelers." },
+  { name: "Chinese Celadon", icon: "🫖", origin: "china", era: "medieval", desc: "Song and Ming dynasty porcelain — evidence of East Asian trade connections." },
+  { name: "Horses", icon: "🐎", origin: "arab", era: "medieval", desc: "Arabian warhorses — imported by Chera kings for cavalry." },
+  { name: "Wine", icon: "🍷", origin: "roman", era: "roman", desc: "Italian wine in amphorae — consumed by Roman merchants and local elites." },
+  { name: "Textiles", icon: "🧶", origin: "india", era: "medieval", desc: "Cotton and silk fabrics — Kerala's fine weaves exported across Asia." }
+];
 
-    // 1. Bookmark functionality
-    bookmarkButtons.forEach((btn) => {
-      const id = btn.dataset.bookmarkId;
-      const title = "Kodungallur Ancient Port (Muziris)";
-      const thumbnail = "frontend/assets/kodungallur_port_banner.png";
-      const category = "heritage";
-
-      const updateBookmarkUI = () => {
-        const isSaved = window.Journey.isSaved(id);
-        btn.classList.toggle("is-saved", isSaved);
-        btn.setAttribute("aria-pressed", String(isSaved));
-        btn.innerHTML = isSaved ? "♥ Saved to Journey" : "♡ Save to Journey";
-      };
-
-      updateBookmarkUI();
-
-      btn.addEventListener("click", (e) => {
-        e.stopPropagation();
-        window.Journey.toggle({
-          id,
-          explorerPage: "frontend/kodungallur-port-explorer/index.html",
-          title,
-          thumbnail,
-          category
-        });
-        updateBookmarkUI();
-      });
-    });
-
-    // 2. Global search index registration
-    window.Journey.registerSearchItems("frontend/kodungallur-port-explorer/index.html", [
-      {
-        id: "kodungallur-port-main",
-        title: "Kodungallur Ancient Port Explorer (Muziris)",
-        description: "Explore Kodungallur, the ancient port of Muziris in Kerala, its role as the global pepper emporium, Pattanam excavations, and syncretic culture.",
-        link: "frontend/kodungallur-port-explorer/index.html"
-      },
-      {
-        id: "kodungallur-port-trade",
-        title: "Malabar Pepper & Roman Trade at Muziris",
-        description: "Learn how black pepper and spices were traded for Roman gold coins via the Hippalus monsoon navigation route.",
-        link: "frontend/kodungallur-port-explorer/index.html#trade"
-      },
-      {
-        id: "kodungallur-port-culture",
-        title: "Interfaith Heritage of Kodungallur",
-        description: "Discover Cheraman Juma Mosque (629 CE), St. Thomas Church (52 CE), Kodungallur Bhagavathy Temple, and Jewish history.",
-        link: "frontend/kodungallur-port-explorer/index.html#culture"
-      },
-      {
-        id: "kodungallur-port-archaeology",
-        title: "Pattanam Excavations & Dugout Canoe",
-        description: "Explore the 2000-year-old wooden dugout canoe, Roman amphorae, and Mediterranean relics discovered at Pattanam.",
-        link: "frontend/kodungallur-port-explorer/index.html#archaeology"
-      }
-    ]);
+const CULTURE_SITES = {
+  cheraman: {
+    title: "Cheraman Juma Mosque (629 CE)",
+    desc: "India's first mosque, built by Malik Dinar during Prophet Muhammad's lifetime. Traditional Kerala gabled architecture with an ancient brass oil lamp that has burned continuously for over 1,400 years. Legend says the Chera king Cheraman Perumal witnessed the splitting of the moon and traveled to Mecca to embrace Islam."
+  },
+  thomas: {
+    title: "St. Thomas Church (52 CE)",
+    desc: "Christian tradition holds that St. Thomas the Apostle landed at Azhikode near Kodungallur in 52 CE, establishing seven original churches in Kerala. This makes Indian Christianity 1,500 years older than European missionary activity. The current church stands on the site of the original foundation."
+  },
+  bhagavathy: {
+    title: "Kodungallur Bhagavathy Temple",
+    desc: "Ancient shrine dedicated to Goddess Bhadrakali/Kannaki, immortalized in the Tamil epic Silappatikaram by Prince Ilango Adigal. Famous for the vibrant Bharani festival (February–March) and Thalappoli procession, where thousands of women carry ceremonial lamps."
+  },
+  shiva: {
+    title: "Thiruvanchikulam Shiva Temple",
+    desc: "The ancestral temple of the Chera emperors and the only Shaivite Paadal Petra Sthalam (sacred shrine sung by Tamil saints) in Kerala. Associated with the great Nayanar saints Sundarar and Cheraman Perumal, who are said to have attained liberation here."
+  },
+  jewish: {
+    title: "Ancient Jewish Quarter",
+    desc: "Tradition records Jewish merchants settling in Kodungallur after the destruction of the Second Temple in Jerusalem (70 CE). They created a thriving Judeo-Malayalam culture, with synagogues and copper-plate grants from Chera kings granting trade privileges and religious freedom."
   }
+};
 
-  // --- Gallery Lightbox Modal Logic -----------------------------------------
-  let lastFocusedElement = null;
+const TIMELINE_EVENTS = [
+  { year: "c. 300 BCE", title: "Sangam Era Begins", desc: "Muziris emerges as the primary spice port of the Chera dynasty. Tamil poets describe 'beautiful Yavana ships arriving with gold and leaving laden with pepper.'" },
+  { year: "52 CE", title: "St. Thomas Arrives", desc: "According to Christian tradition, the Apostle Thomas lands at Azhikode near Kodungallur, establishing Christianity in India 1,500 years before European missionaries." },
+  { year: "77 CE", title: "Pliny Writes of Muziris", desc: "Roman naturalist Pliny the Elder calls Muziris 'Primum Inscriptionis Emporium Indiae' (the first emporium of India) in his Natural History, while warning about nearby pirates." },
+  { year: "2nd c. CE", title: "Peak Roman Trade", desc: "Massive hoards of Roman gold coins (aurei) and silver denarii flow into Muziris. The Muziris Papyrus documents a contract for goods worth 7 million sesterces." },
+  { year: "629 CE", title: "Cheraman Mosque Built", desc: "Malik Dinar builds India's first mosque in Kodungallur during the lifetime of Prophet Muhammad, in traditional Kerala wood-and-tile architecture." },
+  { year: "800–1124 CE", title: "Kulasekhara Dynasty", desc: "Kodungallur (Mahodayapuram) serves as the royal capital of the Second Chera Kingdom under patron kings like Kulasekhara Alvar, a great Vaishnava saint." },
+  { year: "1341 CE", title: "The Great Periyar Flood", desc: "A catastrophic flood silts Muziris harbour permanently and creates the natural port of Cochin, altering Malabar's trade geography forever." },
+  { year: "1523 CE", title: "Portuguese Build Fort", desc: "The Portuguese construct Kottappuram Fort (Cranganore Fort) to control the spice trade, later contested by the Dutch and Tipu Sultan." },
+  { year: "2007–Present", title: "Pattanam Excavations", desc: "Kerala Council for Historical Research conducts systematic excavations, unearthing 2000-year-old canoes, Roman amphorae, and artifacts from 40+ maritime regions — confirming Muziris's global footprint." }
+];
 
-  function openModal(item) {
-    lastFocusedElement = item;
+const GALLERY_ITEMS = [
+  { img: "../../frontend/assets/kodungallur_port_banner.png", title: "Muziris Spice Emporium", cat: "Trade", desc: "Reconstruction of Roman galleys and Indian dhows trading spices at the Periyar delta." },
+  { img: "../../frontend/assets/cheraman_juma_mosque.png", title: "Cheraman Juma Mosque", cat: "Heritage", desc: "India's first mosque (629 CE) in traditional Kerala gabled timber architecture." },
+  { img: "../../frontend/assets/pattanam_excavation_canoe.png", title: "Pattanam Dugout Canoe", cat: "Archaeology", desc: "2000-year-old wooden canoe unearthed by KCHR, demonstrating ancient riverine navigation." }
+];
 
-    modalTitle.textContent = item.dataset.title;
-    modalHeading.textContent = item.querySelector("p")?.textContent || "Gallery Highlight";
-    modalDescription.textContent = item.dataset.desc;
+const REDUCED = matchMedia("(prefers-reduced-motion: reduce)").matches;
 
-    modal.classList.add("open");
-    modal.setAttribute("aria-hidden", "false");
-    document.body.classList.add("modal-open");
+/* ================= STATE ================= */
+const state = {
+  goodsOrigin: "all",
+  goodsEra: "all",
+  activePort: null,
+  currentCulture: null
+};
 
-    if (modalClose) modalClose.focus();
-  }
+/* ================= HELPERS ================= */
+const $ = (id) => document.getElementById(id);
+const escapeHtml = (v) => String(v).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
 
-  function closeModal() {
-    modal.classList.remove("open");
-    modal.setAttribute("aria-hidden", "true");
-    document.body.classList.remove("modal-open");
+function countUp(el, target, dur = 1400) {
+  if (REDUCED) { el.textContent = target.toLocaleString("en-IN"); return; }
+  const t0 = performance.now();
+  (function step(t) {
+    const p = Math.min(1, (t - t0) / dur);
+    const eased = 1 - Math.pow(1 - p, 3);
+    el.textContent = Math.round(target * eased).toLocaleString("en-IN");
+    if (p < 1) requestAnimationFrame(step);
+  })(t0);
+}
 
-    if (lastFocusedElement) {
-      lastFocusedElement.focus();
-    }
-  }
-
-  // Bind gallery click and keyboard events
-  galleryItems.forEach((item) => {
-    item.setAttribute("tabindex", "0");
-    item.addEventListener("click", () => openModal(item));
-    item.addEventListener("keydown", (e) => {
-      if (e.key === "Enter" || e.key === " ") {
-        e.preventDefault();
-        openModal(item);
-      }
-    });
+/* ================= TRADE MAP ================= */
+function renderTradeMap() {
+  const routesG = $("map-routes");
+  const portsG = $("map-ports");
+  
+  TRADE_ROUTES.forEach((r) => {
+    const from = TRADE_PORTS.find((p) => p.id === r.from);
+    const to = TRADE_PORTS.find((p) => p.id === r.to);
+    if (!from || !to) return;
+    
+    const line = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    const dx = to.x - from.x, dy = to.y - from.y;
+    const cx = from.x + dx / 2, cy = from.y + dy / 2 - 50;
+    line.setAttribute("d", `M${from.x},${from.y} Q${cx},${cy} ${to.x},${to.y}`);
+    line.setAttribute("class", "map-route");
+    line.dataset.goods = r.goods;
+    line.addEventListener("mouseenter", (e) => showRouteTooltip(e, r.goods));
+    line.addEventListener("mouseleave", hideTooltip);
+    routesG.appendChild(line);
   });
 
-  if (modalClose) {
-    modalClose.addEventListener("click", closeModal);
-  }
+  TRADE_PORTS.forEach((p) => {
+    const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+    g.setAttribute("class", `map-port ${p.type}`);
+    g.setAttribute("transform", `translate(${p.x}, ${p.y})`);
+    g.innerHTML = `<circle r="8"/><text y="-14">${escapeHtml(p.name)}</text>`;
+    g.addEventListener("click", () => showPortTooltip(p));
+    g.addEventListener("mouseenter", (e) => showPortTooltip(p, e));
+    g.addEventListener("mouseleave", hideTooltip);
+    portsG.appendChild(g);
+  });
+}
 
-  if (modal) {
-    modal.addEventListener("click", (e) => {
-      if (e.target === modal) {
-        closeModal();
-      }
-    });
+function showPortTooltip(port, e) {
+  const tip = $("map-tooltip");
+  tip.innerHTML = `<strong>${escapeHtml(port.name)}</strong><p>${escapeHtml(port.desc)}</p>`;
+  tip.hidden = false;
+  if (e) {
+    const rect = $("trade-map").getBoundingClientRect();
+    tip.style.left = (e.clientX - rect.left + 15) + "px";
+    tip.style.top = (e.clientY - rect.top - 10) + "px";
   }
+}
 
-  document.addEventListener("keydown", (e) => {
-    if (e.key === "Escape" && modal && modal.classList.contains("open")) {
-      closeModal();
-    }
+function showRouteTooltip(e, goods) {
+  const tip = $("map-tooltip");
+  tip.innerHTML = `<strong>Trade Route</strong><p>${escapeHtml(goods)}</p>`;
+  tip.hidden = false;
+  const rect = $("trade-map").getBoundingClientRect();
+  tip.style.left = (e.clientX - rect.left + 15) + "px";
+  tip.style.top = (e.clientY - rect.top - 10) + "px";
+}
+
+function hideTooltip() {
+  $("map-tooltip").hidden = true;
+}
+
+/* ================= TRADE GOODS ================= */
+function renderGoods() {
+  const grid = $("goods-grid");
+  const visible = TRADE_GOODS.filter((g) => {
+    const originOk = state.goodsOrigin === "all" || g.origin === state.goodsOrigin;
+    const eraOk = state.goodsEra === "all" || g.era === state.goodsEra;
+    return originOk && eraOk;
   });
 
-  // Run initialization
-  initJourney();
+  grid.innerHTML = visible.map((g) => `
+    <div class="goods-card">
+      <span class="goods-icon">${g.icon}</span>
+      <h3>${escapeHtml(g.name)}</h3>
+      <p>${escapeHtml(g.desc)}</p>
+      <div class="goods-meta">
+        <span class="goods-tag">${escapeHtml(g.origin)}</span>
+        <span class="goods-tag">${escapeHtml(g.era)}</span>
+      </div>
+    </div>
+  `).join("");
+}
+
+/* ================= CULTURE MAP ================= */
+function setupCultureMap() {
+  document.querySelectorAll(".culture-pin").forEach((pin) => {
+    pin.addEventListener("click", () => {
+      const site = pin.dataset.site;
+      const info = CULTURE_SITES[site];
+      if (!info) return;
+      $("culture-title").textContent = info.title;
+      $("culture-desc").textContent = info.desc;
+      state.currentCulture = site;
+    });
+  });
+}
+
+/* ================= TIMELINE ================= */
+function renderTimeline() {
+  const axis = $("timeline-axis");
+  axis.innerHTML = TIMELINE_EVENTS.map((e) => `
+    <div class="tl-event">
+      <div class="tl-year">${escapeHtml(e.year)}</div>
+      <div class="tl-content">
+        <h3>${escapeHtml(e.title)}</h3>
+        <p>${escapeHtml(e.desc)}</p>
+      </div>
+    </div>
+  `).join("");
+
+  const io = new IntersectionObserver((entries) => {
+    entries.forEach((en) => {
+      if (en.isIntersecting) {
+        en.target.classList.add("in");
+        io.unobserve(en.target);
+      }
+    });
+  }, { threshold: 0.2 });
+  
+  axis.querySelectorAll(".tl-event").forEach((el) => {
+    REDUCED ? el.classList.add("in") : io.observe(el);
+  });
+}
+
+/* ================= GALLERY ================= */
+function renderGallery() {
+  const grid = $("gallery-grid");
+  grid.innerHTML = GALLERY_ITEMS.map((item) => `
+    <div class="gallery-item" data-idx="${GALLERY_ITEMS.indexOf(item)}">
+      <img src="${item.img}" alt="${escapeHtml(item.title)}" loading="lazy">
+      <div class="gallery-overlay">
+        <h4>${escapeHtml(item.title)}</h4>
+        <p>${escapeHtml(item.cat)}</p>
+      </div>
+    </div>
+  `).join("");
+
+  grid.querySelectorAll(".gallery-item").forEach((item) => {
+    item.addEventListener("click", () => openLightbox(+item.dataset.idx));
+  });
+}
+
+function openLightbox(idx) {
+  const item = GALLERY_ITEMS[idx];
+  if (!item) return;
+  $("lightbox-img").src = item.img;
+  $("lightbox-cat").textContent = item.cat;
+  $("lightbox-title").textContent = item.title;
+  $("lightbox-desc").textContent = item.desc;
+  $("lightbox").hidden = false;
+  document.body.style.overflow = "hidden";
+}
+
+function closeLightbox() {
+  $("lightbox").hidden = true;
+  document.body.style.overflow = "";
+}
+
+/* ================= THEME ================= */
+function setupTheme() {
+  const btn = $("theme-toggle");
+  if (!btn) return;
+  const sync = () => { btn.textContent = document.body.classList.contains("light-theme") ? "🌞" : "🌙"; };
+  btn.addEventListener("click", () => {
+    const isLight = document.body.classList.toggle("light-theme");
+    try {
+      const store = JSON.parse(localStorage.getItem("iie_storage") || "{}");
+      store.theme = isLight ? "light" : "dark";
+      localStorage.setItem("iie_storage", JSON.stringify(store));
+    } catch {}
+    sync();
+  });
+  sync();
+}
+
+/* ================= INIT ================= */
+document.addEventListener("DOMContentLoaded", () => {
+  setupTheme();
+  document.querySelectorAll("[data-count]").forEach((el) => countUp(el, +el.dataset.count));
+
+  renderTradeMap();
+  renderGoods();
+  setupCultureMap();
+  renderTimeline();
+  renderGallery();
+
+  // Goods filters
+  $("goods-origins").addEventListener("click", (e) => {
+    const btn = e.target.closest(".chip");
+    if (!btn) return;
+    $("goods-origins").querySelectorAll(".chip").forEach((c) => c.classList.remove("active"));
+    btn.classList.add("active");
+    state.goodsOrigin = btn.dataset.origin;
+    renderGoods();
+  });
+
+  $("goods-eras").addEventListener("click", (e) => {
+    const btn = e.target.closest(".chip");
+    if (!btn) return;
+    $("goods-eras").querySelectorAll(".chip").forEach((c) => c.classList.remove("active"));
+    btn.classList.add("active");
+    state.goodsEra = btn.dataset.era;
+    renderGoods();
+  });
+
+  // Lightbox
+  $("lightbox").addEventListener("click", (e) => {
+    if (e.target.closest("[data-close]")) closeLightbox();
+  });
+  addEventListener("keydown", (e) => {
+    if ($("lightbox").hidden) return;
+    if (e.key === "Escape") closeLightbox();
+  });
+
+  // Back to top
+  const topBtn = $("btn-top");
+  addEventListener("scroll", () => topBtn.classList.toggle("show", scrollY > 600), { passive: true });
+  topBtn.addEventListener("click", () => scrollTo({ top: 0, behavior: REDUCED ? "auto" : "smooth" }));
 });

--- a/frontend/kodungallur-port-explorer/style.css
+++ b/frontend/kodungallur-port-explorer/style.css
@@ -1,691 +1,394 @@
-/* ==========================================================================
-   Kodungallur Ancient Port Explorer - Stylesheet
-   Pure Vanilla CSS matching the Incredible India Explorer premium design system.
-   ========================================================================== */
+/* ============================================================
+   Kodungallur Ancient Port Explorer
+   Palette: deep ocean · aged brass · spice red · parchment
+   ============================================================ */
 
 :root {
-  --port-ocean: #06191d; /* Malabar Deep Emerald Ocean */
-  --port-ocean-light: #0d2a30;
-  --port-emerald: #10b981;
-  --port-emerald-light: #6ee7b7;
-  --port-gold: #d97706; /* Malabar Spice Gold */
-  --port-gold-light: #fef08a;
-  --port-gold-dark: #92400e;
-  --port-stone: #64748b;
-  --port-glass: rgba(13, 42, 48, 0.65);
-  --port-border: rgba(16, 185, 129, 0.2);
+  --ocean: #0a4d68;
+  --ocean-deep: #062c3d;
+  --brass: #d4a64a;
+  --brass-deep: #a77e2e;
+  --spice: #c65d3a;
+  --spice-deep: #8f3a1d;
+  --parchment: #f4ead5;
+  --emerald: #3d7a5f;
+  --bg: #0b1a26;
+  --bg-2: #0d2538;
+  --surface: rgba(255, 255, 255, 0.05);
+  --surface-2: rgba(8, 18, 28, 0.78);
+  --line: rgba(212, 166, 74, 0.2);
+  --text: #f1e7cf;
+  --muted: #a89878;
+  --shadow: 0 22px 55px rgba(0, 0, 0, 0.55);
+  --font-display: "Playfair Display", Georgia, serif;
+  --font-body: "Outfit", system-ui, sans-serif;
 }
 
-/* Light Theme Overrides */
-body.light-theme .port-main {
-  background-color: #f8fafc;
-  color: #1e293b;
+body.light-theme {
+  --bg: #f5efe1;
+  --bg-2: #ebe2ce;
+  --surface: rgba(255, 255, 255, 0.78);
+  --surface-2: rgba(255, 251, 240, 0.92);
+  --line: rgba(167, 126, 46, 0.25);
+  --text: #2a1f13;
+  --muted: #6b5a43;
+  --shadow: 0 18px 44px rgba(10, 77, 104, 0.16);
 }
 
-body.light-theme .port-hero {
-  background: linear-gradient(180deg, rgba(248, 250, 252, 0.75), rgba(248, 250, 252, 0.95)),
-              url('../../frontend/assets/kodungallur_port_banner.png') center/cover no-repeat;
-}
-
-body.light-theme .port-hero h1 {
-  color: #0f172a;
-}
-
-body.light-theme .port-hero p {
-  color: #475569;
-}
-
-body.light-theme .port-card,
-body.light-theme .port-highlight-box,
-body.light-theme .timeline-step-card,
-body.light-theme .port-references,
-body.light-theme .artifact-tab-card {
-  background: rgba(255, 255, 255, 0.9);
-  border-color: rgba(16, 185, 129, 0.25);
-  color: #334155;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.05);
-}
-
-body.light-theme .port-card h3,
-body.light-theme .port-highlight-box h3,
-body.light-theme .timeline-step-card h3,
-body.light-theme .port-references h3,
-body.light-theme .port-text-block h2 {
-  color: #0f172a;
-}
-
-body.light-theme .museum-modal-card {
-  background: #ffffff;
-  color: #0f172a;
-  border-color: #cbd5e1;
-}
-
-/* Page Main Container */
 .port-main {
-  background-color: var(--port-ocean);
-  color: #f1f5f9;
-  font-family: 'Outfit', -apple-system, BlinkMacSystemFont, sans-serif;
-  overflow-x: hidden;
+  font-family: var(--font-body);
+  color: var(--text);
+  background:
+    radial-gradient(circle at 12% 8%, rgba(212, 166, 74, 0.08), transparent 38%),
+    radial-gradient(circle at 88% 82%, rgba(198, 93, 58, 0.06), transparent 34%),
+    linear-gradient(180deg, var(--bg), var(--bg-2));
   min-height: 100vh;
 }
 
-/* Hero Section */
+.port-main h1, .port-main h2, .port-main h3, .port-main h4 { font-family: var(--font-display); font-weight: 700; letter-spacing: 0.01em; }
+
+/* ========== HERO ========== */
 .port-hero {
-  min-height: 65vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  position: relative;
-  overflow: hidden;
-  padding: 130px 0 70px;
-  background: linear-gradient(180deg, rgba(6, 25, 29, 0.5), rgba(6, 25, 29, 0.96)),
-              url('../../frontend/assets/kodungallur_port_banner.png') center/cover no-repeat;
-  text-align: center;
+  position: relative; min-height: 92vh; display: grid; place-items: center;
+  padding: 140px 20px 180px; overflow: hidden;
+}
+.hero-bg { position: absolute; inset: 0; z-index: 0; pointer-events: none; }
+.hero-gradient {
+  position: absolute; inset: 0;
+  background:
+    radial-gradient(circle at 22% 28%, rgba(212, 166, 74, 0.18), transparent 45%),
+    radial-gradient(circle at 82% 68%, rgba(10, 77, 104, 0.22), transparent 42%),
+    linear-gradient(160deg, #062c3d 0%, #0a4d68 48%, #16677f 100%);
+}
+body.light-theme .hero-gradient { background: radial-gradient(circle at 22% 28%, rgba(212, 166, 74, 0.28), transparent 45%), radial-gradient(circle at 82% 68%, rgba(61, 122, 95, 0.18), transparent 42%), linear-gradient(160deg, #e8d8b5 0%, #f4ead5 48%, #d4a64a 100%); }
+
+.wave { position: absolute; left: 0; right: 0; width: 100%; pointer-events: none; }
+.wave path { fill: var(--bg); }
+body.light-theme .wave path { fill: var(--bg-2); }
+.wave-back  { bottom: 80px; opacity: 0.4; animation: wave-drift 18s ease-in-out infinite alternate; }
+.wave-mid   { bottom: 30px; opacity: 0.65; animation: wave-drift 13s ease-in-out infinite alternate-reverse; }
+.wave-front { bottom: -1px; opacity: 0.95; animation: wave-drift 9s ease-in-out infinite alternate; }
+@keyframes wave-drift { from { transform: translateX(-20px); } to { transform: translateX(20px); } }
+
+.hero-ships { position: absolute; inset: 0; overflow: hidden; }
+.ship {
+  position: absolute; font-size: 2rem; opacity: 0.3;
+  animation: ship-float 20s ease-in-out infinite;
+}
+.ship-1 { left: 15%; top: 30%; animation-delay: 0s; }
+.ship-2 { left: 75%; top: 50%; animation-delay: -7s; font-size: 2.5rem; }
+.ship-3 { left: 45%; top: 70%; animation-delay: -14s; }
+@keyframes ship-float {
+  0%, 100% { transform: translate(0, 0) rotate(-5deg); }
+  50% { transform: translate(30px, -10px) rotate(5deg); }
 }
 
-.port-hero::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background: radial-gradient(circle at 50% 40%, rgba(16, 185, 129, 0.15), transparent 70%);
-  z-index: 1;
+.hero-content {
+  position: relative; z-index: 1; text-align: center;
+  width: min(1080px, 92%); color: #fff;
 }
+body.light-theme .hero-content { color: #2a1f13; }
 
-.port-hero-content {
-  position: relative;
-  z-index: 2;
-  width: min(920px, 90%);
-  margin: 0 auto;
-}
-
-.port-kicker {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
+.hero-stamp {
+  display: inline-block; padding: 8px 18px; border-radius: 6px;
+  border: 1.5px solid var(--brass); color: var(--brass);
+  font-size: 0.78rem; font-weight: 800; letter-spacing: 0.22em; text-transform: uppercase;
+  transform: rotate(-1.6deg); background: rgba(0,0,0,0.25);
   margin-bottom: 20px;
-  padding: 8px 20px;
-  background: rgba(16, 185, 129, 0.12);
-  border: 1px solid rgba(16, 185, 129, 0.35);
-  border-radius: 100px;
-  color: var(--port-emerald-light);
-  font-weight: 700;
-  font-size: 0.85rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  backdrop-filter: blur(10px);
 }
+body.light-theme .hero-stamp { background: rgba(255,255,255,0.5); }
 
 .port-hero h1 {
-  font-family: 'Playfair Display', Georgia, serif;
-  font-size: clamp(2.5rem, 5.5vw, 4.5rem);
-  line-height: 1.15;
-  margin: 0 0 20px;
-  font-weight: 700;
-  color: #ffffff;
+  font-size: clamp(2.6rem, 6.8vw, 5.4rem); line-height: 1;
+  margin: 0 0 18px; letter-spacing: 0.01em;
 }
-
-.port-hero h1 span {
-  background: linear-gradient(135deg, #fef08a, #fbbf24, #10b981);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
+.port-hero h1 em {
+  display: block; font-style: italic; font-weight: 500;
+  background: linear-gradient(135deg, var(--brass), var(--spice), var(--brass-deep));
+  -webkit-background-clip: text; background-clip: text; color: transparent;
 }
+.hero-lede { max-width: 760px; margin: 0 auto; font-size: 1.1rem; line-height: 1.75; opacity: 0.9; }
+.hero-lede strong { color: var(--brass); }
 
-.port-hero p {
-  font-size: clamp(1.05rem, 1.8vw, 1.25rem);
-  line-height: 1.65;
-  color: #cbd5e1;
-  margin: 0 auto 30px;
-  max-width: 760px;
+.hero-stats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; margin: 34px auto 28px; width: min(820px, 100%); }
+.stat-pill {
+  padding: 16px 10px; border-radius: 16px; text-align: center;
+  border: 1px solid rgba(212, 166, 74, 0.3); background: rgba(0,0,0,0.22); backdrop-filter: blur(8px);
 }
+body.light-theme .stat-pill { background: rgba(255,255,255,0.6); }
+.stat-pill strong { display: block; font-family: var(--font-display); font-size: 2rem; color: var(--brass); line-height: 1.1; font-variant-numeric: tabular-nums; }
+.stat-pill span { font-size: 0.68rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.12em; color: rgba(255,255,255,0.75); }
+body.light-theme .stat-pill span { color: var(--muted); }
 
-/* Bookmark Button */
-.port-bookmark-container {
-  display: flex;
-  justify-content: center;
-  margin-top: 15px;
+.hero-ctas { display: flex; gap: 14px; justify-content: center; flex-wrap: wrap; align-items: center; }
+.btn-primary, .btn-ghost, .port-bookmark-btn {
+  display: inline-block; padding: 13px 28px; border-radius: 999px;
+  font-weight: 800; text-decoration: none; transition: all 0.3s; border: 0; cursor: pointer; font-family: inherit;
 }
+.btn-primary { background: linear-gradient(135deg, var(--spice), var(--spice-deep)); color: #fff; box-shadow: 0 14px 30px rgba(198, 93, 58, 0.35); }
+.btn-primary:hover { transform: translateY(-3px); box-shadow: 0 20px 40px rgba(198, 93, 58, 0.5); }
+.btn-ghost { border: 1.5px solid var(--brass); color: var(--brass); background: transparent; }
+.btn-ghost:hover { background: rgba(212, 166, 74, 0.18); }
+.port-bookmark-btn { border: 1px solid var(--line); background: var(--surface); color: var(--muted); }
+.port-bookmark-btn:hover { border-color: var(--brass); color: var(--brass); }
 
-.port-bookmark-btn {
-  background: linear-gradient(135deg, rgba(16, 185, 129, 0.2), rgba(217, 119, 6, 0.2));
-  color: #ffffff;
-  border: 1px solid rgba(16, 185, 129, 0.4);
-  padding: 12px 28px;
-  border-radius: 50px;
-  font-family: 'Outfit', sans-serif;
-  font-size: 0.95rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  backdrop-filter: blur(8px);
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
+/* ========== SECTIONS ========== */
+.port-section { padding: 84px 0; position: relative; z-index: 1; }
+.port-container { width: min(1260px, 92%); margin: 0 auto; }
+.section-heading { max-width: 780px; margin-bottom: 36px; }
+.section-badge {
+  display: inline-block; padding: 6px 14px; border-radius: 999px;
+  background: rgba(212, 166, 74, 0.1); border: 1px solid var(--line);
+  color: var(--brass); font-size: 0.7rem; font-weight: 800;
+  letter-spacing: 0.18em; text-transform: uppercase; margin-bottom: 12px;
 }
+.section-heading h2 { font-size: clamp(2rem, 4.5vw, 3.2rem); margin: 0 0 10px; line-height: 1.1; }
+.section-heading p { margin: 0; color: var(--muted); line-height: 1.7; font-size: 1.05rem; }
 
-.port-bookmark-btn:hover {
-  background: linear-gradient(135deg, rgba(16, 185, 129, 0.35), rgba(217, 119, 6, 0.35));
-  border-color: var(--port-emerald-light);
-  transform: translateY(-2px);
-  box-shadow: 0 8px 25px rgba(16, 185, 129, 0.25);
+/* ========== OVERVIEW ========== */
+.overview-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 22px; }
+.overview-card {
+  padding: 28px 24px; border-radius: 20px;
+  border: 1px solid var(--line); background: var(--surface);
+  backdrop-filter: blur(8px); transition: all 0.35s;
 }
+.overview-card:hover { transform: translateY(-5px); box-shadow: var(--shadow); border-color: var(--brass); }
+.oc-icon { font-size: 2.4rem; display: block; margin-bottom: 14px; }
+.overview-card h3 { margin: 0 0 10px; font-size: 1.3rem; }
+.overview-card p { margin: 0; color: var(--muted); line-height: 1.65; font-size: 0.94rem; }
+.overview-card strong { color: var(--brass); }
 
-.port-bookmark-btn.is-saved {
-  background: linear-gradient(135deg, #10b981, #059669);
-  color: #ffffff;
-  border-color: #34d399;
-  box-shadow: 0 4px 15px rgba(16, 185, 129, 0.4);
+/* ========== TRADE MAP ========== */
+.trade-map-wrap {
+  border: 1px solid var(--line); border-radius: 24px;
+  background: var(--surface); backdrop-filter: blur(8px);
+  padding: 24px; box-shadow: var(--shadow);
 }
+.trade-map { position: relative; width: 100%; aspect-ratio: 5 / 3; overflow: hidden; border-radius: 18px; background: linear-gradient(135deg, var(--ocean-deep), var(--ocean)); }
+body.light-theme .trade-map { background: linear-gradient(135deg, #b8d4e3, #d4e8f0); }
+.map-svg { width: 100%; height: 100%; }
 
-/* General Layout Sections */
-.port-section {
-  padding: 90px 0;
-  position: relative;
+.map-port { cursor: pointer; transition: transform 0.25s; }
+.map-port:hover { transform: scale(1.2); }
+.map-port circle { fill: var(--brass); stroke: #fff; stroke-width: 1.5; transition: all 0.25s; }
+.map-port.muziris circle { fill: var(--spice); stroke-width: 2.5; }
+.map-port text { fill: #fff; font-size: 11px; font-weight: 700; font-family: var(--font-body); text-anchor: middle; pointer-events: none; }
+.map-port:hover circle { filter: drop-shadow(0 0 8px var(--brass)); }
+
+.map-route { stroke: var(--brass); stroke-width: 1.5; fill: none; stroke-dasharray: 6 4; opacity: 0.6; transition: opacity 0.25s; }
+.map-route:hover { opacity: 1; stroke-width: 2.5; }
+.map-route.active { opacity: 1; stroke: var(--spice); stroke-width: 2.5; }
+
+.map-tooltip {
+  position: absolute; z-index: 10; max-width: 260px;
+  padding: 14px 18px; border-radius: 14px;
+  background: var(--surface-2); border: 1px solid var(--brass);
+  box-shadow: var(--shadow); pointer-events: none;
+  animation: tip-in 0.2s ease-out;
 }
+@keyframes tip-in { from { opacity: 0; transform: translateY(6px); } }
+.map-tooltip strong { display: block; font-size: 1.05rem; margin-bottom: 6px; color: var(--brass); }
+.map-tooltip p { margin: 0; font-size: 0.86rem; line-height: 1.55; color: var(--text); }
+.map-tooltip small { display: block; margin-top: 6px; font-size: 0.72rem; color: var(--muted); font-style: italic; }
 
-.port-section:nth-of-type(even) {
-  background-color: rgba(255, 255, 255, 0.015);
+.map-legend { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 16px; }
+.legend-chip { display: inline-flex; align-items: center; gap: 8px; font-size: 0.76rem; font-weight: 700; color: var(--muted); }
+.dot { width: 12px; height: 12px; border-radius: 50%; border: 2px solid #fff; }
+.dot-muziris { background: var(--spice); }
+.dot-roman { background: #7fb4ff; }
+.dot-arab { background: var(--brass); }
+.dot-china { background: var(--emerald); }
+
+/* ========== TRADE GOODS ========== */
+.goods-controls { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 24px; }
+.filter-chips { display: flex; gap: 8px; flex-wrap: wrap; }
+.chip {
+  border: 1px solid var(--line); border-radius: 999px; padding: 8px 16px;
+  background: var(--surface); color: var(--muted);
+  font: inherit; font-weight: 700; font-size: 0.82rem; cursor: pointer;
+  transition: all 0.25s;
 }
+.chip:hover { color: var(--text); border-color: var(--brass); }
+.chip.active { background: linear-gradient(135deg, var(--brass), var(--brass-deep)); color: #2a1f13; border-color: transparent; box-shadow: 0 8px 18px rgba(212, 166, 74, 0.3); }
 
-.port-container {
-  width: min(1200px, 90%);
-  margin: 0 auto;
+.goods-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 18px; }
+.goods-card {
+  padding: 20px; border-radius: 18px;
+  border: 1px solid var(--line); background: var(--surface);
+  transition: all 0.3s; cursor: pointer;
 }
+.goods-card:hover { transform: translateY(-4px); box-shadow: var(--shadow); border-color: var(--brass); }
+.goods-icon { font-size: 2.2rem; display: block; margin-bottom: 10px; }
+.goods-card h3 { margin: 0 0 8px; font-size: 1.15rem; }
+.goods-card p { margin: 0 0 12px; font-size: 0.86rem; color: var(--muted); line-height: 1.55; }
+.goods-meta { display: flex; gap: 8px; flex-wrap: wrap; }
+.goods-tag { font-size: 0.68rem; font-weight: 700; padding: 3px 10px; border-radius: 999px; background: rgba(212, 166, 74, 0.15); color: var(--brass); }
 
-.port-section-header {
-  margin-bottom: 55px;
-  text-align: center;
+/* ========== CULTURE MAP ========== */
+.culture-map-wrap { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-bottom: 40px; }
+.culture-map {
+  position: relative; aspect-ratio: 1; border-radius: 20px;
+  background:
+    radial-gradient(circle at 50% 50%, rgba(212, 166, 74, 0.08), transparent 60%),
+    linear-gradient(135deg, var(--ocean-deep), var(--ocean));
+  border: 1px solid var(--line); overflow: hidden;
 }
+body.light-theme .culture-map { background: radial-gradient(circle at 50% 50%, rgba(212, 166, 74, 0.15), transparent 60%), linear-gradient(135deg, #e8d8b5, #d4a64a); }
 
-.port-eyebrow {
-  color: var(--port-emerald-light);
-  font-size: 0.85rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  display: block;
-  margin-bottom: 10px;
+.culture-pin {
+  position: absolute; display: flex; flex-direction: column; align-items: center; gap: 6px;
+  cursor: pointer; transition: transform 0.25s;
 }
-
-.port-section-header h2 {
-  font-family: 'Playfair Display', Georgia, serif;
-  font-size: clamp(2rem, 3.5vw, 3rem);
-  font-weight: 700;
-  margin: 0 0 15px;
-  color: #ffffff;
+.culture-pin:hover { transform: scale(1.15); }
+.pin-icon {
+  width: 48px; height: 48px; border-radius: 50%;
+  background: var(--surface-2); border: 2px solid var(--brass);
+  display: grid; place-items: center; font-size: 1.4rem;
+  box-shadow: 0 6px 18px rgba(0,0,0,0.4);
 }
+.pin-label { font-size: 0.72rem; font-weight: 700; color: var(--brass); white-space: nowrap; }
 
-.port-section-header p {
-  color: #94a3b8;
-  font-size: 1.1rem;
-  max-width: 680px;
-  margin: 0 auto;
+.culture-info {
+  padding: 28px; border-radius: 20px;
+  border: 1px solid var(--line); background: var(--surface);
+  display: flex; flex-direction: column; justify-content: center;
 }
+.culture-info h3 { margin: 0 0 12px; font-size: 1.6rem; color: var(--brass); }
+.culture-info p { margin: 0; line-height: 1.75; font-size: 1rem; }
 
-/* 2-Column Grid Layouts */
-.port-grid-2col {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 50px;
-  align-items: center;
+.culture-cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 20px; }
+.culture-card {
+  padding: 24px; border-radius: 18px;
+  border: 1px solid var(--line); background: var(--surface);
+  transition: all 0.3s;
 }
+.culture-card:hover { transform: translateY(-4px); box-shadow: var(--shadow); }
+.cc-icon { font-size: 2.2rem; display: block; margin-bottom: 12px; }
+.culture-card h3 { margin: 0 0 10px; font-size: 1.2rem; }
+.culture-card p { margin: 0; font-size: 0.9rem; color: var(--muted); line-height: 1.6; }
 
+/* ========== ARCHAEOLOGY ========== */
+.archaeology-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 20px; }
+.arch-card {
+  padding: 24px; border-radius: 18px;
+  border: 1px solid var(--line); background: var(--surface);
+  transition: all 0.3s;
+}
+.arch-card:hover { transform: translateY(-5px); box-shadow: var(--shadow); border-color: var(--brass); }
+.arch-icon { font-size: 2.4rem; display: block; margin-bottom: 12px; }
+.arch-card h3 { margin: 0 0 10px; font-size: 1.2rem; }
+.arch-card p { margin: 0 0 14px; font-size: 0.9rem; color: var(--muted); line-height: 1.6; }
+.arch-meta { display: flex; gap: 8px; flex-wrap: wrap; }
+.arch-meta span { font-size: 0.7rem; font-weight: 700; padding: 4px 10px; border-radius: 999px; background: rgba(212, 166, 74, 0.12); color: var(--brass); }
+
+/* ========== TIMELINE ========== */
+.timeline-wrap {
+  border: 1px solid var(--line); border-radius: 24px;
+  background: var(--surface); backdrop-filter: blur(8px);
+  padding: 30px; box-shadow: var(--shadow);
+}
+.timeline-axis { position: relative; }
+
+.tl-event {
+  display: grid; grid-template-columns: 140px 1fr; gap: 24px;
+  padding: 24px 0; border-bottom: 1px dashed var(--line);
+  opacity: 0; transform: translateX(-20px);
+  transition: opacity 0.5s, transform 0.5s;
+}
+.tl-event.in { opacity: 1; transform: none; }
+.tl-event:last-child { border-bottom: 0; }
+
+.tl-year {
+  font-family: var(--font-display); font-size: 1.4rem; font-weight: 700;
+  color: var(--brass); font-variant-numeric: tabular-nums;
+}
+.tl-content h3 { margin: 0 0 8px; font-size: 1.2rem; }
+.tl-content p { margin: 0; color: var(--muted); line-height: 1.65; font-size: 0.94rem; }
+
+/* ========== GALLERY ========== */
+.gallery-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 18px; }
+.gallery-item {
+  position: relative; aspect-ratio: 4 / 3; border-radius: 18px;
+  overflow: hidden; cursor: pointer; transition: transform 0.3s;
+}
+.gallery-item:hover { transform: scale(1.03); }
+.gallery-item img { width: 100%; height: 100%; object-fit: cover; transition: transform 0.4s; }
+.gallery-item:hover img { transform: scale(1.1); }
+.gallery-overlay {
+  position: absolute; inset: 0; display: flex; flex-direction: column;
+  justify-content: flex-end; padding: 20px;
+  background: linear-gradient(to top, rgba(0,0,0,0.75), transparent 60%);
+  color: #fff;
+}
+.gallery-overlay h4 { margin: 0 0 4px; font-size: 1.1rem; }
+.gallery-overlay p { margin: 0; font-size: 0.82rem; opacity: 0.9; }
+
+/* ========== REFERENCES ========== */
+.references-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 24px; }
+.ref-card {
+  padding: 24px; border-radius: 18px;
+  border: 1px solid var(--line); background: var(--surface);
+}
+.ref-card h4 { margin: 0 0 14px; font-size: 1.15rem; color: var(--brass); }
+.ref-card ul { margin: 0; padding-left: 20px; display: grid; gap: 8px; }
+.ref-card li { line-height: 1.6; font-size: 0.9rem; }
+.ref-card strong { color: var(--text); }
+
+/* ========== LIGHTBOX ========== */
+.lightbox-modal { position: fixed; inset: 0; z-index: 100; display: grid; place-items: center; padding: 20px; }
+.lightbox-modal[hidden] { display: none; }
+.lightbox-backdrop { position: absolute; inset: 0; background: rgba(5, 12, 20, 0.85); backdrop-filter: blur(8px); animation: lb-fade 0.25s; }
+@keyframes lb-fade { from { opacity: 0; } }
+.lightbox-card {
+  position: relative; width: min(800px, 100%); max-height: 90vh; overflow: auto;
+  background: var(--surface-2); border: 1px solid var(--line); border-radius: 24px;
+  box-shadow: var(--shadow); animation: lb-pop 0.3s cubic-bezier(0.2, 0.9, 0.3, 1.15);
+}
+@keyframes lb-pop { from { opacity: 0; transform: translateY(26px) scale(0.96); } }
+.lightbox-close {
+  position: absolute; top: 14px; right: 14px; z-index: 2;
+  width: 40px; height: 40px; border-radius: 50%;
+  border: 1px solid rgba(255,255,255,0.3); background: rgba(0,0,0,0.5); color: #fff;
+  cursor: pointer; font-size: 1rem; transition: all 0.25s;
+}
+.lightbox-close:hover { transform: rotate(90deg); background: var(--spice); }
+.lightbox-card img { width: 100%; height: 360px; object-fit: cover; }
+.lightbox-content { padding: 28px; }
+.lightbox-category { display: inline-block; padding: 4px 12px; border-radius: 999px; background: var(--brass); color: #2a1f13; font-size: 0.7rem; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; margin-bottom: 10px; }
+.lightbox-content h2 { margin: 0 0 12px; font-size: 1.8rem; }
+.lightbox-content p { margin: 0; line-height: 1.75; font-size: 1rem; }
+
+/* ========== FOOTER & TOP ========== */
+.port-footer { border-top: 1px solid var(--line); padding: 36px 20px; text-align: center; color: var(--muted); position: relative; z-index: 1; }
+.port-footer a { color: var(--brass); font-weight: 700; text-decoration: none; }
+
+.btn-top {
+  position: fixed; right: 18px; bottom: 18px; z-index: 60;
+  width: 46px; height: 46px; border-radius: 50%;
+  border: 1px solid var(--line); background: var(--surface-2); color: var(--brass);
+  font-size: 1.1rem; cursor: pointer; opacity: 0; pointer-events: none;
+  transition: opacity 0.3s, transform 0.3s;
+}
+.btn-top.show { opacity: 1; pointer-events: auto; }
+.btn-top:hover { transform: translateY(-3px); border-color: var(--brass); }
+
+/* ========== RESPONSIVE ========== */
 @media (max-width: 900px) {
-  .port-grid-2col {
-    grid-template-columns: 1fr;
-    gap: 35px;
-  }
+  .overview-grid { grid-template-columns: 1fr; }
+  .culture-map-wrap { grid-template-columns: 1fr; }
+  .references-grid { grid-template-columns: 1fr; }
+  .hero-stats { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 640px) {
+  .port-hero { padding: 120px 16px 120px; min-height: 80vh; }
+  .hero-stats { grid-template-columns: repeat(2, 1fr); gap: 8px; }
+  .stat-pill { padding: 12px 8px; }
+  .stat-pill strong { font-size: 1.4rem; }
+  .tl-event { grid-template-columns: 1fr; gap: 8px; }
+  .tl-year { font-size: 1.1rem; }
 }
 
-.port-text-block h2 {
-  font-family: 'Playfair Display', Georgia, serif;
-  font-size: clamp(1.8rem, 3vw, 2.5rem);
-  color: #ffffff;
-  margin: 0 0 20px;
-}
-
-.port-text-block p {
-  color: #cbd5e1;
-  line-height: 1.7;
-  font-size: 1.05rem;
-  margin-bottom: 18px;
-}
-
-.port-highlight-box {
-  background: var(--port-glass);
-  border: 1px solid var(--port-border);
-  border-radius: 20px;
-  padding: 35px;
-  backdrop-filter: blur(12px);
-  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.2);
-  transition: transform 0.3s ease, border-color 0.3s ease;
-}
-
-.port-highlight-box:hover {
-  border-color: rgba(16, 185, 129, 0.4);
-  transform: translateY(-3px);
-}
-
-.port-highlight-box h3 {
-  font-family: 'Playfair Display', Georgia, serif;
-  color: var(--port-gold-light);
-  font-size: 1.4rem;
-  margin-top: 0;
-  margin-bottom: 20px;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.port-highlight-box ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.port-highlight-box li {
-  position: relative;
-  padding-left: 28px;
-  margin-bottom: 16px;
-  color: #cbd5e1;
-  line-height: 1.6;
-  font-size: 0.98rem;
-}
-
-.port-highlight-box li::before {
-  content: '✦';
-  position: absolute;
-  left: 0;
-  top: 0;
-  color: var(--port-emerald-light);
-  font-size: 1.1rem;
-}
-
-/* Cards Grid */
-.port-card-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 30px;
-}
-
-.port-card {
-  background: var(--port-glass);
-  border: 1px solid var(--port-border);
-  border-radius: 20px;
-  padding: 32px;
-  backdrop-filter: blur(10px);
-  transition: all 0.35s cubic-bezier(0.4, 0, 0.2, 1);
-  display: flex;
-  flex-direction: column;
-}
-
-.port-card:hover {
-  transform: translateY(-6px);
-  border-color: rgba(16, 185, 129, 0.5);
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.3), 0 0 20px rgba(16, 185, 129, 0.15);
-}
-
-.port-card-icon {
-  font-size: 2.5rem;
-  margin-bottom: 20px;
-  display: inline-block;
-}
-
-.port-card h3 {
-  font-family: 'Playfair Display', Georgia, serif;
-  font-size: 1.35rem;
-  color: #ffffff;
-  margin: 0 0 12px;
-}
-
-.port-card p {
-  color: #94a3b8;
-  line-height: 1.65;
-  font-size: 0.98rem;
-  margin: 0;
-}
-
-/* Interactive Artifact / Trade Filter Tabs */
-.artifact-tabs-nav {
-  display: flex;
-  justify-content: center;
-  gap: 12px;
-  margin-bottom: 35px;
-  flex-wrap: wrap;
-}
-
-.artifact-tab-btn {
-  background: rgba(13, 42, 48, 0.7);
-  border: 1px solid rgba(16, 185, 129, 0.25);
-  color: #cbd5e1;
-  padding: 10px 22px;
-  border-radius: 30px;
-  font-family: 'Outfit', sans-serif;
-  font-size: 0.92rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.3s ease;
-}
-
-.artifact-tab-btn:hover {
-  border-color: var(--port-emerald-light);
-  color: #ffffff;
-}
-
-.artifact-tab-btn.active {
-  background: linear-gradient(135deg, #10b981, #047857);
-  border-color: #34d399;
-  color: #ffffff;
-  box-shadow: 0 4px 15px rgba(16, 185, 129, 0.35);
-}
-
-.artifact-tab-card {
-  background: var(--port-glass);
-  border: 1px solid var(--port-border);
-  border-radius: 20px;
-  padding: 30px;
-  backdrop-filter: blur(10px);
-}
-
-/* Timeline Flow */
-.timeline-flow {
-  position: relative;
-  max-width: 900px;
-  margin: 0 auto;
-  padding: 20px 0;
-}
-
-.timeline-flow::before {
-  content: '';
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
-  top: 0;
-  bottom: 0;
-  width: 2px;
-  background: linear-gradient(180deg, var(--port-emerald), var(--port-gold), rgba(16, 185, 129, 0.1));
-}
-
-@media (max-width: 768px) {
-  .timeline-flow::before {
-    left: 20px;
-  }
-}
-
-.timeline-step {
-  display: flex;
-  justify-content: flex-end;
-  padding-bottom: 45px;
-  position: relative;
-  width: 50%;
-}
-
-.timeline-step:nth-child(even) {
-  align-self: flex-end;
-  margin-left: 50%;
-  justify-content: flex-start;
-}
-
-@media (max-width: 768px) {
-  .timeline-step,
-  .timeline-step:nth-child(even) {
-    width: 100%;
-    margin-left: 0;
-    padding-left: 50px;
-    justify-content: flex-start;
-  }
-}
-
-.timeline-step-marker {
-  position: absolute;
-  top: 15px;
-  right: -9px;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: var(--port-emerald);
-  border: 4px solid var(--port-ocean);
-  box-shadow: 0 0 12px rgba(16, 185, 129, 0.8);
-  z-index: 2;
-}
-
-.timeline-step:nth-child(even) .timeline-step-marker {
-  right: auto;
-  left: -9px;
-}
-
-@media (max-width: 768px) {
-  .timeline-step-marker,
-  .timeline-step:nth-child(even) .timeline-step-marker {
-    left: 11px;
-    right: auto;
-  }
-}
-
-.timeline-step-card {
-  background: var(--port-glass);
-  border: 1px solid var(--port-border);
-  border-radius: 16px;
-  padding: 24px 28px;
-  width: min(380px, 90%);
-  backdrop-filter: blur(10px);
-  transition: transform 0.3s ease, border-color 0.3s ease;
-}
-
-.timeline-step-card:hover {
-  transform: translateY(-4px);
-  border-color: rgba(16, 185, 129, 0.45);
-}
-
-.timeline-step-year {
-  display: inline-block;
-  color: var(--port-gold-light);
-  font-weight: 700;
-  font-size: 0.85rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  margin-bottom: 6px;
-}
-
-.timeline-step-card h3 {
-  font-family: 'Playfair Display', Georgia, serif;
-  font-size: 1.25rem;
-  color: #ffffff;
-  margin: 0 0 10px;
-}
-
-.timeline-step-card p {
-  color: #94a3b8;
-  font-size: 0.95rem;
-  line-height: 1.6;
-  margin: 0;
-}
-
-/* Gallery Grid & Lightbox Cards */
-.port-gallery-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: 30px;
-}
-
-.port-gallery-item {
-  position: relative;
-  border-radius: 20px;
-  overflow: hidden;
-  aspect-ratio: 4 / 3;
-  cursor: pointer;
-  border: 1px solid var(--port-border);
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
-  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.port-gallery-item img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  transition: transform 0.6s ease;
-}
-
-.port-gallery-overlay {
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(0deg, rgba(6, 25, 29, 0.95) 0%, rgba(6, 25, 29, 0.2) 60%, transparent 100%);
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  padding: 28px;
-  transition: background 0.3s ease;
-}
-
-.port-gallery-overlay h4 {
-  font-family: 'Playfair Display', Georgia, serif;
-  font-size: 1.3rem;
-  color: #ffffff;
-  margin: 0 0 6px;
-}
-
-.port-gallery-overlay p {
-  color: var(--port-emerald-light);
-  font-size: 0.9rem;
-  margin: 0;
-  font-weight: 500;
-}
-
-.port-gallery-item:hover {
-  transform: translateY(-6px);
-  border-color: rgba(16, 185, 129, 0.5);
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4), 0 0 25px rgba(16, 185, 129, 0.2);
-}
-
-.port-gallery-item:hover img {
-  transform: scale(1.08);
-}
-
-/* Lightbox Modal */
-.museum-modal {
-  display: none;
-  position: fixed;
-  inset: 0;
-  z-index: 9999;
-  background: rgba(4, 15, 18, 0.85);
-  backdrop-filter: blur(12px);
-  align-items: center;
-  justify-content: center;
-  padding: 20px;
-}
-
-.museum-modal.open {
-  display: flex;
-  animation: fadeInModal 0.3s ease forwards;
-}
-
-@keyframes fadeInModal {
-  from { opacity: 0; transform: scale(0.96); }
-  to { opacity: 1; transform: scale(1); }
-}
-
-.museum-modal-card {
-  background: #0d2a30;
-  border: 1px solid rgba(16, 185, 129, 0.3);
-  border-radius: 24px;
-  max-width: 650px;
-  width: 100%;
-  padding: 40px;
-  position: relative;
-  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.5), 0 0 30px rgba(16, 185, 129, 0.2);
-}
-
-.museum-modal-close {
-  position: absolute;
-  top: 20px;
-  right: 20px;
-  background: rgba(255, 255, 255, 0.1);
-  border: none;
-  color: #ffffff;
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  font-size: 1.1rem;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transition: background 0.2s ease;
-}
-
-.museum-modal-close:hover {
-  background: rgba(239, 68, 68, 0.8);
-}
-
-.modal-category {
-  color: var(--port-emerald-light);
-  font-size: 0.8rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-}
-
-.museum-modal-card h2 {
-  font-family: 'Playfair Display', Georgia, serif;
-  font-size: 1.8rem;
-  color: #ffffff;
-  margin: 10px 0 6px;
-}
-
-.modal-description {
-  color: #cbd5e1;
-  line-height: 1.7;
-  font-size: 1rem;
-}
-
-/* References Section */
-.port-references {
-  background: var(--port-glass);
-  border: 1px solid var(--port-border);
-  border-radius: 20px;
-  padding: 40px;
-  backdrop-filter: blur(10px);
-}
-
-.port-references h3 {
-  font-family: 'Playfair Display', Georgia, serif;
-  font-size: 1.5rem;
-  color: #ffffff;
-  margin-top: 0;
-  margin-bottom: 20px;
-}
-
-.port-references ul {
-  list-style-type: disc;
-  padding-left: 24px;
-  margin: 0;
-}
-
-.port-references li {
-  color: #94a3b8;
-  line-height: 1.7;
-  margin-bottom: 12px;
-  font-size: 0.98rem;
-}
-
-.port-references li strong {
-  color: #e2e8f0;
-}
-
-/* Footer */
-.port-footer {
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
-  padding: 40px 0;
-  text-align: center;
-  color: #64748b;
-  font-size: 0.95rem;
-}
-
-.port-footer a {
-  color: var(--port-emerald-light);
-  text-decoration: none;
-  font-weight: 600;
-}
-
-.port-footer a:hover {
-  text-decoration: underline;
+@media (prefers-reduced-motion: reduce) {
+  .wave, .ship, * { animation: none !important; transition-duration: 0.001s !important; }
+  .tl-event { opacity: 1; transform: none; }
 }


### PR DESCRIPTION
Closes #2801

🧾 Summary
Replaced the static Kodungallur/Muziris page with an immersive maritime museum experience. Users can now trace 2,000-year-old trade routes on an interactive SVG map, filter 12 traded commodities by origin and era, click through five religious heritage sites, and watch a scroll-animated timeline unfold from 300 BCE to modern excavations. The hero features animated waves, floating ships, and count-up stats — finally giving the page the atmosphere of a port city.

🧪 How to test
Hero: Watch waves animate, ships float, and stats count up (0 → 2000, 0 → 40, 0 → 629, 0 → 52)
Trade Map: Hover any route → tooltip shows "Pepper, ivory → Gold, wine"; click any port → tooltip with port description
Goods Explorer: Filter "India" + "Sangam" → see pepper, cardamom, ivory, beryl; "Roman" + "Roman" → coins, amphorae, wine
Culture Map: Click each of the 5 pins → info panel updates with the site's story
Archaeology: Hover cards → see lift animation + brass border
Timeline: Scroll the timeline section → events reveal with translateX animation
Gallery: Hover images → zoom effect; click → lightbox opens; press Esc → closes
Theme: Toggle light/dark → verify maritime palette adapts (ocean blue vs parchment)
Reduced motion: Enable → verify waves, ships, and reveals are disabled