### PR TITLE
feat: add Garib Rath routes explorer

### DIFF
--- a/frontend/garib-rath-express-explorer/index.html
+++ b/frontend/garib-rath-express-explorer/index.html
@@ -108,6 +108,8 @@
             <div class="routes-container" id="routes-container">
                 <!-- Injected via JS -->
             </div>
+            <a href="../garib-rath-routes-explorer/index.html" class="btn-explore"
+                style="display:inline-block; margin-top:20px;">Open Full Routes Explorer →</a>
         </section>
 
         <!-- Passenger Facilities -->

--- a/frontend/garib-rath-routes-explorer/index.html
+++ b/frontend/garib-rath-routes-explorer/index.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description"
+        content="Interactively explore Garib Rath Express routes: filter services by origin, destination and region, and view major stations along each route.">
+    <title>Garib Rath Express Routes Explorer | Incredible India Explorer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+        href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&display=swap"
+        rel="stylesheet">
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="../../pages-common.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+    <header class="navbar" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html" class="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+            <button class="theme-toggle" id="theme-toggle" aria-label="Toggle Theme">☀️</button>
+        </div>
+    </header>
+
+    <main class="explorer-main">
+        <a class="back-link" href="../garib-rath-express-explorer/index.html">← Back to Garib Rath Express</a>
+
+        <!-- Hero Section -->
+        <section class="hero routes-explorer-hero">
+            <div class="hero-content">
+                <p class="hero-eyebrow">TRAINS OF INDIA · ROUTE EXPLORER</p>
+                <h1 class="hero-title">Garib Rath Routes Explorer</h1>
+                <p class="hero-description">Filter and browse Garib Rath Express services by origin, destination and
+                    region, and see every major stop along the way.</p>
+            </div>
+        </section>
+
+        <!-- Filter Bar -->
+        <section id="route-filters" class="section-container mt-negative">
+            <form class="filter-bar" id="filter-form" role="search" aria-label="Filter Garib Rath routes">
+                <div class="filter-field">
+                    <label for="filter-search">Search</label>
+                    <input type="text" id="filter-search" name="search" placeholder="Search by train, city or station…"
+                        autocomplete="off">
+                </div>
+                <div class="filter-field">
+                    <label for="filter-origin">Origin</label>
+                    <select id="filter-origin" name="origin">
+                        <option value="">All Origins</option>
+                    </select>
+                </div>
+                <div class="filter-field">
+                    <label for="filter-destination">Destination</label>
+                    <select id="filter-destination" name="destination">
+                        <option value="">All Destinations</option>
+                    </select>
+                </div>
+                <div class="filter-field">
+                    <label for="filter-region">Region</label>
+                    <select id="filter-region" name="region">
+                        <option value="">All Regions</option>
+                    </select>
+                </div>
+                <button type="button" id="clear-filters" class="btn-clear-filters">Clear Filters</button>
+            </form>
+            <p class="filter-status" id="filter-status" role="status" aria-live="polite"></p>
+        </section>
+
+        <!-- Route Cards -->
+        <section id="route-results" class="section-container">
+            <div class="route-explorer-grid" id="route-explorer-grid">
+                <!-- Injected via JS -->
+            </div>
+            <div class="no-results" id="no-results" hidden>
+                <p>No Garib Rath services match your filters. Try clearing a filter or searching a different station.
+                </p>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="footer-credits">
+            <p>&copy; 2026 Incredible India Explorer.</p>
+        </div>
+    </footer>
+
+    <script src="../../pages-common.js" defer></script>
+    <script src="script.js" defer></script>
+</body>
+
+</html>

