### PR TITLE
feat: add Dadabhai Naoroji explorer

### DIFF
--- a/frontend/dadabhai-naoroji-explorer/index.html
+++ b/frontend/dadabhai-naoroji-explorer/index.html
@@ -1,0 +1,286 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <meta
+            name="description"
+            content="Explore Dadabhai Naoroji's political life, Drain Theory and influence on India's national movement."
+        />
+        <title>Dadabhai Naoroji — Economic Vision Explorer</title>
+        <link rel="stylesheet" href="style.css" />
+    </head>
+    <body>
+        <header class="header">
+            <a class="brand" href="../../index.html">🇮🇳 <span>Incredible India Explorer</span></a>
+            <nav aria-label="Primary">
+                <a href="#biography">Biography</a><a href="#drain">Drain Theory</a><a href="#timeline">Timeline</a
+                ><a href="#politics">Politics</a><a href="#references">References</a>
+                <button id="theme" aria-label="Toggle theme">☼</button>
+            </nav>
+        </header>
+
+        <main>
+            <section class="hero">
+                <div class="hero-copy">
+                    <p class="eyebrow">ECONOMIC THINKER · NATIONALIST · PARLIAMENTARIAN</p>
+                    <h1>Dadabhai <em>Naoroji</em></h1>
+                    <p class="lead">
+                        Follow the life of the “Grand Old Man of India” and the economic argument that made colonial
+                        wealth transfers a central question of early Indian nationalism.
+                    </p>
+                    <div class="actions">
+                        <a class="btn primary" href="#drain">Explore the Drain Theory</a
+                        ><a class="btn" href="#timeline">View timeline</a>
+                    </div>
+                    <div class="stats">
+                        <div><b>1825–1917</b><span>Life</span></div>
+                        <div><b>1892</b><span>Elected to Parliament</span></div>
+                        <div><b>1906</b><span>INC president</span></div>
+                    </div>
+                </div>
+                <div class="hero-art" aria-hidden="true">
+                    <div class="portrait">DN</div>
+                    <div class="orbit o1"></div>
+                    <div class="orbit o2"></div>
+                    <span class="coin c1">₹</span><span class="coin c2">£</span>
+                </div>
+            </section>
+
+            <section class="section split" id="biography">
+                <div>
+                    <p class="eyebrow">BIOGRAPHY</p>
+                    <h2>A life devoted to public argument</h2>
+                    <p>
+                        Born in Bombay in 1825 into a Parsi family, Naoroji became a professor at Elphinstone College
+                        and later spent substantial periods in Britain advocating Indian interests. He combined
+                        teaching, public service, economic analysis and political organising.
+                    </p>
+                    <p>
+                        He helped establish the Indian National Congress and served as its president three times. In
+                        1892 he became the first British Indian MP, representing Central Finsbury as a Liberal. His
+                        parliamentary career gave him a direct platform for questioning imperial financial policy.
+                    </p>
+                </div>
+                <aside class="quote">
+                    <span>“</span>
+                    <p>His economic analysis connected material poverty with the structure of colonial rule.</p>
+                    <small>Economic-history interpretation</small>
+                </aside>
+            </section>
+
+            <section class="section drain" id="drain">
+                <div class="heading">
+                    <p class="eyebrow">THE DRAIN THEORY</p>
+                    <h2>What did Naoroji mean by an economic “drain”?</h2>
+                    <p>
+                        Naoroji argued that a substantial part of India's resources was transferred abroad without an
+                        equivalent return to India. His analysis treated this as a structural consequence of colonial
+                        administration, not simply ordinary trade.
+                    </p>
+                </div>
+                <div class="flow">
+                    <article>
+                        <b>01</b>
+                        <h3>Revenue raised in India</h3>
+                        <p>
+                            Indian revenues financed colonial administration, military expenditure and other
+                            obligations.
+                        </p>
+                    </article>
+                    <div class="arrow">→</div>
+                    <article>
+                        <b>02</b>
+                        <h3>Payments abroad</h3>
+                        <p>
+                            Salaries, pensions, remittances and “Home Charges” could leave India rather than circulate
+                            in its domestic economy.
+                        </p>
+                    </article>
+                    <div class="arrow">→</div>
+                    <article>
+                        <b>03</b>
+                        <h3>Reduced domestic circulation</h3>
+                        <p>
+                            Naoroji linked this external transfer to poverty and argued for greater Indian participation
+                            in administration and economic life.
+                        </p>
+                    </article>
+                </div>
+                <div class="drain-grid">
+                    <div>
+                        <h3>Channels he examined</h3>
+                        <ul>
+                            <li>Home Charges and payments made in Britain</li>
+                            <li>European officials' salaries, savings and pensions</li>
+                            <li>Military and administrative expenditure connected with empire</li>
+                            <li>Profits and remittances leaving India</li>
+                            <li>
+                                Trade arrangements that could sustain an export surplus without an equivalent capital
+                                inflow
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="formula">
+                        <span>INDIA</span><strong>wealth →</strong><span>BRITAIN</span
+                        ><small>Naoroji's analytical model of the external drain</small>
+                    </div>
+                </div>
+            </section>
+
+            <section class="section" id="politics">
+                <div class="heading">
+                    <p class="eyebrow">POLITICAL ACHIEVEMENTS</p>
+                    <h2>Economic critique became a case for self-government</h2>
+                </div>
+                <div class="cards">
+                    <article>
+                        <span>01</span>
+                        <h3>Indian National Congress</h3>
+                        <p>
+                            Naoroji was associated with the Congress from its early years and served as president in
+                            1886, 1893 and 1906.
+                        </p>
+                    </article>
+                    <article>
+                        <span>02</span>
+                        <h3>British Parliament</h3>
+                        <p>
+                            His 1892 election as Liberal MP for Central Finsbury made him the first Indian to sit in the
+                            British House of Commons.
+                        </p>
+                    </article>
+                    <article>
+                        <span>03</span>
+                        <h3>Swaraj</h3>
+                        <p>
+                            At the 1906 Congress session, his presidential address publicly articulated swaraj as a
+                            political goal.
+                        </p>
+                    </article>
+                    <article>
+                        <span>04</span>
+                        <h3>Indianisation</h3>
+                        <p>
+                            He argued that expanding opportunities for Indians in public services could reduce some of
+                            the financial and “moral” effects he associated with the drain.
+                        </p>
+                    </article>
+                </div>
+            </section>
+
+            <section class="section timeline-section" id="timeline">
+                <div class="heading">
+                    <p class="eyebrow">TIMELINE</p>
+                    <h2>From Bombay educator to national political thinker</h2>
+                </div>
+                <div class="timeline">
+                    <div>
+                        <time>1825</time>
+                        <article>
+                            <h3>Born in Bombay</h3>
+                            <p>Dadabhai Naoroji is born into a Parsi family.</p>
+                        </article>
+                    </div>
+                    <div>
+                        <time>1850s</time>
+                        <article>
+                            <h3>Educator and public intellectual</h3>
+                            <p>
+                                He teaches at Elphinstone College and begins building a public career focused on India's
+                                economic condition.
+                            </p>
+                        </article>
+                    </div>
+                    <div>
+                        <time>1885</time>
+                        <article>
+                            <h3>Indian National Congress</h3>
+                            <p>He participates in the early Congress movement.</p>
+                        </article>
+                    </div>
+                    <div>
+                        <time>1886</time>
+                        <article>
+                            <h3>First Congress presidency</h3>
+                            <p>He presides over the second Congress session at Calcutta.</p>
+                        </article>
+                    </div>
+                    <div>
+                        <time>1892</time>
+                        <article>
+                            <h3>House of Commons</h3>
+                            <p>Elected Liberal MP for Central Finsbury in London.</p>
+                        </article>
+                    </div>
+                    <div>
+                        <time>1895</time>
+                        <article>
+                            <h3>Royal Commission on Indian Expenditure</h3>
+                            <p>He serves on the commission examining Indian financial burdens.</p>
+                        </article>
+                    </div>
+                    <div>
+                        <time>1901</time>
+                        <article>
+                            <h3>Poverty and Un-British Rule in India</h3>
+                            <p>His major book brings together his economic critique and evidence for the drain.</p>
+                        </article>
+                    </div>
+                    <div>
+                        <time>1906</time>
+                        <article>
+                            <h3>Swaraj at the Congress</h3>
+                            <p>As Congress president, he makes self-government a prominent public demand.</p>
+                        </article>
+                    </div>
+                    <div>
+                        <time>1917</time>
+                        <article>
+                            <h3>Death in Bombay</h3>
+                            <p>Naoroji dies after a lifetime of economic and political advocacy.</p>
+                        </article>
+                    </div>
+                </div>
+            </section>
+
+            <section class="section references" id="references">
+                <div class="heading">
+                    <p class="eyebrow">REFERENCES</p>
+                    <h2>Further reading</h2>
+                </div>
+                <div class="refs">
+                    <a
+                        href="https://digital.nios.ac.in/content/315en/315_History_Eng_Lesson20.pdf"
+                        target="_blank"
+                        rel="noopener"
+                        ><b>NIOS</b><span>Nationalism and the Drain Theory</span></a
+                    >
+                    <a
+                        href="https://azimpremjiuniversity.edu.in/indian-economists/dadabhai-naoroji"
+                        target="_blank"
+                        rel="noopener"
+                        ><b>Azim Premji University</b><span>Indian Economists: Dadabhai Naoroji</span></a
+                    >
+                    <a
+                        href="https://cmsadmin.amritmahotsav.nic.in/district-reopsitory-detail.htm?25134="
+                        target="_blank"
+                        rel="noopener"
+                        ><b>Ministry of Culture</b><span>Drain of wealth and Indian nationalism</span></a
+                    >
+                    <a
+                        href="https://theory.tifr.res.in/bombay/persons/dadabhai-naoroji.html"
+                        target="_blank"
+                        rel="noopener"
+                        ><b>TIFR</b><span>Dadabhai Naoroji biography and Bombay history</span></a
+                    >
+                </div>
+            </section>
+        </main>
+        <footer>
+            <a href="../../index.html">← Back to Incredible India Explorer</a
+            ><span>Dadabhai Naoroji · Economic Vision Explorer</span>
+        </footer>
+        <script src="script.js"></script>
+    </body>
+</html>

