### PR TITLE
Fix #2728: Add Ajanta Caves Monument Page

### DIFF
--- a/frontend/ajanta-caves-explorer/index.html
+++ b/frontend/ajanta-caves-explorer/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore the Ajanta Caves in Maharashtra — India's finest surviving collection of ancient Buddhist rock-cut paintings, sculptures, and architecture.">
+  <title>Ajanta Caves Explorer | Incredible India</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="site-header">
+    <nav class="navbar" aria-label="Main navigation">
+      <a href="../../index.html" class="nav-logo" aria-label="Go to homepage">Incredible India Explorer</a>
+      <button id="theme-toggle" class="theme-btn" aria-label="Toggle dark and light theme">🌓 Theme</button>
+    </nav>
+  </header>
+
+  <main>
+    <section class="ajanta-hero" aria-labelledby="hero-title">
+      <div class="hero-content">
+        <h1 id="hero-title">Ajanta Caves Explorer</h1>
+        <p class="hero-subtitle">A UNESCO World Heritage rock-cut complex near Aurangabad (Chhatrapati Sambhajinagar), Maharashtra — home to the finest surviving Buddhist paintings and sculpture from ancient India.</p>
+        <div class="hero-badges">
+          <span class="badge">📍 Maharashtra</span>
+          <span class="badge">🖼️ Ancient Murals</span>
+          <span class="badge">🏛️ UNESCO Site</span>
+        </div>
+        <a href="#history" class="cta-button">Start Exploring ↓</a>
+      </div>
+    </section>
+
+    <section id="history" class="content-section" aria-labelledby="history-title">
+      <h2 id="history-title">History</h2>
+      <p class="section-desc">Carved in two distinct bursts of activity, seven centuries apart, into the volcanic rock of a horseshoe-shaped gorge above the Waghur River.</p>
+      <div id="history-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="buddhist-heritage" class="content-section alt-bg" aria-labelledby="bh-title">
+      <h2 id="bh-title">Buddhist Heritage</h2>
+      <p class="section-desc">Ajanta spans two major phases of Buddhist tradition, each with its own visual language.</p>
+      <div id="buddhist-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="cave-architecture" class="content-section" aria-labelledby="arch-title">
+      <h2 id="arch-title">Cave Architecture: Chaitya Halls vs. Viharas</h2>
+      <p class="section-desc">The 30 caves fall into two architectural types, each serving a different purpose in monastic life.</p>
+      <div id="architecture-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="paintings" class="content-section alt-bg" aria-labelledby="paint-title">
+      <h2 id="paint-title">Paintings</h2>
+      <p class="section-desc">Ajanta preserves the most extensive surviving body of ancient Indian painting, offering an unmatched window into classical Indian art.</p>
+      <div id="paintings-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="sculptures" class="content-section" aria-labelledby="sculpt-title">
+      <h2 id="sculpt-title">Sculptures</h2>
+      <p class="section-desc">Alongside the murals, Ajanta's carved figures and reliefs are central to understanding early Indian sculptural style.</p>
+      <div id="sculptures-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="unesco-heritage" class="content-section alt-bg" aria-labelledby="unesco-title">
+      <h2 id="unesco-title">UNESCO Heritage</h2>
+      <p class="section-desc">Inscribed as a UNESCO World Heritage Site in 1983, recognized as a masterpiece of Buddhist religious art with lasting influence across Asia.</p>
+      <ul id="unesco-list" class="facts-list" role="list"></ul>
+    </section>
+
+    <section id="conservation" class="content-section" aria-labelledby="cons-title">
+      <h2 id="cons-title">Conservation</h2>
+      <p class="section-desc">Managed today by the Archaeological Survey of India (ASI), the caves face ongoing conservation challenges.</p>
+      <div id="conservation-grid" class="card-grid" role="list"></div>
+      <h3 class="sub-heading">Interesting Facts</h3>
+      <ul id="facts-list" class="facts-list" role="list"></ul>
+    </section>
+
+    <section id="gallery" class="content-section alt-bg" aria-labelledby="gallery-title">
+      <h2 id="gallery-title">Gallery</h2>
+      <div id="gallery-grid" class="gallery-grid" role="list"></div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>&copy; 2026 Incredible India Explorer. Educational purposes only.</p>
+    <a href="../../index.html">Back to Home</a>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/ajanta-caves-explorer/script.js
+++ b/frontend/ajanta-caves-explorer/script.js
@@ -1,0 +1,121 @@
+(function() {
+  'use strict';
+
+  // Theme toggle logic
+  const themeBtn = document.getElementById('theme-toggle');
+  const body = document.body;
+
+  if (localStorage.getItem('theme') === 'light') {
+    body.classList.add('light-theme');
+  }
+
+  themeBtn.addEventListener('click', () => {
+    body.classList.toggle('light-theme');
+    localStorage.setItem('theme', body.classList.contains('light-theme') ? 'light' : 'dark');
+  });
+
+  // Data
+  const historyData = [
+    { name: 'Early (Hinayana) Phase', emoji: '⛏️', desc: 'Excavation began around the 2nd century BCE under Satavahana-era patronage, producing early prayer halls and monasteries carved into the gorge.' },
+    { name: 'Centuries of Silence', emoji: '🌿', desc: 'Work paused for several centuries, and the site saw little new activity until royal patronage returned in the 5th century CE.' },
+    { name: 'Golden (Mahayana) Phase', emoji: '🎨', desc: 'Around 460–480 CE, under Vakataka king Harishena and his court, most of the elaborately painted and sculpted caves were excavated.' },
+    { name: 'Abandonment & Rediscovery', emoji: '🐅', desc: 'Patronage ended abruptly after Harishena\'s death, leaving several caves unfinished. The site was reclaimed by jungle until a British officer, John Smith, rediscovered it in 1819 during a tiger hunt.' }
+  ];
+
+  const buddhistData = [
+    { name: 'Hinayana Tradition', emoji: '☸️', desc: 'The earliest caves follow an aniconic style, representing the Buddha through symbols such as the stupa, the Bodhi tree, and the wheel of dharma rather than a human figure.' },
+    { name: 'Mahayana Tradition', emoji: '🧘', desc: 'The later caves embrace a fully iconic style, filled with images of the Buddha and Bodhisattvas, alongside vivid narrative murals of the Jataka tales.' }
+  ];
+
+  const architectureData = [
+    { name: 'Chaitya Halls', emoji: '⛩️', desc: 'Worship halls with a horseshoe-shaped facade and a central stupa at the far end, used for congregational prayer. Caves 9, 10, 19, and 26 are the best-preserved examples.' },
+    { name: 'Viharas', emoji: '🏠', desc: 'Residential monasteries with small monks\' cells arranged around a large central hall, used for study, meditation, and daily monastic life. Most of Ajanta\'s 30 caves are viharas.' }
+  ];
+
+  const paintingsData = [
+    { name: 'Padmapani & Vajrapani', emoji: '🖌️', desc: 'The Bodhisattva figures in Cave 1 are among the most celebrated paintings in Indian art, admired for their serene expression and refined line work.' },
+    { name: 'Jataka Narrative Murals', emoji: '📜', desc: 'Extensive wall paintings in caves such as Cave 17 illustrate Jataka tales — stories of the Buddha\'s previous lives — in vivid, crowded compositions.' },
+    { name: 'Technique & Materials', emoji: '🎨', desc: 'Painted in tempera on a dry lime-plaster ground using natural mineral and plant pigments, a technique that has preserved color and detail for over 1,500 years.' }
+  ];
+
+  const sculpturesData = [
+    { name: 'Reclining Buddha, Cave 26', emoji: '🗿', desc: 'A massive relief of the Buddha in Mahaparinirvana (final release), one of the largest and most striking sculptures at the site.' },
+    { name: 'Carved Pillars & Capitals', emoji: '🏛️', desc: 'Intricately carved columns and capitals throughout the viharas showcase the evolving decorative vocabulary of ancient Indian stonework.' },
+    { name: 'Guardian Figures', emoji: '🛡️', desc: 'Dvarapala (guardian) figures flank many cave entrances, a convention that influenced temple architecture across India for centuries.' }
+  ];
+
+  const unescoData = [
+    'Inscribed as a UNESCO World Heritage Site in 1983.',
+    'Recognized as a masterpiece of human creative genius and for its profound influence on the development of Buddhist art across Asia.',
+    'Considered essential evidence for understanding the artistic, religious, and social life of ancient India, given how few painted monuments from this era survive.'
+  ];
+
+  const conservationData = [
+    { name: 'Managing Authority', emoji: '🏢', desc: 'The Archaeological Survey of India (ASI) manages and protects the site today.' },
+    { name: 'Environmental Threats', emoji: '💧', desc: 'Humidity from visitor breath and body heat encourages microbial growth that can damage the ancient paint layers.' },
+    { name: 'Protective Measures', emoji: '🚧', desc: 'Visitor numbers are regulated, protective railings and low lighting are used, and cave access is periodically rotated to reduce wear.' }
+  ];
+
+  const factsData = [
+    'The caves are carved along a horseshoe-shaped gorge above the Waghur River.',
+    'Cave 10 contains one of the earliest known Brahmi inscriptions found at the site.',
+    'The Ellora Caves, about 100 km away, are often visited together with Ajanta.',
+    'Ajanta\'s painting style directly influenced later Buddhist art across Central and East Asia via ancient trade routes.'
+  ];
+
+  const galleryData = [
+    { type: 'image', src: '../../assets/ajanta_caves.png', alt: 'Rock-cut facade of the Ajanta Caves carved into a horseshoe-shaped cliff above the Waghur River, Maharashtra', caption: 'The rock-cut cave complex above the Waghur River gorge' },
+    { type: 'icon', emoji: '🖌️', alt: 'Illustration representing the Padmapani Bodhisattva painting in Cave 1', caption: 'The celebrated Padmapani mural in Cave 1' },
+    { type: 'icon', emoji: '⛩️', alt: 'Illustration representing the horseshoe-shaped interior of a chaitya prayer hall', caption: 'Interior of a chaitya hall with its central stupa' },
+    { type: 'icon', emoji: '🗿', alt: 'Illustration representing the reclining Buddha relief sculpture in Cave 26', caption: 'The reclining Buddha (Mahaparinirvana) relief in Cave 26' }
+  ];
+
+  // Render Functions
+  function renderCards(containerId, data) {
+    const grid = document.getElementById(containerId);
+    data.forEach(item => {
+      const card = document.createElement('div');
+      card.className = 'data-card';
+      card.setAttribute('role', 'listitem');
+      card.innerHTML = `<h3>${item.emoji} ${item.name}</h3><p>${item.desc}</p>`;
+      grid.appendChild(card);
+    });
+  }
+
+  function renderList(containerId, items) {
+    const list = document.getElementById(containerId);
+    items.forEach(text => {
+      const li = document.createElement('li');
+      li.textContent = text;
+      list.appendChild(li);
+    });
+  }
+
+  function renderGallery() {
+    const grid = document.getElementById('gallery-grid');
+    galleryData.forEach(item => {
+      const div = document.createElement('div');
+      div.className = 'gallery-item';
+      div.setAttribute('role', 'listitem');
+      if (item.type === 'image') {
+        div.innerHTML = `<img src="${item.src}" alt="${item.alt}" loading="lazy"><div class="gallery-caption">${item.caption}</div>`;
+      } else {
+        div.innerHTML = `<div class="gallery-illustration" role="img" aria-label="${item.alt}">${item.emoji}</div><div class="gallery-caption">${item.caption}</div>`;
+      }
+      grid.appendChild(div);
+    });
+  }
+
+  // Initialize
+  document.addEventListener('DOMContentLoaded', () => {
+    renderCards('history-grid', historyData);
+    renderCards('buddhist-grid', buddhistData);
+    renderCards('architecture-grid', architectureData);
+    renderCards('paintings-grid', paintingsData);
+    renderCards('sculptures-grid', sculpturesData);
+    renderList('unesco-list', unescoData);
+    renderCards('conservation-grid', conservationData);
+    renderList('facts-list', factsData);
+    renderGallery();
+  });
+})();

