### PR TITLE
feat(history): add British India coinage timeline

### DIFF
--- a/frontend/british-india-coinage-explorer/index.html
+++ b/frontend/british-india-coinage-explorer/index.html
@@ -1,0 +1,268 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Interactive timeline of British India coinage, from East India Company and Presidency issues through the British Raj and independence."
+        />
+        <title>British India Coinage Timeline | Incredible India Explorer</title>
+        <link rel="preload" href="../../assets/fonts/Outfit-400.woff2" as="font" type="font/woff2" crossorigin />
+        <link rel="preload" href="../../assets/fonts/Outfit-700.woff2" as="font" type="font/woff2" crossorigin />
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="../../frontend/navbar-redesign/navbar.css" />
+        <link rel="stylesheet" href="style.css" />
+    </head>
+    <body>
+        <header class="navbar" id="navbar">
+            <div class="nav-container">
+                <a href="../../index.html#home" class="nav-logo"
+                    ><span class="saffron">Incredible</span> <span class="gold">India</span>
+                    <span class="green">Explorer</span></a
+                >
+                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+                    <span class="bar"></span><span class="bar"></span><span class="bar"></span>
+                </button>
+                <nav class="nav-menu" id="nav-menu">
+                    <a href="../../index.html#home" class="nav-link">Home</a>
+                    <div class="nav-dropdown">
+                        <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+                            Destinations ▾
+                        </button>
+                        <div class="dropdown-menu">
+                            <a href="../../index.html#map" class="dropdown-item">Interactive Map</a
+                            ><a href="../travel/travel.html" class="dropdown-item">Travel & Destinations</a
+                            ><a href="../heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                        </div>
+                    </div>
+                    <div class="nav-dropdown">
+                        <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+                            Culture ▾
+                        </button>
+                        <div class="dropdown-menu">
+                            <a href="../historical-timeline/index.html" class="dropdown-item">Historical Timeline</a
+                            ><a href="../indias-coins-through-time/index.html" class="dropdown-item"
+                                >India's Coins Through Time</a
+                            >
+                        </div>
+                    </div>
+                    <div class="nav-dropdown">
+                        <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+                            History ▾
+                        </button>
+                        <div class="dropdown-menu">
+                            <a href="../mughal-coinage/index.html" class="dropdown-item">Mughal Coinage</a
+                            ><a href="../delhi-sultanate-coin-timeline/index.html" class="dropdown-item"
+                                >Delhi Sultanate Coin Timeline</a
+                            >
+                        </div>
+                    </div>
+                    <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+                </nav>
+            </div>
+        </header>
+
+        <main class="british-page">
+            <section class="hero">
+                <div class="hero-copy">
+                    <span class="eyebrow">NUMISMATIC HISTORY · 1672–1947</span>
+                    <h1>British India Coinage</h1>
+                    <p>
+                        Trace the transformation from East India Company and Presidency coinage to a uniform imperial
+                        currency and the coinage inherited at independence.
+                    </p>
+                    <div class="hero-actions">
+                        <a class="primary-btn" href="#timeline">Explore the timeline</a
+                        ><a class="secondary-btn" href="#sources">View sources</a>
+                    </div>
+                </div>
+                <div class="hero-coin" aria-label="Illustrated British India rupee">
+                    <svg viewBox="0 0 220 220" role="img">
+                        <defs>
+                            <radialGradient id="silver">
+                                <stop offset="0" stop-color="#f5f2e9" />
+                                <stop offset=".75" stop-color="#c7c5bf" />
+                                <stop offset="1" stop-color="#817f7a" />
+                            </radialGradient>
+                        </defs>
+                        <circle cx="110" cy="110" r="92" fill="url(#silver)" stroke="#8f8a7d" stroke-width="5" />
+                        <circle
+                            cx="110"
+                            cy="110"
+                            r="80"
+                            fill="none"
+                            stroke="#8f8a7d"
+                            stroke-width="2"
+                            stroke-dasharray="2 5"
+                        />
+                        <text x="110" y="94" text-anchor="middle" class="coin-royal">VICTORIA</text>
+                        <text x="110" y="117" text-anchor="middle" class="coin-title">ONE RUPEE</text>
+                        <text x="110" y="138" text-anchor="middle" class="coin-small">INDIA · 1877</text>
+                    </svg>
+                </div>
+            </section>
+
+            <section class="facts" aria-label="Key facts">
+                <article><strong>3</strong><span>Presidency traditions</span></article>
+                <article><strong>6+</strong><span>Important mints</span></article>
+                <article><strong>16</strong><span>annas = 1 rupee</span></article>
+                <article><strong>5</strong><span>British monarchs on coins</span></article>
+            </section>
+
+            <section id="timeline" class="section">
+                <div class="section-heading">
+                    <span class="eyebrow">CHRONOLOGY</span>
+                    <h2>From Company to Crown</h2>
+                    <p>
+                        Use the era buttons to narrow the chronology, then select a milestone for its coinage context.
+                    </p>
+                </div>
+                <div class="era-tabs" role="tablist" aria-label="Timeline era">
+                    <button class="era-btn active" data-era="all">All</button
+                    ><button class="era-btn" data-era="presidency">Company & Presidencies</button
+                    ><button class="era-btn" data-era="crown">Crown coinage</button
+                    ><button class="era-btn" data-era="reform">Reforms & war</button>
+                </div>
+                <div class="timeline" id="timeline-list"></div>
+            </section>
+
+            <section class="section explorer-grid" id="presidencies">
+                <div class="panel">
+                    <div class="section-heading compact">
+                        <span class="eyebrow">REGIONAL SYSTEMS</span>
+                        <h2>Presidency selector</h2>
+                        <p>Before uniform coinage, Bengal, Bombay and Madras developed distinct traditions.</p>
+                    </div>
+                    <div class="selector-row" id="presidency-buttons"></div>
+                    <article class="presidency-detail" id="presidency-detail"></article>
+                </div>
+                <div class="panel">
+                    <div class="section-heading compact">
+                        <span class="eyebrow">MINT NETWORK</span>
+                        <h2>Mint map</h2>
+                        <p>Click a mint to inspect its role and active period.</p>
+                    </div>
+                    <div class="mint-map-wrap">
+                        <svg
+                            id="mint-map"
+                            viewBox="0 0 620 440"
+                            role="img"
+                            aria-label="Schematic map of British India coin mints"
+                        >
+                            <path
+                                class="india-outline"
+                                d="M175 58 L255 45 332 76 390 117 462 154 500 212 474 275 414 306 395 365 331 390 285 351 225 360 187 319 145 280 119 222 135 165Z"
+                            />
+                            <g id="mint-nodes"></g>
+                        </svg>
+                    </div>
+                    <p class="map-note" id="mint-note">
+                        Bombay, Calcutta and Madras anchor the principal Indian mint network.
+                    </p>
+                </div>
+            </section>
+
+            <section class="section" id="viewer">
+                <div class="section-heading">
+                    <span class="eyebrow">COIN VIEWER</span>
+                    <h2>Inspect a coin type</h2>
+                    <p>Compare the ruler, denomination, metal, mint, inscriptions and design language.</p>
+                </div>
+                <div class="viewer-layout">
+                    <div class="coin-stage">
+                        <div class="coin-large" id="coin-large"></div>
+                        <div class="viewer-controls">
+                            <label for="coin-select">Coin type</label
+                            ><select id="coin-select"></select>
+                        </div>
+                    </div>
+                    <article class="coin-info" id="coin-info"></article>
+                </div>
+            </section>
+
+            <section class="section" id="comparison">
+                <div class="section-heading">
+                    <span class="eyebrow">COMPARATIVE NUMISMATICS</span>
+                    <h2>Denomination comparison</h2>
+                    <p>Select two denominations to compare value, metal, weight standard and design purpose.</p>
+                </div>
+                <div class="compare-selectors">
+                    <select id="denom-a"></select
+                    ><span>VS</span
+                    ><select id="denom-b"></select>
+                </div>
+                <div class="compare-grid">
+                    <article id="compare-a" class="compare-card"></article>
+                    <article id="compare-b" class="compare-card"></article>
+                </div>
+            </section>
+
+            <section class="section" id="designs">
+                <div class="section-heading">
+                    <span class="eyebrow">DESIGN EVOLUTION</span>
+                    <h2>Slide through the major designs</h2>
+                    <p>
+                        The same rupee denomination changed its authority, portrait and inscriptions as political
+                        control changed.
+                    </p>
+                </div>
+                <div class="slider-card">
+                    <div class="design-header">
+                        <strong id="design-year">1835</strong><span id="design-era">Company uniform coinage</span>
+                    </div>
+                    <input
+                        id="design-slider"
+                        type="range"
+                        min="0"
+                        max="4"
+                        value="0"
+                        step="1"
+                        aria-label="British India rupee design evolution"
+                    />
+                    <div class="design-stops">
+                        <span>William IV</span><span>Victoria Queen</span><span>Victoria Empress</span
+                        ><span>George V</span><span>George VI</span>
+                    </div>
+                    <div class="design-compare">
+                        <div id="design-coin-a"></div>
+                        <div class="design-caption" id="design-caption"></div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="section" id="sources">
+                <div class="section-heading">
+                    <span class="eyebrow">SOURCES</span>
+                    <h2>Historical references</h2>
+                    <p>Sources used for the timeline and coinage facts.</p>
+                </div>
+                <div class="sources-grid">
+                    <a
+                        href="https://systemhealth.rbi.org.in/Scripts/mc_british.aspx%281%29.html"
+                        target="_blank"
+                        rel="noopener"
+                        >Reserve Bank of India Monetary Museum<span>British India Coinage overview and reforms</span></a
+                    >
+                    <a
+                        href="https://production.royalmintmuseum.org.uk/stories/collect/numismatics/empire-to-independence-six-coin-rupee-set/"
+                        target="_blank"
+                        rel="noopener"
+                        >Royal Mint Museum<span>Empire-to-independence rupee set and design history</span></a
+                    >
+                    <a href="https://www.pcgs.com/news/british-colonial-india" target="_blank" rel="noopener"
+                        >PCGS · British Colonial India<span>Dates, denominations and mint marks</span></a
+                    >
+                    <a
+                        href="https://www.museumsvictoria.com.au/collections/items/1879/calcutta-mint-medal-coin-makers-kolkata-india-1757-1952/"
+                        target="_blank"
+                        rel="noopener"
+                        >Museums Victoria<span>Calcutta Mint history and 1835 production</span></a
+                    >
+                </div>
+            </section>
+        </main>
+        <script src="../../frontend/navbar-redesign/navbar.js"></script>
+        <script src="script.js"></script>
+    </body>
+</html>

