### PR TITLE
Fix #2747: Add Jaisalmer Fort Monument Page

### DIFF
--- a/frontend/jaisalmer-fort-explorer/index.html
+++ b/frontend/jaisalmer-fort-explorer/index.html
@@ -1,0 +1,457 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore Jaisalmer Fort in Rajasthan: the golden sandstone living fort of the Bhati Rajputs, its Rawal Jaisal history, Jain temples, royal palace, trade heritage and UNESCO recognition.">
+  <title>Jaisalmer Fort Explorer | Incredible India</title>
+  <!-- Preload Critical Fonts -->
+    <link rel="preload" href="../../assets/fonts/Outfit-400.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="../../assets/fonts/Outfit-700.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="../../assets/fonts/PlayfairDisplay-400.woff2" as="font" type="font/woff2" crossorigin>
+<link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="../js-modules/page-progress/page-progress.css">
+
+  <meta property="og:title" content="Jaisalmer Fort Explorer | Incredible India Explorer">
+  <meta property="og:description" content="Discover Jaisalmer Fort, Rajasthan's golden living fort — its sandstone architecture, Jain temples, royal palace, trade heritage and UNESCO World Heritage status.">
+  <meta property="og:image" content="https://images.unsplash.com/photo-1544616751-eea58efccec4?w=1200&q=80&fm=jpg&fit=crop">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="630">
+  <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/jaisalmer-fort-explorer/index.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Incredible India Explorer">
+  <meta property="og:locale" content="en_IN">
+
+  <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/jaisalmer-fort-explorer/index.html">
+</head>
+<body>
+  <script>
+    (function() {
+      let theme = 'dark'; try { theme = JSON.parse(localStorage.getItem('iie_storage') || '{}').theme || 'dark'; } catch(e) {}
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+
+  <header class="navbar" id="navbar">
+    <div class="nav-container">
+        <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+            <span class="saffron">Incredible</span>
+            <span class="gold">India</span>
+            <span class="green">Explorer</span>
+        </a>
+        <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+            <span class="bar"></span>
+            <span class="bar"></span>
+            <span class="bar"></span>
+        </button>
+        <nav class="nav-menu" id="nav-menu">
+            <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
+                    <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                    <a href="../../frontend/ancient-ports-explorer/index.html" class="dropdown-item">Ancient Ports of India</a>
+                    <a href="../../frontend/islands/islands.html" class="dropdown-item">Islands of India</a>
+                    <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    <a href="../../frontend/forts/forts.html" class="dropdown-item">Forts of India</a>
+                    <a href="../../frontend/route-planner/route-planner.html" class="dropdown-item">Route Planner</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+                    <a href="../../frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
+                    <a href="../../frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
+                    <a href="../../frontend/event-discovery/index.html" class="dropdown-item">Festival & Event Discovery</a>
+                    <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
+                    <a href="../../frontend/national-symbols-gallery/national-symbols-gallery.html" class="dropdown-item">National Symbols</a>
+                    <a href="../../frontend/cuisine-discovery-hub/index.html" class="dropdown-item">UP Cuisine</a>
+                    <a href="../../frontend/handicrafts-showcase/index.html" class="dropdown-item">UP Handicrafts</a>
+                    <a href="../../frontend/national-days-calendar/index.html" class="dropdown-item">National Days</a>
+                    <a href="../../frontend/ganga-ghats-experience/index.html" class="dropdown-item">Ganga Ghats</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Nature ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/national-parks-explorer/index.html" class="dropdown-item">National Parks</a>
+                    <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                    <a href="../../frontend/wildlife-rescue/wildlife-rescue.html" class="dropdown-item">Wildlife Rescue</a>
+                    <a href="../../frontend/endemic-flora-fauna-explorer/index.html" class="dropdown-item">Endemic Flora & Fauna</a>
+                    <a href="../../frontend/harike-wetland/harike-wetland.html" class="dropdown-item">Harike Wetland</a>
+                    <a href="../../frontend/wular-lake/wular-lake.html" class="dropdown-item">Wular Lake</a>
+                    <a href="../../frontend/crowd-density/index.html" class="dropdown-item">Crowd Density Predictor</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Games ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/passport-quest/passport-quest.html" class="dropdown-item">Passport Quest</a>
+                    <a href="../../frontend/culinary-game/culinary-game.html" class="dropdown-item">Culinary Challenge</a>
+                    <a href="../../frontend/monsoon-game/monsoon-game.html" class="dropdown-item">Monsoon Game</a>
+                    <a href="../../frontend/river-game/river-game.html" class="dropdown-item">River Explorer</a>
+                    <a href="../../frontend/geo-guesser-india/index.html" class="dropdown-item">GeoGuesser</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Community ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/contributors/contributors.html" class="dropdown-item">Contributors</a>
+                    <a href="../../frontend/world-records-india/index.html" class="dropdown-item">World Records</a>
+                </div>
+            </div>
+
+            <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+        </nav>
+    </div>
+</header>
+
+  <main id="app-root" class="jaisalmer-main">
+
+    <section class="jaisalmer-hero">
+      <div class="jaisalmer-hero-content">
+        <span class="jaisalmer-kicker">🏜️ Jaisalmer, Rajasthan · Thar Desert</span>
+        <h1>Jaisalmer Fort <span>Explorer</span></h1>
+        <p>Rising from the Thar Desert in golden sandstone, Jaisalmer Fort — the Sonar Kila, or Golden Fort — has been a living stronghold of the Bhati Rajputs for nearly nine centuries, sheltering palaces, Jain temples, markets and homes within its walls.</p>
+        <div class="jaisalmer-bookmark-container">
+          <button class="jaisalmer-bookmark-btn journey-bookmark-btn" type="button" data-bookmark-id="jaisalmer-fort-main" aria-pressed="false" aria-label="Bookmark Jaisalmer Fort">
+            ♡ Save to Journey
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <section class="jaisalmer-section" id="overview">
+      <div class="jaisalmer-container jaisalmer-grid-2col">
+        <div class="jaisalmer-text-block">
+          <span class="jaisalmer-eyebrow">The Golden Fort of the Thar</span>
+          <h2>An Introduction to Jaisalmer Fort</h2>
+          <p>Jaisalmer Fort crowns Trikuta Hill in the heart of the city of Jaisalmer, in the far west of Rajasthan, where the Thar Desert stretches toward the border with Pakistan. Founded in 1156 CE by Rawal Jaisal of the Bhati Rajput clan, the fort is built almost entirely of the honey-gold Jaisalmer sandstone that glows like molten metal at sunset — the reason it is called the Golden Fort.</p>
+          <p>Remarkably, the fort is not a deserted monument: it is a living fort, one of the largest of its kind in the world, with a substantial population still living, trading and praying within its ramparts. In 2013 it was inscribed on the UNESCO World Heritage List as part of the serial property "Hill Forts of Rajasthan".</p>
+          <p><strong>Related:</strong> Compare it with the other forts of Rajasthan in the <a href="../forts/forts.html" class="jaisalmer-link">Forts of India</a> collection.</p>
+        </div>
+        <div class="jaisalmer-highlight-box">
+          <h3>📜 At a Glance</h3>
+          <ul>
+            <li><strong>Location</strong>: Jaisalmer district, Rajasthan, India.</li>
+            <li><strong>Founded</strong>: 1156 CE by Rawal Jaisal.</li>
+            <li><strong>Built on</strong>: Trikuta Hill, ~76 metres above the city.</li>
+            <li><strong>Nickname</strong>: Sonar Kila — the "Golden Fort".</li>
+            <li><strong>Status</strong>: UNESCO World Heritage Site (2013).</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="jaisalmer-section" id="history">
+      <div class="jaisalmer-container">
+        <div class="jaisalmer-section-header">
+          <span class="jaisalmer-eyebrow">A Bhati Rajput Stronghold</span>
+          <h2>Historical Background</h2>
+          <p>From its founding by Rawal Jaisal in the 12th century to its role as a modern heritage icon, the fort's story is written in sieges, alliances and trade.</p>
+        </div>
+        <div class="jaisalmer-card-grid">
+          <div class="jaisalmer-card">
+            <span class="jaisalmer-card-icon">🏯</span>
+            <h3>Rawal Jaisal and the Foundation</h3>
+            <p>According to tradition, Rawal Jaisal — a prince of the Bhati clan whose line traced its ancestry to Krishna's Yadava kin — was forced from his earlier seat at Luderwa. In 1156 CE he founded a new capital on Trikuta Hill, naming it Jaisalmer after himself, and raised the fortress that still bears his name.</p>
+          </div>
+          <div class="jaisalmer-card">
+            <span class="jaisalmer-card-icon">⚔️</span>
+            <h3>Sieges and Survival</h3>
+            <p>The fort's walls were repeatedly tested: Alauddin Khalji besieged it in 1294–95 during a legendary episode of resistance, and Firoz Shah Tughlaq mounted a second famous siege in the mid-14th century. Each time the fort withstood or recovered, and its rulers rebuilt and strengthened it.</p>
+          </div>
+          <div class="jaisalmer-card">
+            <span class="jaisalmer-card-icon">🛡️</span>
+            <h3>From Mughal Peace to Modern Revival</h3>
+            <p>Under the Mughals and their successors the Bhati rulers secured stable relations, and the fort prospered as a trading centre. After Indian independence in 1947, the loss of the old caravan routes brought decline — until tourism rediscovered the Golden City, restoring the fort as a global heritage destination.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="jaisalmer-section" id="architecture">
+      <div class="jaisalmer-container jaisalmer-grid-2col">
+        <div class="jaisalmer-highlight-box" style="background: rgba(212, 149, 47, 0.06); border-color: rgba(212, 149, 47, 0.22);">
+          <h3>🛕 Golden Sandstone at a Glance</h3>
+          <ul>
+            <li><strong>Material</strong>: Locally quarried yellow Jaisalmer sandstone.</li>
+            <li><strong>Walls</strong>: Ramparts rising up to ~76 metres above the plain.</li>
+            <li><strong>Bastions</strong>: 99 bastions stud the curtain walls.</li>
+            <li><strong>Gateways</strong>: Four main gates — Akhai Pol, Suraj Pol, Ganesh Pol and the outer Hawa Pol.</li>
+          </ul>
+        </div>
+        <div class="jaisalmer-text-block">
+          <span class="jaisalmer-eyebrow">Stone That Glows Gold</span>
+          <h2>Golden Sandstone Architecture</h2>
+          <p>Jaisalmer Fort is built of the region's famous yellow sandstone, prized for its warm colour and for the fineness with which it can be carved. The ramparts rise directly from the cliffs of Trikuta Hill, so the fort seems to grow out of the rock itself. At dawn and dusk the entire citadel turns a deep gold — the source of its name, Sonar Kila.</p>
+          <p>The defences are formidable: thick curtain walls climb the hillside, reinforced by 99 bastions and pierced by four sequential gateways — Akhai Pol, Suraj Pol, Ganesh Pol and the main entrance, Hawa Pol — each designed so that attackers had to pass a succession of guarded, angled openings. Within, narrow lanes wind between palaces, temples and havelis, all carved from the same golden stone.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="jaisalmer-section" id="living-fort">
+      <div class="jaisalmer-container">
+        <div class="jaisalmer-section-header">
+          <span class="jaisalmer-eyebrow">Where the Fort Still Lives</span>
+          <h2>A Living Fort</h2>
+          <p>Unlike most forts of Rajasthan, Jaisalmer was never abandoned. It remains one of the largest fully inhabited fortresses in the world.</p>
+        </div>
+        <div class="jaisalmer-card-grid">
+          <div class="jaisalmer-card">
+            <span class="jaisalmer-card-icon">🏘️</span>
+            <h3>Homes Within the Walls</h3>
+            <p>Roughly a quarter of Jaisalmer city's population lives inside the fort, in centuries-old houses that have been continuously occupied by generations of the same families.</p>
+          </div>
+          <div class="jaisalmer-card">
+            <span class="jaisalmer-card-icon">🪣</span>
+            <h3>Water from the Sky</h3>
+            <p>There are no wells in the fort. Instead, its builders harvested every drop of rain in large stone-lined tanks and cisterns — an ingenious desert system that kept the citadel self-sufficient.</p>
+          </div>
+          <div class="jaisalmer-card">
+            <span class="jaisalmer-card-icon">🏪</span>
+            <h3>Shops, Temples and Guesthouses</h3>
+            <p>Today the fort's lanes are alive with markets, craftsmen, cafés and guesthouses, while its temples continue their daily worship — heritage and everyday life sharing the same narrow streets.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="jaisalmer-section" id="jain-temples">
+      <div class="jaisalmer-container jaisalmer-grid-2col">
+        <div class="jaisalmer-text-block">
+          <span class="jaisalmer-eyebrow">Sanctuaries of the Merchants</span>
+          <h2>The Jain Temples of Jaisalmer Fort</h2>
+          <p>Within the fort's eastern quarter stands a celebrated cluster of seven Jain temples, built between the 12th and 16th centuries by wealthy Jain merchant families of Jaisalmer. Dedicated to the tirthankaras — among them Rikhabdev (Adinath), Sambhavnath, Parasnath (Parshvanath), Shitalnath, Kunthunath, Shantinath and Chandraprabhu — they are masterpieces of golden sandstone carving.</p>
+          <p>The temples share a courtyard arrangement and are renowned for their intricate sculpture: finely chiselled pillars, ornately carved ceilings, and walls covered with figures of deities, dancers and mythical beings. The complex also houses the Gyan Bhandar, a library holding ancient manuscripts — some written on palm leaf — that makes it a treasure house of Jain learning.</p>
+        </div>
+        <div class="jaisalmer-highlight-box" style="background: rgba(212, 149, 47, 0.06); border-color: rgba(212, 149, 47, 0.22);">
+          <h3>🕉️ Jain Temple Highlights</h3>
+          <ul>
+            <li><strong>Seven temples</strong> built from the 12th to 16th centuries.</li>
+            <li><strong>Patrons</strong>: The Jain merchant community of Jaisalmer.</li>
+            <li><strong>Carving</strong>: Pillars, ceilings and walls in fine yellow sandstone.</li>
+            <li><strong>Library</strong>: The Gyan Bhandar preserves rare palm-leaf manuscripts.</li>
+            <li><strong>Setting</strong>: Grouped around shared courtyards in the fort's east.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="jaisalmer-section" id="palace">
+      <div class="jaisalmer-container">
+        <div class="jaisalmer-section-header">
+          <span class="jaisalmer-eyebrow">The Maharawal's Residence</span>
+          <h2>The Royal Palace</h2>
+          <p>Dominating the fort's western heights, the Raj Mahal was the seat of the maharawals of Jaisalmer for more than five centuries.</p>
+        </div>
+
+        <div class="jaisalmer-card-grid">
+          <div class="jaisalmer-card">
+            <span class="jaisalmer-card-icon">👑</span>
+            <h3>Raj Mahal</h3>
+            <p>Built and expanded between the 15th and 16th centuries by successive maharawals, the palace rises in several storeys of golden sandstone, crowned with balconies and chhatris that look out over the desert city.</p>
+          </div>
+          <div class="jaisalmer-card">
+            <span class="jaisalmer-card-icon">🪞</span>
+            <h3>Courts and Chambers</h3>
+            <p>Within, courtyards, durbar halls and private chambers are decorated with mirror work, wall paintings and fine jali (lattice) screens, including the elephant-themed Gaj Vilas pavilion.</p>
+          </div>
+          <div class="jaisalmer-card">
+            <span class="jaisalmer-card-icon">🏺</span>
+            <h3>The Fort Palace Museum</h3>
+            <p>Part of the palace now serves as the Fort Palace Museum, displaying royal paintings, arms and armour, manuscripts and personal effects of the maharawals — a window into the fort's courtly life.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="jaisalmer-section" id="trade">
+      <div class="jaisalmer-container jaisalmer-grid-2col">
+        <div class="jaisalmer-highlight-box" style="background: rgba(22, 101, 52, 0.08); border-color: rgba(22, 101, 52, 0.25);">
+          <h3>🐪 Trade Route Legacy</h3>
+          <ul>
+            <li><strong>Caravans</strong>: Camel caravans linked India with Persia, Arabia, Africa and Central Asia.</li>
+            <li><strong>Goods</strong>: Silk, wool, opium, gold, dates, spices and dried fruits passed through the city.</li>
+            <li><strong>Wealth</strong>: Transit taxes on caravans made Jaisalmer one of Rajasthan's richest states.</li>
+            <li><strong>Merchants</strong>: Jain trading families built the ornate havelis that line the city's streets.</li>
+          </ul>
+        </div>
+        <div class="jaisalmer-text-block">
+          <span class="jaisalmer-eyebrow">Where the Caravans Came</span>
+          <h2>Trade and Cultural Heritage</h2>
+          <p>For centuries Jaisalmer stood at the junction of the great camel-caravan routes linking India with Persia, Arabia, Africa and Central Asia. Merchants moving silk, wool, spices, gold, dates and other goods crossed the Thar through Jaisalmer, and the state levied taxes on every passing caravan — a stream of revenue that made the desert kingdom unexpectedly prosperous.</p>
+          <p>That wealth left a deep cultural mark: the Jain mercantile families commissioned the city's famous havelis — tall, richly carved town mansions of golden sandstone, several of which now stand within sight of the fort. The fortunes of the city followed the trade routes: they declined as sea trade shifted commerce to Bombay in the 19th century and collapsed with the Partition of 1947, before modern tourism revived the Golden City.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="jaisalmer-section" id="unesco">
+      <div class="jaisalmer-container jaisalmer-grid-2col">
+        <div class="jaisalmer-highlight-box" style="background: rgba(22, 101, 52, 0.08); border-color: rgba(22, 101, 52, 0.25);">
+          <h3>🌍 UNESCO World Heritage</h3>
+          <ul>
+            <li><strong>Inscribed</strong>: 2013.</li>
+            <li><strong>Property</strong>: "Hill Forts of Rajasthan" — a serial listing of six forts.</li>
+            <li><strong>Sibling forts</strong>: Chittorgarh, Kumbhalgarh, Ranthambore, Amber and Gagron.</li>
+            <li><strong>Criteria</strong>: (ii) — interchange of human values; (iii) — testimony to a cultural tradition.</li>
+          </ul>
+        </div>
+        <div class="jaisalmer-text-block">
+          <span class="jaisalmer-eyebrow">A Desert Fortress on the World Stage</span>
+          <h2>UNESCO Heritage Recognition</h2>
+          <p>In 2013, Jaisalmer Fort was inscribed on the UNESCO World Heritage List as part of the serial property "Hill Forts of Rajasthan", together with the forts of Chittorgarh, Kumbhalgarh, Ranthambore, Amber and Gagron. The listing recognised the hill forts as an exceptional expression of Rajput military architecture, blending fortification, palaces, temples and urban settlement into a single living landscape.</p>
+          <p>For Jaisalmer, the inscription affirmed what makes it unique among them: a fort that is not a ruin but a functioning town — an unbroken fusion of royal, religious, commercial and residential life that continues to this day.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="jaisalmer-section" id="facts">
+      <div class="jaisalmer-container">
+        <div class="jaisalmer-section-header">
+          <span class="jaisalmer-eyebrow">Did You Know?</span>
+          <h2>Interesting Facts</h2>
+        </div>
+
+        <div class="jaisalmer-facts-grid">
+          <div class="jaisalmer-fact-item">
+            <h3>The Golden Fort</h3>
+            <p>Jaisalmer's sandstone turns a luminous gold at sunset, earning the fort its name Sonar Kila and the city the title "Golden City".</p>
+          </div>
+          <div class="jaisalmer-fact-item">
+            <h3>Nearly Nine Centuries Old</h3>
+            <p>Founded in 1156 CE, the fort has been continuously inhabited for over 850 years — one of the oldest living forts in the world.</p>
+          </div>
+          <div class="jaisalmer-fact-item">
+            <h3>99 Bastions</h3>
+            <p>The fort's curtain walls are studded with 99 bastions, and entry is controlled through four successive gateways.</p>
+          </div>
+          <div class="jaisalmer-fact-item">
+            <h3>No Wells Inside</h3>
+            <p>In a desert citadel there are no wells within the walls — the fort relies entirely on ancient rainwater harvesting tanks.</p>
+          </div>
+          <div class="jaisalmer-fact-item">
+            <h3>Palm-Leaf Manuscripts</h3>
+            <p>The Jain Gyan Bhandar library preserves rare manuscripts, some written on palm leaf, collected over centuries.</p>
+          </div>
+          <div class="jaisalmer-fact-item">
+            <h3>A Desert Festival City</h3>
+            <p>Jaisalmer hosts the annual Desert Festival, where folk music, camel races and turban-tying competitions animate the sands below the fort.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="jaisalmer-section" id="gallery">
+      <div class="jaisalmer-container">
+        <div class="jaisalmer-section-header">
+          <span class="jaisalmer-eyebrow">Visual Tour</span>
+          <h2>Gallery</h2>
+          <p>Views of the golden citadel and the desert city that grew up around it, in photographs of the fort and its surroundings.</p>
+        </div>
+
+        <div class="jaisalmer-gallery-grid">
+          <div class="jaisalmer-gallery-item" data-title="Jaisalmer Fort at Golden Hour" data-desc="The Sonar Kila — the Golden Fort — glowing on its hilltop as the desert sun turns its sandstone walls gold.">
+            <img src="https://images.unsplash.com/photo-1544616751-eea58efccec4?w=900&q=80&fm=jpg&fit=crop" alt="Jaisalmer Fort glowing in golden sandstone at sunset" loading="lazy">
+            <div class="jaisalmer-gallery-overlay">
+              <h4>Golden Hour</h4>
+              <p>The fort above the desert city</p>
+            </div>
+          </div>
+          <div class="jaisalmer-gallery-item" data-title="Ramparts and Bastions" data-desc="The massive curtain walls and bastions of Jaisalmer Fort, carved from the yellow sandstone of the Thar.">
+            <img src="https://images.unsplash.com/photo-1544616751-22115079c818?w=900&q=80&fm=jpg&fit=crop" alt="Ramparts and bastions of Jaisalmer Fort" loading="lazy">
+            <div class="jaisalmer-gallery-overlay">
+              <h4>Ramparts & Bastions</h4>
+              <p>Defences of the Golden Fort</p>
+            </div>
+          </div>
+          <div class="jaisalmer-gallery-item" data-title="The Fort at Dusk" data-desc="Jaisalmer Fort as dusk settles over the Thar Desert, its silhouette rising from the sandstone hill.">
+            <img src="https://images.unsplash.com/photo-1586612438666-ffd0ae97ad36?w=900&q=80&fm=jpg&fit=crop" alt="Jaisalmer Fort silhouette at dusk" loading="lazy">
+            <div class="jaisalmer-gallery-overlay">
+              <h4>Fort at Dusk</h4>
+              <p>Dusk over the Thar</p>
+            </div>
+          </div>
+          <div class="jaisalmer-gallery-item" data-title="Walls of the Citadel" data-desc="The warm sandstone walls of the citadel rising from the rock of Trikuta Hill.">
+            <img src="https://images.unsplash.com/photo-1600954700722-b9a768fc9397?w=900&q=80&fm=jpg&fit=crop" alt="Sandstone walls of Jaisalmer Fort" loading="lazy">
+            <div class="jaisalmer-gallery-overlay">
+              <h4>Walls of the Citadel</h4>
+              <p>Sandstone from Trikuta Hill</p>
+            </div>
+          </div>
+          <div class="jaisalmer-gallery-item" data-title="Streets of the Living Fort" data-desc="The lanes and buildings of the living fort, where homes, shops and temples share the same golden stone.">
+            <img src="https://images.unsplash.com/photo-1710347454810-e3d493dcc538?w=900&q=80&fm=jpg&fit=crop" alt="Streets inside Jaisalmer Fort" loading="lazy">
+            <div class="jaisalmer-gallery-overlay">
+              <h4>Living Fort Streets</h4>
+              <p>Lanes of the Golden City</p>
+            </div>
+          </div>
+          <div class="jaisalmer-gallery-item" data-title="The Golden City Below" data-desc="Views over Jaisalmer city from the fort's ramparts, the golden town and desert stretching to the horizon.">
+            <img src="https://images.unsplash.com/photo-1732022648903-737e66c18b08?w=900&q=80&fm=jpg&fit=crop" alt="Jaisalmer city seen from the fort ramparts" loading="lazy">
+            <div class="jaisalmer-gallery-overlay">
+              <h4>The Golden City Below</h4>
+              <p>Jaisalmer from the ramparts</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="jaisalmer-section" id="references">
+      <div class="jaisalmer-container">
+        <div class="jaisalmer-references">
+          <h3>📚 References &amp; Further Reading</h3>
+          <ul>
+            <li><strong>UNESCO World Heritage Centre</strong>. <em>Hill Forts of Rajasthan</em> — serial property documentation.</li>
+            <li><strong>Archaeological Survey of India</strong>. <em>Jaisalmer Fort — conservation and site reports</em>.</li>
+            <li><strong>Tod, James (1829)</strong>. <em>Annals and Antiquities of Rajasthan</em>. Oxford University Press.</li>
+            <li><strong>Hooja, Rima (2006)</strong>. <em>A History of Rajasthan</em>. Rupa &amp; Co.</li>
+            <li><strong>Singh, Jai Prakash (2021)</strong>. <em>The Golden Fort: Life and Heritage of Jaisalmer</em>. Notion Press.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <div class="jaisalmer-modal" id="jaisalmer-modal" role="dialog" aria-modal="true" aria-labelledby="jaisalmer-modal-title" aria-hidden="true">
+    <div class="jaisalmer-modal-card">
+      <button class="jaisalmer-modal-close" id="jaisalmer-modal-close" type="button" aria-label="Close details">✕</button>
+      <span class="jaisalmer-modal-category" id="jaisalmer-modal-category">Gallery Highlight</span>
+      <img class="jaisalmer-modal-image" id="jaisalmer-modal-image" alt="" loading="lazy">
+      <h2 id="jaisalmer-modal-title"></h2>
+      <p class="jaisalmer-modal-location" id="jaisalmer-modal-heading"></p>
+      <div class="jaisalmer-modal-divider">
+        <p class="jaisalmer-modal-description" id="jaisalmer-modal-description"></p>
+      </div>
+    </div>
+  </div>
+
+  <footer class="jaisalmer-footer">
+    <div class="jaisalmer-container">
+      <p>Part of <a href="../../index.html">Incredible India Explorer</a> · Explore the golden living fort of Jaisalmer and the heritage of Rajasthan.</p>
+    </div>
+  </footer>
+
+  <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+
+  <script src="../js-modules/storage.js" defer></script>
+    <script src="../app.js" defer></script>
+  <script src="../../frontend/journey/journey.js" defer></script>
+  <script src="script.js" defer></script>
+  <script type="module" src="../firebase-config.js"></script>
+  <script type="module" src="../auth.js"></script>
+  <script src="../router.js" defer></script>
+  <script src="../js-modules/page-progress/page-progress.js"></script>
+</body>
+</html>

--- a/frontend/jaisalmer-fort-explorer/script.js
+++ b/frontend/jaisalmer-fort-explorer/script.js
@@ -1,0 +1,183 @@
+// ===== Jaisalmer Fort Explorer — Page Script =====
+
+document.addEventListener('DOMContentLoaded', function () {
+
+  // ---------- Gallery Modal ----------
+  const modal = document.getElementById('jaisalmer-modal');
+  const modalClose = document.getElementById('jaisalmer-modal-close');
+  const modalImage = document.getElementById('jaisalmer-modal-image');
+  const modalTitle = document.getElementById('jaisalmer-modal-title');
+  const modalCategory = document.getElementById('jaisalmer-modal-category');
+  const modalHeading = document.getElementById('jaisalmer-modal-heading');
+  const modalDescription = document.getElementById('jaisalmer-modal-description');
+  const galleryItems = document.querySelectorAll('.jaisalmer-gallery-item');
+
+  let lastFocusedElement = null;
+
+  function getFocusableElements() {
+    if (!modal) return [];
+    const selectors = [
+      'a[href]',
+      'button:not([disabled])',
+      'textarea:not([disabled])',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      '[tabindex]:not([tabindex="-1"])'
+    ];
+    return Array.prototype.slice.call(modal.querySelectorAll(selectors.join(',')))
+      .filter(function (el) {
+        return el.offsetParent !== null; // only visible elements
+      });
+  }
+
+  function handleModalKeydown(e) {
+    if (e.key === 'Escape') {
+      closeModal();
+      return;
+    }
+
+    if (e.key !== 'Tab') return;
+
+    const focusable = getFocusableElements();
+    if (focusable.length === 0) {
+      e.preventDefault();
+      return;
+    }
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (e.shiftKey) {
+      // Shift+Tab: if focus is on first element (or outside), wrap to last
+      if (document.activeElement === first || !modal.contains(document.activeElement)) {
+        e.preventDefault();
+        last.focus();
+      }
+    } else {
+      // Tab: if focus is on last element (or outside), wrap to first
+      if (document.activeElement === last || !modal.contains(document.activeElement)) {
+        e.preventDefault();
+        first.focus();
+      }
+    }
+  }
+
+  function openModal(item) {
+    lastFocusedElement = document.activeElement;
+
+    const image = item.querySelector('img');
+    const title = item.getAttribute('data-title') || '';
+    const desc = item.getAttribute('data-desc') || '';
+
+    if (image && modalImage) {
+      modalImage.src = image.currentSrc || image.src;
+      modalImage.alt = image.alt;
+    }
+
+    modalTitle.textContent = title;
+    modalCategory.textContent = 'Gallery Highlight';
+    modalHeading.textContent = 'Jaisalmer Fort';
+    modalDescription.textContent = desc;
+
+    modal.classList.add('active');
+    modal.setAttribute('aria-hidden', 'false');
+    document.body.style.overflow = 'hidden';
+
+    // Move focus into the modal — prefer the close button
+    const focusable = getFocusableElements();
+    if (modalClose) {
+      modalClose.focus();
+    } else if (focusable.length > 0) {
+      focusable[0].focus();
+    }
+
+    modal.addEventListener('keydown', handleModalKeydown);
+  }
+
+  function closeModal() {
+    modal.classList.remove('active');
+    modal.setAttribute('aria-hidden', 'true');
+    document.body.style.overflow = '';
+
+    modal.removeEventListener('keydown', handleModalKeydown);
+
+    if (lastFocusedElement && typeof lastFocusedElement.focus === 'function') {
+      lastFocusedElement.focus();
+    }
+    lastFocusedElement = null;
+  }
+
+  galleryItems.forEach(function (item) {
+    item.addEventListener('click', function () {
+      openModal(item);
+    });
+    item.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        openModal(item);
+      }
+    });
+    item.setAttribute('tabindex', '0');
+    item.setAttribute('role', 'button');
+  });
+
+  if (modalClose) {
+    modalClose.addEventListener('click', closeModal);
+  }
+
+  if (modal) {
+    modal.addEventListener('click', function (e) {
+      if (e.target === modal) closeModal();
+    });
+  }
+
+  // ---------- Bookmark Button (Journey integration) ----------
+  const bookmarkBtn = document.querySelector('.journey-bookmark-btn[data-bookmark-id="jaisalmer-fort-main"]');
+
+  if (bookmarkBtn) {
+    const bookmarkId = bookmarkBtn.getAttribute('data-bookmark-id');
+    const bookmarkTitle = 'Jaisalmer Fort';
+    const bookmarkThumbnail = 'https://images.unsplash.com/photo-1544616751-eea58efccec4?w=400&q=60&fm=jpg&fit=crop';
+
+    function refreshButtonState() {
+      let isSaved = false;
+      if (typeof Journey !== 'undefined' && typeof Journey.isSaved === 'function') {
+        isSaved = Journey.isSaved(bookmarkId);
+      }
+      bookmarkBtn.setAttribute('aria-pressed', isSaved ? 'true' : 'false');
+      bookmarkBtn.textContent = isSaved ? '♥ Saved to Journey' : '♡ Save to Journey';
+    }
+
+    bookmarkBtn.addEventListener('click', function () {
+      if (typeof Journey === 'undefined' || typeof Journey.toggle !== 'function') {
+        console.warn('Journey.toggle() not found — journey.js may not be loaded before script.js, or the shared API differs from what was assumed.');
+        return;
+      }
+      Journey.toggle({
+        id: bookmarkId,
+        title: bookmarkTitle,
+        thumbnail: bookmarkThumbnail,
+        category: 'heritage'
+      });
+      refreshButtonState();
+    });
+
+    refreshButtonState();
+  }
+
+  // ---------- Scroll to top button ----------
+  const scrollTopBtn = document.getElementById('btn-scroll-top');
+  if (scrollTopBtn) {
+    function syncScrollTopVisibility() {
+      scrollTopBtn.classList.toggle('visible', window.scrollY > 400);
+    }
+
+    window.addEventListener('scroll', syncScrollTopVisibility);
+    syncScrollTopVisibility();
+
+    scrollTopBtn.addEventListener('click', function () {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  }
+
+});

--- a/frontend/jaisalmer-fort-explorer/style.css
+++ b/frontend/jaisalmer-fort-explorer/style.css
@@ -1,0 +1,505 @@
+/* ===== Jaisalmer Fort Explorer — Page Styles ===== */
+
+:root {
+  --jaisalmer-brown: #1c150c;
+  --jaisalmer-gold: #d4952f;
+  --jaisalmer-gold-light: #f0c674;
+  --jaisalmer-green: #15803d;
+}
+
+/* ---------- Base (dark theme default) ---------- */
+.jaisalmer-main {
+  background: #141008;
+  color: #f5efe3;
+}
+.jaisalmer-section {
+  background: #141008;
+}
+
+/* ---------- Hero ---------- */
+.jaisalmer-hero {
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 140px 24px 80px;
+  background:
+    radial-gradient(circle at 20% 20%, rgba(212, 149, 47, 0.18), transparent 60%),
+    radial-gradient(circle at 80% 80%, rgba(21, 128, 61, 0.12), transparent 60%),
+    #141008;
+}
+
+.jaisalmer-hero-content {
+  max-width: 760px;
+}
+
+.jaisalmer-kicker {
+  display: inline-block;
+  font-size: 0.85rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--jaisalmer-gold-light);
+  background: rgba(212, 149, 47, 0.1);
+  border: 1px solid rgba(212, 149, 47, 0.3);
+  padding: 6px 16px;
+  border-radius: 999px;
+  margin-bottom: 20px;
+}
+
+.jaisalmer-hero h1 {
+  font-family: "Playfair Display", serif;
+  font-size: clamp(2.2rem, 5vw, 3.4rem);
+  line-height: 1.15;
+  margin: 0 0 18px;
+  color: #f5efe3;
+}
+
+.jaisalmer-hero h1 span {
+  color: var(--jaisalmer-gold);
+  font-style: italic;
+}
+
+.jaisalmer-hero p {
+  font-size: clamp(1rem, 2.4vw, 1.2rem);
+  line-height: 1.75;
+  opacity: 0.85;
+  margin: 0 0 28px;
+}
+
+.jaisalmer-bookmark-container {
+  margin-top: 8px;
+}
+
+.jaisalmer-bookmark-btn {
+  display: inline-block;
+  background: transparent;
+  color: var(--jaisalmer-gold-light);
+  border: 1px solid rgba(212, 149, 47, 0.45);
+  padding: 10px 22px;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 0.25s ease, color 0.25s ease, border-color 0.25s ease;
+}
+
+.jaisalmer-bookmark-btn:hover,
+.jaisalmer-bookmark-btn[aria-pressed="true"] {
+  background: rgba(212, 149, 47, 0.15);
+  border-color: var(--jaisalmer-gold);
+  color: #f5efe3;
+}
+
+/* ---------- Shared layout ---------- */
+.jaisalmer-container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+.jaisalmer-section {
+  padding: 70px 0;
+}
+
+.jaisalmer-grid-2col {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 40px;
+  align-items: start;
+}
+
+@media (max-width: 800px) {
+  .jaisalmer-grid-2col {
+    grid-template-columns: 1fr;
+  }
+}
+
+.jaisalmer-eyebrow {
+  display: block;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--jaisalmer-gold-light);
+  margin-bottom: 10px;
+}
+
+.jaisalmer-text-block h2,
+.jaisalmer-section-header h2 {
+  font-family: "Playfair Display", serif;
+  font-size: clamp(1.6rem, 3.4vw, 2.2rem);
+  margin: 0 0 16px;
+  color: #f5efe3;
+}
+
+.jaisalmer-text-block p,
+.jaisalmer-section-header p {
+  line-height: 1.75;
+  opacity: 0.85;
+  margin: 0 0 14px;
+}
+
+.jaisalmer-section-header {
+  max-width: 720px;
+  margin: 0 auto 44px;
+  text-align: center;
+}
+
+.jaisalmer-link {
+  color: var(--jaisalmer-gold-light);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+/* ---------- Highlight box ---------- */
+.jaisalmer-highlight-box {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 28px;
+}
+
+.jaisalmer-highlight-box h3 {
+  margin: 0 0 16px;
+  font-size: 1.15rem;
+  color: #f5efe3;
+}
+
+.jaisalmer-highlight-box ul {
+  margin: 0;
+  padding-left: 20px;
+  line-height: 1.9;
+}
+
+/* ---------- Card grid ---------- */
+.jaisalmer-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+
+@media (max-width: 800px) {
+  .jaisalmer-card-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.jaisalmer-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 26px;
+  text-align: left;
+  transition: transform 0.25s ease, border-color 0.25s ease;
+}
+
+.jaisalmer-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(212, 149, 47, 0.4);
+}
+
+.jaisalmer-card-icon {
+  font-size: 1.8rem;
+  display: block;
+  margin-bottom: 12px;
+}
+
+.jaisalmer-card h3 {
+  margin: 0 0 8px;
+  font-size: 1.05rem;
+  color: #f5efe3;
+}
+
+.jaisalmer-card p {
+  margin: 0;
+  line-height: 1.6;
+  opacity: 0.8;
+  font-size: 0.95rem;
+}
+
+/* ---------- Facts grid ---------- */
+.jaisalmer-facts-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+}
+
+@media (max-width: 800px) {
+  .jaisalmer-facts-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.jaisalmer-fact-item {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-left: 3px solid var(--jaisalmer-gold);
+  border-radius: 12px;
+  padding: 20px 22px;
+}
+
+.jaisalmer-fact-item h3 {
+  margin: 0 0 8px;
+  font-size: 1rem;
+  color: var(--jaisalmer-gold-light);
+}
+
+.jaisalmer-fact-item p {
+  margin: 0;
+  line-height: 1.6;
+  opacity: 0.8;
+  font-size: 0.92rem;
+}
+
+/* ---------- Gallery ---------- */
+.jaisalmer-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+
+@media (max-width: 900px) {
+  .jaisalmer-gallery-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.jaisalmer-gallery-item {
+  position: relative;
+  border-radius: 14px;
+  overflow: hidden;
+  cursor: pointer;
+  aspect-ratio: 1 / 1;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: #1c150c;
+}
+
+.jaisalmer-gallery-item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: transform 0.4s ease;
+}
+
+.jaisalmer-gallery-item:hover img {
+  transform: scale(1.06);
+}
+
+.jaisalmer-gallery-overlay {
+  position: absolute;
+  inset: auto 0 0 0;
+  background: linear-gradient(0deg, rgba(0,0,0,0.85) 40%, transparent);
+  padding: 14px;
+  pointer-events: none;
+}
+
+.jaisalmer-gallery-overlay h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #ffffff;
+}
+
+.jaisalmer-gallery-overlay p {
+  margin: 2px 0 0;
+  font-size: 0.8rem;
+  opacity: 0.85;
+  color: #f5efe3;
+}
+
+/* ---------- References ---------- */
+.jaisalmer-references {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 16px;
+  padding: 28px;
+}
+
+.jaisalmer-references h3 {
+  margin: 0 0 14px;
+  color: #f5efe3;
+}
+
+.jaisalmer-references ul {
+  margin: 0;
+  padding-left: 20px;
+  line-height: 1.9;
+  font-size: 0.92rem;
+  opacity: 0.85;
+}
+
+/* ---------- Footer ---------- */
+.jaisalmer-footer {
+  padding: 30px 24px;
+  text-align: center;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  font-size: 0.9rem;
+  opacity: 0.7;
+  background: #141008;
+}
+
+.jaisalmer-footer a {
+  color: var(--jaisalmer-gold-light);
+}
+
+/* ---------- Jaisalmer Modal (self-contained, unique names) ---------- */
+.jaisalmer-modal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  z-index: 999;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.jaisalmer-modal.active {
+  display: flex;
+}
+
+.jaisalmer-modal-card {
+  position: relative;
+  background: #1c150c;
+  max-height: calc(100vh - 48px);
+  overflow-y: auto;
+  border: 1px solid rgba(212, 149, 47, 0.3);
+  border-radius: 16px;
+  padding: 32px;
+  max-width: 480px;
+  width: 100%;
+  color: #f5efe3;
+}
+
+.jaisalmer-modal-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  background: transparent;
+  border: none;
+  color: #f5efe3;
+  font-size: 1.2rem;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.jaisalmer-modal-category {
+  display: inline-block;
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--jaisalmer-gold-light);
+  margin-bottom: 10px;
+}
+
+.jaisalmer-modal-image {
+  display: block;
+  width: 100%;
+  max-height: min(55vh, 360px);
+  margin: 0 0 18px;
+  border-radius: 10px;
+  object-fit: contain;
+}
+
+.jaisalmer-modal-card h2 {
+  margin: 0 0 6px;
+  font-family: "Playfair Display", serif;
+  font-size: 1.4rem;
+}
+
+.jaisalmer-modal-location {
+  color: var(--jaisalmer-gold-light);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.jaisalmer-modal-divider {
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  margin-top: 15px;
+  padding-top: 15px;
+}
+
+.jaisalmer-modal-description {
+  margin: 0;
+  line-height: 1.7;
+  opacity: 0.9;
+}
+
+/* ---------- Scroll to top button ---------- */
+.btn-scroll-top {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid rgba(212, 149, 47, 0.4);
+  background: #1c150c;
+  color: var(--jaisalmer-gold-light);
+  font-size: 1.2rem;
+  cursor: pointer;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.25s ease, visibility 0.25s ease;
+  z-index: 90;
+}
+
+.btn-scroll-top.visible {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* ---------- Light theme overrides ---------- */
+body.light-theme .jaisalmer-main,
+body.light-theme .jaisalmer-hero,
+body.light-theme .jaisalmer-section,
+body.light-theme .jaisalmer-footer {
+  background: #faf5ec;
+  color: #2b2118;
+}
+
+body.light-theme .jaisalmer-hero h1,
+body.light-theme .jaisalmer-text-block h2,
+body.light-theme .jaisalmer-section-header h2,
+body.light-theme .jaisalmer-highlight-box h3,
+body.light-theme .jaisalmer-card h3,
+body.light-theme .jaisalmer-references h3 {
+  color: #2b2118;
+}
+
+body.light-theme .jaisalmer-hero h1 span {
+  color: var(--jaisalmer-gold);
+}
+
+body.light-theme .jaisalmer-card,
+body.light-theme .jaisalmer-highlight-box,
+body.light-theme .jaisalmer-references {
+  background: #ffffff;
+  border-color: rgba(43, 33, 24, 0.12);
+}
+
+body.light-theme .jaisalmer-fact-item {
+  background: #ffffff;
+  border-color: rgba(43, 33, 24, 0.1);
+}
+
+body.light-theme .jaisalmer-fact-item h3 {
+  color: #b45309;
+}
+
+body.light-theme .jaisalmer-gallery-item {
+  background: #e9e1d2;
+  border-color: rgba(43, 33, 24, 0.12);
+}
+
+body.light-theme .jaisalmer-bookmark-btn:hover,
+body.light-theme .jaisalmer-bookmark-btn[aria-pressed="true"] {
+  color: #2b2118;
+}
+
+/* ---------- Reduced motion ---------- */
+@media (prefers-reduced-motion: reduce) {
+  .jaisalmer-card,
+  .jaisalmer-gallery-item img {
+    transition: none;
+  }
+}

--- a/tests/unit/jaisalmer-fort-explorer.test.js
+++ b/tests/unit/jaisalmer-fort-explorer.test.js
@@ -1,0 +1,115 @@
+/**
+ * jaisalmer-fort-explorer.test.js
+ * Unit tests for the Jaisalmer Fort Explorer page.
+ * Validates required sections, key heritage content, accessibility,
+ * and page assets for the Jaisalmer Fort monument page.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function readExplorerFile(file) {
+    return readFileSync(
+        resolve(__dirname, '../../frontend/jaisalmer-fort-explorer', file),
+        'utf-8'
+    );
+}
+
+describe('Jaisalmer Fort Explorer — Page Structure', () => {
+    let html;
+
+    beforeAll(() => {
+        html = readExplorerFile('index.html');
+    });
+
+    it('contains a hero section with page title and kicker', () => {
+        expect(html).toContain('class="jaisalmer-hero"');
+        expect(html).toContain('<h1>');
+        expect(html).toContain('Jaisalmer Fort');
+        expect(html).toContain('Rajasthan');
+    });
+
+    it('contains all required content sections from the issue', () => {
+        const sections = ['overview', 'history', 'architecture', 'living-fort', 'jain-temples', 'palace', 'trade', 'unesco', 'facts', 'gallery', 'references'];
+        sections.forEach(id => {
+            expect(html).toContain(`id="${id}"`);
+        });
+    });
+
+    it('contains all required section topics', () => {
+        ['Historical Background', 'Golden Sandstone', 'Living Fort', 'Jain Temples', 'Royal Palace', 'Trade and Cultural Heritage', 'UNESCO Heritage', 'Interesting Facts', 'Gallery'].forEach(topic => {
+            expect(html).toContain(topic);
+        });
+    });
+
+    it('contains the key heritage details', () => {
+        expect(html).toContain('Rawal Jaisal');
+        expect(html).toContain('1156');
+        expect(html).toContain('Trikuta Hill');
+        expect(html).toContain('Sonar Kila');
+        expect(html).toContain('99 bastions');
+        expect(html).toContain('Gyan Bhandar');
+        expect(html).toContain('Raj Mahal');
+    });
+
+    it('mentions the UNESCO serial listing with sibling forts', () => {
+        expect(html).toContain('Hill Forts of Rajasthan');
+        expect(html).toContain('2013');
+        expect(html).toContain('Chittorgarh');
+        expect(html).toContain('Kumbhalgarh');
+    });
+
+    it('has a semantic heading hierarchy (single h1, multiple section h2s)', () => {
+        const h1Count = (html.match(/<h1[\s>]/g) || []).length;
+        const h2Count = (html.match(/<h2[\s>]/g) || []).length;
+        expect(h1Count).toBe(1);
+        expect(h2Count).toBeGreaterThanOrEqual(5);
+    });
+
+    it('uses HTTPS OG image URLs', () => {
+        const ogImages = html.match(/property="og:image" content="([^"]*)"/g) || [];
+        expect(ogImages.length).toBeGreaterThanOrEqual(1);
+        ogImages.forEach(tag => {
+            expect(tag).toMatch(/https:\/\//);
+        });
+    });
+
+    it('links the shared stylesheet, page stylesheet, and script', () => {
+        expect(html).toContain('href="../../styles.css"');
+        expect(html).toContain('href="style.css"');
+        expect(html).toContain('src="script.js"');
+    });
+});
+
+describe('Jaisalmer Fort Explorer — Assets', () => {
+    it('includes a non-empty stylesheet with hero, section and light-theme styles', () => {
+        const css = readExplorerFile('style.css');
+        expect(css.length).toBeGreaterThan(1000);
+        expect(css).toContain('.jaisalmer-hero');
+        expect(css).toContain('.jaisalmer-highlight-box');
+        expect(css).toContain('.jaisalmer-facts-grid');
+        expect(css).toContain('.jaisalmer-references');
+        expect(css).toContain('body.light-theme');
+    });
+
+    it('includes a valid interactive script with required features', () => {
+        const js = readExplorerFile('script.js');
+        expect(js).toContain('jaisalmer-modal');
+        expect(js).toContain('Journey');
+        expect(js).toContain('journey-bookmark-btn');
+        expect(js).toContain('btn-scroll-top');
+    });
+
+    it('gallery images are lazy-loaded', () => {
+        const html = readExplorerFile('index.html');
+        const imgs = html.match(/<img[^>]*>/g) || [];
+        expect(imgs.length).toBeGreaterThanOrEqual(6);
+        imgs.forEach(img => {
+            expect(img).toContain('loading="lazy"');
+        });
+    });
+});


### PR DESCRIPTION
# Pull Request

## Description

Adds a new **Jaisalmer Fort Explorer** monument page (`frontend/jaisalmer-fort-explorer/`) for the Golden Fort of Rajasthan. The page covers the fort's location in Jaisalmer, Rajasthan; the history of Rawal Jaisal and the fort's 1156 CE foundation; the golden sandstone architecture (99 bastions, four gateways); why Jaisalmer Fort is a living fort; the Jain temples within the fort (including the Gyan Bhandar library); the royal palace (Raj Mahal and the Fort Palace Museum); the fort's connection with historic caravan trade routes; its UNESCO World Heritage recognition as part of the "Hill Forts of Rajasthan" serial property (2013); interesting facts; and an image gallery. Includes a Journey bookmark button, gallery modal with keyboard/focus-trap support, full dark and light theme support, and responsive layout. Unit tests added under `tests/unit/jaisalmer-fort-explorer.test.js`.

Fixes #2747

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Tested locally in browser
- [x] Tested in both dark and light themes
- [x] Tested at mobile viewport widths
- [x] Verified no console errors

## Checklist

- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)

## Screenshots (if applicable)