### PR TITLE
Fix #2729: Add Ellora Caves Monument Page

### DIFF
--- a/frontend/ajanta-caves-explorer/index.html
+++ b/frontend/ajanta-caves-explorer/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore the Ajanta Caves in Maharashtra — India's finest surviving collection of ancient Buddhist rock-cut paintings, sculptures, and architecture.">
+  <title>Ajanta Caves Explorer | Incredible India</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="site-header">
+    <nav class="navbar" aria-label="Main navigation">
+      <a href="../../index.html" class="nav-logo" aria-label="Go to homepage">Incredible India Explorer</a>
+      <button id="theme-toggle" class="theme-btn" aria-label="Toggle dark and light theme">🌓 Theme</button>
+    </nav>
+  </header>
+
+  <main>
+    <section class="ajanta-hero" aria-labelledby="hero-title">
+      <div class="hero-content">
+        <h1 id="hero-title">Ajanta Caves Explorer</h1>
+        <p class="hero-subtitle">A UNESCO World Heritage rock-cut complex near Aurangabad (Chhatrapati Sambhajinagar), Maharashtra — home to the finest surviving Buddhist paintings and sculpture from ancient India.</p>
+        <div class="hero-badges">
+          <span class="badge">📍 Maharashtra</span>
+          <span class="badge">🖼️ Ancient Murals</span>
+          <span class="badge">🏛️ UNESCO Site</span>
+        </div>
+        <a href="#history" class="cta-button">Start Exploring ↓</a>
+      </div>
+    </section>
+
+    <section id="history" class="content-section" aria-labelledby="history-title">
+      <h2 id="history-title">History</h2>
+      <p class="section-desc">Carved in two distinct bursts of activity, seven centuries apart, into the volcanic rock of a horseshoe-shaped gorge above the Waghur River.</p>
+      <div id="history-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="buddhist-heritage" class="content-section alt-bg" aria-labelledby="bh-title">
+      <h2 id="bh-title">Buddhist Heritage</h2>
+      <p class="section-desc">Ajanta spans two major phases of Buddhist tradition, each with its own visual language.</p>
+      <div id="buddhist-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="cave-architecture" class="content-section" aria-labelledby="arch-title">
+      <h2 id="arch-title">Cave Architecture: Chaitya Halls vs. Viharas</h2>
+      <p class="section-desc">The 30 caves fall into two architectural types, each serving a different purpose in monastic life.</p>
+      <div id="architecture-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="paintings" class="content-section alt-bg" aria-labelledby="paint-title">
+      <h2 id="paint-title">Paintings</h2>
+      <p class="section-desc">Ajanta preserves the most extensive surviving body of ancient Indian painting, offering an unmatched window into classical Indian art.</p>
+      <div id="paintings-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="sculptures" class="content-section" aria-labelledby="sculpt-title">
+      <h2 id="sculpt-title">Sculptures</h2>
+      <p class="section-desc">Alongside the murals, Ajanta's carved figures and reliefs are central to understanding early Indian sculptural style.</p>
+      <div id="sculptures-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="unesco-heritage" class="content-section alt-bg" aria-labelledby="unesco-title">
+      <h2 id="unesco-title">UNESCO Heritage</h2>
+      <p class="section-desc">Inscribed as a UNESCO World Heritage Site in 1983, recognized as a masterpiece of Buddhist religious art with lasting influence across Asia.</p>
+      <ul id="unesco-list" class="facts-list" role="list"></ul>
+    </section>
+
+    <section id="conservation" class="content-section" aria-labelledby="cons-title">
+      <h2 id="cons-title">Conservation</h2>
+      <p class="section-desc">Managed today by the Archaeological Survey of India (ASI), the caves face ongoing conservation challenges.</p>
+      <div id="conservation-grid" class="card-grid" role="list"></div>
+      <h3 class="sub-heading">Interesting Facts</h3>
+      <ul id="facts-list" class="facts-list" role="list"></ul>
+    </section>
+
+    <section id="gallery" class="content-section alt-bg" aria-labelledby="gallery-title">
+      <h2 id="gallery-title">Gallery</h2>
+      <div id="gallery-grid" class="gallery-grid" role="list"></div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>&copy; 2026 Incredible India Explorer. Educational purposes only.</p>
+    <a href="../../index.html">Back to Home</a>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/ajanta-caves-explorer/script.js
+++ b/frontend/ajanta-caves-explorer/script.js
@@ -1,0 +1,121 @@
+(function() {
+  'use strict';
+
+  // Theme toggle logic
+  const themeBtn = document.getElementById('theme-toggle');
+  const body = document.body;
+
+  if (localStorage.getItem('theme') === 'light') {
+    body.classList.add('light-theme');
+  }
+
+  themeBtn.addEventListener('click', () => {
+    body.classList.toggle('light-theme');
+    localStorage.setItem('theme', body.classList.contains('light-theme') ? 'light' : 'dark');
+  });
+
+  // Data
+  const historyData = [
+    { name: 'Early (Hinayana) Phase', emoji: '⛏️', desc: 'Excavation began around the 2nd century BCE under Satavahana-era patronage, producing early prayer halls and monasteries carved into the gorge.' },
+    { name: 'Centuries of Silence', emoji: '🌿', desc: 'Work paused for several centuries, and the site saw little new activity until royal patronage returned in the 5th century CE.' },
+    { name: 'Golden (Mahayana) Phase', emoji: '🎨', desc: 'Around 460–480 CE, under Vakataka king Harishena and his court, most of the elaborately painted and sculpted caves were excavated.' },
+    { name: 'Abandonment & Rediscovery', emoji: '🐅', desc: 'Patronage ended abruptly after Harishena\'s death, leaving several caves unfinished. The site was reclaimed by jungle until a British officer, John Smith, rediscovered it in 1819 during a tiger hunt.' }
+  ];
+
+  const buddhistData = [
+    { name: 'Hinayana Tradition', emoji: '☸️', desc: 'The earliest caves follow an aniconic style, representing the Buddha through symbols such as the stupa, the Bodhi tree, and the wheel of dharma rather than a human figure.' },
+    { name: 'Mahayana Tradition', emoji: '🧘', desc: 'The later caves embrace a fully iconic style, filled with images of the Buddha and Bodhisattvas, alongside vivid narrative murals of the Jataka tales.' }
+  ];
+
+  const architectureData = [
+    { name: 'Chaitya Halls', emoji: '⛩️', desc: 'Worship halls with a horseshoe-shaped facade and a central stupa at the far end, used for congregational prayer. Caves 9, 10, 19, and 26 are the best-preserved examples.' },
+    { name: 'Viharas', emoji: '🏠', desc: 'Residential monasteries with small monks\' cells arranged around a large central hall, used for study, meditation, and daily monastic life. Most of Ajanta\'s 30 caves are viharas.' }
+  ];
+
+  const paintingsData = [
+    { name: 'Padmapani & Vajrapani', emoji: '🖌️', desc: 'The Bodhisattva figures in Cave 1 are among the most celebrated paintings in Indian art, admired for their serene expression and refined line work.' },
+    { name: 'Jataka Narrative Murals', emoji: '📜', desc: 'Extensive wall paintings in caves such as Cave 17 illustrate Jataka tales — stories of the Buddha\'s previous lives — in vivid, crowded compositions.' },
+    { name: 'Technique & Materials', emoji: '🎨', desc: 'Painted in tempera on a dry lime-plaster ground using natural mineral and plant pigments, a technique that has preserved color and detail for over 1,500 years.' }
+  ];
+
+  const sculpturesData = [
+    { name: 'Reclining Buddha, Cave 26', emoji: '🗿', desc: 'A massive relief of the Buddha in Mahaparinirvana (final release), one of the largest and most striking sculptures at the site.' },
+    { name: 'Carved Pillars & Capitals', emoji: '🏛️', desc: 'Intricately carved columns and capitals throughout the viharas showcase the evolving decorative vocabulary of ancient Indian stonework.' },
+    { name: 'Guardian Figures', emoji: '🛡️', desc: 'Dvarapala (guardian) figures flank many cave entrances, a convention that influenced temple architecture across India for centuries.' }
+  ];
+
+  const unescoData = [
+    'Inscribed as a UNESCO World Heritage Site in 1983.',
+    'Recognized as a masterpiece of human creative genius and for its profound influence on the development of Buddhist art across Asia.',
+    'Considered essential evidence for understanding the artistic, religious, and social life of ancient India, given how few painted monuments from this era survive.'
+  ];
+
+  const conservationData = [
+    { name: 'Managing Authority', emoji: '🏢', desc: 'The Archaeological Survey of India (ASI) manages and protects the site today.' },
+    { name: 'Environmental Threats', emoji: '💧', desc: 'Humidity from visitor breath and body heat encourages microbial growth that can damage the ancient paint layers.' },
+    { name: 'Protective Measures', emoji: '🚧', desc: 'Visitor numbers are regulated, protective railings and low lighting are used, and cave access is periodically rotated to reduce wear.' }
+  ];
+
+  const factsData = [
+    'The caves are carved along a horseshoe-shaped gorge above the Waghur River.',
+    'Cave 10 contains one of the earliest known Brahmi inscriptions found at the site.',
+    'The Ellora Caves, about 100 km away, are often visited together with Ajanta.',
+    'Ajanta\'s painting style directly influenced later Buddhist art across Central and East Asia via ancient trade routes.'
+  ];
+
+  const galleryData = [
+    { type: 'image', src: '../../assets/ajanta_caves.png', alt: 'Rock-cut facade of the Ajanta Caves carved into a horseshoe-shaped cliff above the Waghur River, Maharashtra', caption: 'The rock-cut cave complex above the Waghur River gorge' },
+    { type: 'icon', emoji: '🖌️', alt: 'Illustration representing the Padmapani Bodhisattva painting in Cave 1', caption: 'The celebrated Padmapani mural in Cave 1' },
+    { type: 'icon', emoji: '⛩️', alt: 'Illustration representing the horseshoe-shaped interior of a chaitya prayer hall', caption: 'Interior of a chaitya hall with its central stupa' },
+    { type: 'icon', emoji: '🗿', alt: 'Illustration representing the reclining Buddha relief sculpture in Cave 26', caption: 'The reclining Buddha (Mahaparinirvana) relief in Cave 26' }
+  ];
+
+  // Render Functions
+  function renderCards(containerId, data) {
+    const grid = document.getElementById(containerId);
+    data.forEach(item => {
+      const card = document.createElement('div');
+      card.className = 'data-card';
+      card.setAttribute('role', 'listitem');
+      card.innerHTML = `<h3>${item.emoji} ${item.name}</h3><p>${item.desc}</p>`;
+      grid.appendChild(card);
+    });
+  }
+
+  function renderList(containerId, items) {
+    const list = document.getElementById(containerId);
+    items.forEach(text => {
+      const li = document.createElement('li');
+      li.textContent = text;
+      list.appendChild(li);
+    });
+  }
+
+  function renderGallery() {
+    const grid = document.getElementById('gallery-grid');
+    galleryData.forEach(item => {
+      const div = document.createElement('div');
+      div.className = 'gallery-item';
+      div.setAttribute('role', 'listitem');
+      if (item.type === 'image') {
+        div.innerHTML = `<img src="${item.src}" alt="${item.alt}" loading="lazy"><div class="gallery-caption">${item.caption}</div>`;
+      } else {
+        div.innerHTML = `<div class="gallery-illustration" role="img" aria-label="${item.alt}">${item.emoji}</div><div class="gallery-caption">${item.caption}</div>`;
+      }
+      grid.appendChild(div);
+    });
+  }
+
+  // Initialize
+  document.addEventListener('DOMContentLoaded', () => {
+    renderCards('history-grid', historyData);
+    renderCards('buddhist-grid', buddhistData);
+    renderCards('architecture-grid', architectureData);
+    renderCards('paintings-grid', paintingsData);
+    renderCards('sculptures-grid', sculpturesData);
+    renderList('unesco-list', unescoData);
+    renderCards('conservation-grid', conservationData);
+    renderList('facts-list', factsData);
+    renderGallery();
+  });
+})();

