### PR TITLE
feat: add Dudhsagar Falls explorer

### DIFF
--- a/frontend/dudhsagar-falls-explorer/index.html
+++ b/frontend/dudhsagar-falls-explorer/index.html
@@ -1,0 +1,421 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Dudhsagar Falls Explorer | 310m Four-Tier "Sea of Milk" Cascade | Goa-Karnataka Border</title>
+  <meta name="description" content="Explore Dudhsagar Falls on the Mandovi River, Goa-Karnataka border — India's iconic 310m (1,017 ft) four-tiered waterfall inside Bhagwan Mahavir Wildlife Sanctuary. Interactive tier visualization, seasonal flow comparison, access routes, nearby attractions, and location map.">
+
+  <!-- Preload Critical Fonts -->
+  <link rel="preload" href="../../assets/fonts/Outfit-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="../../assets/fonts/Outfit-700.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="../../assets/fonts/PlayfairDisplay-400.woff2" as="font" type="font/woff2" crossorigin>
+
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <script>
+    (function() {
+      const theme = localStorage.getItem('theme') || 'dark';
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+
+  <!-- Navigation Bar -->
+  <header class="navbar" id="navbar">
+    <div class="nav-container">
+      <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+        <span class="saffron">Incredible</span>
+        <span class="gold">India</span>
+        <span class="green">Explorer</span>
+      </a>
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Navigation Menu">
+        <span class="bar"></span>
+        <span class="bar"></span>
+        <span class="bar"></span>
+      </button>
+      <nav class="nav-menu" id="nav-menu">
+        <a href="../../index.html#home" class="nav-link">Home</a>
+        <a href="../waterfalls-of-india/index.html" class="nav-link">Waterfalls Collection</a>
+        <a href="#journey-section" class="nav-link active">Interactive Journey</a>
+        <a href="#height-section" class="nav-link">Tiers & Height</a>
+        <a href="#landscape-section" class="nav-link">Mandovi Landscape</a>
+        <a href="#seasonal-section" class="nav-link">Seasonal Flow</a>
+        <a href="#attractions-section" class="nav-link">Nearby Attractions</a>
+        <a href="#location-map-section" class="nav-link">Location Map</a>
+        <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <!-- HERO SECTION -->
+    <section class="dudhsagar-hero">
+      <div class="hero-container">
+        <div class="hero-badge">🐘 Bhagwan Mahavir Wildlife Sanctuary · Goa-Karnataka Border</div>
+        <h1>Dudhsagar Falls: <span>The Sea of Milk</span></h1>
+        <p class="hero-subtitle">
+          Cascading 310 meters (1,017 feet) down granite cliffs in four dramatic tiers, Dudhsagar Falls is one of India's tallest and most photographed waterfalls, fed by a headwater stream of the Mandovi River deep within the Western Ghats rainforest of the Bhagwan Mahavir Wildlife Sanctuary.
+        </p>
+        <div class="hero-pills">
+          <span class="pill">📏 310m (1,017 ft) Four-Tier Drop</span>
+          <span class="pill">🌊 Mandovi River Headwaters</span>
+          <span class="pill">🚂 Iconic Railway Viaduct Backdrop</span>
+          <span class="pill">🌳 Bhagwan Mahavir Wildlife Sanctuary</span>
+        </div>
+      </div>
+    </section>
+
+    <!-- INTERACTIVE 5-STEP JOURNEY EXPLORER -->
+    <section class="journey-section" id="journey-section">
+      <div class="section-container">
+        <div class="section-header">
+          <span class="section-tag">Guided Discovery</span>
+          <h2>Explore the 5 Dimensions of Dudhsagar</h2>
+          <p>Step through the complete story: Waterfall → Tiers → Landscape → Season → Location.</p>
+        </div>
+
+        <div class="journey-stepper" role="tablist">
+          <button class="step-btn active" data-step="waterfall" role="tab">1. Waterfall</button>
+          <button class="step-btn" data-step="height" role="tab">2. Tiers</button>
+          <button class="step-btn" data-step="landscape" role="tab">3. Landscape</button>
+          <button class="step-btn" data-step="season" role="tab">4. Season</button>
+          <button class="step-btn" data-step="location" role="tab">5. Location</button>
+        </div>
+
+        <div class="journey-card" id="journey-display-card">
+          <div class="journey-content-grid">
+            <div class="journey-text">
+              <span class="step-badge" id="j-step-badge">Step 1: The Sea of Milk</span>
+              <h3 id="j-title">Why It's Called "Dudhsagar"</h3>
+              <p id="j-desc">As monsoon-fed water crashes down the sheer granite face and breaks apart on rocky ledges, it froths into a milky-white torrent visible from kilometers away — earning the falls its Konkani name, Dudhsagar, meaning "Sea of Milk".</p>
+              <div class="journey-meta" id="j-meta">
+                <div><strong>River:</strong> <span>Headwater stream of the Mandovi River</span></div>
+                <div><strong>Type:</strong> <span>Four-tiered segmented plunge waterfall</span></div>
+                <div><strong>Rank:</strong> <span>Among India's tallest waterfalls (310m / 1,017 ft)</span></div>
+              </div>
+            </div>
+            <div class="journey-visual">
+              <img id="j-img" src="https://images.unsplash.com/photo-1667760334198-d3958029a08b?w=600&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8ZHVkaHNhZ2FyJTIwZmFsbHN8ZW58MHx8MHx8fDA%3D" alt="Full-scale panoramic view of Dudhsagar Falls cascading in tiers over granite cliffs" loading="lazy" width="600" height="400">
+              <span class="img-caption" id="j-caption">Full-scale view of Dudhsagar's milky-white cascade over Western Ghats granite</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- TIER STRUCTURE & HEIGHT SECTION -->
+    <section class="height-section" id="height-section">
+      <div class="section-container">
+        <div class="section-header">
+          <span class="section-tag">Vertical Elevation</span>
+          <h2>310m Four-Tier Height Visualization</h2>
+          <p>Dudhsagar drops in four distinct stages, each with its own character, compared here with other iconic Indian waterfalls.</p>
+        </div>
+
+        <div class="height-grid">
+          <div class="height-tier-card">
+            <div class="tier-meter">
+              <div class="meter-bar" style="height: 35%;">
+                <span class="meter-label">Tier 1 (~110m)</span>
+              </div>
+            </div>
+            <h3>Tier 1: Upper Plunge (~110m)</h3>
+            <p>The stream leaves the Western Ghats plateau and makes its first steep plunge, sending spray high into the forest canopy below.</p>
+          </div>
+
+          <div class="height-tier-card">
+            <div class="tier-meter">
+              <div class="meter-bar" style="height: 26%;">
+                <span class="meter-label">Tier 2 (~80m)</span>
+              </div>
+            </div>
+            <h3>Tier 2: Mid Cascade (~80m)</h3>
+            <p>Water gathers on a rocky ledge before sliding into a second broad cascade, widening across the granite face.</p>
+          </div>
+
+          <div class="height-tier-card">
+            <div class="tier-meter">
+              <div class="meter-bar" style="height: 19%;">
+                <span class="meter-label">Tier 3 (~60m)</span>
+              </div>
+            </div>
+            <h3>Tier 3: Lower Drop (~60m)</h3>
+            <p>A shorter, steeper drop just above the famous railway viaduct, where the mist is thickest and rainbows form on sunny days.</p>
+          </div>
+
+          <div class="height-tier-card">
+            <div class="tier-meter">
+              <div class="meter-bar" style="height: 20%;">
+                <span class="meter-label">Tier 4 (~60m)</span>
+              </div>
+            </div>
+            <h3>Tier 4: Final Plunge (~60m)</h3>
+            <p>The final stage crashes into a natural pool at the base, feeding the stream onward to join the Mandovi River basin.</p>
+          </div>
+
+          <div class="height-comparison-box">
+            <h3>National Height Comparison</h3>
+            <div class="comp-bar-row">
+              <span>Kunchikal (Karnataka)</span>
+              <div class="comp-bar"><div class="bar-fill" style="width: 100%;"></div></div>
+              <span>455m</span>
+            </div>
+            <div class="comp-bar-row">
+              <span>Barehipani (Odisha)</span>
+              <div class="comp-bar"><div class="bar-fill" style="width: 88%;"></div></div>
+              <span>399m</span>
+            </div>
+            <div class="comp-bar-row">
+              <span>Nohkalikai (Meghalaya)</span>
+              <div class="comp-bar"><div class="bar-fill" style="width: 75%;"></div></div>
+              <span>340m</span>
+            </div>
+            <div class="comp-bar-row highlight">
+              <span>Dudhsagar (Goa)</span>
+              <div class="comp-bar"><div class="bar-fill" style="width: 68%; background: #14b8a6;"></div></div>
+              <span>310m</span>
+            </div>
+            <div class="comp-bar-row">
+              <span>Jog Falls (Karnataka)</span>
+              <div class="comp-bar"><div class="bar-fill" style="width: 56%;"></div></div>
+              <span>253m</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- MANDOVI LANDSCAPE & ECOSYSTEM SECTION -->
+    <section class="landscape-section" id="landscape-section">
+      <div class="section-container">
+        <div class="section-header">
+          <span class="section-tag">Western Ghats Biosphere</span>
+          <h2>The Mandovi River & Surrounding Rainforest</h2>
+          <p>Dudhsagar sits inside the Bhagwan Mahavir Wildlife Sanctuary and Mollem National Park, part of the UNESCO-recognized Western Ghats.</p>
+        </div>
+
+        <div class="eco-grid">
+          <article class="eco-card">
+            <div class="eco-img-box">
+              <img src="https://images.unsplash.com/photo-1441974231531-c6227db76b6e?auto=format&fit=crop&q=80&w=600" alt="Mandovi River basin and forested Western Ghats terrain near Goa" loading="lazy" width="400" height="250">
+            </div>
+            <div class="eco-card-body">
+              <h3>River System: Mandovi Headwaters</h3>
+              <p>The falls are formed by a headwater tributary that eventually joins the Mandovi River, Goa's principal river and lifeline of its coastal trade and ecology.</p>
+            </div>
+          </article>
+
+          <article class="eco-card">
+            <div class="eco-img-box">
+              <img src="https://images.unsplash.com/photo-1516214104703-d870798883c5?auto=format&fit=crop&q=80&w=600" alt="Dense evergreen forest canopy of Bhagwan Mahavir Wildlife Sanctuary" loading="lazy" width="400" height="250">
+            </div>
+            <div class="eco-card-body">
+              <h3>Flora: Evergreen & Semi-Evergreen Forest</h3>
+              <p>Tropical evergreen and moist deciduous forests blanket the surrounding hills, with towering trees, epiphytes, and a rich undergrowth typical of the Western Ghats biodiversity hotspot.</p>
+            </div>
+          </article>
+
+          <article class="eco-card">
+            <div class="eco-img-box">
+              <img src="https://images.unsplash.com/photo-1549366021-9f761d450615?auto=format&fit=crop&q=80&w=600" alt="Wildlife of Bhagwan Mahavir Wildlife Sanctuary and Mollem National Park" loading="lazy" width="400" height="250">
+            </div>
+            <div class="eco-card-body">
+              <h3>Fauna: Sanctuary Wildlife</h3>
+              <p>The sanctuary shelters gaur (Indian bison), sambar deer, giant squirrels, leopards, and a striking diversity of birds and butterflies along the trekking and safari routes.</p>
+            </div>
+          </article>
+
+          <article class="eco-card">
+            <div class="eco-img-box">
+              <img src="https://images.unsplash.com/photo-1723726956314-e2d26b69dfdd?w=600&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8VGhlJTIwUmFpbHdheSUyMFZpYWR1Y3R8ZW58MHx8MHx8fDA%3D" alt="Railway viaduct bridge crossing near Dudhsagar Falls" loading="lazy" width="400" height="250">
+            </div>
+            <div class="eco-card-body">
+              <h3>Landmark: The Railway Viaduct</h3>
+              <p>The South Western Railway's Castle Rock–Kulem line runs directly alongside the falls on a century-old viaduct, making it one of India's most photographed rail-and-waterfall scenes.</p>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- SEASONAL VARIATION & BEST VISITING PERIOD -->
+    <section class="seasonal-section" id="seasonal-section">
+      <div class="section-container">
+        <div class="section-header">
+          <span class="section-tag">Travel Seasons</span>
+          <h2>Seasonal Flow & Access Windows</h2>
+          <p>Access to Dudhsagar changes dramatically with the seasons, since jeep tracks and forest trails depend on monsoon conditions.</p>
+        </div>
+
+        <div class="season-tabs" role="tablist">
+          <button class="season-btn" data-season="monsoon" role="tab">🌧️ Monsoon (Jun – Sep) [Limited Access]</button>
+          <button class="season-btn active" data-season="postmonsoon" role="tab">🍃 Post-Monsoon (Oct – Feb) [Best Season]</button>
+          <button class="season-btn" data-season="summer" role="tab">☀️ Summer (Mar – May) [Reduced Flow]</button>
+        </div>
+
+        <div class="season-display-card" id="season-display-card">
+          <h3 id="s-card-title">Post-Monsoon (October to February) — Best Season</h3>
+          <p id="s-card-desc">With the rains easing off, the falls still carry a strong, clear volume of water while jeep safaris from Kulem and Sonaulim run at full capacity. Cool, comfortable weather makes this the most popular and safest window to visit.</p>
+
+          <div class="season-pills-row">
+            <span class="sp-badge" id="sp-flow">Flow: Strong, Clear, Photogenic</span>
+            <span class="sp-badge" id="sp-access">Access: Jeep Safaris & Trekking Fully Open</span>
+            <span class="sp-badge" id="sp-highlight">Highlights: Best photography, safe swimming pools</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- NEARBY ATTRACTION EXPLORER -->
+    <section class="attractions-section" id="attractions-section">
+      <div class="section-container">
+        <div class="section-header">
+          <span class="section-tag">Nearby Attraction Explorer</span>
+          <h2>Rest of the Mollem-Dudhsagar Circuit</h2>
+          <p>Click a card to preview each nearby stop, or select a pin on the map below.</p>
+        </div>
+
+        <div class="attractions-grid" id="attractions-grid">
+          <button class="attraction-card active" data-spot="tambdisurla" type="button">
+            <img src="https://images.unsplash.com/photo-1733561589506-3987c5672642?w=600&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8VGFtYmRpJTIwU3VybGElMjBUZW1wbGV8ZW58MHx8MHx8fDA%3D" alt="Tambdi Surla Temple, Goa's oldest surviving stone temple" loading="lazy">
+            <div class="attraction-card-body">
+              <h4>Tambdi Surla Temple</h4>
+              <p>Goa's oldest surviving temple, a 12th-century basalt shrine hidden deep in the forest.</p>
+            </div>
+          </button>
+          <button class="attraction-card" data-spot="devilscanyon" type="button">
+            <img src="https://images.unsplash.com/photo-1556881798-ea9705321743?w=600&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8Mnx8RGV2aWwncyUyMENhbnlvbiUyMHJvY2t8ZW58MHx8MHx8fDA%3D" alt="Devil's Canyon rock pools near Dudhsagar" loading="lazy">
+            <div class="attraction-card-body">
+              <h4>Devil's Canyon</h4>
+              <p>A dramatic rock gorge with turquoise pools carved by the same headwater stream.</p>
+            </div>
+          </button>
+          <button class="attraction-card" data-spot="mollem" type="button">
+            <img src="https://images.unsplash.com/photo-1686346472914-9430f04e361c?w=600&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8TW9sbGVtJTIwTmF0aW9uYWwlMjBQYXJrfGVufDB8fDB8fHww" alt="Mollem National Park forest trails" loading="lazy">
+            <div class="attraction-card-body">
+              <h4>Mollem National Park</h4>
+              <p>Goa's core protected forest, home to hiking trails, a deer park, and rich birdlife.</p>
+            </div>
+          </button>
+          <button class="attraction-card" data-spot="castlerock" type="button">
+            <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQ24d9PD_YAsRJtstzheo3-uP_3tlz76odgOw9CcvDQBw&s=10" alt="Castle Rock railway station on the Goa-Karnataka border" loading="lazy">
+            <div class="attraction-card-body">
+              <h4>Castle Rock</h4>
+              <p>A scenic Karnataka border village and railway station popular with trekkers.</p>
+            </div>
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- INTERACTIVE LOCATION MAP -->
+    <section class="location-map-section" id="location-map-section">
+      <div class="section-container">
+        <div class="section-header">
+          <span class="section-tag">Sanctuary Map</span>
+          <h2>Interactive Dudhsagar & Mollem Location Map</h2>
+          <p>Click pins to explore the falls, entry points, and nearby circuit stops.</p>
+        </div>
+
+        <div class="loc-map-wrapper">
+          <div class="loc-svg-box">
+            <svg viewBox="0 0 800 500" class="loc-svg" aria-label="Interactive map of Dudhsagar Falls and the Mollem-Dudhsagar circuit">
+              <rect width="100%" height="100%" fill="rgba(15, 23, 42, 0.4)"/>
+
+              <!-- Bhagwan Mahavir Wildlife Sanctuary Perimeter -->
+              <ellipse cx="420" cy="250" rx="330" ry="190" fill="none" stroke="#22c55e" stroke-width="2" stroke-dasharray="6,4" opacity="0.4"/>
+
+              <!-- Mandovi headwater stream -->
+              <path d="M 460,120 Q 440,220 420,270 T 320,420" fill="none" stroke="#5eead4" stroke-width="16" opacity="0.35"/>
+              <path d="M 460,120 Q 440,220 420,270 T 320,420" fill="none" stroke="#0d9488" stroke-width="8"/>
+
+              <!-- Railway line -->
+              <path d="M 620,140 L 500,220 L 420,270 L 300,340 L 200,420" fill="none" stroke="#f59e0b" stroke-width="3" stroke-dasharray="5,3"/>
+
+              <!-- Map Pins -->
+              <g class="circuit-pin" data-spot="dudhsagar" tabindex="0" role="button" aria-label="Dudhsagar Falls (310m)">
+                <circle cx="420" cy="270" r="18" fill="rgba(20, 184, 166, 0.4)"/>
+                <circle cx="420" cy="270" r="9" fill="#14b8a6"/>
+                <text x="420" y="240" fill="#ffffff" font-weight="bold" font-size="12" text-anchor="middle">Dudhsagar Falls (310m)</text>
+              </g>
+
+              <g class="circuit-pin" data-spot="tambdisurla" tabindex="0" role="button" aria-label="Tambdi Surla Temple">
+                <circle cx="560" cy="330" r="14" fill="rgba(245, 158, 11, 0.4)"/>
+                <circle cx="560" cy="330" r="7" fill="#f59e0b"/>
+                <text x="560" y="360" fill="#ffffff" font-weight="bold" font-size="11" text-anchor="middle">Tambdi Surla Temple</text>
+              </g>
+
+              <g class="circuit-pin" data-spot="devilscanyon" tabindex="0" role="button" aria-label="Devil's Canyon">
+                <circle cx="480" cy="200" r="14" fill="rgba(94, 234, 212, 0.4)"/>
+                <circle cx="480" cy="200" r="7" fill="#5eead4"/>
+                <text x="480" y="180" fill="#ffffff" font-weight="bold" font-size="11" text-anchor="middle">Devil's Canyon</text>
+              </g>
+
+              <g class="circuit-pin" data-spot="mollem" tabindex="0" role="button" aria-label="Mollem National Park">
+                <circle cx="300" cy="340" r="14" fill="rgba(34, 197, 94, 0.4)"/>
+                <circle cx="300" cy="340" r="7" fill="#22c55e"/>
+                <text x="300" y="370" fill="#ffffff" font-weight="bold" font-size="11" text-anchor="middle">Mollem National Park</text>
+              </g>
+
+              <g class="circuit-pin" data-spot="castlerock" tabindex="0" role="button" aria-label="Castle Rock Railway Station">
+                <circle cx="620" cy="140" r="14" fill="rgba(239, 68, 68, 0.4)"/>
+                <circle cx="620" cy="140" r="7" fill="#ef4444"/>
+                <text x="620" y="120" fill="#ffffff" font-weight="bold" font-size="11" text-anchor="middle">Castle Rock (Karnataka)</text>
+              </g>
+
+              <g class="circuit-pin" data-spot="kulem" tabindex="0" role="button" aria-label="Kulem / Sonaulim Jeep Entry Point">
+                <circle cx="200" cy="420" r="14" fill="rgba(34, 197, 94, 0.4)"/>
+                <circle cx="200" cy="420" r="7" fill="#22c55e"/>
+                <text x="200" y="450" fill="#ffffff" font-weight="bold" font-size="11" text-anchor="middle">Kulem / Sonaulim Entry</text>
+              </g>
+            </svg>
+          </div>
+
+          <div class="loc-card" id="loc-info-card">
+            <h3 id="loc-title">Dudhsagar Falls Viewpoint</h3>
+            <span class="loc-tag" id="loc-sub">Bhagwan Mahavir Wildlife Sanctuary, Goa</span>
+            <div id="loc-body">
+              <p>The main viewing platform sits at the base of the fourth tier, offering close-up views of the plunge pool and the railway viaduct arching overhead.</p>
+            </div>
+            <div class="loc-meta-grid">
+              <div><strong>Access:</strong> <span id="loc-dist">60 km from Panaji, 10 km from Kulem</span></div>
+              <div><strong>Approach:</strong> <span id="loc-vehicle">Authorized open jeep safari from Kulem or Sonaulim</span></div>
+              <div><strong>Nearest Railhead:</strong> <span id="loc-rail">Kulem / Collem (10 km) / Castle Rock (14 km)</span></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- SOURCES & CREDITS -->
+    <section class="sources-section">
+      <div class="section-container">
+        <h2>Sources & Image Credits</h2>
+        <ul class="sources-list">
+          <li>Goa Tourism (Department of Tourism, Government of Goa) – Dudhsagar Falls & Bhagwan Mahavir Wildlife Sanctuary records.</li>
+          <li>Goa Forest Department – Bhagwan Mahavir Wildlife Sanctuary and Mollem National Park visitor guide.</li>
+          <li>South Western Railway – Castle Rock–Kulem section heritage line information.</li>
+          <li>Photographs curated under Unsplash Open License with contextual alt descriptions.</li>
+        </ul>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer-container">
+      <p>© 2026 Incredible India Explorer. Created under Open Source Contribution Guidelines.</p>
+      <div class="footer-links">
+        <a href="../../index.html#home">Home</a>
+        <a href="../waterfalls-of-india/index.html">Waterfalls Collection</a>
+        <a href="../../frontend/sources/sources.html">Sources</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/dudhsagar-falls-explorer/script.js
+++ b/frontend/dudhsagar-falls-explorer/script.js
@@ -1,0 +1,308 @@
+/**
+ * script.js
+ * Dudhsagar Falls Explorer Logic
+ */
+
+(function () {
+  'use strict';
+
+  // 5-STEP JOURNEY DATASET
+  // Waterfall -> Height/Tiers -> Landscape -> Season -> Location
+  const JOURNEY_STEPS = {
+    waterfall: {
+      badge: "Step 1: The Sea of Milk",
+      title: "Why It's Called \"Dudhsagar\"",
+      desc: "As monsoon-fed water crashes down the sheer granite face and breaks apart on rocky ledges, it froths into a milky-white torrent visible from kilometers away — earning the falls its Konkani name, Dudhsagar, meaning \"Sea of Milk\".",
+      img: "https://images.unsplash.com/photo-1667760334198-d3958029a08b?w=600&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8RHVkaHNhZ2FyfGVufDB8fDB8fHww",
+      caption: "Full-scale view of Dudhsagar's milky-white cascade over Western Ghats granite",
+      meta: [
+        { label: "River", val: "Headwater stream of the Mandovi River" },
+        { label: "Type", val: "Four-tiered segmented plunge waterfall" },
+        { label: "Rank", val: "Among India's tallest waterfalls (310m / 1,017 ft)" }
+      ]
+    },
+    height: {
+      badge: "Step 2: Four Dramatic Tiers",
+      title: "310 Meters Across Four Stages",
+      desc: "The cascade descends in four distinct segments carved into the granite of the Western Ghats, each stage widening or narrowing depending on rainfall, before crashing into a plunge pool beside the historic railway viaduct.",
+      img: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSKZaLl7yMySTVDhZkcD47H5s072E--gji2-r7nLf-3xg&s=10",
+      caption: "The four-tiered plunge structure of Dudhsagar Falls, viewed from the base pool",
+      meta: [
+        { label: "Total Height", val: "310 meters (1,017 feet)" },
+        { label: "Tiers", val: "Four segmented drops of roughly 110m, 80m, 60m, 60m" },
+        { label: "Base Feature", val: "Natural plunge pool beside the railway viaduct" }
+      ]
+    },
+    landscape: {
+      badge: "Step 3: Bhagwan Mahavir Wildlife Sanctuary",
+      title: "Mandovi Headwaters & Western Ghats Rainforest",
+      desc: "The falls lie inside the Bhagwan Mahavir Wildlife Sanctuary and Mollem National Park, part of the UNESCO-recognized Western Ghats, feeding a headwater stream that eventually joins the Mandovi River, Goa's principal waterway.",
+      img: "https://plus.unsplash.com/premium_photo-1661832611972-b6ee1aba3581?w=600&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8QmhhZ3dhbiUyME1haGF2aXIlMjBXaWxkbGlmZSUyMFNhbmN0dWFyeXxlbnwwfHwwfHx8MA%3D%3D",
+      caption: "Evergreen Western Ghats forest surrounding the Mandovi headwaters near Dudhsagar",
+      meta: [
+        { label: "Protected Area", val: "Bhagwan Mahavir Wildlife Sanctuary & Mollem National Park" },
+        { label: "Key Wildlife", val: "Gaur, sambar deer, giant squirrels, leopards" },
+        { label: "River System", val: "Feeds into the Mandovi River basin" }
+      ]
+    },
+    season: {
+      badge: "Step 4: Seasonal Transformation",
+      title: "Monsoon Torrent to Post-Monsoon Calm",
+      desc: "June to September brings the falls to full milky-white flood, though jeep access is restricted for safety. October to February offers the best balance of strong flow and open access, while March to May sees the falls reduced to a slender trickle.",
+      img: "https://images.unsplash.com/photo-1652120704209-14cbc87b603f?w=600&auto=format&fit=crop&q=60&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxzZWFyY2h8NHx8RHVkaHNhZ2FyfGVufDB8fDB8fHww",
+      caption: "Post-monsoon view of Dudhsagar with clear skies and full jeep-safari access",
+      meta: [
+        { label: "Best Visiting Season", val: "October to February" },
+        { label: "Monsoon Access", val: "Jeep tracks often closed for safety (Jun-Sep)" },
+        { label: "Summer Flow", val: "Reduced to a slender stream (Mar-May)" }
+      ]
+    },
+    location: {
+      badge: "Step 5: Geographic Setting",
+      title: "Goa-Karnataka Border, Western Ghats",
+      desc: "Dudhsagar sits on the Goa-Karnataka border inside Dharbandora taluka, roughly 60 km from Panaji, reached via jeep safari from Kulem or Sonaulim, or by rail along the scenic Castle Rock-Kulem line.",
+      img: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRUNq5KqnCVKdSbN16l0tkIuv-3Wk4YzhMfFPZnHP3Jvg&s=10",
+      caption: "Western Ghats terrain along the Goa-Karnataka border near Dudhsagar",
+      meta: [
+        { label: "District", val: "South Goa, Dharbandora taluka" },
+        { label: "Entry Points", val: "Kulem / Sonaulim (jeep) & Castle Rock (rail/trek)" },
+        { label: "Nearest Hub", val: "Panaji (60 km) / Kulem Railway Station (10 km)" }
+      ]
+    }
+  };
+
+  // SEASONAL DATASET
+  const SEASON_DATA = {
+    monsoon: {
+      title: "Monsoon (June to September) — Limited Access",
+      desc: "The falls reach their most spectacular, thunderous volume, living up to the 'Sea of Milk' name. However, jeep safari tracks and forest trails are frequently closed by the forest department for visitor safety during heavy rain.",
+      flow: "Flow: Maximum, Thunderous, Milky White",
+      access: "Access: Jeep Safaris Often Suspended for Safety",
+      highlight: "Highlights: Most dramatic volume, lush green surroundings"
+    },
+    postmonsoon: {
+      title: "Post-Monsoon (October to February) — Best Season",
+      desc: "With the rains easing off, the falls still carry a strong, clear volume of water while jeep safaris from Kulem and Sonaulim run at full capacity. Cool, comfortable weather makes this the most popular and safest window to visit.",
+      flow: "Flow: Strong, Clear, Photogenic",
+      access: "Access: Jeep Safaris & Trekking Fully Open",
+      highlight: "Highlights: Best photography, safe swimming pools"
+    },
+    summer: {
+      title: "Summer (March to May) — Reduced Flow",
+      desc: "The stream thins into a slender ribbon as the dry season sets in. Fewer crowds and cooler forest shade make it a quieter visit, though the milky cascade effect is far less pronounced than in other seasons.",
+      flow: "Flow: Thin, Slender Ribbon",
+      access: "Access: Open, Lower Water Levels at Base Pool",
+      highlight: "Highlights: Fewer crowds, easier forest trekking"
+    }
+  };
+
+  // NEARBY ATTRACTIONS / LOCATION MAP SPOTS DATASET
+  const LOCATION_SPOTS = {
+    dudhsagar: {
+      title: "Dudhsagar Falls Viewpoint",
+      sub: "Bhagwan Mahavir Wildlife Sanctuary, Goa",
+      desc: "The main viewing platform sits at the base of the fourth tier, offering close-up views of the plunge pool and the railway viaduct arching overhead.",
+      dist: "60 km from Panaji, 10 km from Kulem",
+      vehicle: "Authorized open jeep safari from Kulem or Sonaulim",
+      rail: "Kulem / Collem (10 km) / Castle Rock (14 km)"
+    },
+    tambdisurla: {
+      title: "Tambdi Surla Temple",
+      sub: "Goa's Oldest Surviving Stone Temple",
+      desc: "A 12th-century Kadamba-Yadava era basalt temple dedicated to Lord Mahadev, tucked deep in the forest and reachable via a separate forest road from the main jeep circuit.",
+      dist: "~18 km from Dudhsagar Falls",
+      vehicle: "Car or bike via forest road",
+      rail: "Kulem Railway Station (~20 km)"
+    },
+    devilscanyon: {
+      title: "Devil's Canyon",
+      sub: "Turquoise Rock-Pool Gorge",
+      desc: "A striking rock gorge carved by the same headwater stream, with clear turquoise pools popular for a short, scenic stop along the jeep safari route.",
+      dist: "~5 km from Dudhsagar Falls",
+      vehicle: "Included on most jeep safari routes",
+      rail: "Kulem Railway Station (~12 km)"
+    },
+    mollem: {
+      title: "Mollem National Park",
+      sub: "Goa's Core Protected Rainforest",
+      desc: "The wider protected area surrounding the falls, with hiking trails, a small deer park, and rich birdlife across its evergreen and moist deciduous forest.",
+      dist: "Falls lie within the park boundary",
+      vehicle: "Forest department entry gate at Mollem",
+      rail: "Kulem / Collem Railway Station (~8 km)"
+    },
+    castlerock: {
+      title: "Castle Rock",
+      sub: "Scenic Karnataka Border Railway Village",
+      desc: "A quiet hill village and railway station just across the Goa-Karnataka border, popular as a starting point for treks along the scenic rail line toward the falls.",
+      dist: "~14 km from Dudhsagar Falls",
+      vehicle: "Rail or forest trekking trail",
+      rail: "Castle Rock Railway Station"
+    },
+    kulem: {
+      title: "Kulem / Sonaulim Jeep Entry Point",
+      sub: "Main Jeep Safari Starting Point",
+      desc: "The primary staging area where visitors board authorized open jeeps for the rugged ride up to the falls, with ticket counters and parking facilities.",
+      dist: "10 km to Dudhsagar Falls",
+      vehicle: "Jeep safari boarding point",
+      rail: "Kulem (Collem) Railway Station"
+    }
+  };
+
+  document.addEventListener('DOMContentLoaded', function () {
+    // Stepper Elements
+    const stepBtns = document.querySelectorAll('.step-btn');
+    const jStepBadge = document.getElementById('j-step-badge');
+    const jTitle = document.getElementById('j-title');
+    const jDesc = document.getElementById('j-desc');
+    const jMeta = document.getElementById('j-meta');
+    const jImg = document.getElementById('j-img');
+    const jCaption = document.getElementById('j-caption');
+
+    // Seasonal Elements
+    const seasonBtns = document.querySelectorAll('.season-btn');
+    const sCardTitle = document.getElementById('s-card-title');
+    const sCardDesc = document.getElementById('s-card-desc');
+    const spFlow = document.getElementById('sp-flow');
+    const spAccess = document.getElementById('sp-access');
+    const spHighlight = document.getElementById('sp-highlight');
+
+    // Attraction Cards
+    const attractionCards = document.querySelectorAll('.attraction-card');
+
+    // Map Elements
+    const circuitPins = document.querySelectorAll('.circuit-pin');
+    const locTitle = document.getElementById('loc-title');
+    const locSub = document.getElementById('loc-sub');
+    const locBody = document.getElementById('loc-body');
+    const locDist = document.getElementById('loc-dist');
+    const locVehicle = document.getElementById('loc-vehicle');
+    const locRail = document.getElementById('loc-rail');
+
+    // Theme Toggle
+    const themeToggleBtn = document.getElementById('theme-toggle');
+    if (themeToggleBtn) {
+      themeToggleBtn.addEventListener('click', function () {
+        document.body.classList.toggle('light-theme');
+        const isLight = document.body.classList.contains('light-theme');
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+      });
+    }
+
+    /**
+     * 5-Step Journey Stepper Handler
+     */
+    stepBtns.forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        stepBtns.forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+
+        const stepKey = btn.getAttribute('data-step');
+        const data = JOURNEY_STEPS[stepKey];
+        if (!data) return;
+
+        if (jStepBadge) jStepBadge.textContent = data.badge;
+        if (jTitle) jTitle.textContent = data.title;
+        if (jDesc) jDesc.textContent = data.desc;
+        if (jImg) {
+          jImg.src = data.img;
+          jImg.alt = data.caption;
+        }
+        if (jCaption) jCaption.textContent = data.caption;
+
+        if (jMeta) {
+          jMeta.innerHTML = data.meta
+            .map(m => `<div><strong>${m.label}:</strong> <span>${m.val}</span></div>`)
+            .join('');
+        }
+      });
+    });
+
+    /**
+     * Seasonal Toggle Handler
+     */
+    seasonBtns.forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        seasonBtns.forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+
+        const seasonKey = btn.getAttribute('data-season');
+        const sdata = SEASON_DATA[seasonKey];
+        if (sdata) {
+          if (sCardTitle) sCardTitle.textContent = sdata.title;
+          if (sCardDesc) sCardDesc.textContent = sdata.desc;
+          if (spFlow) spFlow.textContent = sdata.flow;
+          if (spAccess) spAccess.textContent = sdata.access;
+          if (spHighlight) spHighlight.textContent = sdata.highlight;
+        }
+      });
+    });
+
+    /**
+     * Shared updater for location/attraction info card
+     */
+    function updateLocationCard(spotKey) {
+      const data = LOCATION_SPOTS[spotKey];
+      if (!data) return;
+
+      if (locTitle) locTitle.textContent = data.title;
+      if (locSub) locSub.textContent = data.sub;
+      if (locBody) locBody.innerHTML = `<p>${data.desc}</p>`;
+      if (locDist) locDist.textContent = data.dist;
+      if (locVehicle) locVehicle.textContent = data.vehicle;
+      if (locRail) locRail.textContent = data.rail;
+    }
+
+    /**
+     * Nearby Attraction Explorer Card Handler
+     */
+    attractionCards.forEach(function (card) {
+      card.addEventListener('click', function () {
+        attractionCards.forEach(c => c.classList.remove('active'));
+        card.classList.add('active');
+
+        const spotKey = card.getAttribute('data-spot');
+        updateLocationCard(spotKey);
+
+        // Sync the map pin highlight, if present
+        circuitPins.forEach(function (pin) {
+          pin.classList.toggle('active', pin.getAttribute('data-spot') === spotKey);
+        });
+
+        // Scroll the map into gentle view context on smaller screens
+        const mapSection = document.getElementById('location-map-section');
+        if (mapSection && window.innerWidth < 768) {
+          mapSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+      });
+    });
+
+    /**
+     * Location Map Pin Handler
+     */
+    circuitPins.forEach(function (pin) {
+      pin.addEventListener('click', function () {
+        const spotKey = pin.getAttribute('data-spot');
+        updateLocationCard(spotKey);
+
+        // Sync matching attraction card, if present
+        attractionCards.forEach(function (card) {
+          card.classList.toggle('active', card.getAttribute('data-spot') === spotKey);
+        });
+      });
+
+      pin.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          pin.click();
+        }
+      });
+    });
+
+    // Mobile Menu Toggle
+    const menuToggle = document.getElementById('menu-toggle');
+    const navMenu = document.getElementById('nav-menu');
+    if (menuToggle && navMenu) {
+      menuToggle.addEventListener('click', () => navMenu.classList.toggle('active'));
+    }
+  });
+})();