--- a/frontend/british-india-coinage-explorer/script.js
+++ b/frontend/british-india-coinage-explorer/script.js
@@ -1,0 +1,525 @@
+const TIMELINE = [
+    {
+        year: 1672,
+        era: 'presidency',
+        title: 'English-style coinage begins at Bombay',
+        tag: 'East India Company',
+        text: 'The East India Company began striking English-style coins at Bombay, alongside the older Mughal-pattern currency used for commerce.'
+    },
+    {
+        year: 1717,
+        era: 'presidency',
+        title: 'Bombay receives Mughal-style minting authority',
+        tag: 'Bombay Presidency',
+        text: 'The Company obtained permission from the Mughal emperor Farrukhsiyar to coin Mughal money at Bombay, helping establish a durable local minting tradition.'
+    },
+    {
+        year: 1835,
+        era: 'presidency',
+        title: 'Uniform Coinage Act unifies the Presidencies',
+        tag: 'Major reform',
+        text: 'The Presidency systems gave way to a uniform Company coinage. The silver rupee was standardised at 180 troy grains and 11/12 fine.'
+    },
+    {
+        year: 1840,
+        era: 'presidency',
+        title: 'Victoria replaces William IV on the uniform series',
+        tag: 'Design change',
+        text: 'Victoria portrait types replaced William IV, while the Company legend remained on the reverse of the early series.'
+    },
+    {
+        year: 1858,
+        era: 'crown',
+        title: 'Authority passes from Company to Crown',
+        tag: 'Political change',
+        text: 'After the 1857 uprising, the Government of India Act transferred administration to the British Crown.'
+    },
+    {
+        year: 1862,
+        era: 'crown',
+        title: 'First British Crown coinage for India',
+        tag: 'Crown series',
+        text: 'Crown issues removed EAST INDIA COMPANY from the reverse and introduced the new imperial design family.'
+    },
+    {
+        year: 1877,
+        era: 'crown',
+        title: 'VICTORIA EMPRESS appears on the coinage',
+        tag: 'Design change',
+        text: 'Queen Victoria was proclaimed Empress of India; from 1 January 1877 the title VICTORIA EMPRESS replaced VICTORIA QUEEN on coins.'
+    },
+    {
+        year: 1893,
+        era: 'reform',
+        title: 'Free coinage of silver is closed',
+        tag: 'Monetary reform',
+        text: 'India closed the free coinage of silver at government mints, a major step in the monetary transition that ultimately linked the rupee more closely to sterling.'
+    },
+    {
+        year: 1906,
+        era: 'reform',
+        title: 'Indian Coinage Act sets mint and standard framework',
+        tag: 'Legislation',
+        text: 'The Indian Coinage Act formalised the framework for mints, denominations and standards; the rupee standard remained 180 grains and 916.66 silver.'
+    },
+    {
+        year: 1917,
+        era: 'reform',
+        title: 'Silver shortage changes the small-coin system',
+        tag: 'World War I',
+        text: 'Wartime silver scarcity encouraged paper one-rupee currency and the use of cupro-nickel for smaller silver denominations.'
+    },
+    {
+        year: 1940,
+        era: 'reform',
+        title: 'Quaternary silver alloy introduced',
+        tag: 'World War II',
+        text: 'The rupee standard was reduced to a quaternary silver alloy as wartime conditions made the traditional silver content difficult to sustain.'
+    },
+    {
+        year: 1943,
+        era: 'reform',
+        title: 'Lahore and overseas production expand supply',
+        tag: 'Mint network',
+        text: 'Lahore began minting British India coins, while Pretoria also produced selected wartime issues.'
+    },
+    {
+        year: 1947,
+        era: 'crown',
+        title: 'Nickel replaces wartime silver alloys; independence follows',
+        tag: 'Transition',
+        text: 'Pure nickel coins replaced the quaternary alloy for some issues. On 15 August 1947 India became independent while the existing coinage continued temporarily.'
+    }
+];
+
+const PRESIDENCIES = [
+    {
+        id: 'bengal',
+        name: 'Bengal / Calcutta',
+        period: '18th century–1835',
+        mint: 'Calcutta',
+        metals: 'Gold, silver, copper',
+        tradition: 'Mughal-pattern rupees and later milled Company coinage',
+        note: 'Bengal coinage retained Mughal conventions for a long period. The Calcutta Mint became the principal producer of the 1835 uniform series.'
+    },
+    {
+        id: 'bombay',
+        name: 'Bombay',
+        period: '1672–1835 as a distinct tradition',
+        mint: 'Bombay',
+        metals: 'Gold, silver, copper',
+        tradition: 'Mughal-style rupees and English-pattern issues',
+        note: 'Bombay was the earliest English-style mint in the Company network and received permission to strike Mughal rupees in 1717.'
+    },
+    {
+        id: 'madras',
+        name: 'Madras',
+        period: '17th century–1835',
+        mint: 'Madras',
+        metals: 'Gold, silver, copper',
+        tradition: 'Pagoda, fanam and Mughal-pattern issues',
+        note: 'Madras developed a distinctive southern metrology and designs, including the gold pagoda tradition, before uniform coinage.'
+    }
+];
+
+const MINTS = [
+    {
+        id: 'bombay',
+        name: 'Bombay',
+        x: 260,
+        y: 280,
+        period: '1835–1947',
+        role: 'Major Indian mint; gold and silver under the uniform series and extensive later production.',
+        presidency: 'Bombay'
+    },
+    {
+        id: 'calcutta',
+        name: 'Calcutta',
+        x: 450,
+        y: 160,
+        period: '1835–1947',
+        role: 'Major eastern mint; produced the uniform series in all metals and later Crown issues.',
+        presidency: 'Bengal'
+    },
+    {
+        id: 'madras',
+        name: 'Madras',
+        x: 380,
+        y: 355,
+        period: '1835–1862',
+        role: 'Produced selected uniform coinage; the historic Presidency mint closed after the early Crown period.',
+        presidency: 'Madras'
+    },
+    {
+        id: 'lahore',
+        name: 'Lahore',
+        x: 205,
+        y: 125,
+        period: '1943–1947',
+        role: 'Wartime mint producing British India issues during the final years of the Raj.',
+        presidency: 'Punjab'
+    },
+    {
+        id: 'pretoria',
+        name: 'Pretoria',
+        x: 92,
+        y: 405,
+        period: '1943–1944',
+        role: 'Overseas production site for selected wartime British India issues.',
+        presidency: 'Overseas'
+    },
+    {
+        id: 'birmingham',
+        name: 'Birmingham',
+        x: 150,
+        y: 70,
+        period: '1857–1860',
+        role: 'Selected contract production for India, including issues from Birmingham makers.',
+        presidency: 'Overseas'
+    }
+];
+
+const COINS = [
+    {
+        id: 'william-rupee',
+        name: 'William IV — 1 Rupee',
+        year: '1835',
+        ruler: 'William IV',
+        authority: 'East India Company',
+        denom: '1 Rupee',
+        metal: 'Silver',
+        weight: '180 grains ≈ 11.66 g',
+        mint: 'Bombay / Calcutta / Madras',
+        obverse: 'William IV effigy',
+        reverse: 'EAST INDIA COMPANY · ONE RUPEE; English and Persian value',
+        design: 'Uniform Company coinage; royal effigy with bilingual denomination.'
+    },
+    {
+        id: 'victoria-rupee',
+        name: 'Victoria — 1 Rupee',
+        year: '1840',
+        ruler: 'Victoria',
+        authority: 'East India Company',
+        denom: '1 Rupee',
+        metal: 'Silver',
+        weight: '180 grains ≈ 11.66 g',
+        mint: 'Bombay / Calcutta / Madras',
+        obverse: 'Victoria Queen portrait',
+        reverse: 'EAST INDIA COMPANY · ONE RUPEE; bilingual value',
+        design: 'Victoria replaced William IV while the Company authority remained visible.'
+    },
+    {
+        id: 'victoria-empress',
+        name: 'Victoria — 1 Rupee, Empress',
+        year: '1877',
+        ruler: 'Victoria',
+        authority: 'British Crown',
+        denom: '1 Rupee',
+        metal: 'Silver',
+        weight: '180 grains ≈ 11.66 g',
+        mint: 'Bombay / Calcutta',
+        obverse: 'VICTORIA EMPRESS portrait',
+        reverse: 'ONE RUPEE and bilingual value within ornamental border',
+        design: 'The imperial title marks the shift from Queen to Empress of India.'
+    },
+    {
+        id: 'edward-rupee',
+        name: 'Edward VII — 1 Rupee',
+        year: '1903',
+        ruler: 'Edward VII',
+        authority: 'British Crown',
+        denom: '1 Rupee',
+        metal: 'Silver',
+        weight: '180 grains ≈ 11.66 g',
+        mint: 'Bombay / Calcutta',
+        obverse: 'Bare-head Edward VII portrait',
+        reverse: 'ONE RUPEE and denomination legends',
+        design: 'New monarch portrait while the rupee standard and imperial framework continued.'
+    },
+    {
+        id: 'george-v-anna',
+        name: 'George V — 1 Anna',
+        year: '1912',
+        ruler: 'George V',
+        authority: 'British Crown',
+        denom: '1 Anna',
+        metal: 'Copper / cupro-nickel later',
+        weight: 'Varied by issue',
+        mint: 'Bombay / Calcutta',
+        obverse: 'Crowned George V portrait',
+        reverse: 'ONE ANNA with ornamental design',
+        design: 'Small denomination used changing metals as silver shortages intensified.'
+    },
+    {
+        id: 'george-vi-rupee',
+        name: 'George VI — 1 Rupee',
+        year: '1940',
+        ruler: 'George VI',
+        authority: 'British Crown',
+        denom: '1 Rupee',
+        metal: 'Quaternary silver',
+        weight: 'Reduced silver standard',
+        mint: 'Bombay / Calcutta / Lahore',
+        obverse: 'GEORGE VI KING EMPEROR',
+        reverse: 'ONE RUPEE and date within wartime design',
+        design: 'Wartime alloy change preserved the rupee denomination while reducing silver content.'
+    }
+];
+
+const DENOMS = [
+    {
+        id: 'pie',
+        name: '1/12 Anna (Pie)',
+        value: '1/192 rupee',
+        metal: 'Copper',
+        weight: 'Issue dependent',
+        purpose: 'Smallest common copper denomination in the British India series.'
+    },
+    {
+        id: 'halfanna',
+        name: '1/2 Anna',
+        value: '1/32 rupee',
+        metal: 'Copper; later cupro-nickel issues in the small-denomination family',
+        weight: '200 grains in early copper issues',
+        purpose: 'Two pice; important everyday copper denomination.'
+    },
+    {
+        id: 'anna',
+        name: '1 Anna',
+        value: '1/16 rupee',
+        metal: 'Copper / cupro-nickel',
+        weight: 'Issue dependent',
+        purpose: 'Four pice; widely used small denomination.'
+    },
+    {
+        id: 'twoanna',
+        name: '2 Annas',
+        value: '1/8 rupee',
+        metal: 'Silver in early series',
+        weight: '22.5 grains in early silver',
+        purpose: 'Fractional silver denomination introduced in the uniform era.'
+    },
+    {
+        id: 'quarter',
+        name: '1/4 Rupee (4 Annas)',
+        value: '1/4 rupee',
+        metal: 'Silver',
+        weight: '45 grains',
+        purpose: 'Quarter rupee, one of the core silver denominations.'
+    },
+    {
+        id: 'half',
+        name: '1/2 Rupee (8 Annas)',
+        value: '1/2 rupee',
+        metal: 'Silver',
+        weight: '90 grains',
+        purpose: 'Half rupee silver denomination.'
+    },
+    {
+        id: 'rupee',
+        name: '1 Rupee',
+        value: '1 rupee = 16 annas',
+        metal: 'Silver; quaternary silver; nickel in late transition',
+        weight: '180 grains under the classic standard',
+        purpose: 'Principal unit and anchor of British India coinage.'
+    },
+    {
+        id: 'mohur',
+        name: '1 Mohur',
+        value: '15 rupees equivalent',
+        metal: 'Gold',
+        weight: '11.66 g at .917 fine in 1835 issues',
+        purpose: 'Gold bullion denomination equivalent to fifteen silver rupees.'
+    }
+];
+
+const DESIGNS = [
+    {
+        year: '1835',
+        era: 'Company uniform coinage',
+        ruler: 'William IV',
+        caption:
+            'The 1835 uniform rupee places William IV on the obverse. The reverse combines EAST INDIA COMPANY, ONE RUPEE and the value in Persian, making the new all-India standard legible across linguistic traditions.',
+        color: '#c8c6bd'
+    },
+    {
+        year: '1840',
+        era: 'Victoria Queen',
+        ruler: 'Queen Victoria',
+        caption:
+            'Victoria replaces William IV. Early Victoria issues retain the East India Company reverse legend, showing continuity of Company authority despite the new royal portrait.',
+        color: '#c8c6bd'
+    },
+    {
+        year: '1877',
+        era: 'Victoria Empress',
+        ruler: 'Queen Victoria',
+        caption:
+            'VICTORIA EMPRESS signals imperial status. The 1877 title change is one of the clearest design markers of the Crown era.',
+        color: '#c8c6bd'
+    },
+    {
+        year: '1910',
+        era: 'George V',
+        ruler: 'George V',
+        caption:
+            'George V introduces a new crowned royal portrait. The core rupee standard remains familiar, but wartime pressures soon affect the composition of smaller denominations.',
+        color: '#c8c6bd'
+    },
+    {
+        year: '1940',
+        era: 'George VI wartime issue',
+        ruler: 'George VI',
+        caption:
+            'Wartime quaternary silver reduces the silver content while retaining the rupee denomination and the KING EMPEROR inscription.',
+        color: '#aaa89f'
+    }
+];
+
+function $(id) {
+    return document.getElementById(id);
+}
+function escapeHTML(value) {
+    return String(value).replace(
+        /[&<>"']/g,
+        c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c]
+    );
+}
+
+function coinSVG(coin, { large = false } = {}) {
+    const year = coin.year;
+    const portrait = coin.ruler.includes('William')
+        ? 'WILLIAM IV'
+        : coin.ruler.includes('Victoria')
+          ? year === '1877'
+              ? 'VICTORIA'
+              : 'VICTORIA QUEEN'
+          : coin.ruler.toUpperCase();
+    const fill = coin.metal.toLowerCase().includes('gold')
+        ? '#d2aa52'
+        : coin.metal.toLowerCase().includes('copper')
+          ? '#b8794d'
+          : coin.metal.toLowerCase().includes('nickel')
+            ? '#b8bdba'
+            : '#c8c6bd';
+    return `<svg viewBox="0 0 260 260" role="img" aria-label="${escapeHTML(coin.name)}"><defs><radialGradient id="coin-${coin.id}"><stop offset="0" stop-color="#f8f6ef"/><stop offset=".72" stop-color="${fill}"/><stop offset="1" stop-color="#716e68"/></radialGradient></defs><circle cx="130" cy="130" r="112" fill="url(#coin-${coin.id})" stroke="#77736b" stroke-width="6"/><circle cx="130" cy="130" r="96" fill="none" stroke="#817d74" stroke-width="2" stroke-dasharray="2 5"/><circle cx="130" cy="130" r="72" fill="none" stroke="#aaa59a" stroke-width="1"/><text x="130" y="108" text-anchor="middle" font-size="16" font-weight="700" fill="#433f39">${portrait}</text><text x="130" y="134" text-anchor="middle" font-size="12" font-weight="700" fill="#433f39">${coin.denom.toUpperCase()}</text><text x="130" y="155" text-anchor="middle" font-size="9" fill="#433f39">${year} · INDIA</text><text x="130" y="183" text-anchor="middle" font-size="8" fill="#433f39">✦ ✦ ✦</text></svg>`;
+}
+
+function renderTimeline(filter = 'all') {
+    const list = $('timeline-list');
+    list.innerHTML = '';
+    TIMELINE.filter(x => filter === 'all' || x.era === filter).forEach(item => {
+        const el = document.createElement('article');
+        el.className = 'timeline-item';
+        el.innerHTML = `<div class="timeline-card"><div class="timeline-meta"><span class="timeline-year">${item.year}</span><span class="tag">${escapeHTML(item.tag)}</span></div><h3>${escapeHTML(item.title)}</h3><p>${escapeHTML(item.text)}</p></div>`;
+        list.appendChild(el);
+    });
+}
+function renderPresidencies() {
+    const buttons = $('presidency-buttons'),
+        detail = $('presidency-detail');
+    PRESIDENCIES.forEach((p, i) => {
+        const b = document.createElement('button');
+        b.className = 'selector-btn' + (i === 0 ? ' active' : '');
+        b.textContent = p.name;
+        b.addEventListener('click', () => {
+            document.querySelectorAll('.selector-btn').forEach(x => x.classList.remove('active'));
+            b.classList.add('active');
+            detail.innerHTML = `<h3>${escapeHTML(p.name)}</h3><p>${escapeHTML(p.note)}</p><div class="detail-list"><div><strong>Period</strong><span>${escapeHTML(p.period)}</span></div><div><strong>Principal mint</strong><span>${escapeHTML(p.mint)}</span></div><div><strong>Metals</strong><span>${escapeHTML(p.metals)}</span></div><div><strong>Tradition</strong><span>${escapeHTML(p.tradition)}</span></div></div>`;
+            focusMint(p.mint.toLowerCase());
+        });
+        buttons.appendChild(b);
+        if (i === 0) b.click();
+    });
+}
+function renderMints() {
+    const group = $('mint-nodes');
+    MINTS.forEach(m => {
+        const g = document.createElement('g');
+        g.innerHTML = `<circle class="mint-node" data-id="${m.id}" cx="${m.x}" cy="${m.y}" r="7" tabindex="0"/><text class="mint-label" x="${m.x + 11}" y="${m.y + 4}">${escapeHTML(m.name)}</text>`;
+        const circle = g.querySelector('circle');
+        circle.addEventListener('click', () => selectMint(m));
+        circle.addEventListener('keydown', e => {
+            if (e.key === 'Enter' || e.key === ' ') selectMint(m);
+        });
+        group.appendChild(g);
+    });
+}
+function focusMint(name) {
+    const m = MINTS.find(x => x.name.toLowerCase().includes(name));
+    if (m) selectMint(m);
+}
+function selectMint(m) {
+    document.querySelectorAll('.mint-node').forEach(x => x.classList.toggle('active', x.dataset.id === m.id));
+    $('mint-note').innerHTML =
+        `<strong>${escapeHTML(m.name)}</strong> · ${escapeHTML(m.period)}<br>${escapeHTML(m.role)}`;
+}
+function renderCoins() {
+    const select = $('coin-select');
+    COINS.forEach(c => select.add(new Option(`${c.year} · ${c.name}`, c.id)));
+    select.addEventListener('change', () => showCoin(COINS.find(c => c.id === select.value)));
+    showCoin(COINS[0]);
+}
+function showCoin(c) {
+    $('coin-large').innerHTML = coinSVG(c, { large: true });
+    $('coin-info').innerHTML =
+        `<h3>${escapeHTML(c.name)}</h3><p>${escapeHTML(c.design)}</p><div class="info-grid"><div><strong>Authority</strong><span>${escapeHTML(c.authority)}</span></div><div><strong>Ruler</strong><span>${escapeHTML(c.ruler)}</span></div><div><strong>Denomination</strong><span>${escapeHTML(c.denom)}</span></div><div><strong>Metal</strong><span>${escapeHTML(c.metal)}</span></div><div><strong>Weight</strong><span>${escapeHTML(c.weight)}</span></div><div><strong>Mint(s)</strong><span>${escapeHTML(c.mint)}</span></div><div><strong>Obverse</strong><span>${escapeHTML(c.obverse)}</span></div><div><strong>Reverse / inscription</strong><span>${escapeHTML(c.reverse)}</span></div></div>`;
+}
+function renderCompare() {
+    const a = $('denom-a'),
+        b = $('denom-b');
+    DENOMS.forEach(d => {
+        a.add(new Option(d.name, d.id));
+        b.add(new Option(d.name, d.id));
+    });
+    b.selectedIndex = 6;
+    const update = () => {
+        showDenom(a.value, 'compare-a');
+        showDenom(b.value, 'compare-b');
+    };
+    a.addEventListener('change', update);
+    b.addEventListener('change', update);
+    update();
+}
+function showDenom(id, target) {
+    const d = DENOMS.find(x => x.id === id);
+    $(target).innerHTML =
+        `<h3>${escapeHTML(d.name)}</h3><table><tr><td>Value</td><td>${escapeHTML(d.value)}</td></tr><tr><td>Metal</td><td>${escapeHTML(d.metal)}</td></tr><tr><td>Weight</td><td>${escapeHTML(d.weight)}</td></tr><tr><td>Role</td><td>${escapeHTML(d.purpose)}</td></tr></table>`;
+}
+function renderDesign() {
+    const input = $('design-slider');
+    const update = () => {
+        const d = DESIGNS[Number(input.value)];
+        $('design-year').textContent = d.year;
+        $('design-era').textContent = d.era;
+        $('design-coin-a').innerHTML = coinSVG({
+            id: `design-${d.year}`,
+            name: `${d.ruler} rupee`,
+            year: d.year,
+            ruler: d.ruler,
+            denom: 'ONE RUPEE',
+            metal: 'Silver',
+            design: d.caption
+        });
+        $('design-caption').textContent = d.caption;
+    };
+    input.addEventListener('input', update);
+    update();
+}
+document.addEventListener('DOMContentLoaded', () => {
+    renderTimeline();
+    renderPresidencies();
+    renderMints();
+    renderCoins();
+    renderCompare();
+    renderDesign();
+    document.querySelectorAll('.era-btn').forEach(b =>
+        b.addEventListener('click', () => {
+            document.querySelectorAll('.era-btn').forEach(x => x.classList.remove('active'));
+            b.classList.add('active');
+            renderTimeline(b.dataset.era);
+        })
+    );
+    const toggle = $('theme-toggle');
+    if (toggle) toggle.addEventListener('click', () => document.body.classList.toggle('dark-mode'));
+});