--- a/frontend/ajanta-caves-explorer/style.css
+++ b/frontend/ajanta-caves-explorer/style.css
@@ -1,0 +1,258 @@
+/* =========================================
+   Ajanta Caves Explorer Styles
+   Supports Dark (default) and Light themes
+   ========================================= */
+
+:root {
+  --bg-primary: #1a140e;
+  --bg-secondary: #251c14;
+  --bg-alt: #2f241a;
+  --text-primary: #f7f1e8;
+  --text-secondary: #cbb99e;
+  --terracotta: #c1652f;
+  --gold: #d9a441;
+  --stone: #8a7256;
+  --card-bg: #251c14;
+  --border-color: #3d2f21;
+  --shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+}
+
+body.light-theme {
+  --bg-primary: #fbf7f0;
+  --bg-secondary: #ffffff;
+  --bg-alt: #f3e9db;
+  --text-primary: #241a10;
+  --text-secondary: #5c4a35;
+  --terracotta: #a8501f;
+  --gold: #a97a1f;
+  --stone: #6b5843;
+  --card-bg: #ffffff;
+  --border-color: #eaded0;
+  --shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.site-header {
+  background-color: var(--bg-secondary);
+  padding: 1rem 2rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  box-shadow: var(--shadow);
+}
+
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.nav-logo {
+  color: var(--terracotta);
+  text-decoration: none;
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.theme-btn {
+  background: var(--bg-alt);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+
+.theme-btn:hover {
+  background: var(--border-color);
+}
+
+.ajanta-hero {
+  background: linear-gradient(135deg, var(--bg-secondary), var(--bg-primary));
+  padding: 5rem 2rem;
+  text-align: center;
+}
+
+.hero-content {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.hero-content h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  color: var(--terracotta);
+}
+
+.hero-subtitle {
+  font-size: 1.15rem;
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.hero-badges {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.badge {
+  background: var(--bg-alt);
+  border: 1px solid var(--border-color);
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+}
+
+.cta-button {
+  display: inline-block;
+  background: var(--terracotta);
+  color: #fff;
+  padding: 0.75rem 1.75rem;
+  border-radius: 0.5rem;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.cta-button:hover {
+  opacity: 0.9;
+}
+
+.content-section {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 4rem 2rem;
+}
+
+.content-section h2 {
+  font-size: 1.8rem;
+  margin-bottom: 0.5rem;
+  color: var(--terracotta);
+}
+
+.sub-heading {
+  font-size: 1.2rem;
+  margin-top: 2rem;
+  margin-bottom: 0.25rem;
+  color: var(--gold);
+}
+
+.section-desc {
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.alt-bg {
+  background: var(--bg-secondary);
+  border-radius: 1rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.data-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  box-shadow: var(--shadow);
+}
+
+.data-card h3 {
+  margin-bottom: 0.5rem;
+  color: var(--gold);
+}
+
+.data-card p {
+  color: var(--text-secondary);
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.gallery-item {
+  border-radius: 0.75rem;
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  background: var(--card-bg);
+}
+
+.gallery-item img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  display: block;
+}
+
+.gallery-illustration {
+  width: 100%;
+  height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.75rem;
+  background: linear-gradient(135deg, var(--bg-alt), var(--border-color));
+}
+
+.gallery-caption {
+  padding: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.facts-list {
+  list-style: none;
+  margin-top: 1.5rem;
+}
+
+.facts-list li {
+  background: var(--card-bg);
+  border-left: 4px solid var(--terracotta);
+  padding: 0.9rem 1.25rem;
+  margin-bottom: 0.75rem;
+  border-radius: 0.5rem;
+  color: var(--text-secondary);
+}
+
+.site-footer {
+  text-align: center;
+  padding: 2rem;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+}
+
+.site-footer a {
+  color: var(--terracotta);
+  margin-left: 0.5rem;
+}
+
+@media (max-width: 700px) {
+  .content-section {
+    padding: 3rem 1.25rem;
+  }
+}


### PR DESCRIPTION
## What this PR does
Adds a new, dedicated Ajanta Caves page at `frontend/ajanta-caves-explorer/`, covering:
- Hero section with location (Aurangabad district, Maharashtra) and quick badges
- History of the site's two excavation phases and its 1819 rediscovery
- Buddhist Heritage: the Hinayana (aniconic) and Mahayana (iconic) traditions represented at Ajanta
- Cave Architecture: the difference between Chaitya halls (prayer halls) and Viharas (monasteries)
- Paintings: famous murals (Padmapani, Vajrapani, Jataka tale narratives) and painting technique
- Sculptures: key carved works including the reclining Buddha in Cave 26
- UNESCO Heritage: World Heritage status (inscribed 1983) and its significance for ancient Indian art
- Conservation: ASI stewardship and the environmental challenges facing the murals
- Interesting facts about the site
- A dedicated image gallery with descriptive alt text for every image, using the existing `assets/ajanta_caves.png` asset
- Responsive layout (mobile-friendly grid and spacing)

## Files added
- `frontend/ajanta-caves-explorer/index.html`
- `frontend/ajanta-caves-explorer/style.css`
- `frontend/ajanta-caves-explorer/script.js`

## Files changed
- None — this issue does not request landing-page integration, so no existing files were modified.

Closes #2728 

@Eshajha19 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Ajanta Caves Explorer webpage with historical, cultural, architectural, UNESCO, and conservation content.
  * Added image galleries, fact cards, navigation, hero content, and footer links.
  * Added persistent light and dark theme switching.
  * Added responsive layouts and accessible navigation for mobile and desktop screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->