--- a/frontend/dudhsagar-falls-explorer/style.css
+++ b/frontend/dudhsagar-falls-explorer/style.css
@@ -1,0 +1,592 @@
+/* ==========================================================================
+   DUDHSAGAR FALLS EXPLORER STYLES
+   ========================================================================== */
+
+:root {
+  --dudh-teal: #14b8a6;
+  --dudh-milk: #f0fdfa;
+  --forest-green: #16a34a;
+  --mist-cyan: #5eead4;
+  --water-blue: #0d9488;
+  --bg-dark: #0f172a;
+  --bg-card: #1e293b;
+  --text-primary: #f8fafc;
+  --text-secondary: #94a3b8;
+  --border-dark: rgba(255, 255, 255, 0.1);
+  --shadow-lg: 0 10px 25px -5px rgba(0, 0, 0, 0.5);
+  --radius-lg: 16px;
+  --radius-md: 10px;
+}
+
+body.light-theme {
+  --bg-dark: #f8fafc;
+  --bg-card: #ffffff;
+  --text-primary: #0f172a;
+  --text-secondary: #475569;
+  --border-dark: rgba(0, 0, 0, 0.1);
+}
+
+.dudhsagar-hero {
+  padding: 120px 24px 60px;
+  background: radial-gradient(circle at 50% 30%, rgba(20, 184, 166, 0.2) 0%, transparent 60%),
+              radial-gradient(circle at 80% 80%, rgba(94, 234, 212, 0.15) 0%, transparent 60%),
+              var(--bg-dark);
+  text-align: center;
+}
+
+.hero-container {
+  max-width: 920px;
+  margin: 0 auto;
+}
+
+.hero-badge {
+  display: inline-block;
+  padding: 6px 16px;
+  border-radius: 9999px;
+  background: rgba(20, 184, 166, 0.15);
+  border: 1px solid rgba(20, 184, 166, 0.4);
+  color: #5eead4;
+  font-weight: 600;
+  font-size: 0.9rem;
+  margin-bottom: 20px;
+}
+
+.dudhsagar-hero h1 {
+  font-family: 'Playfair Display', Georgia, serif;
+  font-size: 3.2rem;
+  color: var(--text-primary);
+  margin-bottom: 20px;
+}
+
+.dudhsagar-hero h1 span {
+  background: linear-gradient(135deg, #5eead4, #f0fdfa);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.hero-subtitle {
+  font-size: 1.15rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin-bottom: 30px;
+}
+
+.hero-pills {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.hero-pills .pill {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--border-dark);
+  padding: 6px 14px;
+  border-radius: 8px;
+  font-size: 0.85rem;
+  color: var(--text-primary);
+}
+
+/* Sections Common */
+.journey-section, .height-section, .landscape-section, .seasonal-section,
+.attractions-section, .location-map-section, .sources-section {
+  padding: 80px 24px;
+}
+
+.section-container {
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+.section-header {
+  text-align: center;
+  max-width: 760px;
+  margin: 0 auto 50px;
+}
+
+.section-tag {
+  display: inline-block;
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--dudh-teal);
+  margin-bottom: 8px;
+}
+
+.section-header h2 {
+  font-family: 'Playfair Display', Georgia, serif;
+  font-size: 2.3rem;
+  color: var(--text-primary);
+  margin-bottom: 14px;
+}
+
+.section-header p {
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+/* 5-Step Journey Stepper */
+.journey-stepper {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin-bottom: 30px;
+  flex-wrap: wrap;
+}
+
+.step-btn {
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-dark);
+  padding: 10px 20px;
+  border-radius: 9999px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.step-btn.active, .step-btn:hover {
+  background: var(--dudh-teal);
+  color: #0f172a;
+  border-color: var(--dudh-teal);
+  font-weight: 700;
+}
+
+.journey-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-dark);
+  border-radius: var(--radius-lg);
+  padding: 36px;
+  box-shadow: var(--shadow-lg);
+}
+
+.journey-content-grid {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: 36px;
+  align-items: center;
+}
+
+.step-badge {
+  display: inline-block;
+  background: rgba(20, 184, 166, 0.15);
+  color: #5eead4;
+  font-size: 0.85rem;
+  font-weight: 700;
+  padding: 4px 12px;
+  border-radius: 9999px;
+  margin-bottom: 14px;
+}
+
+.journey-text h3 {
+  font-size: 1.7rem;
+  color: var(--text-primary);
+  margin-bottom: 14px;
+}
+
+.journey-text p {
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+  line-height: 1.6;
+  margin-bottom: 24px;
+}
+
+.journey-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-top: 1px solid var(--border-dark);
+  padding-top: 18px;
+  font-size: 0.95rem;
+}
+
+.journey-meta strong {
+  color: var(--text-primary);
+}
+
+.journey-meta span {
+  color: var(--text-secondary);
+}
+
+.journey-visual img {
+  width: 100%;
+  height: 280px;
+  object-fit: cover;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
+  display: block;
+}
+
+.img-caption {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  text-align: center;
+  margin-top: 10px;
+  font-style: italic;
+}
+
+/* Height / Tier Layout */
+.height-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 24px;
+}
+
+.height-comparison-box {
+  grid-column: 1 / -1;
+}
+
+.height-tier-card, .height-comparison-box {
+  background: var(--bg-card);
+  border: 1px solid var(--border-dark);
+  border-radius: var(--radius-lg);
+  padding: 30px;
+  box-shadow: var(--shadow-lg);
+}
+
+.tier-meter {
+  height: 140px;
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 8px;
+  position: relative;
+  overflow: hidden;
+  margin-bottom: 20px;
+  display: flex;
+  align-items: flex-end;
+}
+
+.meter-bar {
+  width: 100%;
+  background: linear-gradient(180deg, #5eead4, #0d9488);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #0f172a;
+  font-weight: 700;
+  font-size: 0.8rem;
+  text-align: center;
+  padding: 4px;
+}
+
+.height-tier-card h3 {
+  font-size: 1.2rem;
+  color: var(--text-primary);
+  margin-bottom: 10px;
+}
+
+.height-tier-card p {
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+.height-comparison-box h3 {
+  font-size: 1.3rem;
+  color: var(--text-primary);
+  margin-bottom: 24px;
+}
+
+.comp-bar-row {
+  display: grid;
+  grid-template-columns: 160px 1fr 55px;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 16px;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.comp-bar-row.highlight {
+  color: var(--dudh-teal);
+  font-weight: 700;
+}
+
+.comp-bar {
+  height: 12px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.bar-fill {
+  height: 100%;
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 6px;
+}
+
+/* Landscape / Ecosystem Grid */
+.eco-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.eco-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-dark);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-lg);
+}
+
+.eco-img-box img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  display: block;
+}
+
+.eco-card-body {
+  padding: 24px;
+}
+
+.eco-card-body h3 {
+  font-size: 1.2rem;
+  color: var(--text-primary);
+  margin-bottom: 10px;
+}
+
+.eco-card-body p {
+  color: var(--text-secondary);
+  font-size: 0.92rem;
+  line-height: 1.5;
+}
+
+/* Seasonal Section */
+.season-tabs {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  margin-bottom: 30px;
+  flex-wrap: wrap;
+}
+
+.season-btn {
+  background: var(--bg-card);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-dark);
+  padding: 10px 22px;
+  border-radius: 9999px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.season-btn.active, .season-btn:hover {
+  background: var(--dudh-teal);
+  color: #0f172a;
+  border-color: var(--dudh-teal);
+  font-weight: 700;
+}
+
+.season-display-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-dark);
+  border-radius: var(--radius-lg);
+  padding: 40px;
+  max-width: 840px;
+  margin: 0 auto;
+  box-shadow: var(--shadow-lg);
+  text-align: center;
+}
+
+.season-display-card h3 {
+  font-size: 1.7rem;
+  color: var(--text-primary);
+  margin-bottom: 16px;
+}
+
+.season-display-card p {
+  color: var(--text-secondary);
+  font-size: 1.05rem;
+  line-height: 1.6;
+  margin-bottom: 28px;
+}
+
+.season-pills-row {
+  display: flex;
+  justify-content: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.sp-badge {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--border-dark);
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+/* Nearby Attraction Explorer */
+.attractions-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.attraction-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-dark);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-lg);
+  cursor: pointer;
+  text-align: left;
+  padding: 0;
+  font-family: inherit;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.attraction-card img {
+  width: 100%;
+  height: 150px;
+  object-fit: cover;
+  display: block;
+}
+
+.attraction-card-body {
+  padding: 16px 18px;
+}
+
+.attraction-card-body h4 {
+  font-size: 1.05rem;
+  color: var(--text-primary);
+  margin-bottom: 6px;
+}
+
+.attraction-card-body p {
+  font-size: 0.88rem;
+  color: var(--text-secondary);
+  line-height: 1.45;
+}
+
+.attraction-card:hover {
+  transform: translateY(-3px);
+}
+
+.attraction-card.active {
+  border-color: var(--dudh-teal);
+  box-shadow: 0 0 0 2px rgba(20, 184, 166, 0.4);
+}
+
+/* Location Map Grid */
+.loc-map-wrapper {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 30px;
+  align-items: center;
+}
+
+.loc-svg-box {
+  background: var(--bg-card);
+  border: 1px solid var(--border-dark);
+  border-radius: var(--radius-lg);
+  padding: 16px;
+  box-shadow: var(--shadow-lg);
+}
+
+.loc-svg {
+  width: 100%;
+  height: auto;
+  border-radius: var(--radius-md);
+  display: block;
+}
+
+.circuit-pin {
+  cursor: pointer;
+  transition: transform 0.2s ease;
+}
+
+.circuit-pin:hover, .circuit-pin:focus {
+  transform: scale(1.15);
+  outline: none;
+}
+
+.loc-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border-dark);
+  border-radius: var(--radius-lg);
+  padding: 36px;
+  box-shadow: var(--shadow-lg);
+}
+
+.loc-card h3 {
+  font-size: 1.6rem;
+  color: var(--text-primary);
+  margin-bottom: 8px;
+}
+
+.loc-tag {
+  display: inline-block;
+  font-size: 0.85rem;
+  color: #5eead4;
+  margin-bottom: 20px;
+  font-weight: 600;
+}
+
+.loc-card p {
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin-bottom: 24px;
+}
+
+.loc-meta-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border-top: 1px solid var(--border-dark);
+  padding-top: 20px;
+  font-size: 0.95rem;
+}
+
+.loc-meta-grid strong {
+  color: var(--text-primary);
+}
+
+.loc-meta-grid span {
+  color: var(--text-secondary);
+}
+
+/* Sources */
+.sources-section {
+  background: rgba(0, 0, 0, 0.2);
+  border-top: 1px solid var(--border-dark);
+}
+
+.sources-list {
+  list-style-type: square;
+  padding-left: 20px;
+  color: var(--text-secondary);
+  line-height: 1.8;
+}
+
+/* Responsive */
+@media (max-width: 992px) {
+  .journey-content-grid, .loc-map-wrapper {
+    grid-template-columns: 1fr;
+  }
+  .dudhsagar-hero h1 {
+    font-size: 2.5rem;
+  }
+  .comp-bar-row {
+    grid-template-columns: 120px 1fr 50px;
+  }
+}
+
+@media (max-width: 560px) {
+  .height-grid {
+    grid-template-columns: 1fr;
+  }
+  .comp-bar-row {
+    grid-template-columns: 90px 1fr 45px;
+    font-size: 0.78rem;
+  }
+}