--- a/frontend/ajanta-caves-explorer/style.css
+++ b/frontend/ajanta-caves-explorer/style.css
@@ -1,0 +1,258 @@
+/* =========================================
+   Ajanta Caves Explorer Styles
+   Supports Dark (default) and Light themes
+   ========================================= */
+
+:root {
+  --bg-primary: #1a140e;
+  --bg-secondary: #251c14;
+  --bg-alt: #2f241a;
+  --text-primary: #f7f1e8;
+  --text-secondary: #cbb99e;
+  --terracotta: #c1652f;
+  --gold: #d9a441;
+  --stone: #8a7256;
+  --card-bg: #251c14;
+  --border-color: #3d2f21;
+  --shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+}
+
+body.light-theme {
+  --bg-primary: #fbf7f0;
+  --bg-secondary: #ffffff;
+  --bg-alt: #f3e9db;
+  --text-primary: #241a10;
+  --text-secondary: #5c4a35;
+  --terracotta: #a8501f;
+  --gold: #a97a1f;
+  --stone: #6b5843;
+  --card-bg: #ffffff;
+  --border-color: #eaded0;
+  --shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.site-header {
+  background-color: var(--bg-secondary);
+  padding: 1rem 2rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  box-shadow: var(--shadow);
+}
+
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.nav-logo {
+  color: var(--terracotta);
+  text-decoration: none;
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.theme-btn {
+  background: var(--bg-alt);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+
+.theme-btn:hover {
+  background: var(--border-color);
+}
+
+.ajanta-hero {
+  background: linear-gradient(135deg, var(--bg-secondary), var(--bg-primary));
+  padding: 5rem 2rem;
+  text-align: center;
+}
+
+.hero-content {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.hero-content h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  color: var(--terracotta);
+}
+
+.hero-subtitle {
+  font-size: 1.15rem;
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.hero-badges {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.badge {
+  background: var(--bg-alt);
+  border: 1px solid var(--border-color);
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+}
+
+.cta-button {
+  display: inline-block;
+  background: var(--terracotta);
+  color: #fff;
+  padding: 0.75rem 1.75rem;
+  border-radius: 0.5rem;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.cta-button:hover {
+  opacity: 0.9;
+}
+
+.content-section {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 4rem 2rem;
+}
+
+.content-section h2 {
+  font-size: 1.8rem;
+  margin-bottom: 0.5rem;
+  color: var(--terracotta);
+}
+
+.sub-heading {
+  font-size: 1.2rem;
+  margin-top: 2rem;
+  margin-bottom: 0.25rem;
+  color: var(--gold);
+}
+
+.section-desc {
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.alt-bg {
+  background: var(--bg-secondary);
+  border-radius: 1rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.data-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  box-shadow: var(--shadow);
+}
+
+.data-card h3 {
+  margin-bottom: 0.5rem;
+  color: var(--gold);
+}
+
+.data-card p {
+  color: var(--text-secondary);
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.gallery-item {
+  border-radius: 0.75rem;
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  background: var(--card-bg);
+}
+
+.gallery-item img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  display: block;
+}
+
+.gallery-illustration {
+  width: 100%;
+  height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.75rem;
+  background: linear-gradient(135deg, var(--bg-alt), var(--border-color));
+}
+
+.gallery-caption {
+  padding: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.facts-list {
+  list-style: none;
+  margin-top: 1.5rem;
+}
+
+.facts-list li {
+  background: var(--card-bg);
+  border-left: 4px solid var(--terracotta);
+  padding: 0.9rem 1.25rem;
+  margin-bottom: 0.75rem;
+  border-radius: 0.5rem;
+  color: var(--text-secondary);
+}
+
+.site-footer {
+  text-align: center;
+  padding: 2rem;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+}
+
+.site-footer a {
+  color: var(--terracotta);
+  margin-left: 0.5rem;
+}
+
+@media (max-width: 700px) {
+  .content-section {
+    padding: 3rem 1.25rem;
+  }
+}

--- a/frontend/ellora-caves-explorer/index.html
+++ b/frontend/ellora-caves-explorer/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore the Ellora Caves in Maharashtra — a UNESCO World Heritage site of Buddhist, Hindu, and Jain rock-cut monuments, home to the monolithic Kailasa Temple.">
+  <title>Ellora Caves Explorer | Incredible India</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="site-header">
+    <nav class="navbar" aria-label="Main navigation">
+      <a href="../../index.html" class="nav-logo" aria-label="Go to homepage">Incredible India Explorer</a>
+      <button id="theme-toggle" class="theme-btn" aria-label="Toggle dark and light theme">🌓 Theme</button>
+    </nav>
+  </header>
+
+  <main>
+    <section class="ellora-hero" aria-labelledby="hero-title">
+      <div class="hero-content">
+        <h1 id="hero-title">Ellora Caves Explorer</h1>
+        <p class="hero-subtitle">Carved into the Charanandri Hills near Aurangabad (Chhatrapati Sambhajinagar), Maharashtra — 34 rock-cut Buddhist, Hindu, and Jain monuments standing side by side.</p>
+        <div class="hero-badges">
+          <span class="badge">📍 Maharashtra</span>
+          <span class="badge">🛕 Kailasa Temple</span>
+          <span class="badge">⛰️ Rock-Cut Wonder</span>
+        </div>
+        <a href="#history" class="cta-button">Start Exploring ↓</a>
+      </div>
+    </section>
+
+    <section id="history" class="content-section" aria-labelledby="history-title">
+      <h2 id="history-title">History</h2>
+      <p class="section-desc">Excavated in overlapping phases between roughly the 6th and 10th centuries CE, Ellora's caves record three faiths carved into the same cliff face.</p>
+      <div id="history-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="buddhist-caves" class="content-section alt-bg" aria-labelledby="buddhist-title">
+      <h2 id="buddhist-title">Buddhist Caves (1–12)</h2>
+      <p class="section-desc">The earliest group at Ellora, built as monasteries and prayer halls for Buddhist monks.</p>
+      <div id="buddhist-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="hindu-caves" class="content-section" aria-labelledby="hindu-title">
+      <h2 id="hindu-title">Hindu Caves (13–29)</h2>
+      <p class="section-desc">The largest and most elaborately carved group, dedicated mainly to Shiva and Vishnu.</p>
+      <div id="hindu-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="jain-caves" class="content-section alt-bg" aria-labelledby="jain-title">
+      <h2 id="jain-title">Jain Caves (30–34)</h2>
+      <p class="section-desc">The final phase at Ellora, marked by intricate, smaller-scale shrines to the Tirthankaras.</p>
+      <div id="jain-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="kailasa-temple" class="content-section" aria-labelledby="kailasa-title">
+      <h2 id="kailasa-title">Kailasa Temple</h2>
+      <p class="section-desc">Cave 16 — the largest monolithic rock-cut structure in the world, carved top-down from a single basalt outcrop.</p>
+      <div id="kailasa-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="rock-cut-engineering" class="content-section alt-bg" aria-labelledby="engineering-title">
+      <h2 id="engineering-title">Rock-Cut Engineering</h2>
+      <p class="section-desc">How ancient artisans carved entire temples out of solid rock — with no room for error.</p>
+      <div id="engineering-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="unesco-heritage" class="content-section" aria-labelledby="unesco-title">
+      <h2 id="unesco-title">UNESCO Heritage</h2>
+      <p class="section-desc">Inscribed as a UNESCO World Heritage Site in 1983, recognized for its architectural achievement and its testimony to religious tolerance in ancient India.</p>
+      <ul id="unesco-list" class="facts-list" role="list"></ul>
+      <h3 class="sub-heading">Interesting Facts</h3>
+      <ul id="facts-list" class="facts-list" role="list"></ul>
+    </section>
+
+    <section id="gallery" class="content-section alt-bg" aria-labelledby="gallery-title">
+      <h2 id="gallery-title">Gallery</h2>
+      <div id="gallery-grid" class="gallery-grid" role="list"></div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>&copy; 2026 Incredible India Explorer. Educational purposes only.</p>
+    <a href="../../index.html">Back to Home</a>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/ellora-caves-explorer/script.js
+++ b/frontend/ellora-caves-explorer/script.js
@@ -1,0 +1,124 @@
+(function() {
+  'use strict';
+
+  // Theme toggle logic
+  const themeBtn = document.getElementById('theme-toggle');
+  const body = document.body;
+
+  if (localStorage.getItem('theme') === 'light') {
+    body.classList.add('light-theme');
+  }
+
+  themeBtn.addEventListener('click', () => {
+    body.classList.toggle('light-theme');
+    localStorage.setItem('theme', body.classList.contains('light-theme') ? 'light' : 'dark');
+  });
+
+  // Data
+  const historyData = [
+    { name: 'Buddhist Beginnings', emoji: '☸️', desc: 'Work began around the 6th century CE with monasteries and prayer halls (Caves 1–12), built under Kalachuri and early Chalukya-era patronage.' },
+    { name: 'The Hindu Resurgence', emoji: '🕉️', desc: 'As Hindu revival gathered pace under the Rashtrakuta dynasty, work shifted to grand Hindu shrines (Caves 13–29), culminating in the Kailasa Temple in the 8th century.' },
+    { name: 'The Jain Final Phase', emoji: '🙏', desc: 'Between roughly the 9th and 12th centuries, smaller but intricately detailed Jain caves (Caves 30–34) were added at the northern end of the site.' },
+    { name: 'Religious Coexistence', emoji: '🤝', desc: 'Unlike most sacred sites, Ellora shows three religions excavating in the same cliff face over centuries without displacing one another — a rare physical record of religious tolerance in ancient India.' }
+  ];
+
+  const buddhistData = [
+    { name: 'Viharas & Chaityas', emoji: '🏠', desc: 'The 12 Buddhist caves combine monasteries (viharas) with prayer halls (chaityas), including sleeping cells carved for resident monks.' },
+    { name: 'Cave 10 — Vishwakarma', emoji: '⛩️', desc: 'A two-storeyed chaitya hall with a seated Buddha and a lively carved frieze of dancing, music-making figures.' },
+    { name: 'Cave 12 — Teen Thal', emoji: '🏛️', desc: 'A striking triple-storeyed monastery, one of the most architecturally ambitious of the Buddhist caves.' }
+  ];
+
+  const hinduData = [
+    { name: 'Dedicated Mainly to Shiva', emoji: '🔱', desc: 'Most Hindu caves at Ellora honor Shiva, alongside shrines to Vishnu and scenes from the Ramayana and Mahabharata.' },
+    { name: 'Cave 15 — Dashavatara', emoji: '🐚', desc: 'Originally begun as a Buddhist cave, later reworked with Shaiva carvings — physical evidence of the site\'s shifting religious currents.' },
+    { name: 'Cave 29 — Dhumar Lena', emoji: '🗻', desc: 'A large, dramatic Shiva temple with multiple entrances, echoing the layout of the famous Elephanta cave temple near Mumbai.' }
+  ];
+
+  const jainData = [
+    { name: 'Tirthankara Imagery', emoji: '🕊️', desc: 'The Jain caves are dedicated to the Tirthankaras — spiritual teachers of Jainism — including Mahavira and Bahubali.' },
+    { name: 'Cave 32 — Indra Sabha', emoji: '🪷', desc: 'The finest Jain cave at Ellora, a two-storeyed shrine famous for its detailed carving and a lotus motif on the ceiling.' },
+    { name: 'Cave 30 — Chhota Kailash', emoji: '🛕', desc: 'An unfinished cave echoing the Kailasa Temple\'s design in miniature, complete with a carved rock-cut elephant.' }
+  ];
+
+  const kailasaData = [
+    { name: 'Scale & Dimensions', emoji: '📏', desc: 'The structure rises about 32.6 metres (107 ft) above the court below, and its excavation is estimated to have removed roughly 200,000 tonnes of basalt rock.' },
+    { name: 'Top-Down Excavation', emoji: '⬇️', desc: 'Unlike normal construction, Kailasa was carved downward from the top of a single rock outcrop, meaning the architects had to plan the entire structure before the first cut was made.' },
+    { name: 'Royal Patronage', emoji: '👑', desc: 'Inscriptions link the temple to the Rashtrakuta king Krishna I (r. 756–773 CE), though the full extent of his role remains debated among historians.' },
+    { name: 'Sculptural Program', emoji: '🗿', desc: 'Detailed relief panels depict scenes from the Ramayana and Mahabharata, including the famous carving of the demon king Ravana shaking Mount Kailasa.' }
+  ];
+
+  const engineeringData = [
+    { name: 'Subtractive Construction', emoji: '⛏️', desc: 'Rather than building up from a foundation, artisans carved away stone from a solid cliff face — a subtractive process with no way to add material back if a mistake was made.' },
+    { name: 'Tools of the Trade', emoji: '🔨', desc: 'Craftsmen used iron chisels, hammers, and picks to remove rock in stages, gradually revealing pillars, chambers, and sculpture from the mountain itself.' },
+    { name: 'Planning in Advance', emoji: '🧭', desc: 'Especially at the Kailasa Temple, the full three-dimensional design had to be visualized before excavation began, since the finished form could not be corrected once material was removed.' }
+  ];
+
+  const unescoData = [
+    'Inscribed as a UNESCO World Heritage Site in 1983.',
+    'Recognized as a unique artistic and technological achievement and as evidence of the spirit of religious tolerance in ancient India.',
+    'Extends over more than 2 km of basalt cliff face in the Charanandri Hills.'
+  ];
+
+  const factsData = [
+    'Ellora has around 100 caves in total, of which 34 are open to the public.',
+    'The word "Ellora" is a short form of the older name "Elapura", and local caves are traditionally called "Lena" or "Leni".',
+    'Ellora lies about 30 km from Aurangabad and roughly 100 km from the Ajanta Caves.',
+    'The Kailasa Temple originally had a coat of white plaster, designed to resemble the snow-capped peak of Mount Kailash.'
+  ];
+
+  const galleryData = [
+    { type: 'image', src: '../../assets/kailasa_temple_banner.png', alt: 'The monolithic Kailasa Temple (Cave 16) carved from a single basalt rock at Ellora, Maharashtra', caption: 'The Kailasa Temple, the world\'s largest monolithic rock-cut structure' },
+    { type: 'icon', emoji: '☸️', alt: 'Illustration representing a Buddhist chaitya prayer hall at Ellora', caption: 'Buddhist prayer hall, Caves 1–12' },
+    { type: 'icon', emoji: '🔱', alt: 'Illustration representing carved Hindu deity reliefs at Ellora', caption: 'Carved Hindu deity reliefs, Caves 13–29' },
+    { type: 'icon', emoji: '🪷', alt: 'Illustration representing the Indra Sabha Jain shrine at Ellora', caption: 'The Indra Sabha Jain shrine, Cave 32' }
+  ];
+
+  // Render Functions
+  function renderCards(containerId, data) {
+    const grid = document.getElementById(containerId);
+    data.forEach(item => {
+      const card = document.createElement('div');
+      card.className = 'data-card';
+      card.setAttribute('role', 'listitem');
+      card.innerHTML = `<h3>${item.emoji} ${item.name}</h3><p>${item.desc}</p>`;
+      grid.appendChild(card);
+    });
+  }
+
+  function renderList(containerId, items) {
+    const list = document.getElementById(containerId);
+    items.forEach(text => {
+      const li = document.createElement('li');
+      li.textContent = text;
+      list.appendChild(li);
+    });
+  }
+
+  function renderGallery() {
+    const grid = document.getElementById('gallery-grid');
+    galleryData.forEach(item => {
+      const div = document.createElement('div');
+      div.className = 'gallery-item';
+      div.setAttribute('role', 'listitem');
+      if (item.type === 'image') {
+        div.innerHTML = `<img src="${item.src}" alt="${item.alt}" loading="lazy"><div class="gallery-caption">${item.caption}</div>`;
+      } else {
+        div.innerHTML = `<div class="gallery-illustration" role="img" aria-label="${item.alt}">${item.emoji}</div><div class="gallery-caption">${item.caption}</div>`;
+      }
+      grid.appendChild(div);
+    });
+  }
+
+  // Initialize
+  document.addEventListener('DOMContentLoaded', () => {
+    renderCards('history-grid', historyData);
+    renderCards('buddhist-grid', buddhistData);
+    renderCards('hindu-grid', hinduData);
+    renderCards('jain-grid', jainData);
+    renderCards('kailasa-grid', kailasaData);
+    renderCards('engineering-grid', engineeringData);
+    renderList('unesco-list', unescoData);
+    renderList('facts-list', factsData);
+    renderGallery();
+  });
+})();

--- a/frontend/ellora-caves-explorer/style.css
+++ b/frontend/ellora-caves-explorer/style.css
@@ -1,0 +1,258 @@
+/* =========================================
+   Ellora Caves Explorer Styles
+   Supports Dark (default) and Light themes
+   ========================================= */
+
+:root {
+  --bg-primary: #14181a;
+  --bg-secondary: #1e2528;
+  --bg-alt: #262f33;
+  --text-primary: #f4f7f8;
+  --text-secondary: #b9c4c8;
+  --basalt: #4a6b73;
+  --copper: #c17a3e;
+  --gold: #d9a441;
+  --card-bg: #1e2528;
+  --border-color: #33403f;
+  --shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+}
+
+body.light-theme {
+  --bg-primary: #f5f8f8;
+  --bg-secondary: #ffffff;
+  --bg-alt: #eaf0f0;
+  --text-primary: #16201f;
+  --text-secondary: #4a5a58;
+  --basalt: #2f4d54;
+  --copper: #a05f28;
+  --gold: #a97a1f;
+  --card-bg: #ffffff;
+  --border-color: #dde7e6;
+  --shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.site-header {
+  background-color: var(--bg-secondary);
+  padding: 1rem 2rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  box-shadow: var(--shadow);
+}
+
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.nav-logo {
+  color: var(--copper);
+  text-decoration: none;
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.theme-btn {
+  background: var(--bg-alt);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+
+.theme-btn:hover {
+  background: var(--border-color);
+}
+
+.ellora-hero {
+  background: linear-gradient(135deg, var(--bg-secondary), var(--bg-primary));
+  padding: 5rem 2rem;
+  text-align: center;
+}
+
+.hero-content {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.hero-content h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  color: var(--copper);
+}
+
+.hero-subtitle {
+  font-size: 1.15rem;
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.hero-badges {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.badge {
+  background: var(--bg-alt);
+  border: 1px solid var(--border-color);
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+}
+
+.cta-button {
+  display: inline-block;
+  background: var(--copper);
+  color: #fff;
+  padding: 0.75rem 1.75rem;
+  border-radius: 0.5rem;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.cta-button:hover {
+  opacity: 0.9;
+}
+
+.content-section {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 4rem 2rem;
+}
+
+.content-section h2 {
+  font-size: 1.8rem;
+  margin-bottom: 0.5rem;
+  color: var(--copper);
+}
+
+.sub-heading {
+  font-size: 1.2rem;
+  margin-top: 2rem;
+  margin-bottom: 0.25rem;
+  color: var(--gold);
+}
+
+.section-desc {
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.alt-bg {
+  background: var(--bg-secondary);
+  border-radius: 1rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.data-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  box-shadow: var(--shadow);
+}
+
+.data-card h3 {
+  margin-bottom: 0.5rem;
+  color: var(--gold);
+}
+
+.data-card p {
+  color: var(--text-secondary);
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.gallery-item {
+  border-radius: 0.75rem;
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  background: var(--card-bg);
+}
+
+.gallery-item img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  display: block;
+}
+
+.gallery-illustration {
+  width: 100%;
+  height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.75rem;
+  background: linear-gradient(135deg, var(--bg-alt), var(--border-color));
+}
+
+.gallery-caption {
+  padding: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.facts-list {
+  list-style: none;
+  margin-top: 1.5rem;
+}
+
+.facts-list li {
+  background: var(--card-bg);
+  border-left: 4px solid var(--copper);
+  padding: 0.9rem 1.25rem;
+  margin-bottom: 0.75rem;
+  border-radius: 0.5rem;
+  color: var(--text-secondary);
+}
+
+.site-footer {
+  text-align: center;
+  padding: 2rem;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+}
+
+.site-footer a {
+  color: var(--copper);
+  margin-left: 0.5rem;
+}
+
+@media (max-width: 700px) {
+  .content-section {
+    padding: 3rem 1.25rem;
+  }
+}


### PR DESCRIPTION
## What this PR does
Adds a new, dedicated Ellora Caves page at `frontend/ellora-caves-explorer/`, covering:
- Hero section with location (Charanandri Hills, near Aurangabad, Maharashtra) and quick badges
- History of the site's Buddhist, Hindu, and Jain excavation phases, including a note on religious coexistence
- Buddhist Caves (1–12): monasteries, prayer halls, and highlights like the Vishwakarma cave
- Hindu Caves (13–29): major shrines including the Dashavatara and Dhumar Lena caves
- Jain Caves (30–34): Tirthankara imagery and the Indra Sabha shrine
- A dedicated Kailasa Temple section covering its scale, top-down excavation method, patronage, and sculptural program
- Rock-Cut Engineering: an explanation of subtractive, top-down rock-cut construction
- UNESCO Heritage: World Heritage status (inscribed 1983) and interesting facts about the site
- An image gallery using the existing `assets/kailasa_temple_banner.png` asset, with descriptive alt text on every image
- Responsive layout (mobile-friendly grid and spacing)

## Files added
- `frontend/ellora-caves-explorer/index.html`
- `frontend/ellora-caves-explorer/style.css`
- `frontend/ellora-caves-explorer/script.js`

## Files changed
- None — this issue does not request landing-page integration, so no existing files were modified.

Closes #2729 

@Eshajha19 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.