### PR TITLE
Fix #2099: Add Travancore Conch Coins Explorer

### DIFF
--- a/frontend/travancore-conch-coins-explorer/index.html
+++ b/frontend/travancore-conch-coins-explorer/index.html
@@ -1,0 +1,235 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description"
+        content="Explore Travancore's Conch Coins — an interactive symbol-evolution timeline, zoomable obverse/reverse coin viewer, ruler selector, regional mint map, and coin comparison for the coinage of the Kingdom of Travancore." />
+    <title>Explore Travancore's Conch Coins | Incredible India</title>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+        href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+        rel="stylesheet" />
+
+    <link rel="stylesheet" href="../../styles.css" />
+    <link rel="stylesheet" href="travancore.css" />
+</head>
+
+<body class="travancore-main">
+    <script>
+        (function () {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+
+    <header class="navbar" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+                <div class="nav-dropdown">
+                    <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture
+                        ▾</button>
+                    <div class="dropdown-menu">
+                        <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+                        <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical
+                            Timeline</a>
+                        <a href="../../frontend/gupta-coinage-gallery/index.html" class="dropdown-item">Gupta Coinage
+                            Gallery</a>
+                        <a href="../../frontend/kushan-gold-coinage/index.html" class="dropdown-item">Kushan Gold
+                            Coinage</a>
+                        <a href="../../frontend/vijayanagara-gold-coinage-explorer/index.html"
+                            class="dropdown-item">Vijayanagara Gold Coinage</a>
+                        <a href="../../frontend/travancore-conch-coins-explorer/index.html"
+                            class="dropdown-item">Travancore Conch Coins</a>
+                    </div>
+                </div>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+            </nav>
+        </div>
+    </header>
+
+    <main>
+        <section class="travancore-hero">
+            <div class="section-container">
+                <div class="hero-badges-row">
+                    <span class="hero-pill pill-era">👑 1729 – 1949 CE</span>
+                    <span class="hero-pill pill-mints">📍 Thiruvananthapuram & the Malabar Coast</span>
+                    <span class="hero-pill pill-metal">🐚 Gold, Silver & Copper — Marked by the Conch</span>
+                </div>
+                <h1>Explore Travancore's Conch Coins <span>(The Shankha Standard)</span></h1>
+                <p class="hero-subtitle">
+                    In 1750 CE, Maharaja Marthanda Varma dedicated the Kingdom of Travancore to
+                    Sree Padmanabhaswamy, and the deity's conch shell — the Shankha — became the
+                    kingdom's unbroken royal emblem. For two centuries it appeared on every
+                    Travancore Fanam, Chuckram, Cash, and Rupee, from tiny hand-punched gold
+                    fanams to machine-struck rupees bearing English legends, before passing into
+                    the modern emblem of Kerala after 1949.
+                </p>
+                <div id="stats-grid" class="stats-grid"></div>
+            </div>
+        </section>
+
+        <section class="travancore-ruler-section">
+            <div class="section-container">
+                <h2 class="sec-title">Select a Ruler</h2>
+                <div class="ruler-selector" id="ruler-selector"></div>
+                <div class="ruler-blurb" id="ruler-blurb"></div>
+            </div>
+        </section>
+
+        <section class="travancore-coins-section">
+            <div class="section-container">
+                <h2 class="sec-title">Coins of the Selected Ruler</h2>
+                <div class="travancore-coin-grid" id="travancore-coin-grid"></div>
+            </div>
+        </section>
+
+        <section class="travancore-viewer-section">
+            <div class="section-container">
+                <h2 class="sec-title">Interactive Coin Viewer</h2>
+                <p class="viewer-hint">Click the glowing dots to inspect symbols and inscriptions. Use the zoom
+                    controls to magnify the coin.</p>
+                <div class="info-card travancore-viewer-card" id="travancore-viewer-card">
+                    <div class="viewer-header">
+                        <h3 id="viewer-name">Select a Coin Above</h3>
+                        <div class="viewer-header-controls">
+                            <div class="zoom-controls" id="zoom-controls">
+                                <button class="zoom-btn" id="zoom-out-btn" aria-label="Zoom Out">−</button>
+                                <span class="zoom-level" id="zoom-level">100%</span>
+                                <button class="zoom-btn" id="zoom-in-btn" aria-label="Zoom In">+</button>
+                                <button class="zoom-btn zoom-reset-btn" id="zoom-reset-btn"
+                                    aria-label="Reset Zoom">Reset</button>
+                            </div>
+                            <div class="viewer-toggle" id="viewer-toggle">
+                                <button class="viewer-toggle-btn active" data-side="obverse">Obverse</button>
+                                <button class="viewer-toggle-btn" data-side="reverse">Reverse</button>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="viewer-body">
+                        <div class="viewer-coin-wrap">
+                            <div class="viewer-coin-disc" id="viewer-coin-disc">
+                                <div class="viewer-coin-inner" id="viewer-coin-inner">
+                                    <span class="disc-icon">🐚</span>
+                                    <div class="hotspot-layer" id="hotspot-layer"></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="viewer-info">
+                            <p class="viewer-face-text" id="viewer-face-text">
+                                Choose a coin from the collection above to inspect it.
+                            </p>
+                            <div class="inscription-box" id="inscription-box" hidden>
+                                <span class="inscription-label">📜 Inscription / Symbol Note</span>
+                                <p id="inscription-text"></p>
+                            </div>
+                            <div class="viewer-meta">
+                                <p id="viewer-denomination"></p>
+                                <p id="viewer-script"></p>
+                                <p id="viewer-circulation"></p>
+                                <p id="viewer-history"></p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="travancore-symbol-section">
+            <div class="section-container">
+                <h2 class="sec-title">Symbol Evolution</h2>
+                <p class="section-desc">Trace how a single symbol changed across coin types, dies, and reigns —
+                    Coin → Symbol → Design Variation → Period.</p>
+                <div class="symbol-selector" id="symbol-selector"></div>
+                <div class="symbol-meaning" id="symbol-meaning"></div>
+                <div class="symbol-evolution-track" id="symbol-evolution-track"></div>
+            </div>
+        </section>
+
+        <section class="travancore-compare-section">
+            <div class="section-container">
+                <h2 class="sec-title">Compare Coins Side-by-Side</h2>
+                <p class="section-desc">Select any two coins from across Travancore's reigns to compare their
+                    metal, denomination, script, and iconography.</p>
+                <div class="comparison-selectors">
+                    <div class="selector-group">
+                        <label for="coin-a-select">Coin A</label>
+                        <select id="coin-a-select" class="comparison-select"></select>
+                    </div>
+                    <div class="comparison-vs">VS</div>
+                    <div class="selector-group">
+                        <label for="coin-b-select">Coin B</label>
+                        <select id="coin-b-select" class="comparison-select"></select>
+                    </div>
+                </div>
+                <div class="comparison-results" id="comparison-results"></div>
+            </div>
+        </section>
+
+        <section class="travancore-timeline-section">
+            <div class="section-container">
+                <h2 class="sec-title">Historical Timeline</h2>
+                <div class="travancore-timeline" id="travancore-timeline"></div>
+            </div>
+        </section>
+
+        <section class="travancore-territory-section">
+            <div class="section-container">
+                <h2 class="sec-title">Mints & Trade Centres</h2>
+                <p class="section-desc">Click a marker to learn about that town's role in Travancore's conch
+                    coinage.</p>
+                <div class="map-layout">
+                    <div class="map-container">
+                        <div class="map-wrapper" id="map-wrapper">
+                            <svg class="india-map-svg" viewBox="0 0 400 500" xmlns="http://www.w3.org/2000/svg">
+                                <path class="map-country-outline"
+                                    d="M 200,40 L 250,60 L 280,110 L 300,160 L 310,220 L 290,270 L 300,320 L 280,380 L 250,430 L 210,470 L 170,460 L 140,410 L 120,350 L 100,290 L 90,230 L 100,170 L 120,120 L 150,70 Z" />
+                                <path class="map-peak-extent"
+                                    d="M 190,80 L 230,95 L 255,140 L 265,190 L 255,240 L 265,290 L 245,340 L 215,390 L 185,420 L 160,400 L 140,350 L 130,300 L 125,250 L 135,190 L 155,140 L 175,100 Z" />
+                                <path class="map-river" d="M 110,180 Q 200,200 280,190" />
+                                <g id="map-mint-markers"></g>
+                            </svg>
+                            <div id="map-tooltip" class="map-tooltip"></div>
+                        </div>
+                    </div>
+                    <div class="mint-info-panel" id="mint-info-panel">
+                        <div class="mint-placeholder">
+                            <span class="mint-placeholder-icon">📍</span>
+                            <h3>Select a Marker</h3>
+                            <p>Click any marker on the map to explore that town's role in Travancore's conch
+                                coinage.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="references-section">
+            <div class="section-container">
+                <h2>References & Numismatic Sources</h2>
+                <ul class="references-list" id="references-list"></ul>
+            </div>
+        </section>
+    </main>
+
+    <script src="travancore-data.js"></script>
+    <script src="travancore.js"></script>
+</body>
+
+</html>

--- a/frontend/travancore-conch-coins-explorer/travancore-data.js
+++ b/frontend/travancore-conch-coins-explorer/travancore-data.js
@@ -1,0 +1,382 @@
+// travancore-data.js
+// Data for "Explore Travancore's Conch Coins" (Kingdom of Travancore, c. 1729 CE – 1949 CE)
+
+const TRAVANCORE_STATS = [
+    { label: "Rulers Featured", value: "7" },
+    { label: "Coin Types", value: "11" },
+    { label: "Time Span", value: "~220 Years" },
+    { label: "Scripts", value: "Malayalam, Grantha, English" },
+];
+
+const TRAVANCORE_RULERS = [
+    {
+        id: "marthanda-varma",
+        name: "Marthanda Varma",
+        period: "1729 – 1758 CE",
+        blurb: "Founder of the modern Kingdom of Travancore, who unified the smaller Venad principalities and defeated the Dutch East India Company at Colachel in 1741. In 1750 CE he ceremonially dedicated the kingdom to Sree Padmanabhaswamy, ruling afterward as 'Padmanabha Dasa' — an act that fixed the deity's conch (Shankha) at the centre of Travancore's coinage and state identity.",
+        territoryNote: "Capital at Padmanabhapuram; core Venad and southern Kerala territories",
+    },
+    {
+        id: "karthika-thirunal",
+        name: "Karthika Thirunal Rama Varma (Dharma Raja)",
+        period: "1758 – 1798 CE",
+        blurb: "Remembered for his religious tolerance and for sheltering refugees during the Mysorean invasions of Kerala. Coinage under his reign continued the conch-and-Sree design established by his predecessor, while administrative activity gradually shifted toward Thiruvananthapuram.",
+        territoryNote: "Padmanabhapuram to Thiruvananthapuram; defended by the Nedumkotta line",
+    },
+    {
+        id: "gowri-lakshmi-bayi",
+        name: "Gowri Lakshmi Bayi",
+        period: "1810 – 1815 CE",
+        blurb: "One of the few Travancore rulers to issue coinage in a queen's name, ascending as ruling Maharani during a period of growing British Resident influence. Her fanams retain the conch and Sree character with subtle die variations from earlier reigns.",
+        territoryNote: "Thiruvananthapuram as capital; increasing British Resident oversight",
+    },
+    {
+        id: "swathi-thirunal",
+        name: "Swathi Thirunal Rama Varma",
+        period: "1829 – 1846 CE",
+        blurb: "A polymath king, composer, and patron of the arts and sciences, under whom die-cutting for Travancore's gold and silver coins became noticeably more refined, with sharper conch and Sree-character engraving.",
+        territoryNote: "Thiruvananthapuram; era of cultural and administrative flourishing",
+    },
+    {
+        id: "ayilyam-thirunal",
+        name: "Ayilyam Thirunal Rama Varma",
+        period: "1860 – 1880 CE",
+        blurb: "An administrative moderniser who expanded roads, postal services, and public works. Minting technology advanced from older hand-struck punches toward machine-struck dies, giving later Chuckrams far more uniform detail.",
+        territoryNote: "Thiruvananthapuram; deepening ties with British India's monetary system",
+    },
+    {
+        id: "sri-mulam-thirunal",
+        name: "Sri Mulam Thirunal Rama Varma",
+        period: "1885 – 1924 CE",
+        blurb: "Travancore's longest-reigning Maharaja, who oversaw a major currency reform introducing the machine-struck Travancore Rupee and standardising it against the older Fanam, Chuckram, and Cash denominations. He also established the Sri Mulam Popular Assembly, an early legislative body.",
+        territoryNote: "Thiruvananthapuram; currency tied closely to British Indian trade",
+    },
+    {
+        id: "chithira-thirunal",
+        name: "Sri Chithira Thirunal Bala Rama Varma",
+        period: "1931 – 1949 CE",
+        blurb: "The last ruling Maharaja of Travancore. Coinage continued through the Second World War years, including debased-metal Chuckram and Cash issues, before Travancore's 1949 accession to independent India ended royal minting — though the conch motif lived on in the new emblem of Kerala.",
+        territoryNote: "Thiruvananthapuram, until integration into the Indian Union",
+    },
+];
+
+const TRAVANCORE_COINS = [
+    {
+        id: "marthanda-varma-anantapadmanabha-fanam",
+        rulerId: "marthanda-varma",
+        coinType: "Anantapadmanabha Gold Fanam",
+        metal: "Gold",
+        denomination: "Fanam",
+        script: "Malayalam / Grantha",
+        circulation: "Padmanabhapuram and core Venad territory",
+        obverse: {
+            desc: "A dextrally-coiled conch shell (Shankha), the emblem of Sree Padmanabhaswamy, struck prominently at the centre of the tiny gold flan.",
+            hotspots: [
+                { x: 50, y: 42, label: "Conch (Shankha)", note: "The sacred conch of Vishnu-Padmanabha, adopted as Travancore's central emblem after the 1750 CE dedication of the kingdom to the deity." },
+                { x: 50, y: 72, label: "Beaded Border", note: "A dotted rim framing the design, typical of the very small punch-struck fanams of the period." },
+            ],
+        },
+        reverse: {
+            desc: "The Malayalam/Grantha 'Sree' character, an auspicious glyph invoking prosperity, filling the reverse field.",
+            hotspots: [{ x: 50, y: 50, label: "Sree Character", note: "A single ornamental glyph meaning 'auspicious' or 'sacred', used instead of a royal name on many early Travancore gold fanams." }],
+        },
+        history: "Struck soon after Marthanda Varma's 1750 CE dedication of the kingdom to Sree Padmanabhaswamy, this tiny gold coin is among the earliest to fix the conch as Travancore's defining emblem, a role it would keep for two centuries.",
+    },
+    {
+        id: "marthanda-varma-chuckram",
+        rulerId: "marthanda-varma",
+        coinType: "Silver Chuckram",
+        metal: "Silver",
+        denomination: "Chuckram (Chakram)",
+        script: "Malayalam / Grantha",
+        circulation: "Venad and expanding Travancore territory",
+        obverse: {
+            desc: "A stylised conch shell flanked by dots, hand-struck slightly off-centre as was common for the irregular flans of the period.",
+            hotspots: [{ x: 50, y: 45, label: "Conch (Shankha)", note: "The same conch emblem as the gold fanam, now extended to the silver denomination used for everyday trade." }],
+        },
+        reverse: {
+            desc: "A simple dotted or granulated field, with no royal name — identification relied on the conch alone.",
+            hotspots: [{ x: 50, y: 55, label: "Granulated Field", note: "The plain reverse reflects the small size and rapid, high-volume striking of everyday silver Chuckrams." }],
+        },
+        history: "The Chuckram was the standard silver coin of daily commerce in Travancore, worth a fraction of a gold Fanam; sixteen Cash made one Chuckram, and four Chuckrams made one Fanam.",
+    },
+    {
+        id: "karthika-thirunal-chuckram",
+        rulerId: "karthika-thirunal",
+        coinType: "Silver Chuckram",
+        metal: "Silver",
+        denomination: "Chuckram (Chakram)",
+        script: "Malayalam / Grantha",
+        circulation: "Thiruvananthapuram and Nedumkotta frontier",
+        obverse: {
+            desc: "The conch shell, now paired with the Sree character above it, a combination that becomes standard on later Travancore coinage.",
+            hotspots: [
+                { x: 50, y: 36, label: "Sree Character", note: "Added above the conch, this glyph became a near-constant companion symbol on Travancore coins from this reign onward." },
+                { x: 50, y: 62, label: "Conch (Shankha)", note: "Retained from Marthanda Varma's coinage as the unbroken royal and state emblem." },
+            ],
+        },
+        reverse: {
+            desc: "A plain granulated or dotted field, continuing the earlier reverse convention.",
+            hotspots: [{ x: 50, y: 50, label: "Dotted Field", note: "Minimal reverse decoration kept striking fast during a period of frequent Mysorean military pressure on the kingdom's northern frontier." }],
+        },
+        history: "Struck while the Nedumkotta defensive line was being built against Mysorean incursions, this Chuckram shows the Sree-and-conch pairing that would define Travancore's coin identity for the rest of its history.",
+    },
+    {
+        id: "gowri-lakshmi-bayi-fanam",
+        rulerId: "gowri-lakshmi-bayi",
+        coinType: "Gold Fanam (Queen's Issue)",
+        metal: "Gold",
+        denomination: "Fanam",
+        script: "Malayalam / Grantha",
+        circulation: "Thiruvananthapuram region",
+        obverse: {
+            desc: "The conch shell rendered with slightly finer, more rounded punch-work than earlier reigns.",
+            hotspots: [{ x: 50, y: 44, label: "Conch (Shankha)", note: "One of the rare Travancore coin issues struck under a ruling Maharani rather than a Maharaja." }],
+        },
+        reverse: {
+            desc: "The Sree character, slightly enlarged to fill more of the tiny gold flan.",
+            hotspots: [{ x: 50, y: 52, label: "Sree Character", note: "The enlarged glyph reflects small but real stylistic drift in die-cutting between reigns, useful for dating unsigned fanams." }],
+        },
+        history: "Gowri Lakshmi Bayi's coinage illustrates how Travancore's mint kept its core conch-and-Sree formula unchanged even as rule passed to a queen, prioritising currency continuity over any new royal portrait or name.",
+    },
+    {
+        id: "swathi-thirunal-fanam",
+        rulerId: "swathi-thirunal",
+        coinType: "Refined Gold Fanam",
+        metal: "Gold",
+        denomination: "Fanam",
+        script: "Malayalam / Grantha",
+        circulation: "Thiruvananthapuram and wider Travancore",
+        obverse: {
+            desc: "A crisply detailed conch shell with visible spiral ridging, reflecting improved die-cutting under Swathi Thirunal's patronage of the arts.",
+            hotspots: [{ x: 50, y: 42, label: "Conch (Shankha)", note: "The spiral ridges are engraved with noticeably more precision than on earlier fanams, a hallmark of this artistically inclined reign." }],
+        },
+        reverse: {
+            desc: "The Sree character, now flanked by small decorative dots forming a light border.",
+            hotspots: [{ x: 50, y: 50, label: "Sree Character with Border", note: "The added dotted border is a modest but deliberate design refinement typical of Swathi Thirunal-era dies." }],
+        },
+        history: "Swathi Thirunal is remembered as a composer and scholar-king; his mint's more refined conch and Sree dies mirror the broader artistic flourishing of his court.",
+    },
+    {
+        id: "swathi-thirunal-cash",
+        rulerId: "swathi-thirunal",
+        coinType: "Copper Cash (Kasu)",
+        metal: "Copper",
+        denomination: "Cash (Kasu)",
+        script: "Malayalam / Grantha",
+        circulation: "Local markets across Travancore",
+        obverse: {
+            desc: "A small conch shell at the centre of a thick copper flan, worn smooth on many surviving examples from heavy circulation.",
+            hotspots: [{ x: 50, y: 46, label: "Conch (Shankha)", note: "Even the lowest-value copper Cash carried the conch, ensuring the emblem was seen in everyday small transactions across the kingdom." }],
+        },
+        reverse: {
+            desc: "A plain field, sometimes with faint traces of a Sree character where striking pressure was uneven.",
+            hotspots: [{ x: 50, y: 55, label: "Worn Reverse", note: "Copper Cash coins saw the heaviest daily use of any Travancore denomination, so their designs wore down fastest." }],
+        },
+        history: "Sixteen Cash made one Chuckram; these small copper coins were the everyday currency of Travancore's markets, fairs, and ferry tolls.",
+    },
+    {
+        id: "ayilyam-thirunal-chuckram",
+        rulerId: "ayilyam-thirunal",
+        coinType: "Machine-Struck Silver Chuckram",
+        metal: "Silver",
+        denomination: "Chuckram (Chakram)",
+        script: "Malayalam / Grantha",
+        circulation: "Thiruvananthapuram mint, empire-wide circulation",
+        obverse: {
+            desc: "A conch shell struck with the sharp, even relief of machine minting, replacing the slightly uneven hand-struck punches of earlier reigns.",
+            hotspots: [{ x: 50, y: 40, label: "Conch (Shankha)", note: "The crisp, uniform strike marks the shift from hand punches to mechanised screw-press minting during Ayilyam Thirunal's modernisation drive." }],
+        },
+        reverse: {
+            desc: "The Sree character rendered with new mechanical precision, perfectly centred for the first time in Travancore's coin history.",
+            hotspots: [{ x: 50, y: 52, label: "Sree Character", note: "Centring this precise reflects the improved dies and striking equipment introduced as part of broader administrative modernisation." }],
+        },
+        history: "Ayilyam Thirunal's public-works modernisation extended to the mint itself, where machine striking finally gave Travancore's silver coinage consistent, well-centred designs.",
+    },
+    {
+        id: "sri-mulam-thirunal-rupee",
+        rulerId: "sri-mulam-thirunal",
+        coinType: "Travancore Rupee",
+        metal: "Silver",
+        denomination: "Rupee (= 7 Fanams)",
+        script: "Malayalam and English",
+        circulation: "Thiruvananthapuram mint; state-wide, tied to British Indian trade",
+        obverse: {
+            desc: "The conch shell at the centre, now surrounded by a Malayalam legend giving the ruler's name and regnal year, framed in a beaded circle.",
+            hotspots: [
+                { x: 50, y: 40, label: "Conch (Shankha)", note: "Kept as the coin's central device even as the denomination system was overhauled to interlock with British Indian currency." },
+                { x: 50, y: 70, label: "Regnal-Year Legend", note: "Travancore dates were given in the Malayalam Era (Kollam Era); a coin dated ME 1000 corresponds to 1825 CE, so later dates like ME 1116 fall in 1940–41 CE." },
+            ],
+        },
+        reverse: {
+            desc: "An English-language legend reading 'TRAVANCORE' with the denomination value, reflecting closer integration with British Indian commerce.",
+            hotspots: [{ x: 50, y: 50, label: "English Legend", note: "The first widespread use of English lettering on Travancore's own coinage, aimed at easing trade with British India." }],
+        },
+        history: "Introduced as part of Sri Mulam Thirunal's currency reform, the Travancore Rupee was the kingdom's highest circulating denomination, worth 7 Fanams, each Fanam worth 4 Chuckrams, each Chuckram worth 16 Cash.",
+    },
+    {
+        id: "sri-mulam-thirunal-cash",
+        rulerId: "sri-mulam-thirunal",
+        coinType: "Copper Cash with English Legend",
+        metal: "Copper",
+        denomination: "Cash (Kasu)",
+        script: "Malayalam and English",
+        circulation: "Local markets, state-wide",
+        obverse: {
+            desc: "A simplified conch shell, now smaller in relation to the coin's face to make room for a numeral value.",
+            hotspots: [{ x: 50, y: 42, label: "Conch (Shankha)", note: "Even as new numerals and English text were added, the conch remained the one constant across every Travancore denomination." }],
+        },
+        reverse: {
+            desc: "A numeral indicating the coin's cash value, with a short English abbreviation.",
+            hotspots: [{ x: 50, y: 55, label: "Numeral Value", note: "Clear numeral values made the reformed currency easier for both local and British Indian traders to use side by side." }],
+        },
+        history: "This reformed copper Cash shows how the 1901 currency overhaul modernised even the smallest denomination without displacing the conch from its central place.",
+    },
+    {
+        id: "chithira-thirunal-chuckram",
+        rulerId: "chithira-thirunal",
+        coinType: "Wartime Bronze Chuckram",
+        metal: "Bronze (debased alloy)",
+        denomination: "Chuckram (Chakram)",
+        script: "Malayalam and English",
+        circulation: "Thiruvananthapuram mint; wartime state-wide circulation",
+        obverse: {
+            desc: "A simplified conch shell struck in a duller bronze alloy, reflecting metal shortages during the Second World War.",
+            hotspots: [{ x: 50, y: 42, label: "Conch (Shankha)", note: "Even wartime economising on precious metal did not remove the conch, underlining how central it remained to Travancore's coin identity." }],
+        },
+        reverse: {
+            desc: "The Malayalam Era date and denomination, with a small English numeral for cross-reference.",
+            hotspots: [{ x: 50, y: 55, label: "Malayalam Era Date", note: "Late Chithira Thirunal coins carry Malayalam Era dates in the ME 1110s–1120s, corresponding to the 1930s–1940s CE." }],
+        },
+        history: "Issued during the last two decades of Travancore's existence as an independent kingdom, this coin bridges the wartime economy and the 1949 accession that ended royal minting altogether.",
+    },
+    {
+        id: "chithira-thirunal-final-cash",
+        rulerId: "chithira-thirunal",
+        coinType: "Final Copper Cash Issue",
+        metal: "Copper",
+        denomination: "Cash (Kasu)",
+        script: "Malayalam and English",
+        circulation: "Thiruvananthapuram mint, final years of the kingdom",
+        obverse: {
+            desc: "A small conch shell within a plain circular border, among the last coin designs struck before Travancore's 1949 accession.",
+            hotspots: [{ x: 50, y: 44, label: "Conch (Shankha)", note: "The very last coin device to carry Travancore's conch before royal minting ended — the emblem itself outlived the kingdom, passing into Kerala's state emblem." }],
+        },
+        reverse: {
+            desc: "A minimal numeral and date, with striking quality showing the mint's declining output in its final years.",
+            hotspots: [{ x: 50, y: 55, label: "Final-Years Striking", note: "Softer, less precise striking on these last issues reflects the winding down of the royal mint as integration with India approached." }],
+        },
+        history: "Among the final coins struck at the Thiruvananthapuram mint, this humble copper Cash closes two centuries of continuous conch-marked Travancore coinage.",
+    },
+];
+
+// Symbol Evolution: Coin → Symbol → Design Variation → Period
+const TRAVANCORE_SYMBOLS = [
+    {
+        id: "conch",
+        name: "Conch Shell (Shankha)",
+        icon: "🐚",
+        meaning: "The dextrally-coiled conch of Sree Padmanabhaswamy (a form of Vishnu) — Travancore's central royal and state emblem after Marthanda Varma's 1750 CE dedication of the kingdom to the deity.",
+        timeline: [
+            { period: "1729 – 1750 CE", ruler: "Marthanda Varma (early)", coinType: "Early Venad-style Fanam", variation: "A plain, simply punched conch outline, inherited from older Venad coin traditions predating the 1750 dedication." },
+            { period: "1750 – 1758 CE", ruler: "Marthanda Varma (post-dedication)", coinType: "Anantapadmanabha Gold Fanam", variation: "The conch becomes the fixed centrepiece of the coin, formally linked to the kingdom's new dedication to Padmanabhaswamy." },
+            { period: "1829 – 1846 CE", ruler: "Swathi Thirunal", variation: "Spiral ridging engraved with new precision, reflecting finer die-cutting under an artistically minded court.", coinType: "Refined Gold Fanam" },
+            { period: "1860 – 1880 CE", ruler: "Ayilyam Thirunal", coinType: "Machine-Struck Silver Chuckram", variation: "Sharp, uniform machine-struck relief replaces the slightly uneven hand-struck punches of earlier reigns." },
+            { period: "1885 – 1949 CE", ruler: "Sri Mulam Thirunal to Chithira Thirunal", coinType: "Travancore Rupee & later Cash issues", variation: "Simplified for smaller, numeral-marked coins, but never dropped — remaining the one constant symbol across every denomination until 1949." },
+        ],
+    },
+    {
+        id: "sree-character",
+        name: "Sree Character (ஸ்ரீ / ശ്രീ)",
+        icon: "🕉️",
+        meaning: "An auspicious Malayalam/Grantha glyph meaning 'sacred' or 'prosperous', used on many early fanams instead of a royal name.",
+        timeline: [
+            { period: "1750 – 1758 CE", ruler: "Marthanda Varma", coinType: "Anantapadmanabha Gold Fanam", variation: "A single plain glyph fills the reverse field, with no accompanying royal name." },
+            { period: "1758 – 1798 CE", ruler: "Karthika Thirunal (Dharma Raja)", coinType: "Silver Chuckram", variation: "Paired above the conch on the obverse for the first time, establishing the classic Sree-and-conch combination." },
+            { period: "1810 – 1815 CE", ruler: "Gowri Lakshmi Bayi", coinType: "Gold Fanam (Queen's Issue)", variation: "Slightly enlarged glyph, a subtle stylistic shift useful for dating otherwise unsigned fanams." },
+            { period: "1829 – 1846 CE", ruler: "Swathi Thirunal", coinType: "Refined Gold Fanam", variation: "Framed with a light dotted border, adding decorative refinement without changing the core glyph." },
+        ],
+    },
+    {
+        id: "lotus",
+        name: "Lotus (Padma)",
+        icon: "🪷",
+        meaning: "A recurring Vaishnava motif referencing Padmanabha ('lotus-naveled' Vishnu), sometimes appearing as a border or field ornament on higher-value coins.",
+        timeline: [
+            { period: "1750 – 1798 CE", ruler: "Marthanda Varma to Karthika Thirunal", coinType: "Ceremonial gold presentation Fanams", variation: "Small lotus-petal borders occasionally frame the conch on presentation-quality gold pieces, though rare on circulating coin." },
+            { period: "1885 – 1924 CE", ruler: "Sri Mulam Thirunal", coinType: "Commemorative & assembly medals", variation: "Lotus motifs appear more often on ceremonial medals tied to the Sri Mulam Popular Assembly rather than everyday coinage." },
+        ],
+    },
+    {
+        id: "elephant",
+        name: "Elephant",
+        icon: "🐘",
+        meaning: "A royal and auspicious animal in Kerala tradition, later adopted (alongside the conch) as a supporter figure in Travancore's formal coat of arms.",
+        timeline: [
+            { period: "19th century CE", ruler: "Various", coinType: "State seals and royal insignia (non-circulating)", variation: "Appears on official seals and royal insignia rather than everyday coin faces during most of the 19th century." },
+            { period: "20th century CE (from 1949)", ruler: "Post-1949 (Kerala state emblem)", coinType: "State Emblem of Kerala", variation: "Two elephants are added flanking the conch and national emblem in the 1960 Kerala state emblem, derived directly from Travancore's royal coat of arms." },
+        ],
+    },
+    {
+        id: "sun-moon",
+        name: "Sun and Crescent Moon",
+        icon: "☀️",
+        meaning: "A pairing symbolising eternal royal legitimacy ('as long as the sun and moon endure'), a convention shared with several other South Indian kingdoms.",
+        timeline: [
+            { period: "1758 – 1798 CE", ruler: "Karthika Thirunal (Dharma Raja)", coinType: "Ceremonial gold Fanam varieties", variation: "Occasionally struck as tiny field ornaments beside the conch on select ceremonial gold issues." },
+            { period: "1829 – 1846 CE", ruler: "Swathi Thirunal", coinType: "Presentation Fanam", variation: "Rendered with finer, smaller punches as part of the era's generally more detailed die work." },
+        ],
+    },
+    {
+        id: "palm-leaf",
+        name: "Palm Leaf / Coconut Palm",
+        icon: "🌴",
+        meaning: "A regional motif referencing Kerala's coconut and palm economy, occasionally used as a border decoration on trade-oriented coinage.",
+        timeline: [
+            { period: "1885 – 1924 CE", ruler: "Sri Mulam Thirunal", coinType: "Trade tokens and commemorative issues", variation: "Appears mainly on commercial tokens and exhibition medals tied to Travancore's coir and coconut trade, rather than on standard state coinage." },
+        ],
+    },
+];
+
+const TRAVANCORE_TIMELINE = [
+    { year: "1729 CE", title: "Marthanda Varma's Accession", desc: "Marthanda Varma begins unifying the smaller Venad principalities into the modern Kingdom of Travancore." },
+    { year: "1741 CE", title: "Battle of Colachel", desc: "Travancore defeats the Dutch East India Company, cementing regional power and confidence in the kingdom's coinage." },
+    { year: "1750 CE", title: "Thripadidanam — Dedication to Padmanabhaswamy", desc: "Marthanda Varma dedicates the kingdom to Sree Padmanabhaswamy, ruling as 'Padmanabha Dasa'; the conch becomes Travancore's fixed royal emblem." },
+    { year: "1758 CE", title: "Karthika Thirunal's Reign Begins", desc: "The Sree-and-conch pairing becomes standard on coin dies amid Mysorean military pressure on the northern frontier." },
+    { year: "1810 CE", title: "Gowri Lakshmi Bayi Ascends", desc: "One of Travancore's rare ruling-queen coin issues, struck under growing British Resident oversight." },
+    { year: "1829 CE", title: "Swathi Thirunal's Artistic Reign", desc: "Die-cutting for gold and silver coinage becomes noticeably more refined under the polymath king's patronage." },
+    { year: "c. 1870s CE", title: "Machine Minting Introduced", desc: "Ayilyam Thirunal's modernisation drive replaces hand-struck punches with mechanised screw-press striking." },
+    { year: "1901 CE", title: "Sri Mulam Thirunal's Currency Reform", desc: "The Travancore Rupee is introduced: 1 Rupee = 7 Fanams, 1 Fanam = 4 Chuckrams, 1 Chuckram = 16 Cash, with new English-language legends." },
+    { year: "1931 CE", title: "Chithira Thirunal's Reign Begins", desc: "Travancore's last ruling Maharaja takes the throne; coinage continues through the difficult wartime economy of the 1940s." },
+    { year: "1949 CE", title: "Accession to India", desc: "Travancore joins the Indian Union and royal minting ends; the conch motif is carried forward into the emblem of the new Kerala state." },
+];
+
+const TRAVANCORE_TERRITORY = [
+    { id: "thiruvananthapuram", region: "Thiruvananthapuram (Trivandrum)", note: "Travancore's capital from the later 18th century and the site of its principal mint, standing beside the Sree Padmanabhaswamy Temple whose conch gave the kingdom its central emblem.", x: 40, y: 90 },
+    { id: "padmanabhapuram", region: "Padmanabhapuram", note: "The kingdom's earlier capital under Marthanda Varma, where the earliest conch-marked gold Fanams were struck before the capital moved north.", x: 41, y: 92 },
+    { id: "nagercoil", region: "Nagercoil", note: "A key southern administrative and market town, helping circulate Travancore's silver Chuckrams and copper Cash across the far south of the kingdom.", x: 42, y: 93 },
+    { id: "kollam", region: "Kollam (Quilon)", note: "An ancient trading port with its own long coinage history, later absorbed into Travancore's monetary network as a major commercial hub.", x: 38, y: 85 },
+    { id: "alappuzha", region: "Alappuzha (Alleppey)", note: "A major 19th-century trade port built up under royal patronage, where Travancore's Rupees and Fanams changed hands alongside British Indian currency in the coir and spice trade.", x: 37, y: 80 },
+    { id: "kottayam", region: "Kottayam", note: "An inland commercial centre for the spice and plantation trade, where lower-value Chuckram and Cash coins saw the heaviest everyday circulation.", x: 39, y: 78 },
+];
+
+const TRAVANCORE_REFERENCES = [
+    { text: "Wikipedia — Travancore Fanam: history, denominations, and circulation of Travancore's traditional gold coinage.", url: "https://en.wikipedia.org/wiki/Travancore_fanam" },
+    { text: "Wikipedia — Travancore Rupee: the 1901 currency reform and its subdivision into Fanams, Chuckrams, and Cash.", url: "https://en.wikipedia.org/wiki/Travancore_rupee" },
+    { text: "Wikipedia — Emblem of Kerala: the conch (Shankha) of Padmanabhaswamy as it passed from Travancore's royal coat of arms into the modern state emblem.", url: "https://en.wikipedia.org/wiki/Emblem_of_Kerala" },
+    { text: "Wikipedia — Marthanda Varma: the founder-king's unification of Travancore and 1750 CE dedication of the kingdom to Sree Padmanabhaswamy.", url: "https://en.wikipedia.org/wiki/Marthanda_Varma" },
+    { text: "American Numismatic Society — digital collection records for South Indian princely-state coinage.", url: "https://numismatics.org/" },
+    { text: "British Museum Collection — holdings of Travancore and other South Indian princely-state coins.", url: "https://www.britishmuseum.org/collection" },
+];
+
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = {
+        TRAVANCORE_STATS,
+        TRAVANCORE_RULERS,
+        TRAVANCORE_COINS,
+        TRAVANCORE_SYMBOLS,
+        TRAVANCORE_TIMELINE,
+        TRAVANCORE_TERRITORY,
+        TRAVANCORE_REFERENCES,
+    };
+}

--- a/frontend/travancore-conch-coins-explorer/travancore.css
+++ b/frontend/travancore-conch-coins-explorer/travancore.css
@@ -1,0 +1,857 @@
+/* travancore.css — Explore Travancore's Conch Coins */
+
+:root {
+    --tv-accent: #7fd8c8;
+    /* pearl / sea-glass teal, evoking the conch shell */
+    --tv-accent-deep: #3a8f7f;
+    --tv-accent-glow: rgba(127, 216, 200, 0.35);
+}
+
+.travancore-hero {
+    padding: 4rem 0 2.5rem;
+    text-align: center;
+    background: linear-gradient(180deg, rgba(127, 216, 200, 0.08), transparent);
+}
+
+.hero-badges-row {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    margin-bottom: 1.25rem;
+}
+
+.hero-pill {
+    padding: 0.35rem 0.9rem;
+    border-radius: 999px;
+    background: rgba(127, 216, 200, 0.12);
+    border: 1px solid rgba(127, 216, 200, 0.35);
+    font-size: 0.85rem;
+    font-weight: 500;
+}
+
+.travancore-hero h1 {
+    font-family: "Playfair Display", serif;
+    font-size: clamp(2rem, 4vw, 3rem);
+    margin-bottom: 0.75rem;
+}
+
+.travancore-hero h1 span {
+    display: block;
+    font-size: 0.5em;
+    font-weight: 500;
+    opacity: 0.75;
+    margin-top: 0.35rem;
+}
+
+.hero-subtitle {
+    max-width: 720px;
+    margin: 0 auto 2rem;
+    opacity: 0.85;
+    line-height: 1.6;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 1rem;
+    max-width: 700px;
+    margin: 0 auto;
+}
+
+.stats-grid .stat-item {
+    padding: 1rem;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(127, 216, 200, 0.2);
+}
+
+.stats-grid .stat-value {
+    font-family: "Playfair Display", serif;
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--tv-accent);
+}
+
+.stats-grid .stat-label {
+    font-size: 0.78rem;
+    opacity: 0.7;
+}
+
+.sec-title {
+    font-family: "Playfair Display", serif;
+    margin-bottom: 1.25rem;
+}
+
+.section-desc {
+    font-size: 0.9rem;
+    opacity: 0.75;
+    margin: -0.5rem 0 1.25rem;
+    line-height: 1.6;
+}
+
+/* Ruler selector */
+.travancore-ruler-section {
+    padding: 1.5rem 0;
+}
+
+.ruler-selector {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-bottom: 1.25rem;
+}
+
+.ruler-chip {
+    padding: 0.6rem 1.1rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    cursor: pointer;
+    font-size: 0.9rem;
+    transition: all 0.2s ease;
+}
+
+.ruler-chip:hover {
+    border-color: var(--tv-accent);
+}
+
+.ruler-chip.active {
+    background: linear-gradient(135deg, var(--tv-accent), var(--tv-accent-deep));
+    color: #0a2622;
+    font-weight: 600;
+    border-color: var(--tv-accent);
+}
+
+.ruler-blurb {
+    padding: 1rem 1.25rem;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(127, 216, 200, 0.18);
+    font-size: 0.92rem;
+    line-height: 1.6;
+}
+
+.ruler-blurb strong {
+    color: var(--tv-accent);
+}
+
+/* Coin grid */
+.travancore-coins-section {
+    padding: 1.5rem 0;
+}
+
+.travancore-coin-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 1.1rem;
+}
+
+.travancore-coin-card {
+    padding: 1.1rem;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.035);
+    border: 1px solid rgba(127, 216, 200, 0.18);
+    cursor: pointer;
+    transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.travancore-coin-card:hover {
+    transform: translateY(-3px);
+    border-color: var(--tv-accent);
+}
+
+.travancore-coin-card.selected {
+    border-color: var(--tv-accent);
+    box-shadow: 0 0 0 2px rgba(127, 216, 200, 0.35);
+}
+
+.coin-card-icon {
+    font-size: 1.6rem;
+    margin-bottom: 0.4rem;
+}
+
+.coin-card-title {
+    font-weight: 700;
+    margin-bottom: 0.35rem;
+}
+
+.coin-card-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem;
+}
+
+.coin-card-tags span {
+    font-size: 0.68rem;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.06);
+    opacity: 0.85;
+}
+
+/* Viewer */
+.travancore-viewer-section {
+    padding: 1.5rem 0 2.5rem;
+}
+
+.viewer-hint {
+    font-size: 0.85rem;
+    opacity: 0.65;
+    margin-bottom: 1rem;
+}
+
+.travancore-viewer-card {
+    padding: 1.75rem;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.035);
+    border: 1px solid rgba(127, 216, 200, 0.2);
+}
+
+.viewer-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
+}
+
+.viewer-header h3 {
+    font-family: "Playfair Display", serif;
+    font-size: 1.25rem;
+}
+
+.viewer-header-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+}
+
+.zoom-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 999px;
+    border: 1px solid rgba(127, 216, 200, 0.3);
+    background: rgba(255, 255, 255, 0.03);
+}
+
+.zoom-btn {
+    width: 26px;
+    height: 26px;
+    border-radius: 50%;
+    border: 1px solid rgba(127, 216, 200, 0.4);
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    font-size: 0.95rem;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: all 0.2s ease;
+}
+
+.zoom-btn:hover {
+    background: rgba(127, 216, 200, 0.2);
+}
+
+.zoom-reset-btn {
+    width: auto;
+    padding: 0 0.6rem;
+    border-radius: 999px;
+    font-size: 0.72rem;
+}
+
+.zoom-level {
+    font-size: 0.75rem;
+    opacity: 0.75;
+    min-width: 38px;
+    text-align: center;
+}
+
+.viewer-toggle {
+    display: flex;
+    border-radius: 999px;
+    overflow: hidden;
+    border: 1px solid rgba(127, 216, 200, 0.4);
+}
+
+.viewer-toggle-btn {
+    padding: 0.4rem 1rem;
+    background: transparent;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    font-size: 0.85rem;
+    opacity: 0.7;
+}
+
+.viewer-toggle-btn.active {
+    background: linear-gradient(135deg, var(--tv-accent), var(--tv-accent-deep));
+    color: #0a2622;
+    font-weight: 600;
+    opacity: 1;
+}
+
+.viewer-body {
+    display: grid;
+    grid-template-columns: minmax(200px, 280px) 1fr;
+    gap: 2rem;
+    align-items: start;
+}
+
+.viewer-coin-wrap {
+    display: flex;
+    justify-content: center;
+    overflow: hidden;
+    padding: 1.5rem;
+}
+
+.viewer-coin-disc {
+    position: relative;
+    width: 220px;
+    height: 220px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: visible;
+}
+
+.viewer-coin-inner {
+    position: relative;
+    width: 220px;
+    height: 220px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: radial-gradient(circle at 35% 30%, #e8f6f2, #7fd8c8 55%, #3a8f7f 100%);
+    box-shadow: 0 0 0 4px rgba(127, 216, 200, 0.3), inset 0 0 18px rgba(0, 0, 0, 0.35);
+    transition: transform 0.25s ease;
+    transform-origin: center center;
+}
+
+.disc-icon {
+    font-size: 3.5rem;
+    opacity: 0.5;
+}
+
+.hotspot-layer {
+    position: absolute;
+    inset: 0;
+}
+
+.hotspot-dot {
+    position: absolute;
+    width: 22px;
+    height: 22px;
+    margin-left: -11px;
+    margin-top: -11px;
+    border-radius: 50%;
+    background: rgba(255, 255, 255, 0.85);
+    border: 2px solid #d7fff5;
+    box-shadow: 0 0 8px rgba(215, 255, 245, 0.9);
+    cursor: pointer;
+    animation: hotspot-pulse 1.8s ease-in-out infinite;
+}
+
+.hotspot-dot:hover,
+.hotspot-dot.active {
+    background: #d7fff5;
+    transform: scale(1.15);
+}
+
+@keyframes hotspot-pulse {
+
+    0%,
+    100% {
+        box-shadow: 0 0 6px rgba(215, 255, 245, 0.7);
+    }
+
+    50% {
+        box-shadow: 0 0 14px rgba(215, 255, 245, 1);
+    }
+}
+
+.viewer-face-text {
+    line-height: 1.6;
+    opacity: 0.9;
+    margin-bottom: 1rem;
+}
+
+.inscription-box {
+    padding: 0.85rem 1rem;
+    border-radius: 10px;
+    background: rgba(127, 216, 200, 0.1);
+    border: 1px solid rgba(127, 216, 200, 0.3);
+    margin-bottom: 1rem;
+}
+
+.inscription-label {
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--tv-accent);
+    display: block;
+    margin-bottom: 0.3rem;
+}
+
+.viewer-meta p {
+    font-size: 0.85rem;
+    line-height: 1.7;
+    opacity: 0.85;
+    margin-bottom: 0.3rem;
+}
+
+.viewer-meta p:empty {
+    display: none;
+}
+
+/* Symbol Evolution */
+.travancore-symbol-section {
+    padding: 1.5rem 0 2.5rem;
+}
+
+.symbol-selector {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-bottom: 1.25rem;
+}
+
+.symbol-chip {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.6rem 1.1rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    cursor: pointer;
+    font-size: 0.88rem;
+    transition: all 0.2s ease;
+}
+
+.symbol-chip-icon {
+    font-size: 1.05rem;
+}
+
+.symbol-chip:hover {
+    border-color: var(--tv-accent);
+}
+
+.symbol-chip.active {
+    background: linear-gradient(135deg, var(--tv-accent), var(--tv-accent-deep));
+    color: #0a2622;
+    font-weight: 600;
+    border-color: var(--tv-accent);
+}
+
+.symbol-meaning {
+    padding: 1rem 1.25rem;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(127, 216, 200, 0.18);
+    font-size: 0.92rem;
+    line-height: 1.6;
+    margin-bottom: 1.5rem;
+}
+
+.symbol-meaning strong {
+    color: var(--tv-accent);
+}
+
+.symbol-meaning-icon {
+    font-size: 1.2rem;
+}
+
+.symbol-evolution-track {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: stretch;
+    gap: 0.75rem;
+}
+
+.evolution-step {
+    flex: 1 1 220px;
+    min-width: 200px;
+    display: flex;
+    gap: 0.75rem;
+    padding: 1rem;
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(127, 216, 200, 0.2);
+}
+
+.evolution-step-num {
+    flex-shrink: 0;
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--tv-accent), var(--tv-accent-deep));
+    color: #0a2622;
+    font-weight: 700;
+    font-size: 0.85rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.evolution-period {
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: var(--tv-accent);
+}
+
+.evolution-coin {
+    font-weight: 600;
+    margin-top: 0.15rem;
+}
+
+.evolution-ruler {
+    font-size: 0.78rem;
+    opacity: 0.7;
+    margin-bottom: 0.4rem;
+}
+
+.evolution-variation {
+    font-size: 0.85rem;
+    line-height: 1.55;
+    opacity: 0.9;
+}
+
+.evolution-arrow {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.3rem;
+    color: var(--tv-accent);
+    opacity: 0.6;
+    flex: 0 0 auto;
+}
+
+/* Comparison */
+.travancore-compare-section {
+    padding: 1.5rem 0 2.5rem;
+}
+
+.comparison-selectors {
+    display: flex;
+    justify-content: center;
+    align-items: flex-end;
+    gap: 2rem;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+}
+
+.selector-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.selector-group label {
+    font-size: 0.78rem;
+    opacity: 0.7;
+}
+
+.comparison-select {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(127, 216, 200, 0.3);
+    border-radius: 8px;
+    padding: 0.6rem 1rem;
+    color: inherit;
+    font-size: 0.9rem;
+    min-width: 260px;
+    cursor: pointer;
+}
+
+.comparison-select:focus {
+    outline: none;
+    border-color: var(--tv-accent);
+}
+
+.comparison-vs {
+    font-family: "Playfair Display", serif;
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: var(--tv-accent);
+    margin-bottom: 0.5rem;
+}
+
+.comparison-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+}
+
+.comparison-table th {
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--tv-accent);
+    font-weight: 700;
+    padding: 0.9rem;
+    text-align: left;
+    border-bottom: 2px solid rgba(127, 216, 200, 0.2);
+    font-size: 0.9rem;
+}
+
+.comparison-table td {
+    padding: 0.9rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    font-size: 0.85rem;
+    line-height: 1.6;
+    vertical-align: top;
+}
+
+.attribute-name {
+    font-weight: 600;
+    width: 16%;
+}
+
+.comp-column-value {
+    width: 42%;
+}
+
+/* Timeline */
+.travancore-timeline-section {
+    padding: 1.5rem 0 2.5rem;
+}
+
+.travancore-timeline {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    border-left: 2px solid rgba(127, 216, 200, 0.35);
+    padding-left: 1.5rem;
+}
+
+.timeline-item {
+    position: relative;
+    padding: 0.75rem 1rem;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(127, 216, 200, 0.15);
+}
+
+.timeline-item::before {
+    content: "";
+    position: absolute;
+    left: -1.75rem;
+    top: 1.1rem;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--tv-accent);
+}
+
+.timeline-year {
+    font-size: 0.78rem;
+    font-weight: 700;
+    color: var(--tv-accent);
+}
+
+.timeline-title {
+    font-weight: 600;
+    margin: 0.2rem 0;
+}
+
+.timeline-desc {
+    font-size: 0.85rem;
+    opacity: 0.8;
+    line-height: 1.5;
+}
+
+/* Regional map */
+.travancore-territory-section {
+    padding: 1.5rem 0 2.5rem;
+}
+
+.map-layout {
+    display: grid;
+    grid-template-columns: minmax(260px, 380px) 1fr;
+    gap: 1.5rem;
+    align-items: start;
+}
+
+.map-container {
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid rgba(127, 216, 200, 0.18);
+    border-radius: 16px;
+    padding: 1.5rem;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    position: relative;
+}
+
+.map-wrapper {
+    position: relative;
+    width: 100%;
+    max-width: 340px;
+}
+
+.india-map-svg {
+    width: 100%;
+    height: auto;
+}
+
+.map-country-outline {
+    fill: rgba(255, 255, 255, 0.03);
+    stroke: rgba(127, 216, 200, 0.3);
+    stroke-width: 2.5px;
+}
+
+.map-peak-extent {
+    fill: rgba(127, 216, 200, 0.05);
+    stroke: rgba(127, 216, 200, 0.3);
+    stroke-width: 1.5px;
+    stroke-dasharray: 4, 4;
+}
+
+.map-river {
+    fill: none;
+    stroke: rgba(96, 165, 250, 0.25);
+    stroke-width: 2px;
+}
+
+.map-mint-marker {
+    fill: var(--tv-accent-deep);
+    stroke: #fff;
+    stroke-width: 1.5px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.map-mint-marker:hover,
+.map-mint-marker.active {
+    fill: var(--tv-accent);
+    stroke: var(--tv-accent);
+    r: 9px;
+    filter: drop-shadow(0 0 6px var(--tv-accent));
+}
+
+.map-tooltip {
+    position: absolute;
+    background: rgba(15, 23, 42, 0.95);
+    border: 1px solid rgba(127, 216, 200, 0.3);
+    border-radius: 8px;
+    padding: 0.5rem 0.75rem;
+    color: #fff;
+    font-size: 0.85rem;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+    z-index: 5;
+}
+
+.mint-info-panel {
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid rgba(127, 216, 200, 0.18);
+    border-radius: 16px;
+    padding: 1.75rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    min-height: 220px;
+}
+
+.mint-placeholder {
+    text-align: center;
+    opacity: 0.7;
+}
+
+.mint-placeholder-icon {
+    font-size: 2rem;
+    display: block;
+    margin-bottom: 0.5rem;
+}
+
+.mint-details h3 {
+    font-family: "Playfair Display", serif;
+    margin-bottom: 0.6rem;
+}
+
+.mint-desc {
+    font-size: 0.9rem;
+    line-height: 1.6;
+    opacity: 0.85;
+}
+
+/* References */
+.references-section {
+    padding: 1.5rem 0 3rem;
+}
+
+.references-section h2 {
+    font-family: "Playfair Display", serif;
+    font-size: 1.5rem;
+    margin-bottom: 1rem;
+}
+
+.references-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+}
+
+.references-list li {
+    padding: 0.75rem 1rem;
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid rgba(127, 216, 200, 0.15);
+    font-size: 0.85rem;
+    line-height: 1.5;
+}
+
+.references-list a {
+    color: var(--tv-accent);
+    text-decoration: none;
+}
+
+.references-list a:hover {
+    text-decoration: underline;
+}
+
+/* Mobile responsiveness */
+@media (max-width: 768px) {
+    .viewer-body {
+        grid-template-columns: 1fr;
+    }
+
+    .viewer-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .ruler-selector {
+        overflow-x: auto;
+        flex-wrap: nowrap;
+        padding-bottom: 0.25rem;
+    }
+
+    .symbol-selector {
+        overflow-x: auto;
+        flex-wrap: nowrap;
+        padding-bottom: 0.25rem;
+    }
+
+    .symbol-evolution-track {
+        flex-direction: column;
+    }
+
+    .evolution-arrow {
+        transform: rotate(90deg);
+    }
+
+    .map-layout {
+        grid-template-columns: 1fr;
+    }
+}