--- a/frontend/garib-rath-routes-explorer/script.js
+++ b/frontend/garib-rath-routes-explorer/script.js
@@ -1,0 +1,183 @@
+/* script.js */
+
+/*
+ * ROUTES DATA
+ * Add a new Garib Rath service here to have it appear automatically in the
+ * explorer, including filter dropdown options and the expandable station timeline.
+ * Required fields: id, name, origin, destination, majorStations (array), regions (array), description.
+ */
+const garibRathRoutes = [
+    {
+        id: "saharsa-amritsar",
+        name: "Saharsa – Amritsar Garib Rath Express",
+        origin: "Saharsa Junction",
+        destination: "Amritsar Junction",
+        majorStations: ["Patna", "Lucknow", "Delhi", "Ambala"],
+        regions: ["Bihar", "Uttar Pradesh", "Delhi", "Punjab"],
+        description: "India's first Garib Rath Express, launched in October 2006, connecting Bihar to Punjab across the Gangetic plain."
+    },
+    {
+        id: "delhi-bikaner",
+        name: "Delhi Sarai Rohilla – Bikaner Garib Rath Express",
+        origin: "Delhi Sarai Rohilla",
+        destination: "Bikaner",
+        majorStations: ["Rewari", "Sikar", "Churu"],
+        regions: ["Delhi", "Haryana", "Rajasthan"],
+        description: "A shorter route linking the national capital with Bikaner in western Rajasthan."
+    },
+    {
+        id: "kolkata-yesvantpur",
+        name: "Kolkata – Yesvantpur Garib Rath Express",
+        origin: "Kolkata",
+        destination: "Yesvantpur (Bengaluru)",
+        majorStations: ["Bhubaneswar", "Vijayawada", "Chennai"],
+        regions: ["West Bengal", "Odisha", "Andhra Pradesh", "Tamil Nadu", "Karnataka"],
+        description: "Connects eastern India to Bengaluru, one of the longest Garib Rath routes in the network."
+    },
+    {
+        id: "chennai-nizamuddin",
+        name: "Chennai – Hazrat Nizamuddin Garib Rath Express",
+        origin: "Chennai Egmore",
+        destination: "Hazrat Nizamuddin (Delhi)",
+        majorStations: ["Vijayawada", "Nagpur", "Jhansi"],
+        regions: ["Tamil Nadu", "Andhra Pradesh", "Maharashtra", "Madhya Pradesh", "Delhi"],
+        description: "A superfast link between Tamil Nadu's capital and the national capital, cutting through central India."
+    },
+    {
+        id: "bandra-amritsar",
+        name: "Bandra – Amritsar Garib Rath Express",
+        origin: "Bandra Terminus",
+        destination: "Amritsar Junction",
+        majorStations: ["Surat", "Vadodara", "Kota", "Delhi"],
+        regions: ["Maharashtra", "Gujarat", "Rajasthan", "Delhi", "Punjab"],
+        description: "Connects Mumbai's western suburbs directly with Punjab, serving passengers across five states."
+    }
+];
+
+document.addEventListener('DOMContentLoaded', () => {
+
+    const grid = document.getElementById('route-explorer-grid');
+    const noResults = document.getElementById('no-results');
+    const filterStatus = document.getElementById('filter-status');
+    const searchInput = document.getElementById('filter-search');
+    const originSelect = document.getElementById('filter-origin');
+    const destinationSelect = document.getElementById('filter-destination');
+    const regionSelect = document.getElementById('filter-region');
+    const clearButton = document.getElementById('clear-filters');
+
+    // Populate filter dropdowns from the routes data
+    function populateFilters() {
+        const origins = [...new Set(garibRathRoutes.map(r => r.origin))].sort();
+        const destinations = [...new Set(garibRathRoutes.map(r => r.destination))].sort();
+        const regions = [...new Set(garibRathRoutes.flatMap(r => r.regions))].sort();
+
+        origins.forEach(origin => {
+            const opt = document.createElement('option');
+            opt.value = origin;
+            opt.textContent = origin;
+            originSelect.appendChild(opt);
+        });
+
+        destinations.forEach(destination => {
+            const opt = document.createElement('option');
+            opt.value = destination;
+            opt.textContent = destination;
+            destinationSelect.appendChild(opt);
+        });
+
+        regions.forEach(region => {
+            const opt = document.createElement('option');
+            opt.value = region;
+            opt.textContent = region;
+            regionSelect.appendChild(opt);
+        });
+    }
+
+    // Render a set of route cards
+    function renderRoutes(routes) {
+        if (routes.length === 0) {
+            grid.innerHTML = '';
+            noResults.hidden = false;
+            filterStatus.textContent = 'No services found.';
+            return;
+        }
+
+        noResults.hidden = true;
+        filterStatus.textContent = `Showing ${routes.length} of ${garibRathRoutes.length} Garib Rath service${garibRathRoutes.length === 1 ? '' : 's'}.`;
+
+        grid.innerHTML = routes.map(route => `
+            <div class="route-explorer-card" id="card-${route.id}">
+                <h3>${route.name}</h3>
+                <div class="route-od">${route.origin} <span aria-hidden="true">→</span> ${route.destination}</div>
+                <p class="route-explorer-desc">${route.description}</p>
+                <div class="region-badges">
+                    ${route.regions.map(region => `<span class="region-badge">${region}</span>`).join('')}
+                </div>
+                <button type="button" class="btn-expand-route" data-route-id="${route.id}" aria-expanded="false" aria-controls="timeline-${route.id}">
+                    Show major stations ▾
+                </button>
+                <div class="route-station-timeline" id="timeline-${route.id}">
+                    <div class="station-stop"><strong>${route.origin}</strong> (Origin)</div>
+                    ${route.majorStations.map(station => `<div class="station-stop">${station}</div>`).join('')}
+                    <div class="station-stop"><strong>${route.destination}</strong> (Destination)</div>
+                </div>
+            </div>
+        `).join('');
+
+        // Wire up expand/collapse buttons
+        grid.querySelectorAll('.btn-expand-route').forEach(btn => {
+            btn.addEventListener('click', () => {
+                const card = document.getElementById(`card-${btn.dataset.routeId}`);
+                const isExpanded = card.classList.toggle('expanded');
+                btn.setAttribute('aria-expanded', String(isExpanded));
+                btn.textContent = isExpanded ? 'Hide major stations ▴' : 'Show major stations ▾';
+            });
+        });
+    }
+
+    // Apply current filter values
+    function applyFilters() {
+        const query = searchInput.value.trim().toLowerCase();
+        const origin = originSelect.value;
+        const destination = destinationSelect.value;
+        const region = regionSelect.value;
+
+        const filtered = garibRathRoutes.filter(route => {
+            const matchesQuery = !query ||
+                route.name.toLowerCase().includes(query) ||
+                route.origin.toLowerCase().includes(query) ||
+                route.destination.toLowerCase().includes(query) ||
+                route.majorStations.some(station => station.toLowerCase().includes(query));
+
+            const matchesOrigin = !origin || route.origin === origin;
+            const matchesDestination = !destination || route.destination === destination;
+            const matchesRegion = !region || route.regions.includes(region);
+
+            return matchesQuery && matchesOrigin && matchesDestination && matchesRegion;
+        });
+
+        renderRoutes(filtered);
+    }
+
+    // Event listeners — filtering updates live, no page reload
+    searchInput.addEventListener('input', applyFilters);
+    originSelect.addEventListener('change', applyFilters);
+    destinationSelect.addEventListener('change', applyFilters);
+    regionSelect.addEventListener('change', applyFilters);
+
+    clearButton.addEventListener('click', () => {
+        searchInput.value = '';
+        originSelect.value = '';
+        destinationSelect.value = '';
+        regionSelect.value = '';
+        applyFilters();
+        searchInput.focus();
+    });
+
+    // Prevent accidental form submission (Enter key in search field)
+    document.getElementById('filter-form').addEventListener('submit', (e) => e.preventDefault());
+
+    // Initialize
+    populateFilters();
+    renderRoutes(garibRathRoutes);
+});