--- a/frontend/waterfalls-of-india/script.js
+++ b/frontend/waterfalls-of-india/script.js
@@ -35,7 +35,8 @@
             flow: "Heavy during monsoons, creating a milky white appearance as it cascades down.",
             attractions: "Bhagwan Mahavir Wildlife Sanctuary, Tambdi Surla Temple.",
             image: "https://images.unsplash.com/photo-1599394676579-a1b73e35186b?auto=format&fit=crop&q=80&w=600",
-            thumb: "https://images.unsplash.com/photo-1599394676579-a1b73e35186b?auto=format&fit=crop&q=40&w=400"
+            thumb: "https://images.unsplash.com/photo-1599394676579-a1b73e35186b?auto=format&fit=crop&q=40&w=400",
+            url: "../dudhsagar-falls-explorer/index.html"
         },
         {
             id: "nohkalikai",


### PR DESCRIPTION
# Pull Request

## Description

Added a dedicated interactive explorer page for Dudhsagar Falls, covering its location, Mandovi River context, multi-tier waterfall structure, forest ecosystem, seasonal variation, access information, nearby attractions, and best visiting season.

### Interactive Features

* Multi-tier waterfall visualization
* Interactive location map
* Seasonal comparison
* Nearby attraction explorer
* Responsive layout for different viewport sizes

Also updated the Waterfalls of India landing page so the existing Dudhsagar Falls card links directly to the new explorer page.

Fixes #2165 

## Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Accessibility improvement
* [ ] Performance improvement

## How Has This Been Tested?

* [x] Tested locally in browser
* [x] Tested in both dark and light themes
* [x] Tested at mobile viewport widths
* [x] Verified no console errors

## Checklist

* [x] My code follows the [[coding standards](https://chatgpt.com/c/CONTRIBUTING.md#coding-standards)](CONTRIBUTING.md#coding-standards) of this project
* [x] I have performed a self-review of my own code
* [x] My changes generate no new warnings or errors
* [x] I have tested responsive layout (if UI change)
* [x] I have considered accessibility (aria labels, keyboard nav, focus)

## Screenshots 
<img width="1920" height="863" alt="Screenshot 2026-08-19 171015" src="https://github.com/user-attachments/assets/b94c9759-8080-40e4-a975-4ae3b3378a6e" />
<img width="1920" height="868" alt="Screenshot 2026-08-19 171025" src="https://github.com/user-attachments/assets/564f35f4-3737-4ccb-88ec-fe78dbed9166" />