--- a/frontend/british-india-coinage-explorer/style.css
+++ b/frontend/british-india-coinage-explorer/style.css
@@ -1,0 +1,507 @@
+:root {
+    --bi-bg: #f6f1e7;
+    --bi-panel: #fffdf8;
+    --bi-ink: #2a211a;
+    --bi-muted: #6f6255;
+    --bi-red: #8c2f2f;
+    --bi-gold: #b8893c;
+    --bi-green: #315f4a;
+    --bi-line: #d9cdbb;
+    --bi-shadow: 0 18px 50px rgba(49, 36, 20, 0.12);
+}
+* {
+    box-sizing: border-box;
+}
+.british-page {
+    background: var(--bi-bg);
+    color: var(--bi-ink);
+    min-height: 100vh;
+    font-family: Outfit, system-ui, sans-serif;
+    padding-bottom: 5rem;
+}
+.british-page a {
+    color: inherit;
+}
+.hero {
+    max-width: 1180px;
+    margin: auto;
+    padding: 7rem 1.5rem 3.5rem;
+    display: grid;
+    grid-template-columns: 1.35fr 0.65fr;
+    gap: 3rem;
+    align-items: center;
+}
+.eyebrow {
+    display: inline-block;
+    letter-spacing: 0.14em;
+    font-size: 0.74rem;
+    font-weight: 700;
+    color: var(--bi-red);
+    margin-bottom: 0.7rem;
+}
+.hero h1 {
+    font-size: clamp(3rem, 7vw, 6rem);
+    line-height: 0.94;
+    margin: 0 0 1.2rem;
+    max-width: 800px;
+}
+.hero-copy p {
+    font-size: 1.15rem;
+    line-height: 1.7;
+    max-width: 680px;
+    color: var(--bi-muted);
+}
+.hero-actions {
+    display: flex;
+    gap: 0.8rem;
+    flex-wrap: wrap;
+    margin-top: 1.5rem;
+}
+.primary-btn,
+.secondary-btn,
+.era-btn,
+.selector-btn {
+    border: 1px solid var(--bi-line);
+    border-radius: 999px;
+    padding: 0.75rem 1rem;
+    font: inherit;
+    cursor: pointer;
+    text-decoration: none;
+    background: var(--bi-panel);
+}
+.primary-btn {
+    background: var(--bi-red);
+    color: #fff;
+}
+.secondary-btn {
+    color: var(--bi-ink);
+}
+.hero-coin {
+    justify-self: center;
+    width: min(360px, 80vw);
+    filter: drop-shadow(0 20px 25px rgba(45, 30, 10, 0.22));
+}
+.hero-coin svg {
+    width: 100%;
+}
+.coin-royal {
+    font: 700 11px Outfit;
+    letter-spacing: 2px;
+}
+.coin-title {
+    font: 700 9px Outfit;
+    letter-spacing: 1px;
+}
+.coin-small {
+    font: 400 5px Outfit;
+    letter-spacing: 1px;
+}
+.facts {
+    max-width: 1180px;
+    margin: 0 auto 4rem;
+    padding: 0 1.5rem;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1px;
+    background: var(--bi-line);
+    border: 1px solid var(--bi-line);
+}
+.facts article {
+    background: var(--bi-panel);
+    padding: 1.3rem;
+}
+.facts strong {
+    display: block;
+    font-size: 2rem;
+    color: var(--bi-red);
+}
+.facts span {
+    color: var(--bi-muted);
+}
+.section {
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: 3.5rem 1.5rem;
+}
+.section-heading {
+    max-width: 780px;
+    margin-bottom: 1.5rem;
+}
+.section-heading h2 {
+    font-size: clamp(2rem, 4vw, 3.2rem);
+    margin: 0.1rem 0 0.5rem;
+}
+.section-heading p {
+    color: var(--bi-muted);
+    line-height: 1.65;
+}
+.section-heading.compact h2 {
+    font-size: 2rem;
+}
+.era-tabs,
+.selector-row {
+    display: flex;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+}
+.era-btn.active,
+.selector-btn.active {
+    background: var(--bi-red);
+    color: #fff;
+    border-color: var(--bi-red);
+}
+.timeline {
+    position: relative;
+    padding-left: 2rem;
+    border-left: 2px solid var(--bi-line);
+}
+.timeline-item {
+    position: relative;
+    padding: 0 0 1.6rem 1.3rem;
+}
+.timeline-item:before {
+    content: '';
+    position: absolute;
+    left: -0.48rem;
+    top: 0.3rem;
+    width: 0.75rem;
+    height: 0.75rem;
+    border-radius: 50%;
+    background: var(--bi-gold);
+    box-shadow: 0 0 0 5px var(--bi-bg);
+}
+.timeline-card {
+    background: var(--bi-panel);
+    border: 1px solid var(--bi-line);
+    border-radius: 18px;
+    padding: 1.2rem;
+    box-shadow: 0 7px 25px rgba(49, 36, 20, 0.05);
+}
+.timeline-meta {
+    display: flex;
+    gap: 0.6rem;
+    align-items: center;
+    flex-wrap: wrap;
+    color: var(--bi-muted);
+    font-size: 0.85rem;
+}
+.timeline-year {
+    font-size: 1.2rem;
+    font-weight: 800;
+    color: var(--bi-red);
+}
+.timeline-card h3 {
+    margin: 0.4rem 0;
+}
+.timeline-card p {
+    margin: 0.3rem 0;
+    line-height: 1.55;
+    color: var(--bi-muted);
+}
+.tag {
+    display: inline-flex;
+    border-radius: 999px;
+    padding: 0.2rem 0.55rem;
+    background: #eee4d4;
+    font-size: 0.75rem;
+}
+.explorer-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+}
+.panel,
+.slider-card {
+    background: var(--bi-panel);
+    border: 1px solid var(--bi-line);
+    border-radius: 24px;
+    padding: 1.5rem;
+    box-shadow: var(--bi-shadow);
+}
+.presidency-detail h3 {
+    margin-top: 0;
+}
+.presidency-detail p {
+    color: var(--bi-muted);
+    line-height: 1.6;
+}
+.detail-list {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.7rem;
+    margin-top: 1rem;
+}
+.detail-list div {
+    border-top: 1px solid var(--bi-line);
+    padding-top: 0.6rem;
+}
+.detail-list strong {
+    display: block;
+}
+.detail-list span {
+    font-size: 0.9rem;
+    color: var(--bi-muted);
+}
+.mint-map-wrap {
+    background: #e9e1d3;
+    border-radius: 18px;
+    overflow: hidden;
+}
+.mint-map-wrap svg {
+    width: 100%;
+    height: auto;
+    display: block;
+}
+.india-outline {
+    fill: #d6c8b1;
+    stroke: #927e63;
+    stroke-width: 3;
+}
+.mint-node {
+    cursor: pointer;
+    fill: var(--bi-red);
+    stroke: #fff;
+    stroke-width: 4;
+}
+.mint-node.active {
+    fill: var(--bi-green);
+    r: 9;
+}
+.mint-label {
+    font-size: 13px;
+    font-weight: 700;
+    fill: #35291e;
+    pointer-events: none;
+}
+.map-note {
+    color: var(--bi-muted);
+    line-height: 1.5;
+}
+.viewer-layout {
+    display: grid;
+    grid-template-columns: 0.8fr 1.2fr;
+    gap: 1.5rem;
+}
+.coin-stage,
+.coin-info,
+.compare-card {
+    background: var(--bi-panel);
+    border: 1px solid var(--bi-line);
+    border-radius: 24px;
+    padding: 1.5rem;
+}
+.coin-stage {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+.coin-large {
+    width: min(340px, 100%);
+    margin: auto;
+}
+.coin-large svg {
+    width: 100%;
+    filter: drop-shadow(0 15px 18px rgba(45, 30, 10, 0.18));
+}
+.viewer-controls {
+    width: 100%;
+    margin-top: 1rem;
+}
+.viewer-controls label {
+    display: block;
+    font-weight: 700;
+    margin-bottom: 0.35rem;
+}
+select,
+input[type='range'] {
+    font: inherit;
+}
+select {
+    width: 100%;
+    padding: 0.7rem;
+    border: 1px solid var(--bi-line);
+    border-radius: 12px;
+    background: var(--bi-panel);
+    color: inherit;
+}
+.coin-info h3 {
+    font-size: 1.8rem;
+    margin-top: 0;
+}
+.coin-info p {
+    line-height: 1.6;
+    color: var(--bi-muted);
+}
+.info-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+}
+.info-grid div {
+    border-top: 1px solid var(--bi-line);
+    padding-top: 0.6rem;
+}
+.info-grid strong {
+    display: block;
+}
+.info-grid span {
+    color: var(--bi-muted);
+}
+.compare-selectors {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    gap: 1rem;
+    align-items: center;
+    max-width: 800px;
+    margin-bottom: 1rem;
+}
+.compare-selectors > span {
+    font-weight: 800;
+    color: var(--bi-red);
+}
+.compare-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+}
+.compare-card h3 {
+    margin-top: 0;
+}
+.compare-card table {
+    width: 100%;
+    border-collapse: collapse;
+}
+.compare-card td {
+    padding: 0.55rem;
+    border-bottom: 1px solid var(--bi-line);
+}
+.compare-card td:first-child {
+    font-weight: 700;
+}
+.design-header {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: end;
+    margin-bottom: 1rem;
+}
+.design-header strong {
+    font-size: 2.5rem;
+    color: var(--bi-red);
+}
+.design-header span {
+    color: var(--bi-muted);
+}
+#design-slider {
+    width: 100%;
+    accent-color: var(--bi-red);
+}
+.design-stops {
+    display: flex;
+    justify-content: space-between;
+    font-size: 0.78rem;
+    color: var(--bi-muted);
+    gap: 0.5rem;
+}
+.design-stops span {
+    text-align: center;
+}
+.design-compare {
+    display: grid;
+    grid-template-columns: 240px 1fr;
+    gap: 1.5rem;
+    align-items: center;
+    margin-top: 1.5rem;
+}
+.design-compare > div:first-child {
+    width: 220px;
+}
+.design-compare svg {
+    width: 100%;
+    filter: drop-shadow(0 12px 15px rgba(45, 30, 10, 0.15));
+}
+.design-caption {
+    line-height: 1.7;
+    color: var(--bi-muted);
+}
+.sources-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+}
+.sources-grid a {
+    display: block;
+    padding: 1.1rem 1.2rem;
+    background: var(--bi-panel);
+    border: 1px solid var(--bi-line);
+    border-radius: 16px;
+    text-decoration: none;
+}
+.sources-grid a:hover {
+    border-color: var(--bi-red);
+}
+.sources-grid span {
+    display: block;
+    color: var(--bi-muted);
+    margin-top: 0.35rem;
+    font-size: 0.9rem;
+}
+@media (max-width: 800px) {
+    .hero,
+    .explorer-grid,
+    .viewer-layout,
+    .compare-grid {
+        grid-template-columns: 1fr;
+    }
+    .hero {
+        padding-top: 5rem;
+    }
+    .facts {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    .sources-grid {
+        grid-template-columns: 1fr;
+    }
+    .design-compare {
+        grid-template-columns: 1fr;
+    }
+    .design-compare > div:first-child {
+        width: 190px;
+        margin: auto;
+    }
+    .compare-selectors {
+        grid-template-columns: 1fr;
+    }
+    .compare-selectors > span {
+        text-align: center;
+    }
+    .detail-list {
+        grid-template-columns: 1fr;
+    }
+}
+@media (prefers-reduced-motion: reduce) {
+    * {
+        scroll-behavior: auto !important;
+        transition: none !important;
+    }
+}
+
+body.dark-mode .british-page {
+    --bi-bg: #17130f;
+    --bi-panel: #241e18;
+    --bi-ink: #f4eee5;
+    --bi-muted: #c4b8a9;
+    --bi-line: #55483a;
+    --bi-shadow: 0 18px 50px rgba(0, 0, 0, 0.3);
+}
+body.dark-mode .mint-map-wrap {
+    background: #33291f;
+}
+.mint-node:focus {
+    outline: 3px solid var(--bi-gold);
+    outline-offset: 3px;
+}
+.timeline-card:focus-within {
+    outline: 2px solid var(--bi-gold);
+}

--- a/tests/unit/british-india-coinage-explorer.test.js
+++ b/tests/unit/british-india-coinage-explorer.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const baseDir = path.resolve(__dirname, '../../frontend/british-india-coinage-explorer');
+
+describe('British India Coinage Timeline (#2101)', () => {
+    it('contains the explorer page, styles and interactive script', () => {
+        expect(fs.existsSync(path.join(baseDir, 'index.html'))).toBe(true);
+        expect(fs.existsSync(path.join(baseDir, 'style.css'))).toBe(true);
+        expect(fs.existsSync(path.join(baseDir, 'script.js'))).toBe(true);
+    });
+
+    it('includes all requested interactive sections', () => {
+        const html = fs.readFileSync(path.join(baseDir, 'index.html'), 'utf8');
+        expect(html).toContain('id="timeline-list"');
+        expect(html).toContain('id="presidency-buttons"');
+        expect(html).toContain('id="mint-map"');
+        expect(html).toContain('id="coin-select"');
+        expect(html).toContain('id="denom-a"');
+        expect(html).toContain('id="denom-b"');
+        expect(html).toContain('id="design-slider"');
+        expect(html).toContain('Historical references');
+    });
+
+    it('covers Company, Presidency, Crown and wartime milestones', () => {
+        const js = fs.readFileSync(path.join(baseDir, 'script.js'), 'utf8');
+        for (const marker of ['1672', '1717', '1835', '1858', '1862', '1877', '1893', '1906', '1940', '1943', '1947']) {
+            expect(js).toContain(`year:${marker}`);
+        }
+        for (const ruler of ['William IV', 'Victoria', 'Edward VII', 'George V', 'George VI']) {
+            expect(js).toContain(ruler);
+        }
+        for (const mint of ['Bombay', 'Calcutta', 'Madras', 'Lahore', 'Pretoria']) {
+            expect(js).toContain(mint);
+        }
+    });
+
+    it('contains denomination, metal and inscription data', () => {
+        const js = fs.readFileSync(path.join(baseDir, 'script.js'), 'utf8');
+        for (const denomination of [
+            '1/12 Anna (Pie)',
+            '1/2 Anna',
+            '1 Anna',
+            '2 Annas',
+            '1/4 Rupee (4 Annas)',
+            '1/2 Rupee (8 Annas)',
+            '1 Rupee',
+            '1 Mohur'
+        ]) {
+            expect(js).toContain(denomination);
+        }
+        expect(js).toContain('EAST INDIA COMPANY');
+        expect(js).toContain('VICTORIA EMPRESS');
+        expect(js).toContain('Quaternary silver');
+    });
+
+    it('links to authoritative historical references', () => {
+        const html = fs.readFileSync(path.join(baseDir, 'index.html'), 'utf8');
+        expect(html).toContain('systemhealth.rbi.org.in');
+        expect(html).toContain('royalmintmuseum.org.uk');
+        expect(html).toContain('pcgs.com');
+        expect(html).toContain('museumsvictoria.com.au');
+    });
+});


### PR DESCRIPTION

## Summary

Implements #2101 with an interactive British India coinage timeline
covering East India Company issues through the British Raj and the
1947 transition.

## Features

- Chronological British India coinage timeline
- East India Company and Presidency history
- Bengal/Calcutta, Bombay and Madras selector
- Interactive mint map
- Bombay, Calcutta, Madras, Lahore, Pretoria and Birmingham mint data
- Interactive coin viewer
- Major British monarchs and rulers
- Denomination comparison
- Metal and weight information
- Inscriptions and design descriptions
- Design evolution slider from William IV through George VI
- Major monetary reforms including 1835, 1893 and 1906
- Wartime silver/alloy changes
- Historical source references
- Dedicated unit/integration test coverage

## Historical coverage

The timeline covers 1672–1947 and distinguishes Presidency,
East India Company, Crown and wartime/reform phases.

## Validation

- Node syntax checks pass
- Static acceptance smoke test passes
- Full dependency installation timed out in the execution environment,
  so the complete Vitest/build pipeline could not be executed here

Closes #2101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a British India Coinage Explorer with responsive navigation, historical timeline, presidency selector, mint map, coin viewer, denomination comparisons, and design previews.
  * Added era filtering, dark mode, keyboard-focus support, reduced-motion behavior, and interactive historical content.
  * Included historical sources and reference links throughout the explorer.

* **Tests**
  * Added coverage verifying page structure, historical data, coin details, and source references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->