--- a/frontend/garib-rath-routes-explorer/style.css
+++ b/frontend/garib-rath-routes-explorer/style.css
@@ -1,0 +1,587 @@
+/* style.css */
+
+.explorer-main {
+    padding-top: 80px;
+    background: var(--bg-dark);
+}
+
+.back-link {
+    display: inline-block;
+    padding: 20px;
+    color: var(--primary-gold);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.3s ease;
+}
+
+.back-link:hover {
+    color: white;
+}
+
+/* Hero Section */
+.routes-explorer-hero {
+    background: linear-gradient(rgba(0, 0, 0, 0.6), rgba(0, 0, 0, 0.88)), url('../assets/garib_rath_hero.svg') center/cover;
+    height: 50vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 0 20px;
+}
+
+.hero-content {
+    animation: fadeIn 1s ease-out;
+    max-width: 800px;
+}
+
+.hero-eyebrow {
+    font-size: 1rem;
+    font-weight: 600;
+    letter-spacing: 2px;
+    color: var(--primary-gold);
+    margin-bottom: 10px;
+    text-transform: uppercase;
+}
+
+.hero-title {
+    font-family: 'Playfair Display', serif;
+    font-size: 4rem;
+    color: var(--primary-saffron);
+    margin-bottom: 20px;
+}
+
+.hero-description {
+    font-size: 1.2rem;
+    color: #e0e0e0;
+    line-height: 1.6;
+    margin-bottom: 30px;
+}
+
+.btn-explore {
+    display: inline-block;
+    padding: 12px 28px;
+    background: var(--primary-gold);
+    color: var(--bg-dark);
+    text-decoration: none;
+    font-weight: 600;
+    border-radius: 30px;
+    transition: all 0.3s ease;
+}
+
+.btn-explore:hover {
+    background: white;
+    transform: translateY(-2px);
+}
+
+/* Sections */
+.section-container {
+    max-width: 1000px;
+    margin: 60px auto;
+    padding: 0 20px;
+}
+
+.section-container.mt-negative {
+    margin-top: -40px;
+    position: relative;
+    z-index: 10;
+}
+
+.section-header {
+    margin-bottom: 30px;
+}
+
+.section-header p {
+    color: var(--text-color, #e0e0e0);
+    font-size: 1.1rem;
+}
+
+.section-header h2 {
+    color: var(--primary-saffron);
+    font-size: 2.5rem;
+    margin-bottom: 10px;
+}
+
+.content-card {
+    background: var(--bg-dark-card, #1e1e1e);
+    padding: 30px;
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.content-card p {
+    font-size: 1.1rem;
+    line-height: 1.8;
+    color: var(--text-color, #e0e0e0);
+    margin-bottom: 15px;
+}
+
+.content-card p:last-child {
+    margin-bottom: 0;
+}
+
+/* Train Figure */
+.train-figure {
+    max-width: 1000px;
+    margin: 40px auto 0;
+    padding: 0 20px;
+    text-align: center;
+}
+
+.train-figure img {
+    width: 100%;
+    height: auto;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    display: block;
+}
+
+.train-figure figcaption {
+    margin-top: 10px;
+    font-size: 0.85rem;
+    color: #9a9a9a;
+}
+
+/* Quick Facts Grid */
+.facts-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 15px;
+}
+
+.fact-card {
+    background: var(--bg-dark-card, #1e1e1e);
+    padding: 20px;
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    text-align: center;
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+}
+
+.fact-label {
+    font-size: 0.9rem;
+    color: var(--primary-gold);
+    margin-bottom: 8px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.fact-value {
+    font-size: 1.2rem;
+    font-weight: bold;
+    color: white;
+}
+
+/* Timeline */
+.timeline {
+    position: relative;
+    padding: 20px 0;
+}
+
+.timeline::after {
+    content: '';
+    position: absolute;
+    width: 2px;
+    background: var(--primary-gold);
+    top: 0;
+    bottom: 0;
+    left: 20px;
+}
+
+.timeline-item {
+    padding: 10px 0 30px 50px;
+    position: relative;
+    opacity: 0;
+    transform: translateY(20px);
+    transition: all 0.5s ease;
+}
+
+.timeline-item.visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.timeline-item::after {
+    content: '';
+    position: absolute;
+    width: 16px;
+    height: 16px;
+    left: 13px;
+    top: 15px;
+    background: var(--bg-dark);
+    border: 3px solid var(--primary-saffron);
+    border-radius: 50%;
+    z-index: 1;
+    transition: background 0.3s ease;
+}
+
+.timeline-item:hover::after,
+.timeline-item:focus-within::after {
+    background: var(--primary-gold);
+}
+
+.timeline-year {
+    font-weight: bold;
+    color: var(--primary-gold);
+    font-size: 1.2rem;
+    margin-bottom: 5px;
+}
+
+.timeline-content {
+    background: var(--bg-dark-card, #1e1e1e);
+    padding: 20px;
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.timeline-content h3 {
+    color: white;
+    margin-bottom: 10px;
+}
+
+/* Features Grid (Train Design) */
+.features-grid,
+.facilities-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 20px;
+}
+
+.facility-card,
+.feature-card {
+    background: var(--bg-dark-card, #1e1e1e);
+    padding: 25px;
+    border-radius: 8px;
+    border-left: 4px solid var(--primary-green);
+}
+
+.feature-card {
+    border-left: 4px solid var(--primary-saffron);
+}
+
+.facility-icon {
+    font-size: 1.5rem;
+    margin-bottom: 10px;
+}
+
+.facility-card h3,
+.feature-card h3 {
+    color: white;
+    margin-bottom: 10px;
+}
+
+.facility-card p,
+.feature-card p {
+    color: #ccc;
+    font-size: 0.95rem;
+    line-height: 1.5;
+}
+
+/* Routes */
+.routes-container {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}
+
+.route-card {
+    background: var(--bg-dark-card, #1e1e1e);
+    padding: 15px 20px;
+    border-radius: 8px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 15px;
+    border-left: 4px solid var(--primary-gold);
+}
+
+.route-card .origin-dest {
+    font-size: 1.2rem;
+    font-weight: bold;
+    color: white;
+}
+
+.route-card .stations {
+    color: #ccc;
+    font-size: 0.9rem;
+    margin-top: 4px;
+}
+
+.route-card .regions-tag {
+    background: var(--primary-saffron);
+    color: var(--bg-dark);
+    padding: 5px 10px;
+    border-radius: 4px;
+    font-size: 0.8rem;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
+/* Trivia Grid */
+.trivia-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 20px;
+}
+
+.trivia-card {
+    background: rgba(255, 153, 51, 0.1);
+    border: 1px solid rgba(255, 153, 51, 0.3);
+    padding: 20px;
+    border-radius: 8px;
+    position: relative;
+    padding-left: 45px;
+}
+
+.trivia-card::before {
+    content: "💡";
+    position: absolute;
+    left: 15px;
+    top: 20px;
+    font-size: 1.2rem;
+}
+
+/* Accessibility & Responsive */
+@media screen and (max-width: 768px) {
+    .hero-title {
+        font-size: 2.8rem;
+    }
+
+    .route-card {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 10px;
+    }
+}
+
+@media screen and (max-width: 480px) {
+    .hero-title {
+        font-size: 2.2rem;
+    }
+
+    .hero-description {
+        font-size: 1rem;
+    }
+
+    .section-header h2 {
+        font-size: 2rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .timeline-item {
+        transition: none;
+        transform: none;
+        opacity: 1;
+    }
+
+    .hero-content {
+        animation: none;
+        transition: none;
+        transform: none !important;
+    }
+}
+
+/* Filter Bar */
+.filter-bar {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr 1fr 1fr auto;
+    gap: 15px;
+    align-items: end;
+    background: var(--bg-dark-card, #1e1e1e);
+    padding: 24px;
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.filter-field {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.filter-field label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--primary-gold);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.filter-field input,
+.filter-field select {
+    padding: 10px 12px;
+    border-radius: 6px;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    background: var(--bg-dark, #121212);
+    color: white;
+    font-size: 0.95rem;
+    font-family: inherit;
+}
+
+.filter-field input:focus,
+.filter-field select:focus {
+    outline: 2px solid var(--primary-gold);
+    outline-offset: 1px;
+}
+
+.btn-clear-filters {
+    padding: 10px 20px;
+    border-radius: 6px;
+    border: 1px solid var(--primary-gold);
+    background: transparent;
+    color: var(--primary-gold);
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    white-space: nowrap;
+}
+
+.btn-clear-filters:hover,
+.btn-clear-filters:focus-visible {
+    background: var(--primary-gold);
+    color: var(--bg-dark);
+    outline: none;
+}
+
+.filter-status {
+    margin-top: 14px;
+    color: #aaa;
+    font-size: 0.9rem;
+}
+
+/* Route Explorer Grid */
+.route-explorer-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 20px;
+}
+
+.route-explorer-card {
+    background: var(--bg-dark-card, #1e1e1e);
+    border-radius: 8px;
+    border-top: 4px solid var(--primary-gold);
+    padding: 22px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.route-explorer-card h3 {
+    color: white;
+    margin: 0;
+    font-size: 1.15rem;
+}
+
+.route-od {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--primary-saffron);
+    font-weight: 700;
+    font-size: 1.05rem;
+    flex-wrap: wrap;
+}
+
+.route-explorer-desc {
+    color: #ccc;
+    font-size: 0.92rem;
+    line-height: 1.55;
+    margin: 0;
+}
+
+.region-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.region-badge {
+    background: rgba(255, 153, 51, 0.15);
+    border: 1px solid rgba(255, 153, 51, 0.4);
+    color: var(--primary-saffron);
+    padding: 3px 10px;
+    border-radius: 100px;
+    font-size: 0.78rem;
+    font-weight: 600;
+}
+
+.btn-expand-route {
+    align-self: flex-start;
+    margin-top: 6px;
+    background: none;
+    border: none;
+    color: var(--primary-gold);
+    font-weight: 600;
+    font-size: 0.9rem;
+    cursor: pointer;
+    padding: 6px 0;
+}
+
+.btn-expand-route:hover,
+.btn-expand-route:focus-visible {
+    text-decoration: underline;
+    outline: none;
+}
+
+.route-station-timeline {
+    display: none;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 6px;
+    padding-left: 18px;
+    border-left: 2px solid var(--primary-gold);
+}
+
+.route-explorer-card.expanded .route-station-timeline {
+    display: flex;
+}
+
+.route-station-timeline .station-stop {
+    position: relative;
+    color: #ddd;
+    font-size: 0.9rem;
+    padding-left: 4px;
+}
+
+.route-station-timeline .station-stop::before {
+    content: '';
+    position: absolute;
+    left: -23px;
+    top: 5px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--primary-gold);
+}
+
+/* No Results */
+.no-results {
+    text-align: center;
+    padding: 40px 20px;
+    color: #aaa;
+    background: var(--bg-dark-card, #1e1e1e);
+    border-radius: 8px;
+    border: 1px dashed rgba(255, 255, 255, 0.15);
+}
+
+/* Responsive */
+@media screen and (max-width: 900px) {
+    .filter-bar {
+        grid-template-columns: 1fr 1fr;
+    }
+
+    .btn-clear-filters {
+        grid-column: 1 / -1;
+    }
+}
+
+@media screen and (max-width: 480px) {
+    .filter-bar {
+        grid-template-columns: 1fr;
+        padding: 18px;
+    }
+
+    .route-explorer-card {
+        padding: 18px;
+    }
+}


### PR DESCRIPTION
# Pull Request

## Description

Adds an interactive Garib Rath Express Routes Explorer within the Trains of India section.

The explorer allows users to browse Garib Rath services, view origin and destination stations, explore major intermediate stations, and filter services by origin, destination, and region.

Fixes #2259

## Type of change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Tested locally in browser
- [x] Tested filters
- [x] Tested empty search results
- [x] Tested mobile layout
- [x] Tested keyboard navigation
- [x] Verified route information
- [x] Verified no console errors

## Checklist

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have tested responsive layout
- [x] I have considered accessibility (aria labels, keyboard nav, focus)

## Screenshots
<img width="1919" height="503" alt="Screenshot 2026-08-18 104706" src="https://github.com/user-attachments/assets/a9314385-fccb-41c5-a8e2-7ae08f594887" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Garib Rath Express routes explorer page.
  * Added searchable and filterable routes by origin, destination, region, and text.
  * Added route cards with expandable station timelines and no-results messaging.
  * Added theme toggle, responsive design, accessibility support, and navigation from the Routes section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->