--- a/frontend/travancore-conch-coins-explorer/travancore.js
+++ b/frontend/travancore-conch-coins-explorer/travancore.js
@@ -1,0 +1,390 @@
+// travancore.js — Explore Travancore's Conch Coins logic
+
+(function () {
+    let selectedRulerId = TRAVANCORE_RULERS[0].id;
+    let selectedCoinId = null;
+    let currentSide = "obverse";
+    let activeHotspotIndex = null;
+    let zoomLevel = 1;
+    let selectedSymbolId = TRAVANCORE_SYMBOLS[0].id;
+    const ZOOM_MIN = 1;
+    const ZOOM_MAX = 2.5;
+    const ZOOM_STEP = 0.25;
+
+    function renderStats() {
+        const grid = document.getElementById("stats-grid");
+        if (!grid) return;
+        grid.innerHTML = TRAVANCORE_STATS.map(
+            (s) => `
+            <div class="stat-item">
+                <div class="stat-value">${s.value}</div>
+                <div class="stat-label">${s.label}</div>
+            </div>`
+        ).join("");
+    }
+
+    function renderRulerSelector() {
+        const container = document.getElementById("ruler-selector");
+        if (!container) return;
+        container.innerHTML = TRAVANCORE_RULERS.map(
+            (r) => `
+            <button class="ruler-chip${r.id === selectedRulerId ? " active" : ""}" data-id="${r.id}">
+                ${r.name}
+            </button>`
+        ).join("");
+
+        container.querySelectorAll(".ruler-chip").forEach((btn) => {
+            btn.addEventListener("click", () => {
+                selectedRulerId = btn.dataset.id;
+                selectedCoinId = null;
+                renderRulerSelector();
+                renderRulerBlurb();
+                renderCoinGrid();
+                renderViewer();
+            });
+        });
+    }
+
+    function renderRulerBlurb() {
+        const ruler = TRAVANCORE_RULERS.find((r) => r.id === selectedRulerId);
+        const el = document.getElementById("ruler-blurb");
+        if (!el || !ruler) return;
+        el.innerHTML = `<strong>${ruler.name}</strong> (${ruler.period}) — ${ruler.blurb} <br/><em>Territory: ${ruler.territoryNote}</em>`;
+    }
+
+    function getRulerCoins() {
+        return TRAVANCORE_COINS.filter((c) => c.rulerId === selectedRulerId);
+    }
+
+    function renderCoinGrid() {
+        const grid = document.getElementById("travancore-coin-grid");
+        if (!grid) return;
+        const coins = getRulerCoins();
+
+        grid.innerHTML = coins
+            .map(
+                (coin) => `
+            <div class="travancore-coin-card${coin.id === selectedCoinId ? " selected" : ""}" data-id="${coin.id}">
+                <div class="coin-card-icon">🐚</div>
+                <div class="coin-card-title">${coin.coinType}</div>
+                <div class="coin-card-tags">
+                    <span>${coin.metal}</span>
+                    <span>${coin.denomination}</span>
+                    <span>${coin.script}</span>
+                </div>
+            </div>`
+            )
+            .join("");
+
+        grid.querySelectorAll(".travancore-coin-card").forEach((card) => {
+            card.addEventListener("click", () => selectCoin(card.dataset.id));
+        });
+    }
+
+    function selectCoin(id) {
+        selectedCoinId = id;
+        currentSide = "obverse";
+        activeHotspotIndex = null;
+        resetZoom();
+        renderCoinGrid();
+        renderViewer();
+        document.getElementById("travancore-viewer-card").scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+
+    function applyZoom() {
+        const inner = document.getElementById("viewer-coin-inner");
+        const levelEl = document.getElementById("zoom-level");
+        if (inner) inner.style.transform = `scale(${zoomLevel})`;
+        if (levelEl) levelEl.textContent = `${Math.round(zoomLevel * 100)}%`;
+    }
+
+    function resetZoom() {
+        zoomLevel = 1;
+        applyZoom();
+    }
+
+    function bindZoomControls() {
+        const inBtn = document.getElementById("zoom-in-btn");
+        const outBtn = document.getElementById("zoom-out-btn");
+        const resetBtn = document.getElementById("zoom-reset-btn");
+        if (inBtn) {
+            inBtn.addEventListener("click", () => {
+                zoomLevel = Math.min(ZOOM_MAX, +(zoomLevel + ZOOM_STEP).toFixed(2));
+                applyZoom();
+            });
+        }
+        if (outBtn) {
+            outBtn.addEventListener("click", () => {
+                zoomLevel = Math.max(ZOOM_MIN, +(zoomLevel - ZOOM_STEP).toFixed(2));
+                applyZoom();
+            });
+        }
+        if (resetBtn) {
+            resetBtn.addEventListener("click", resetZoom);
+        }
+    }
+
+    function renderViewer() {
+        const coin = TRAVANCORE_COINS.find((c) => c.id === selectedCoinId);
+        const nameEl = document.getElementById("viewer-name");
+        const faceText = document.getElementById("viewer-face-text");
+        const hotspotLayer = document.getElementById("hotspot-layer");
+        const inscriptionBox = document.getElementById("inscription-box");
+        const inscriptionText = document.getElementById("inscription-text");
+        const denomEl = document.getElementById("viewer-denomination");
+        const scriptEl = document.getElementById("viewer-script");
+        const circEl = document.getElementById("viewer-circulation");
+        const historyEl = document.getElementById("viewer-history");
+
+        document.querySelectorAll(".viewer-toggle-btn").forEach((btn) => {
+            btn.classList.toggle("active", btn.dataset.side === currentSide);
+        });
+
+        if (!coin) {
+            nameEl.textContent = "Select a Coin Above";
+            faceText.textContent = "Choose a coin from the collection above to inspect it.";
+            hotspotLayer.innerHTML = "";
+            inscriptionBox.hidden = true;
+            denomEl.textContent = "";
+            scriptEl.textContent = "";
+            circEl.textContent = "";
+            historyEl.textContent = "";
+            return;
+        }
+
+        const ruler = TRAVANCORE_RULERS.find((r) => r.id === coin.rulerId);
+        const face = coin[currentSide];
+
+        nameEl.textContent = `${ruler ? ruler.name : ""} — ${coin.coinType}`;
+        faceText.textContent = face.desc;
+        denomEl.textContent = `🐚 Denomination: ${coin.denomination}`;
+        scriptEl.textContent = `📝 Script: ${coin.script}`;
+        circEl.textContent = `📍 Circulation: ${coin.circulation}`;
+        historyEl.textContent = `📖 ${coin.history}`;
+
+        inscriptionBox.hidden = true;
+        inscriptionText.textContent = "";
+
+        hotspotLayer.innerHTML = face.hotspots
+            .map(
+                (h, i) => `
+            <div class="hotspot-dot${i === activeHotspotIndex ? " active" : ""}"
+                 style="left:${h.x}%; top:${h.y}%;"
+                 data-index="${i}"
+                 title="${h.label}"></div>`
+            )
+            .join("");
+
+        hotspotLayer.querySelectorAll(".hotspot-dot").forEach((dot) => {
+            dot.addEventListener("click", () => {
+                const idx = Number(dot.dataset.index);
+                activeHotspotIndex = idx;
+                const h = face.hotspots[idx];
+                inscriptionBox.hidden = false;
+                inscriptionText.textContent = `${h.label}: ${h.note}`;
+                renderViewer();
+            });
+        });
+    }
+
+    function bindViewerToggle() {
+        document.querySelectorAll(".viewer-toggle-btn").forEach((btn) => {
+            btn.addEventListener("click", () => {
+                currentSide = btn.dataset.side;
+                activeHotspotIndex = null;
+                renderViewer();
+            });
+        });
+    }
+
+    // --- Symbol Evolution: Coin → Symbol → Design Variation → Period ---
+    function renderSymbolSelector() {
+        const container = document.getElementById("symbol-selector");
+        if (!container) return;
+        container.innerHTML = TRAVANCORE_SYMBOLS.map(
+            (s) => `
+            <button class="symbol-chip${s.id === selectedSymbolId ? " active" : ""}" data-id="${s.id}">
+                <span class="symbol-chip-icon">${s.icon}</span> ${s.name}
+            </button>`
+        ).join("");
+
+        container.querySelectorAll(".symbol-chip").forEach((btn) => {
+            btn.addEventListener("click", () => {
+                selectedSymbolId = btn.dataset.id;
+                renderSymbolSelector();
+                renderSymbolEvolution();
+            });
+        });
+    }
+
+    function renderSymbolEvolution() {
+        const symbol = TRAVANCORE_SYMBOLS.find((s) => s.id === selectedSymbolId);
+        const meaningEl = document.getElementById("symbol-meaning");
+        const evoEl = document.getElementById("symbol-evolution-track");
+        if (!symbol || !meaningEl || !evoEl) return;
+
+        meaningEl.innerHTML = `<span class="symbol-meaning-icon">${symbol.icon}</span> <strong>${symbol.name}</strong> — ${symbol.meaning}`;
+
+        evoEl.innerHTML = symbol.timeline
+            .map(
+                (t, i) => `
+            <div class="evolution-step">
+                <div class="evolution-step-num">${i + 1}</div>
+                <div class="evolution-step-body">
+                    <div class="evolution-period">${t.period}</div>
+                    <div class="evolution-coin">${t.coinType}</div>
+                    <div class="evolution-ruler">${t.ruler}</div>
+                    <p class="evolution-variation">${t.variation}</p>
+                </div>
+            </div>`
+            )
+            .join(`<div class="evolution-arrow">→</div>`);
+    }
+
+    function renderTimeline() {
+        const el = document.getElementById("travancore-timeline");
+        if (!el) return;
+        el.innerHTML = TRAVANCORE_TIMELINE.map(
+            (t) => `
+            <div class="timeline-item">
+                <div class="timeline-year">${t.year}</div>
+                <div class="timeline-title">${t.title}</div>
+                <div class="timeline-desc">${t.desc}</div>
+            </div>`
+        ).join("");
+    }
+
+    // --- Regional Map ---
+    function renderTerritoryMap() {
+        const markersContainer = document.getElementById("map-mint-markers");
+        if (!markersContainer) return;
+
+        markersContainer.innerHTML = TRAVANCORE_TERRITORY.map(
+            (mint, index) => `
+            <circle class="map-mint-marker"
+                    cx="${(mint.x / 100) * 400}"
+                    cy="${(mint.y / 100) * 500}"
+                    r="7"
+                    data-index="${index}"
+                    tabindex="0"
+                    aria-label="Mint or trade centre at ${mint.region}"></circle>`
+        ).join("");
+
+        const tooltip = document.getElementById("map-tooltip");
+        const markers = markersContainer.querySelectorAll(".map-mint-marker");
+
+        markers.forEach((marker) => {
+            marker.addEventListener("mouseenter", function (e) {
+                const index = parseInt(this.getAttribute("data-index"), 10);
+                const mint = TRAVANCORE_TERRITORY[index];
+                if (tooltip) {
+                    tooltip.textContent = mint.region;
+                    tooltip.style.opacity = "1";
+                    tooltip.style.left = `${e.offsetX + 15}px`;
+                    tooltip.style.top = `${e.offsetY - 15}px`;
+                }
+            });
+
+            marker.addEventListener("mouseleave", () => {
+                if (tooltip) tooltip.style.opacity = "0";
+            });
+
+            marker.addEventListener("click", function () {
+                const index = parseInt(this.getAttribute("data-index"), 10);
+                markers.forEach((m) => m.classList.remove("active"));
+                this.classList.add("active");
+                renderMintDetails(index);
+            });
+        });
+    }
+
+    function renderMintDetails(index) {
+        const panel = document.getElementById("mint-info-panel");
+        if (!panel) return;
+        const mint = TRAVANCORE_TERRITORY[index];
+        panel.innerHTML = `
+            <div class="mint-details">
+                <h3>📍 ${mint.region}</h3>
+                <p class="mint-desc">${mint.note}</p>
+            </div>`;
+    }
+
+    // --- Coin Comparison ---
+    function initComparison() {
+        const selectA = document.getElementById("coin-a-select");
+        const selectB = document.getElementById("coin-b-select");
+        if (!selectA || !selectB) return;
+
+        const optionsHtml = TRAVANCORE_COINS.map((coin, index) => {
+            const ruler = TRAVANCORE_RULERS.find((r) => r.id === coin.rulerId);
+            return `<option value="${index}">${coin.coinType} (${ruler ? ruler.name : ""})</option>`;
+        }).join("");
+
+        selectA.innerHTML = optionsHtml;
+        selectB.innerHTML = optionsHtml;
+        if (TRAVANCORE_COINS.length > 1) selectB.value = 1;
+
+        renderComparison();
+        selectA.addEventListener("change", renderComparison);
+        selectB.addEventListener("change", renderComparison);
+    }
+
+    function renderComparison() {
+        const indexA = parseInt(document.getElementById("coin-a-select").value, 10);
+        const indexB = parseInt(document.getElementById("coin-b-select").value, 10);
+        const results = document.getElementById("comparison-results");
+        if (!results) return;
+
+        const coinA = TRAVANCORE_COINS[indexA];
+        const coinB = TRAVANCORE_COINS[indexB];
+        const rulerA = TRAVANCORE_RULERS.find((r) => r.id === coinA.rulerId);
+        const rulerB = TRAVANCORE_RULERS.find((r) => r.id === coinB.rulerId);
+
+        results.innerHTML = `
+            <table class="comparison-table">
+                <thead>
+                    <tr>
+                        <th class="attribute-name">Attribute</th>
+                        <th class="comp-column-value">${coinA.coinType}</th>
+                        <th class="comp-column-value">${coinB.coinType}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr><td class="attribute-name">Ruler</td><td>${rulerA ? rulerA.name : ""}</td><td>${rulerB ? rulerB.name : ""}</td></tr>
+                    <tr><td class="attribute-name">Metal</td><td>${coinA.metal}</td><td>${coinB.metal}</td></tr>
+                    <tr><td class="attribute-name">Denomination</td><td>${coinA.denomination}</td><td>${coinB.denomination}</td></tr>
+                    <tr><td class="attribute-name">Script</td><td>${coinA.script}</td><td>${coinB.script}</td></tr>
+                    <tr><td class="attribute-name">Circulation</td><td>${coinA.circulation}</td><td>${coinB.circulation}</td></tr>
+                    <tr><td class="attribute-name">Obverse</td><td>${coinA.obverse.desc}</td><td>${coinB.obverse.desc}</td></tr>
+                    <tr><td class="attribute-name">Reverse</td><td>${coinA.reverse.desc}</td><td>${coinB.reverse.desc}</td></tr>
+                    <tr><td class="attribute-name">Historical Note</td><td>${coinA.history}</td><td>${coinB.history}</td></tr>
+                </tbody>
+            </table>`;
+    }
+
+    function renderReferences() {
+        const el = document.getElementById("references-list");
+        if (!el) return;
+        el.innerHTML = TRAVANCORE_REFERENCES.map(
+            (r) => `<li><a href="${r.url}" target="_blank" rel="noopener">${r.text}</a></li>`
+        ).join("");
+    }
+
+    function init() {
+        renderStats();
+        renderRulerSelector();
+        renderRulerBlurb();
+        renderCoinGrid();
+        bindViewerToggle();
+        bindZoomControls();
+        renderViewer();
+        renderSymbolSelector();
+        renderSymbolEvolution();
+        renderTimeline();
+        renderTerritoryMap();
+        initComparison();
+        renderReferences();
+    }
+
+    document.addEventListener("DOMContentLoaded", init);
+})();


### PR DESCRIPTION
## Description
Adds a new interactive page — **Explore Travancore's Conch Coins** — covering the coinage of the Kingdom of Travancore (c. 1729–1949 CE), built following the existing pattern of the Gupta/Kushan/Vijayanagara coinage explorer pages.

Closes #2099

## What's Included
- **Representative coins**: 11 coin types (Fanam, Chuckram, Cash, Rupee) across 7 rulers, in Gold, Silver, and Copper
- **Conch symbol**: The Shankha of Sree Padmanabhaswamy featured as the central, unbroken emblem across every ruler and denomination
- **Other recurring symbols**: Sree character, Lotus, Elephant, Sun & Crescent Moon, Palm Leaf
- **Rulers**: Marthanda Varma through Sri Chithira Thirunal Bala Rama Varma, with selector and blurbs
- **Metals / Denominations / Scripts**: shown per coin (Malayalam, Grantha, English)
- **Mint information**: interactive regional map — Thiruvananthapuram, Padmanabhapuram, Nagercoil, Kollam, Alappuzha, Kottayam
- **Historical period**: 10-point historical timeline (1729–1949 CE)

## Interactive Features
- **Symbol Evolution component**: Coin → Symbol → Design Variation → Period, as required
- Zoomable obverse/reverse coin viewer with clickable symbol hotspots
- Side-by-side coin comparison table
- Clickable regional mint map with tooltips

## Acceptance Criteria
- [x] Symbols can be explored (Symbol Evolution section)
- [x] Different coin types can be compared (Compare Coins section)
- [x] Timeline works (Historical Timeline section)
- [x] Sources are provided (References section — Wikipedia, ANS, British Museum)

## Files Added
- `frontend/travancore-conch-coins-explorer/index.html`
- `frontend/travancore-conch-coins-explorer/travancore-data.js`
- `frontend/travancore-conch-coins-explorer/travancore.js`
- `frontend/travancore-conch-coins-explorer/travancore.css`

## Files Modified
- Added nav-dropdown link to Travancore page in: `gupta-coinage-gallery`, `kushan-gold-coinage`, `vijayanagara-gold-coinage-explorer`

## Testing
Tested locally via `python3 -m http.server 8000` — ruler selector, coin grid, zoom/hotspots, symbol evolution, comparison, timeline, and map markers all verified working. Responsive layout checked at mobile width.
<img width="1440" height="852" alt="Screenshot 2026-08-20 134803" src="https://github.com/user-attachments/assets/de97dce8-7fe1-4796-82b1-6fe6c356ebb7" />
<img width="1440" height="852" alt="Screenshot 2026-08-20 134742" src="https://github.com/user-attachments/assets/2be726c5-a508-404f-8690-bbac64219042" />
<img width="1440" height="852" alt="Screenshot 2026-08-20 134759" src="https://github.com/user-attachments/assets/61154499-06ce-4b57-bfcc-c3731b1d8dd5" />