--- a/frontend/dadabhai-naoroji-explorer/script.js
+++ b/frontend/dadabhai-naoroji-explorer/script.js
@@ -1,0 +1,13 @@
+(() => {
+    const btn = document.getElementById('theme');
+    const saved = localStorage.getItem('naoroji-theme');
+    const setTheme = t => {
+        document.documentElement.dataset.theme = t;
+        localStorage.setItem('naoroji-theme', t);
+        btn.textContent = t === 'light' ? '☾' : '☼';
+    };
+    setTheme(saved || (matchMedia('(prefers-color-scheme:light)').matches ? 'light' : 'dark'));
+    btn.addEventListener('click', () =>
+        setTheme(document.documentElement.dataset.theme === 'light' ? 'dark' : 'light')
+    );
+})();

--- a/frontend/dadabhai-naoroji-explorer/style.css
+++ b/frontend/dadabhai-naoroji-explorer/style.css
@@ -1,0 +1,463 @@
+@import url('../../fonts_local.css');
+:root {
+    --bg: #08111d;
+    --panel: #111e2d;
+    --panel2: #15263a;
+    --text: #eef4fa;
+    --muted: #a7b6c8;
+    --gold: #e9b84f;
+    --accent: #c97947;
+    --line: rgba(255, 255, 255, 0.1);
+}
+html[data-theme='light'] {
+    --bg: #f5f7fa;
+    --panel: #fff;
+    --panel2: #edf1f5;
+    --text: #182233;
+    --muted: #58667a;
+    --line: rgba(20, 35, 55, 0.12);
+}
+* {
+    box-sizing: border-box;
+}
+html {
+    scroll-behavior: smooth;
+}
+body {
+    margin: 0;
+    background: radial-gradient(circle at 85% 0, rgba(233, 184, 79, 0.12), transparent 30rem), var(--bg);
+    color: var(--text);
+    font:
+        16px/1.7 Inter,
+        system-ui,
+        sans-serif;
+}
+a {
+    color: inherit;
+}
+.header {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.8rem clamp(1rem, 5vw, 5rem);
+    background: color-mix(in srgb, var(--bg) 82%, transparent);
+    backdrop-filter: blur(18px);
+    border-bottom: 1px solid var(--line);
+}
+.brand {
+    text-decoration: none;
+    font-weight: 850;
+}
+.header nav {
+    display: flex;
+    gap: 0.2rem;
+    align-items: center;
+}
+.header nav a,
+.header button {
+    padding: 0.45rem 0.6rem;
+    color: var(--muted);
+    text-decoration: none;
+    border: 0;
+    background: transparent;
+    border-radius: 8px;
+    cursor: pointer;
+}
+.header nav a:hover,
+.header button:hover {
+    background: var(--line);
+    color: var(--text);
+}
+.hero {
+    min-height: 88vh;
+    display: grid;
+    grid-template-columns: 1.1fr 0.9fr;
+    gap: 3rem;
+    align-items: center;
+    padding: clamp(4rem, 9vw, 8rem) clamp(1.25rem, 7vw, 7rem);
+    overflow: hidden;
+}
+.hero-copy {
+    max-width: 780px;
+}
+.eyebrow {
+    color: var(--gold);
+    font-size: 0.75rem;
+    font-weight: 900;
+    letter-spacing: 0.17em;
+    margin: 0 0 0.7rem;
+}
+h1,
+h2,
+h3 {
+    line-height: 1.12;
+    letter-spacing: -0.025em;
+}
+h1 {
+    font-size: clamp(3.5rem, 8vw, 7rem);
+    margin: 0.2rem 0 1rem;
+}
+h1 em {
+    font-style: normal;
+    color: var(--gold);
+}
+h2 {
+    font-size: clamp(2rem, 4vw, 3.5rem);
+    margin: 0 0 1rem;
+}
+h3 {
+    margin: 0.4rem 0;
+}
+.lead {
+    font-size: 1.2rem;
+    color: var(--muted);
+    max-width: 680px;
+}
+.actions {
+    display: flex;
+    gap: 0.7rem;
+    flex-wrap: wrap;
+    margin: 2rem 0;
+}
+.btn {
+    display: inline-flex;
+    padding: 0.75rem 1.1rem;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    text-decoration: none;
+}
+.primary {
+    background: var(--gold);
+    color: #16120a;
+    border-color: var(--gold);
+    font-weight: 800;
+}
+.stats {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    max-width: 650px;
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    overflow: hidden;
+}
+.stats div {
+    padding: 1rem;
+    background: var(--panel);
+    border-right: 1px solid var(--line);
+}
+.stats div:last-child {
+    border: 0;
+}
+.stats b,
+.stats span {
+    display: block;
+}
+.stats span {
+    font-size: 0.8rem;
+    color: var(--muted);
+}
+.hero-art {
+    height: 500px;
+    position: relative;
+    display: grid;
+    place-items: center;
+}
+.portrait {
+    width: 270px;
+    height: 350px;
+    border-radius: 48% 48% 18% 18%;
+    display: grid;
+    place-items: center;
+    background: linear-gradient(150deg, #b67b48, #e4b15b 45%, #6d3f35);
+    font-size: 4.5rem;
+    font-weight: 900;
+    color: #fff4d2;
+    box-shadow: 0 35px 90px rgba(0, 0, 0, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+}
+.orbit {
+    position: absolute;
+    border: 1px dashed rgba(233, 184, 79, 0.55);
+    border-radius: 50%;
+    width: 430px;
+    height: 260px;
+    transform: rotate(-20deg);
+}
+.o2 {
+    width: 350px;
+    height: 430px;
+    transform: rotate(35deg);
+    opacity: 0.55;
+}
+.coin {
+    position: absolute;
+    width: 60px;
+    height: 60px;
+    border: 1px solid var(--gold);
+    border-radius: 50%;
+    display: grid;
+    place-items: center;
+    color: var(--gold);
+    background: var(--panel);
+    font-size: 1.5rem;
+}
+.c1 {
+    top: 16%;
+    right: 15%;
+}
+.c2 {
+    bottom: 15%;
+    left: 10%;
+}
+.section {
+    width: min(1120px, calc(100% - 2rem));
+    margin: auto;
+    padding: clamp(4rem, 8vw, 7rem) 0;
+}
+.split {
+    display: grid;
+    grid-template-columns: 1.3fr 0.7fr;
+    gap: 3rem;
+    align-items: center;
+}
+.split p,
+.heading > p {
+    color: var(--muted);
+}
+.quote {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    padding: 2rem;
+    border-radius: 24px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+}
+.quote span {
+    font-size: 4rem;
+    color: var(--gold);
+    line-height: 0.4;
+}
+.quote p {
+    font-size: 1.3rem;
+    font-weight: 750;
+}
+.quote small {
+    color: var(--muted);
+}
+.heading {
+    max-width: 800px;
+    margin-bottom: 2rem;
+}
+.flow {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr auto 1fr;
+    align-items: stretch;
+    gap: 0.8rem;
+}
+.flow article,
+.cards article {
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 20px;
+    padding: 1.4rem;
+}
+.flow article > b,
+.cards article > span {
+    color: var(--gold);
+    font-weight: 900;
+}
+.flow p,
+.cards p {
+    color: var(--muted);
+}
+.arrow {
+    display: grid;
+    place-items: center;
+    color: var(--gold);
+    font-size: 2rem;
+}
+.drain-grid {
+    display: grid;
+    grid-template-columns: 1.2fr 0.8fr;
+    gap: 1rem;
+    margin-top: 1rem;
+}
+.drain-grid > div {
+    padding: 1.5rem;
+    border: 1px solid var(--line);
+    border-radius: 20px;
+    background: var(--panel);
+}
+li {
+    margin: 0.5rem 0;
+    color: var(--muted);
+}
+.formula {
+    display: grid;
+    place-items: center;
+    text-align: center;
+    min-height: 250px;
+}
+.formula span {
+    font-weight: 900;
+    font-size: 1.3rem;
+}
+.formula strong {
+    font-size: 2rem;
+    color: var(--gold);
+}
+.formula small {
+    color: var(--muted);
+}
+.cards {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+}
+.cards article {
+    transition: transform 0.2s;
+}
+.cards article:hover {
+    transform: translateY(-4px);
+}
+.timeline {
+    position: relative;
+}
+.timeline:before {
+    content: '';
+    position: absolute;
+    left: 120px;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: linear-gradient(var(--gold), transparent);
+}
+.timeline > div {
+    display: grid;
+    grid-template-columns: 100px 1fr;
+    gap: 3rem;
+    padding-bottom: 2rem;
+    position: relative;
+}
+.timeline time {
+    color: var(--gold);
+    font-weight: 900;
+    text-align: right;
+}
+.timeline article {
+    position: relative;
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    padding: 1rem 1.2rem;
+}
+.timeline article:before {
+    content: '';
+    position: absolute;
+    left: -2.85rem;
+    top: 1.35rem;
+    width: 9px;
+    height: 9px;
+    background: var(--gold);
+    border-radius: 50%;
+    box-shadow: 0 0 0 5px rgba(233, 184, 79, 0.12);
+}
+.timeline p {
+    color: var(--muted);
+    margin: 0;
+}
+.refs {
+    display: grid;
+    gap: 0.7rem;
+}
+.refs a {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem 1.2rem;
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    background: var(--panel);
+    text-decoration: none;
+}
+.refs span {
+    color: var(--muted);
+    text-align: right;
+}
+footer {
+    width: min(1120px, calc(100% - 2rem));
+    margin: auto;
+    border-top: 1px solid var(--line);
+    padding: 2rem 0 3rem;
+    display: flex;
+    justify-content: space-between;
+    color: var(--muted);
+}
+footer a {
+    color: var(--text);
+    text-decoration: none;
+}
+@media (max-width: 850px) {
+    .header nav a {
+        display: none;
+    }
+    .hero {
+        grid-template-columns: 1fr;
+        padding-top: 5rem;
+    }
+    .hero-art {
+        height: 350px;
+    }
+    .stats {
+        grid-template-columns: 1fr;
+    }
+    .stats div {
+        border-right: 0;
+        border-bottom: 1px solid var(--line);
+    }
+    .split,
+    .drain-grid {
+        grid-template-columns: 1fr;
+    }
+    .flow {
+        grid-template-columns: 1fr;
+    }
+    .arrow {
+        transform: rotate(90deg);
+    }
+    .cards {
+        grid-template-columns: 1fr 1fr;
+    }
+    .timeline:before {
+        left: 5px;
+    }
+    .timeline > div {
+        grid-template-columns: 1fr;
+        gap: 0.4rem;
+        padding-left: 2rem;
+    }
+    .timeline time {
+        text-align: left;
+    }
+    .timeline article:before {
+        left: -2.15rem;
+    }
+    .refs a,
+    footer {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    .refs span {
+        text-align: left;
+    }
+}
+@media (max-width: 520px) {
+    .cards {
+        grid-template-columns: 1fr;
+    }
+    .hero-art {
+        transform: scale(0.78);
+    }
+}


### PR DESCRIPTION
# Pull Request Description

## Summary

Closes #1911

Adds a dedicated Dadabhai Naoroji explorer presenting his biography, political leadership, economic vision and Drain Theory, with a focus on his contribution to India's early national movement.

## What changed?

* Added a dedicated Dadabhai Naoroji explorer page.
* Added a concise biographical overview.
* Added a dedicated explanation of the Drain Theory.
* Added a visual three-stage explanation of the economic drain.
* Added the major channels Naoroji identified in his analysis.
* Added his political achievements and leadership.
* Added his involvement with the Indian National Congress.
* Added his 1892 British parliamentary career.
* Added the Royal Commission on Indian Expenditure.
* Added his 1901 publication *Poverty and Un-British Rule in India*.
* Added his advocacy of Indianisation and self-government.
* Added a chronological timeline from 1825 to 1917.
* Added authoritative references for further reading.
* Added responsive desktop/tablet/mobile layouts.
* Added persistent dark/light theme support.
* Added navigation back to the main Incredible India Explorer.
* Added a Dadabhai Naoroji card to the landing page.

## Acceptance Criteria

* [x] Biography
* [x] Timeline
* [x] Drain Theory
* [x] Political achievements
* [x] References
* [x] Landing page integration
* [x] Responsive UI
* [x] Proper navigation
* [x] Accurate historical content

## Validation

* `git diff --check`
* `npm test`
* `npm run a11y`
* Manual responsive browser verification
* Verified explorer navigation
* Verified landing-page link

## Content accuracy

The economic section distinguishes Naoroji's historical argument from modern economic interpretation and presents the Drain Theory through the mechanisms he discussed, including Home Charges, remittances, pensions, salaries and other transfers from India to Britain.
::: 
