### PR TITLE
Fix #2738: Add Rani ki Vav Monument Page

### DIFF
--- a/frontend/ajanta-caves-explorer/index.html
+++ b/frontend/ajanta-caves-explorer/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore the Ajanta Caves in Maharashtra — India's finest surviving collection of ancient Buddhist rock-cut paintings, sculptures, and architecture.">
+  <title>Ajanta Caves Explorer | Incredible India</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="site-header">
+    <nav class="navbar" aria-label="Main navigation">
+      <a href="../../index.html" class="nav-logo" aria-label="Go to homepage">Incredible India Explorer</a>
+      <button id="theme-toggle" class="theme-btn" aria-label="Toggle dark and light theme">🌓 Theme</button>
+    </nav>
+  </header>
+
+  <main>
+    <section class="ajanta-hero" aria-labelledby="hero-title">
+      <div class="hero-content">
+        <h1 id="hero-title">Ajanta Caves Explorer</h1>
+        <p class="hero-subtitle">A UNESCO World Heritage rock-cut complex near Aurangabad (Chhatrapati Sambhajinagar), Maharashtra — home to the finest surviving Buddhist paintings and sculpture from ancient India.</p>
+        <div class="hero-badges">
+          <span class="badge">📍 Maharashtra</span>
+          <span class="badge">🖼️ Ancient Murals</span>
+          <span class="badge">🏛️ UNESCO Site</span>
+        </div>
+        <a href="#history" class="cta-button">Start Exploring ↓</a>
+      </div>
+    </section>
+
+    <section id="history" class="content-section" aria-labelledby="history-title">
+      <h2 id="history-title">History</h2>
+      <p class="section-desc">Carved in two distinct bursts of activity, seven centuries apart, into the volcanic rock of a horseshoe-shaped gorge above the Waghur River.</p>
+      <div id="history-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="buddhist-heritage" class="content-section alt-bg" aria-labelledby="bh-title">
+      <h2 id="bh-title">Buddhist Heritage</h2>
+      <p class="section-desc">Ajanta spans two major phases of Buddhist tradition, each with its own visual language.</p>
+      <div id="buddhist-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="cave-architecture" class="content-section" aria-labelledby="arch-title">
+      <h2 id="arch-title">Cave Architecture: Chaitya Halls vs. Viharas</h2>
+      <p class="section-desc">The 30 caves fall into two architectural types, each serving a different purpose in monastic life.</p>
+      <div id="architecture-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="paintings" class="content-section alt-bg" aria-labelledby="paint-title">
+      <h2 id="paint-title">Paintings</h2>
+      <p class="section-desc">Ajanta preserves the most extensive surviving body of ancient Indian painting, offering an unmatched window into classical Indian art.</p>
+      <div id="paintings-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="sculptures" class="content-section" aria-labelledby="sculpt-title">
+      <h2 id="sculpt-title">Sculptures</h2>
+      <p class="section-desc">Alongside the murals, Ajanta's carved figures and reliefs are central to understanding early Indian sculptural style.</p>
+      <div id="sculptures-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="unesco-heritage" class="content-section alt-bg" aria-labelledby="unesco-title">
+      <h2 id="unesco-title">UNESCO Heritage</h2>
+      <p class="section-desc">Inscribed as a UNESCO World Heritage Site in 1983, recognized as a masterpiece of Buddhist religious art with lasting influence across Asia.</p>
+      <ul id="unesco-list" class="facts-list" role="list"></ul>
+    </section>
+
+    <section id="conservation" class="content-section" aria-labelledby="cons-title">
+      <h2 id="cons-title">Conservation</h2>
+      <p class="section-desc">Managed today by the Archaeological Survey of India (ASI), the caves face ongoing conservation challenges.</p>
+      <div id="conservation-grid" class="card-grid" role="list"></div>
+      <h3 class="sub-heading">Interesting Facts</h3>
+      <ul id="facts-list" class="facts-list" role="list"></ul>
+    </section>
+
+    <section id="gallery" class="content-section alt-bg" aria-labelledby="gallery-title">
+      <h2 id="gallery-title">Gallery</h2>
+      <div id="gallery-grid" class="gallery-grid" role="list"></div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>&copy; 2026 Incredible India Explorer. Educational purposes only.</p>
+    <a href="../../index.html">Back to Home</a>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/ajanta-caves-explorer/script.js
+++ b/frontend/ajanta-caves-explorer/script.js
@@ -1,0 +1,121 @@
+(function() {
+  'use strict';
+
+  // Theme toggle logic
+  const themeBtn = document.getElementById('theme-toggle');
+  const body = document.body;
+
+  if (localStorage.getItem('theme') === 'light') {
+    body.classList.add('light-theme');
+  }
+
+  themeBtn.addEventListener('click', () => {
+    body.classList.toggle('light-theme');
+    localStorage.setItem('theme', body.classList.contains('light-theme') ? 'light' : 'dark');
+  });
+
+  // Data
+  const historyData = [
+    { name: 'Early (Hinayana) Phase', emoji: '⛏️', desc: 'Excavation began around the 2nd century BCE under Satavahana-era patronage, producing early prayer halls and monasteries carved into the gorge.' },
+    { name: 'Centuries of Silence', emoji: '🌿', desc: 'Work paused for several centuries, and the site saw little new activity until royal patronage returned in the 5th century CE.' },
+    { name: 'Golden (Mahayana) Phase', emoji: '🎨', desc: 'Around 460–480 CE, under Vakataka king Harishena and his court, most of the elaborately painted and sculpted caves were excavated.' },
+    { name: 'Abandonment & Rediscovery', emoji: '🐅', desc: 'Patronage ended abruptly after Harishena\'s death, leaving several caves unfinished. The site was reclaimed by jungle until a British officer, John Smith, rediscovered it in 1819 during a tiger hunt.' }
+  ];
+
+  const buddhistData = [
+    { name: 'Hinayana Tradition', emoji: '☸️', desc: 'The earliest caves follow an aniconic style, representing the Buddha through symbols such as the stupa, the Bodhi tree, and the wheel of dharma rather than a human figure.' },
+    { name: 'Mahayana Tradition', emoji: '🧘', desc: 'The later caves embrace a fully iconic style, filled with images of the Buddha and Bodhisattvas, alongside vivid narrative murals of the Jataka tales.' }
+  ];
+
+  const architectureData = [
+    { name: 'Chaitya Halls', emoji: '⛩️', desc: 'Worship halls with a horseshoe-shaped facade and a central stupa at the far end, used for congregational prayer. Caves 9, 10, 19, and 26 are the best-preserved examples.' },
+    { name: 'Viharas', emoji: '🏠', desc: 'Residential monasteries with small monks\' cells arranged around a large central hall, used for study, meditation, and daily monastic life. Most of Ajanta\'s 30 caves are viharas.' }
+  ];
+
+  const paintingsData = [
+    { name: 'Padmapani & Vajrapani', emoji: '🖌️', desc: 'The Bodhisattva figures in Cave 1 are among the most celebrated paintings in Indian art, admired for their serene expression and refined line work.' },
+    { name: 'Jataka Narrative Murals', emoji: '📜', desc: 'Extensive wall paintings in caves such as Cave 17 illustrate Jataka tales — stories of the Buddha\'s previous lives — in vivid, crowded compositions.' },
+    { name: 'Technique & Materials', emoji: '🎨', desc: 'Painted in tempera on a dry lime-plaster ground using natural mineral and plant pigments, a technique that has preserved color and detail for over 1,500 years.' }
+  ];
+
+  const sculpturesData = [
+    { name: 'Reclining Buddha, Cave 26', emoji: '🗿', desc: 'A massive relief of the Buddha in Mahaparinirvana (final release), one of the largest and most striking sculptures at the site.' },
+    { name: 'Carved Pillars & Capitals', emoji: '🏛️', desc: 'Intricately carved columns and capitals throughout the viharas showcase the evolving decorative vocabulary of ancient Indian stonework.' },
+    { name: 'Guardian Figures', emoji: '🛡️', desc: 'Dvarapala (guardian) figures flank many cave entrances, a convention that influenced temple architecture across India for centuries.' }
+  ];
+
+  const unescoData = [
+    'Inscribed as a UNESCO World Heritage Site in 1983.',
+    'Recognized as a masterpiece of human creative genius and for its profound influence on the development of Buddhist art across Asia.',
+    'Considered essential evidence for understanding the artistic, religious, and social life of ancient India, given how few painted monuments from this era survive.'
+  ];
+
+  const conservationData = [
+    { name: 'Managing Authority', emoji: '🏢', desc: 'The Archaeological Survey of India (ASI) manages and protects the site today.' },
+    { name: 'Environmental Threats', emoji: '💧', desc: 'Humidity from visitor breath and body heat encourages microbial growth that can damage the ancient paint layers.' },
+    { name: 'Protective Measures', emoji: '🚧', desc: 'Visitor numbers are regulated, protective railings and low lighting are used, and cave access is periodically rotated to reduce wear.' }
+  ];
+
+  const factsData = [
+    'The caves are carved along a horseshoe-shaped gorge above the Waghur River.',
+    'Cave 10 contains one of the earliest known Brahmi inscriptions found at the site.',
+    'The Ellora Caves, about 100 km away, are often visited together with Ajanta.',
+    'Ajanta\'s painting style directly influenced later Buddhist art across Central and East Asia via ancient trade routes.'
+  ];
+
+  const galleryData = [
+    { type: 'image', src: '../../assets/ajanta_caves.png', alt: 'Rock-cut facade of the Ajanta Caves carved into a horseshoe-shaped cliff above the Waghur River, Maharashtra', caption: 'The rock-cut cave complex above the Waghur River gorge' },
+    { type: 'icon', emoji: '🖌️', alt: 'Illustration representing the Padmapani Bodhisattva painting in Cave 1', caption: 'The celebrated Padmapani mural in Cave 1' },
+    { type: 'icon', emoji: '⛩️', alt: 'Illustration representing the horseshoe-shaped interior of a chaitya prayer hall', caption: 'Interior of a chaitya hall with its central stupa' },
+    { type: 'icon', emoji: '🗿', alt: 'Illustration representing the reclining Buddha relief sculpture in Cave 26', caption: 'The reclining Buddha (Mahaparinirvana) relief in Cave 26' }
+  ];
+
+  // Render Functions
+  function renderCards(containerId, data) {
+    const grid = document.getElementById(containerId);
+    data.forEach(item => {
+      const card = document.createElement('div');
+      card.className = 'data-card';
+      card.setAttribute('role', 'listitem');
+      card.innerHTML = `<h3>${item.emoji} ${item.name}</h3><p>${item.desc}</p>`;
+      grid.appendChild(card);
+    });
+  }
+
+  function renderList(containerId, items) {
+    const list = document.getElementById(containerId);
+    items.forEach(text => {
+      const li = document.createElement('li');
+      li.textContent = text;
+      list.appendChild(li);
+    });
+  }
+
+  function renderGallery() {
+    const grid = document.getElementById('gallery-grid');
+    galleryData.forEach(item => {
+      const div = document.createElement('div');
+      div.className = 'gallery-item';
+      div.setAttribute('role', 'listitem');
+      if (item.type === 'image') {
+        div.innerHTML = `<img src="${item.src}" alt="${item.alt}" loading="lazy"><div class="gallery-caption">${item.caption}</div>`;
+      } else {
+        div.innerHTML = `<div class="gallery-illustration" role="img" aria-label="${item.alt}">${item.emoji}</div><div class="gallery-caption">${item.caption}</div>`;
+      }
+      grid.appendChild(div);
+    });
+  }
+
+  // Initialize
+  document.addEventListener('DOMContentLoaded', () => {
+    renderCards('history-grid', historyData);
+    renderCards('buddhist-grid', buddhistData);
+    renderCards('architecture-grid', architectureData);
+    renderCards('paintings-grid', paintingsData);
+    renderCards('sculptures-grid', sculpturesData);
+    renderList('unesco-list', unescoData);
+    renderCards('conservation-grid', conservationData);
+    renderList('facts-list', factsData);
+    renderGallery();
+  });
+})();

--- a/frontend/ajanta-caves-explorer/style.css
+++ b/frontend/ajanta-caves-explorer/style.css
@@ -1,0 +1,258 @@
+/* =========================================
+   Ajanta Caves Explorer Styles
+   Supports Dark (default) and Light themes
+   ========================================= */
+
+:root {
+  --bg-primary: #1a140e;
+  --bg-secondary: #251c14;
+  --bg-alt: #2f241a;
+  --text-primary: #f7f1e8;
+  --text-secondary: #cbb99e;
+  --terracotta: #c1652f;
+  --gold: #d9a441;
+  --stone: #8a7256;
+  --card-bg: #251c14;
+  --border-color: #3d2f21;
+  --shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+}
+
+body.light-theme {
+  --bg-primary: #fbf7f0;
+  --bg-secondary: #ffffff;
+  --bg-alt: #f3e9db;
+  --text-primary: #241a10;
+  --text-secondary: #5c4a35;
+  --terracotta: #a8501f;
+  --gold: #a97a1f;
+  --stone: #6b5843;
+  --card-bg: #ffffff;
+  --border-color: #eaded0;
+  --shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.site-header {
+  background-color: var(--bg-secondary);
+  padding: 1rem 2rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  box-shadow: var(--shadow);
+}
+
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.nav-logo {
+  color: var(--terracotta);
+  text-decoration: none;
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.theme-btn {
+  background: var(--bg-alt);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+
+.theme-btn:hover {
+  background: var(--border-color);
+}
+
+.ajanta-hero {
+  background: linear-gradient(135deg, var(--bg-secondary), var(--bg-primary));
+  padding: 5rem 2rem;
+  text-align: center;
+}
+
+.hero-content {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.hero-content h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  color: var(--terracotta);
+}
+
+.hero-subtitle {
+  font-size: 1.15rem;
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.hero-badges {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.badge {
+  background: var(--bg-alt);
+  border: 1px solid var(--border-color);
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+}
+
+.cta-button {
+  display: inline-block;
+  background: var(--terracotta);
+  color: #fff;
+  padding: 0.75rem 1.75rem;
+  border-radius: 0.5rem;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.cta-button:hover {
+  opacity: 0.9;
+}
+
+.content-section {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 4rem 2rem;
+}
+
+.content-section h2 {
+  font-size: 1.8rem;
+  margin-bottom: 0.5rem;
+  color: var(--terracotta);
+}
+
+.sub-heading {
+  font-size: 1.2rem;
+  margin-top: 2rem;
+  margin-bottom: 0.25rem;
+  color: var(--gold);
+}
+
+.section-desc {
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.alt-bg {
+  background: var(--bg-secondary);
+  border-radius: 1rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.data-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  box-shadow: var(--shadow);
+}
+
+.data-card h3 {
+  margin-bottom: 0.5rem;
+  color: var(--gold);
+}
+
+.data-card p {
+  color: var(--text-secondary);
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.gallery-item {
+  border-radius: 0.75rem;
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  background: var(--card-bg);
+}
+
+.gallery-item img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  display: block;
+}
+
+.gallery-illustration {
+  width: 100%;
+  height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.75rem;
+  background: linear-gradient(135deg, var(--bg-alt), var(--border-color));
+}
+
+.gallery-caption {
+  padding: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.facts-list {
+  list-style: none;
+  margin-top: 1.5rem;
+}
+
+.facts-list li {
+  background: var(--card-bg);
+  border-left: 4px solid var(--terracotta);
+  padding: 0.9rem 1.25rem;
+  margin-bottom: 0.75rem;
+  border-radius: 0.5rem;
+  color: var(--text-secondary);
+}
+
+.site-footer {
+  text-align: center;
+  padding: 2rem;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+}
+
+.site-footer a {
+  color: var(--terracotta);
+  margin-left: 0.5rem;
+}
+
+@media (max-width: 700px) {
+  .content-section {
+    padding: 3rem 1.25rem;
+  }
+}

--- a/frontend/elephanta-caves-explorer/index.html
+++ b/frontend/elephanta-caves-explorer/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore the Elephanta Caves near Mumbai — a UNESCO World Heritage island of rock-cut Shiva temples, home to the monumental Trimurti sculpture.">
+  <title>Elephanta Caves Explorer | Incredible India</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="site-header">
+    <nav class="navbar" aria-label="Main navigation">
+      <a href="../../index.html" class="nav-logo" aria-label="Go to homepage">Incredible India Explorer</a>
+      <button id="theme-toggle" class="theme-btn" aria-label="Toggle dark and light theme">🌓 Theme</button>
+    </nav>
+  </header>
+
+  <main>
+    <section class="elephanta-hero" aria-labelledby="hero-title">
+      <div class="hero-content">
+        <h1 id="hero-title">Elephanta Caves Explorer</h1>
+        <p class="hero-subtitle">A rock-cut island temple in Mumbai Harbour, near Mumbai, Maharashtra — home to the monumental Trimurti and some of India's finest Shaivite sculpture.</p>
+        <div class="hero-badges">
+          <span class="badge">📍 Near Mumbai</span>
+          <span class="badge">🗿 Trimurti</span>
+          <span class="badge">🏝️ Island Temple</span>
+        </div>
+        <a href="#history" class="cta-button">Start Exploring ↓</a>
+      </div>
+    </section>
+
+    <section id="history" class="content-section" aria-labelledby="history-title">
+      <h2 id="history-title">History</h2>
+      <p class="section-desc">A site shaped by ancient devotion, colonial conflict, and modern restoration.</p>
+      <div id="history-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="island-heritage" class="content-section alt-bg" aria-labelledby="island-title">
+      <h2 id="island-title">Island Heritage</h2>
+      <p class="section-desc">Elephanta Island, locally called Gharapuri — "the city of caves" — sits about 10 km east of Mumbai's Gateway of India, reached by a roughly one-hour ferry across the harbour.</p>
+      <div id="island-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="rock-cut-architecture" class="content-section" aria-labelledby="arch-title">
+      <h2 id="arch-title">Rock-Cut Architecture</h2>
+      <p class="section-desc">Cave 1, the Great Cave, is carved entirely from solid basalt rock and remains the site's architectural centerpiece.</p>
+      <div id="architecture-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="trimurti" class="content-section alt-bg" aria-labelledby="trimurti-title">
+      <h2 id="trimurti-title">Trimurti</h2>
+      <p class="section-desc">The monumental three-faced Shiva bust is the single most celebrated sculpture at Elephanta.</p>
+      <div id="trimurti-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="shiva-sculptures" class="content-section" aria-labelledby="shiva-title">
+      <h2 id="shiva-title">Shiva Sculptures</h2>
+      <p class="section-desc">Beyond the Trimurti, Cave 1 holds a rich gallery of large relief panels depicting Shiva's many forms and legends.</p>
+      <div id="shiva-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="unesco-heritage" class="content-section alt-bg" aria-labelledby="unesco-title">
+      <h2 id="unesco-title">UNESCO Heritage</h2>
+      <p class="section-desc">Inscribed as a UNESCO World Heritage Site in 1987, recognized for its outstanding contribution to Indian rock-cut art.</p>
+      <ul id="unesco-list" class="facts-list" role="list"></ul>
+    </section>
+
+    <section id="interesting-facts" class="content-section" aria-labelledby="facts-title">
+      <h2 id="facts-title">Interesting Facts</h2>
+      <ul id="facts-list" class="facts-list" role="list"></ul>
+    </section>
+
+    <section id="gallery" class="content-section alt-bg" aria-labelledby="gallery-title">
+      <h2 id="gallery-title">Gallery</h2>
+      <div id="gallery-grid" class="gallery-grid" role="list"></div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>&copy; 2026 Incredible India Explorer. Educational purposes only.</p>
+    <a href="../../index.html">Back to Home</a>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/elephanta-caves-explorer/script.js
+++ b/frontend/elephanta-caves-explorer/script.js
@@ -1,0 +1,117 @@
+(function() {
+  'use strict';
+
+  // Theme toggle logic
+  const themeBtn = document.getElementById('theme-toggle');
+  const body = document.body;
+
+  if (localStorage.getItem('theme') === 'light') {
+    body.classList.add('light-theme');
+  }
+
+  themeBtn.addEventListener('click', () => {
+    body.classList.toggle('light-theme');
+    localStorage.setItem('theme', body.classList.contains('light-theme') ? 'light' : 'dark');
+  });
+
+  // Data
+  const historyData = [
+    { name: 'Ancient Origins', emoji: '⛏️', desc: 'Most of the caves were carved between the mid-5th and 8th centuries CE, though scholars still debate exact dates and which dynasty — Kalachuri, Chalukya, or Rashtrakuta — sponsored the work.' },
+    { name: 'A Portuguese Name', emoji: '🐘', desc: 'In 1534, Portuguese sailors found a large stone elephant statue near the shore and renamed the island "Elephanta." Locally it was, and still is, called Gharapuri.' },
+    { name: 'Colonial Damage', emoji: '💥', desc: 'Portuguese soldiers used several of the Shiva reliefs for musket and cannon target practice in the 16th and 17th centuries, defacing many carvings — though the Trimurti was largely spared.' },
+    { name: 'Restoration & Recognition', emoji: '🏛️', desc: 'The Indian government restored the main cave in the 1970s, and UNESCO inscribed Elephanta as a World Heritage Site in 1987.' }
+  ];
+
+  const islandData = [
+    { name: 'Two Hills, Seven Caves', emoji: '⛰️', desc: 'The island has two low hills separated by a narrow valley: five Hindu caves on the western hill, and two smaller Buddhist caves with stupas and water tanks on the eastern hill.' },
+    { name: 'Reaching the Island', emoji: '⛴️', desc: 'Visitors take a roughly one-hour ferry from the Gateway of India, followed by a short walk or toy-train ride up to the cave entrance.' },
+    { name: 'Long Human Presence', emoji: '🏘️', desc: 'Archaeological evidence suggests people lived on the island for around two millennia — long before the main caves were carved.' }
+  ];
+
+  const architectureData = [
+    { name: 'Carved from Basalt', emoji: '🪨', desc: 'Cave 1, the Great Cave, was cut directly out of solid basalt rock rather than built up from a foundation, in the western Deccan rock-cut tradition.' },
+    { name: 'A Grand Hall', emoji: '🏛️', desc: 'The main hall spans roughly 27 metres square and stretches about 39 metres in a cruciform plan, held up by massive rock-cut pillars.' },
+    { name: 'Mandala Layout', emoji: '🧭', desc: 'Key shrines and sculptural panels are arranged around a central linga chapel, following a mandala-like spatial plan.' }
+  ];
+
+  const trimurtiData = [
+    { name: 'What It Depicts', emoji: '🗿', desc: 'The Trimurti Sadashiva shows Shiva in three visible faces representing his roles as creator, preserver, and destroyer — technically part of a five-faced (Panchamukhi) form, with two faces hidden from view.' },
+    { name: 'Scale', emoji: '📏', desc: 'The bust rises about 5.4–6 metres (roughly 18–20 feet) high, carved into the south wall of the main hall.' },
+    { name: 'Artistic Importance', emoji: '🎨', desc: 'Widely regarded as one of the finest achievements of ancient Indian sculpture, and the single most iconic image associated with the site.' }
+  ];
+
+  const shivaData = [
+    { name: 'Ardhanarishvara', emoji: '⚖️', desc: 'A half-male, half-female depiction of Shiva merged with Parvati, symbolizing the unity of masculine and feminine cosmic principles.' },
+    { name: 'Nataraja', emoji: '💃', desc: 'Shiva as the cosmic dancer, a form associated with the eternal cycle of creation and destruction.' },
+    { name: 'Gangadhara', emoji: '🌊', desc: 'A panel showing Shiva receiving the descent of the river Ganga into his matted hair to soften her fall to earth.' },
+    { name: 'Ravananugraha', emoji: '🏔️', desc: 'A dramatic relief of the demon king Ravana attempting to shake Mount Kailasa, with Shiva calmly subduing him.' }
+  ];
+
+  const unescoData = [
+    'Inscribed as a UNESCO World Heritage Site in 1987 under Criteria (i) and (iii).',
+    'Criterion (i) recognizes the large reliefs around the linga chapel as one of the greatest examples of Indian art dedicated to the cult of Shiva.',
+    'Criterion (iii) recognizes the caves as the most magnificent achievement in the history of rock-cut architecture in western India.'
+  ];
+
+  const factsData = [
+    'The stone elephant statue that gave the island its name now stands in Mumbai\'s Jijamata Udyaan (Byculla) zoo and museum.',
+    'The famous "Trimurti" is technically a Panchamukhi (five-faced) Shiva — only three of the five faces are visible to visitors.',
+    'The island also holds Buddhist stupa mounds dating back as far as the 2nd century BCE, predating the main Hindu caves.',
+    'Despite heavy damage from Portuguese-era target practice, the central Trimurti sculpture survived largely intact.'
+  ];
+
+  const galleryData = [
+    { type: 'image', src: '../../assets/travel_islands.png', alt: 'View of Elephanta Island in Mumbai Harbour, home to the rock-cut Elephanta Caves', caption: 'Elephanta Island, reached by ferry from Mumbai\'s Gateway of India' },
+    { type: 'icon', emoji: '🗿', alt: 'Illustration representing the three-faced Trimurti Sadashiva sculpture', caption: 'The monumental Trimurti Sadashiva' },
+    { type: 'icon', emoji: '🏛️', alt: 'Illustration representing the rock-cut pillared hall of Cave 1', caption: 'The pillared main hall of Cave 1' },
+    { type: 'icon', emoji: '💃', alt: 'Illustration representing the Nataraja relief of Shiva as the cosmic dancer', caption: 'The Nataraja relief, Shiva as cosmic dancer' }
+  ];
+
+  // Render Functions
+  function renderCards(containerId, data) {
+    const grid = document.getElementById(containerId);
+    data.forEach(item => {
+      const card = document.createElement('div');
+      card.className = 'data-card';
+      card.setAttribute('role', 'listitem');
+      card.innerHTML = `<h3>${item.emoji} ${item.name}</h3><p>${item.desc}</p>`;
+      grid.appendChild(card);
+    });
+  }
+
+  function renderList(containerId, items) {
+    const list = document.getElementById(containerId);
+    items.forEach(text => {
+      const li = document.createElement('li');
+      li.textContent = text;
+      list.appendChild(li);
+    });
+  }
+
+  function renderGallery() {
+    const grid = document.getElementById('gallery-grid');
+    galleryData.forEach(item => {
+      const div = document.createElement('div');
+      div.className = 'gallery-item';
+      div.setAttribute('role', 'listitem');
+      if (item.type === 'image') {
+        div.innerHTML = `<img src="${item.src}" alt="${item.alt}" loading="lazy"><div class="gallery-caption">${item.caption}</div>`;
+      } else {
+        div.innerHTML = `<div class="gallery-illustration" role="img" aria-label="${item.alt}">${item.emoji}</div><div class="gallery-caption">${item.caption}</div>`;
+      }
+      grid.appendChild(div);
+    });
+  }
+
+  // Initialize
+  document.addEventListener('DOMContentLoaded', () => {
+    renderCards('history-grid', historyData);
+    renderCards('island-grid', islandData);
+    renderCards('architecture-grid', architectureData);
+    renderCards('trimurti-grid', trimurtiData);
+    renderCards('shiva-grid', shivaData);
+    renderList('unesco-list', unescoData);
+    renderList('facts-list', factsData);
+    renderGallery();
+  });
+})();

--- a/frontend/elephanta-caves-explorer/style.css
+++ b/frontend/elephanta-caves-explorer/style.css
@@ -1,0 +1,251 @@
+/* =========================================
+   Elephanta Caves Explorer Styles
+   Supports Dark (default) and Light themes
+   ========================================= */
+
+:root {
+  --bg-primary: #101820;
+  --bg-secondary: #182430;
+  --bg-alt: #1f2f3d;
+  --text-primary: #f2f6f9;
+  --text-secondary: #b6c3cd;
+  --sea-blue: #2f7ea3;
+  --stone: #8f7a5e;
+  --gold: #d9a441;
+  --card-bg: #182430;
+  --border-color: #2c3c4a;
+  --shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+}
+
+body.light-theme {
+  --bg-primary: #f4f8fa;
+  --bg-secondary: #ffffff;
+  --bg-alt: #e8f0f4;
+  --text-primary: #101820;
+  --text-secondary: #4a5c66;
+  --sea-blue: #1f6688;
+  --stone: #6b5a42;
+  --gold: #a97a1f;
+  --card-bg: #ffffff;
+  --border-color: #dbe6ea;
+  --shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.site-header {
+  background-color: var(--bg-secondary);
+  padding: 1rem 2rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  box-shadow: var(--shadow);
+}
+
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.nav-logo {
+  color: var(--sea-blue);
+  text-decoration: none;
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.theme-btn {
+  background: var(--bg-alt);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+
+.theme-btn:hover {
+  background: var(--border-color);
+}
+
+.elephanta-hero {
+  background: linear-gradient(135deg, var(--bg-secondary), var(--bg-primary));
+  padding: 5rem 2rem;
+  text-align: center;
+}
+
+.hero-content {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.hero-content h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  color: var(--sea-blue);
+}
+
+.hero-subtitle {
+  font-size: 1.15rem;
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.hero-badges {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.badge {
+  background: var(--bg-alt);
+  border: 1px solid var(--border-color);
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+}
+
+.cta-button {
+  display: inline-block;
+  background: var(--sea-blue);
+  color: #fff;
+  padding: 0.75rem 1.75rem;
+  border-radius: 0.5rem;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.cta-button:hover {
+  opacity: 0.9;
+}
+
+.content-section {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 4rem 2rem;
+}
+
+.content-section h2 {
+  font-size: 1.8rem;
+  margin-bottom: 0.5rem;
+  color: var(--sea-blue);
+}
+
+.section-desc {
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.alt-bg {
+  background: var(--bg-secondary);
+  border-radius: 1rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.data-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  box-shadow: var(--shadow);
+}
+
+.data-card h3 {
+  margin-bottom: 0.5rem;
+  color: var(--gold);
+}
+
+.data-card p {
+  color: var(--text-secondary);
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.gallery-item {
+  border-radius: 0.75rem;
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  background: var(--card-bg);
+}
+
+.gallery-item img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  display: block;
+}
+
+.gallery-illustration {
+  width: 100%;
+  height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.75rem;
+  background: linear-gradient(135deg, var(--bg-alt), var(--border-color));
+}
+
+.gallery-caption {
+  padding: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.facts-list {
+  list-style: none;
+  margin-top: 1.5rem;
+}
+
+.facts-list li {
+  background: var(--card-bg);
+  border-left: 4px solid var(--sea-blue);
+  padding: 0.9rem 1.25rem;
+  margin-bottom: 0.75rem;
+  border-radius: 0.5rem;
+  color: var(--text-secondary);
+}
+
+.site-footer {
+  text-align: center;
+  padding: 2rem;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+}
+
+.site-footer a {
+  color: var(--sea-blue);
+  margin-left: 0.5rem;
+}
+
+@media (max-width: 700px) {
+  .content-section {
+    padding: 3rem 1.25rem;
+  }
+}

--- a/frontend/ellora-caves-explorer/index.html
+++ b/frontend/ellora-caves-explorer/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore the Ellora Caves in Maharashtra — a UNESCO World Heritage site of Buddhist, Hindu, and Jain rock-cut monuments, home to the monolithic Kailasa Temple.">
+  <title>Ellora Caves Explorer | Incredible India</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="site-header">
+    <nav class="navbar" aria-label="Main navigation">
+      <a href="../../index.html" class="nav-logo" aria-label="Go to homepage">Incredible India Explorer</a>
+      <button id="theme-toggle" class="theme-btn" aria-label="Toggle dark and light theme">🌓 Theme</button>
+    </nav>
+  </header>
+
+  <main>
+    <section class="ellora-hero" aria-labelledby="hero-title">
+      <div class="hero-content">
+        <h1 id="hero-title">Ellora Caves Explorer</h1>
+        <p class="hero-subtitle">Carved into the Charanandri Hills near Aurangabad (Chhatrapati Sambhajinagar), Maharashtra — 34 rock-cut Buddhist, Hindu, and Jain monuments standing side by side.</p>
+        <div class="hero-badges">
+          <span class="badge">📍 Maharashtra</span>
+          <span class="badge">🛕 Kailasa Temple</span>
+          <span class="badge">⛰️ Rock-Cut Wonder</span>
+        </div>
+        <a href="#history" class="cta-button">Start Exploring ↓</a>
+      </div>
+    </section>
+
+    <section id="history" class="content-section" aria-labelledby="history-title">
+      <h2 id="history-title">History</h2>
+      <p class="section-desc">Excavated in overlapping phases between roughly the 6th and 10th centuries CE, Ellora's caves record three faiths carved into the same cliff face.</p>
+      <div id="history-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="buddhist-caves" class="content-section alt-bg" aria-labelledby="buddhist-title">
+      <h2 id="buddhist-title">Buddhist Caves (1–12)</h2>
+      <p class="section-desc">The earliest group at Ellora, built as monasteries and prayer halls for Buddhist monks.</p>
+      <div id="buddhist-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="hindu-caves" class="content-section" aria-labelledby="hindu-title">
+      <h2 id="hindu-title">Hindu Caves (13–29)</h2>
+      <p class="section-desc">The largest and most elaborately carved group, dedicated mainly to Shiva and Vishnu.</p>
+      <div id="hindu-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="jain-caves" class="content-section alt-bg" aria-labelledby="jain-title">
+      <h2 id="jain-title">Jain Caves (30–34)</h2>
+      <p class="section-desc">The final phase at Ellora, marked by intricate, smaller-scale shrines to the Tirthankaras.</p>
+      <div id="jain-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="kailasa-temple" class="content-section" aria-labelledby="kailasa-title">
+      <h2 id="kailasa-title">Kailasa Temple</h2>
+      <p class="section-desc">Cave 16 — the largest monolithic rock-cut structure in the world, carved top-down from a single basalt outcrop.</p>
+      <div id="kailasa-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="rock-cut-engineering" class="content-section alt-bg" aria-labelledby="engineering-title">
+      <h2 id="engineering-title">Rock-Cut Engineering</h2>
+      <p class="section-desc">How ancient artisans carved entire temples out of solid rock — with no room for error.</p>
+      <div id="engineering-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="unesco-heritage" class="content-section" aria-labelledby="unesco-title">
+      <h2 id="unesco-title">UNESCO Heritage</h2>
+      <p class="section-desc">Inscribed as a UNESCO World Heritage Site in 1983, recognized for its architectural achievement and its testimony to religious tolerance in ancient India.</p>
+      <ul id="unesco-list" class="facts-list" role="list"></ul>
+      <h3 class="sub-heading">Interesting Facts</h3>
+      <ul id="facts-list" class="facts-list" role="list"></ul>
+    </section>
+
+    <section id="gallery" class="content-section alt-bg" aria-labelledby="gallery-title">
+      <h2 id="gallery-title">Gallery</h2>
+      <div id="gallery-grid" class="gallery-grid" role="list"></div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>&copy; 2026 Incredible India Explorer. Educational purposes only.</p>
+    <a href="../../index.html">Back to Home</a>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/ellora-caves-explorer/script.js
+++ b/frontend/ellora-caves-explorer/script.js
@@ -1,0 +1,124 @@
+(function() {
+  'use strict';
+
+  // Theme toggle logic
+  const themeBtn = document.getElementById('theme-toggle');
+  const body = document.body;
+
+  if (localStorage.getItem('theme') === 'light') {
+    body.classList.add('light-theme');
+  }
+
+  themeBtn.addEventListener('click', () => {
+    body.classList.toggle('light-theme');
+    localStorage.setItem('theme', body.classList.contains('light-theme') ? 'light' : 'dark');
+  });
+
+  // Data
+  const historyData = [
+    { name: 'Buddhist Beginnings', emoji: '☸️', desc: 'Work began around the 6th century CE with monasteries and prayer halls (Caves 1–12), built under Kalachuri and early Chalukya-era patronage.' },
+    { name: 'The Hindu Resurgence', emoji: '🕉️', desc: 'As Hindu revival gathered pace under the Rashtrakuta dynasty, work shifted to grand Hindu shrines (Caves 13–29), culminating in the Kailasa Temple in the 8th century.' },
+    { name: 'The Jain Final Phase', emoji: '🙏', desc: 'Between roughly the 9th and 12th centuries, smaller but intricately detailed Jain caves (Caves 30–34) were added at the northern end of the site.' },
+    { name: 'Religious Coexistence', emoji: '🤝', desc: 'Unlike most sacred sites, Ellora shows three religions excavating in the same cliff face over centuries without displacing one another — a rare physical record of religious tolerance in ancient India.' }
+  ];
+
+  const buddhistData = [
+    { name: 'Viharas & Chaityas', emoji: '🏠', desc: 'The 12 Buddhist caves combine monasteries (viharas) with prayer halls (chaityas), including sleeping cells carved for resident monks.' },
+    { name: 'Cave 10 — Vishwakarma', emoji: '⛩️', desc: 'A two-storeyed chaitya hall with a seated Buddha and a lively carved frieze of dancing, music-making figures.' },
+    { name: 'Cave 12 — Teen Thal', emoji: '🏛️', desc: 'A striking triple-storeyed monastery, one of the most architecturally ambitious of the Buddhist caves.' }
+  ];
+
+  const hinduData = [
+    { name: 'Dedicated Mainly to Shiva', emoji: '🔱', desc: 'Most Hindu caves at Ellora honor Shiva, alongside shrines to Vishnu and scenes from the Ramayana and Mahabharata.' },
+    { name: 'Cave 15 — Dashavatara', emoji: '🐚', desc: 'Originally begun as a Buddhist cave, later reworked with Shaiva carvings — physical evidence of the site\'s shifting religious currents.' },
+    { name: 'Cave 29 — Dhumar Lena', emoji: '🗻', desc: 'A large, dramatic Shiva temple with multiple entrances, echoing the layout of the famous Elephanta cave temple near Mumbai.' }
+  ];
+
+  const jainData = [
+    { name: 'Tirthankara Imagery', emoji: '🕊️', desc: 'The Jain caves are dedicated to the Tirthankaras — spiritual teachers of Jainism — including Mahavira and Bahubali.' },
+    { name: 'Cave 32 — Indra Sabha', emoji: '🪷', desc: 'The finest Jain cave at Ellora, a two-storeyed shrine famous for its detailed carving and a lotus motif on the ceiling.' },
+    { name: 'Cave 30 — Chhota Kailash', emoji: '🛕', desc: 'An unfinished cave echoing the Kailasa Temple\'s design in miniature, complete with a carved rock-cut elephant.' }
+  ];
+
+  const kailasaData = [
+    { name: 'Scale & Dimensions', emoji: '📏', desc: 'The structure rises about 32.6 metres (107 ft) above the court below, and its excavation is estimated to have removed roughly 200,000 tonnes of basalt rock.' },
+    { name: 'Top-Down Excavation', emoji: '⬇️', desc: 'Unlike normal construction, Kailasa was carved downward from the top of a single rock outcrop, meaning the architects had to plan the entire structure before the first cut was made.' },
+    { name: 'Royal Patronage', emoji: '👑', desc: 'Inscriptions link the temple to the Rashtrakuta king Krishna I (r. 756–773 CE), though the full extent of his role remains debated among historians.' },
+    { name: 'Sculptural Program', emoji: '🗿', desc: 'Detailed relief panels depict scenes from the Ramayana and Mahabharata, including the famous carving of the demon king Ravana shaking Mount Kailasa.' }
+  ];
+
+  const engineeringData = [
+    { name: 'Subtractive Construction', emoji: '⛏️', desc: 'Rather than building up from a foundation, artisans carved away stone from a solid cliff face — a subtractive process with no way to add material back if a mistake was made.' },
+    { name: 'Tools of the Trade', emoji: '🔨', desc: 'Craftsmen used iron chisels, hammers, and picks to remove rock in stages, gradually revealing pillars, chambers, and sculpture from the mountain itself.' },
+    { name: 'Planning in Advance', emoji: '🧭', desc: 'Especially at the Kailasa Temple, the full three-dimensional design had to be visualized before excavation began, since the finished form could not be corrected once material was removed.' }
+  ];
+
+  const unescoData = [
+    'Inscribed as a UNESCO World Heritage Site in 1983.',
+    'Recognized as a unique artistic and technological achievement and as evidence of the spirit of religious tolerance in ancient India.',
+    'Extends over more than 2 km of basalt cliff face in the Charanandri Hills.'
+  ];
+
+  const factsData = [
+    'Ellora has around 100 caves in total, of which 34 are open to the public.',
+    'The word "Ellora" is a short form of the older name "Elapura", and local caves are traditionally called "Lena" or "Leni".',
+    'Ellora lies about 30 km from Aurangabad and roughly 100 km from the Ajanta Caves.',
+    'The Kailasa Temple originally had a coat of white plaster, designed to resemble the snow-capped peak of Mount Kailash.'
+  ];
+
+  const galleryData = [
+    { type: 'image', src: '../../assets/kailasa_temple_banner.png', alt: 'The monolithic Kailasa Temple (Cave 16) carved from a single basalt rock at Ellora, Maharashtra', caption: 'The Kailasa Temple, the world\'s largest monolithic rock-cut structure' },
+    { type: 'icon', emoji: '☸️', alt: 'Illustration representing a Buddhist chaitya prayer hall at Ellora', caption: 'Buddhist prayer hall, Caves 1–12' },
+    { type: 'icon', emoji: '🔱', alt: 'Illustration representing carved Hindu deity reliefs at Ellora', caption: 'Carved Hindu deity reliefs, Caves 13–29' },
+    { type: 'icon', emoji: '🪷', alt: 'Illustration representing the Indra Sabha Jain shrine at Ellora', caption: 'The Indra Sabha Jain shrine, Cave 32' }
+  ];
+
+  // Render Functions
+  function renderCards(containerId, data) {
+    const grid = document.getElementById(containerId);
+    data.forEach(item => {
+      const card = document.createElement('div');
+      card.className = 'data-card';
+      card.setAttribute('role', 'listitem');
+      card.innerHTML = `<h3>${item.emoji} ${item.name}</h3><p>${item.desc}</p>`;
+      grid.appendChild(card);
+    });
+  }
+
+  function renderList(containerId, items) {
+    const list = document.getElementById(containerId);
+    items.forEach(text => {
+      const li = document.createElement('li');
+      li.textContent = text;
+      list.appendChild(li);
+    });
+  }
+
+  function renderGallery() {
+    const grid = document.getElementById('gallery-grid');
+    galleryData.forEach(item => {
+      const div = document.createElement('div');
+      div.className = 'gallery-item';
+      div.setAttribute('role', 'listitem');
+      if (item.type === 'image') {
+        div.innerHTML = `<img src="${item.src}" alt="${item.alt}" loading="lazy"><div class="gallery-caption">${item.caption}</div>`;
+      } else {
+        div.innerHTML = `<div class="gallery-illustration" role="img" aria-label="${item.alt}">${item.emoji}</div><div class="gallery-caption">${item.caption}</div>`;
+      }
+      grid.appendChild(div);
+    });
+  }
+
+  // Initialize
+  document.addEventListener('DOMContentLoaded', () => {
+    renderCards('history-grid', historyData);
+    renderCards('buddhist-grid', buddhistData);
+    renderCards('hindu-grid', hinduData);
+    renderCards('jain-grid', jainData);
+    renderCards('kailasa-grid', kailasaData);
+    renderCards('engineering-grid', engineeringData);
+    renderList('unesco-list', unescoData);
+    renderList('facts-list', factsData);
+    renderGallery();
+  });
+})();

--- a/frontend/ellora-caves-explorer/style.css
+++ b/frontend/ellora-caves-explorer/style.css
@@ -1,0 +1,258 @@
+/* =========================================
+   Ellora Caves Explorer Styles
+   Supports Dark (default) and Light themes
+   ========================================= */
+
+:root {
+  --bg-primary: #14181a;
+  --bg-secondary: #1e2528;
+  --bg-alt: #262f33;
+  --text-primary: #f4f7f8;
+  --text-secondary: #b9c4c8;
+  --basalt: #4a6b73;
+  --copper: #c17a3e;
+  --gold: #d9a441;
+  --card-bg: #1e2528;
+  --border-color: #33403f;
+  --shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+}
+
+body.light-theme {
+  --bg-primary: #f5f8f8;
+  --bg-secondary: #ffffff;
+  --bg-alt: #eaf0f0;
+  --text-primary: #16201f;
+  --text-secondary: #4a5a58;
+  --basalt: #2f4d54;
+  --copper: #a05f28;
+  --gold: #a97a1f;
+  --card-bg: #ffffff;
+  --border-color: #dde7e6;
+  --shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.site-header {
+  background-color: var(--bg-secondary);
+  padding: 1rem 2rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  box-shadow: var(--shadow);
+}
+
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.nav-logo {
+  color: var(--copper);
+  text-decoration: none;
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.theme-btn {
+  background: var(--bg-alt);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+
+.theme-btn:hover {
+  background: var(--border-color);
+}
+
+.ellora-hero {
+  background: linear-gradient(135deg, var(--bg-secondary), var(--bg-primary));
+  padding: 5rem 2rem;
+  text-align: center;
+}
+
+.hero-content {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.hero-content h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  color: var(--copper);
+}
+
+.hero-subtitle {
+  font-size: 1.15rem;
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.hero-badges {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.badge {
+  background: var(--bg-alt);
+  border: 1px solid var(--border-color);
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+}
+
+.cta-button {
+  display: inline-block;
+  background: var(--copper);
+  color: #fff;
+  padding: 0.75rem 1.75rem;
+  border-radius: 0.5rem;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.cta-button:hover {
+  opacity: 0.9;
+}
+
+.content-section {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 4rem 2rem;
+}
+
+.content-section h2 {
+  font-size: 1.8rem;
+  margin-bottom: 0.5rem;
+  color: var(--copper);
+}
+
+.sub-heading {
+  font-size: 1.2rem;
+  margin-top: 2rem;
+  margin-bottom: 0.25rem;
+  color: var(--gold);
+}
+
+.section-desc {
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.alt-bg {
+  background: var(--bg-secondary);
+  border-radius: 1rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.data-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  box-shadow: var(--shadow);
+}
+
+.data-card h3 {
+  margin-bottom: 0.5rem;
+  color: var(--gold);
+}
+
+.data-card p {
+  color: var(--text-secondary);
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.gallery-item {
+  border-radius: 0.75rem;
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  background: var(--card-bg);
+}
+
+.gallery-item img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  display: block;
+}
+
+.gallery-illustration {
+  width: 100%;
+  height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.75rem;
+  background: linear-gradient(135deg, var(--bg-alt), var(--border-color));
+}
+
+.gallery-caption {
+  padding: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.facts-list {
+  list-style: none;
+  margin-top: 1.5rem;
+}
+
+.facts-list li {
+  background: var(--card-bg);
+  border-left: 4px solid var(--copper);
+  padding: 0.9rem 1.25rem;
+  margin-bottom: 0.75rem;
+  border-radius: 0.5rem;
+  color: var(--text-secondary);
+}
+
+.site-footer {
+  text-align: center;
+  padding: 2rem;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+}
+
+.site-footer a {
+  color: var(--copper);
+  margin-left: 0.5rem;
+}
+
+@media (max-width: 700px) {
+  .content-section {
+    padding: 3rem 1.25rem;
+  }
+}

--- a/frontend/rani-ki-vav-explorer/index.html
+++ b/frontend/rani-ki-vav-explorer/index.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore Rani ki Vav in Patan, Gujarat — an 11th-century stepwell built by Queen Udayamati, designed as an inverted temple celebrating the sanctity of water.">
+  <title>Rani ki Vav Explorer | Incredible India</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="site-header">
+    <nav class="navbar" aria-label="Main navigation">
+      <a href="../../index.html" class="nav-logo" aria-label="Go to homepage">Incredible India Explorer</a>
+      <button id="theme-toggle" class="theme-btn" aria-label="Toggle dark and light theme">🌓 Theme</button>
+    </nav>
+  </header>
+
+  <main>
+    <section class="vav-hero" aria-labelledby="hero-title">
+      <div class="hero-content">
+        <h1 id="hero-title">Rani ki Vav Explorer</h1>
+        <p class="hero-subtitle">An 11th-century stepwell in Patan, Gujarat, built by Queen Udayamati as an inverted temple to the sanctity of water.</p>
+        <div class="hero-badges">
+          <span class="badge">📍 Patan, Gujarat</span>
+          <span class="badge">💧 Queen's Stepwell</span>
+          <span class="badge">🏛️ UNESCO Site</span>
+        </div>
+        <a href="#history" class="cta-button">Start Exploring ↓</a>
+      </div>
+    </section>
+
+    <section id="history" class="content-section" aria-labelledby="history-title">
+      <h2 id="history-title">History</h2>
+      <p class="section-desc">Built as a royal memorial, buried by a flooding river, and rediscovered centuries later almost perfectly preserved.</p>
+      <div id="history-grid" class="card-grid" role="list"></div>
+      <h3 class="sub-heading">Timeline</h3>
+      <div id="timeline-list" class="timeline-list" role="list"></div>
+    </section>
+
+    <section id="stepwell-architecture" class="content-section alt-bg" aria-labelledby="arch-title">
+      <h2 id="arch-title">Stepwell Architecture</h2>
+      <p class="section-desc">Designed as an inverted temple, Rani ki Vav descends seven levels into the earth through a sequence of pillared pavilions.</p>
+      <div id="architecture-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="water-management" class="content-section" aria-labelledby="water-title">
+      <h2 id="water-title">Water Management</h2>
+      <p class="section-desc">Stepwells were a practical answer to Gujarat's dry climate and seasonally fluctuating groundwater.</p>
+      <div id="water-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="sculptures" class="content-section alt-bg" aria-labelledby="sculpt-title">
+      <h2 id="sculpt-title">Sculptures and Carvings</h2>
+      <p class="section-desc">More than 500 principal sculptures and 1,000 minor carvings line the walls and pillars.</p>
+      <div id="sculptures-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="solanki-heritage" class="content-section" aria-labelledby="solanki-title">
+      <h2 id="solanki-title">Solanki Heritage</h2>
+      <p class="section-desc">Rani ki Vav was built at the height of the Solanki (Chaulukya) dynasty's golden age of art and architecture.</p>
+      <div id="solanki-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="unesco-recognition" class="content-section alt-bg" aria-labelledby="unesco-title">
+      <h2 id="unesco-title">UNESCO Recognition</h2>
+      <ul id="unesco-list" class="facts-list" role="list"></ul>
+    </section>
+
+    <section id="interesting-facts" class="content-section" aria-labelledby="facts-title">
+      <h2 id="facts-title">Interesting Facts</h2>
+      <ul id="facts-list" class="facts-list" role="list"></ul>
+    </section>
+
+    <section id="gallery" class="content-section alt-bg" aria-labelledby="gallery-title">
+      <h2 id="gallery-title">Gallery</h2>
+      <div id="gallery-grid" class="gallery-grid" role="list"></div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>&copy; 2026 Incredible India Explorer. Educational purposes only.</p>
+    <a href="../../index.html">Back to Home</a>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/rani-ki-vav-explorer/script.js
+++ b/frontend/rani-ki-vav-explorer/script.js
@@ -1,0 +1,134 @@
+(function() {
+  'use strict';
+
+  // Theme toggle logic
+  const themeBtn = document.getElementById('theme-toggle');
+  const body = document.body;
+
+  if (localStorage.getItem('theme') === 'light') {
+    body.classList.add('light-theme');
+  }
+
+  themeBtn.addEventListener('click', () => {
+    body.classList.toggle('light-theme');
+    localStorage.setItem('theme', body.classList.contains('light-theme') ? 'light' : 'dark');
+  });
+
+  // Data
+  const historyData = [
+    { name: 'A Queen\'s Memorial', emoji: '👑', desc: 'Queen Udayamati of the Solanki (Chaulukya) dynasty commissioned Rani ki Vav around 1063 CE in memory of her husband, King Bhima I.' },
+    { name: 'Buried by the River', emoji: '🌊', desc: 'Sometime in the 13th century, flooding of the Saraswati River buried the stepwell under layers of silt, hiding it for nearly 700 years.' },
+    { name: 'Rediscovery & Restoration', emoji: '⛏️', desc: 'The stepwell was fully excavated in the 1940s and restored by the Archaeological Survey of India (ASI) in the 1980s, revealing sculptures in remarkably good condition.' }
+  ];
+
+  const timelineData = [
+    { year: 'c. 1022–1064', desc: 'Reign of King Bhima I of the Solanki (Chaulukya) dynasty.' },
+    { year: '1063 CE', desc: 'Construction of Rani ki Vav begins, commissioned by Queen Udayamati.' },
+    { year: 'c. 1083 CE', desc: 'Construction is completed after roughly twenty years.' },
+    { year: '13th century', desc: 'Flooding of the Saraswati River buries the stepwell under silt.' },
+    { year: '1940s', desc: 'The stepwell is fully excavated and rediscovered.' },
+    { year: '1980s', desc: 'The Archaeological Survey of India completes major restoration work.' },
+    { year: '2014', desc: 'UNESCO inscribes Rani ki Vav as a World Heritage Site on 22 June.' }
+  ];
+
+  const architectureData = [
+    { name: 'An Inverted Temple', emoji: '🛕', desc: 'Rani ki Vav is designed as a temple turned upside down, with seven levels of stairs descending into the earth instead of rising toward the sky.' },
+    { name: 'Scale', emoji: '📏', desc: 'The stepwell measures roughly 65 metres long, 20 metres wide, and 27 metres deep, oriented east-west and facing east.' },
+    { name: 'Four Core Elements', emoji: '🏛️', desc: 'A stepped corridor leads from ground level to an underground reservoir, broken up by multi-storeyed pillared pavilions, with a circular draw well at the rear.' },
+    { name: 'What Survives Today', emoji: '🧱', desc: 'Of the original seven storeys, about five remain intact, preserved by the very silt that once buried the site.' }
+  ];
+
+  const waterData = [
+    { name: 'Answering an Arid Climate', emoji: '☀️', desc: 'Stepwells developed in the dry regions of Gujarat and Rajasthan as a way to reach groundwater that dropped well below the surface for much of the year.' },
+    { name: 'From Pit to Monument', emoji: '📈', desc: 'Stepwells evolved over centuries from simple pits dug in sandy soil into elaborate multi-storey works of art and engineering.' },
+    { name: 'More Than a Water Source', emoji: '🤝', desc: 'Beyond storing water, stepwells offered shaded gathering spaces and served as sites of social and religious life for local communities.' }
+  ];
+
+  const sculpturesData = [
+    { name: 'Over 1,500 Carvings', emoji: '🗿', desc: 'More than 500 principal sculptures and over 1,000 minor carvings decorate the walls and pillars of the stepwell.' },
+    { name: 'Dashavatara Imagery', emoji: '🕉️', desc: 'Many panels depict the ten avatars of Vishnu (Dashavatara), alongside apsaras, yoginis, and other mythological figures.' },
+    { name: 'Echoes of Patola Weaving', emoji: '🧵', desc: 'The stepwell\'s geometric latticework closely resembles the patterns of Patan\'s famous Patola textiles, pointing to a shared local artistic tradition.' }
+  ];
+
+  const solankiData = [
+    { name: 'A Golden Age', emoji: '🏰', desc: 'The Solanki (Chaulukya) dynasty ruled Gujarat and parts of Rajasthan from roughly the 10th to 13th centuries, a period of great prosperity and artistic achievement.' },
+    { name: 'Anahilwad Patan', emoji: '🏙️', desc: 'Patan, then called Anahilwad Patan, was the flourishing Solanki capital, renowned for its wealth, learning, and monumental building projects.' },
+    { name: 'Sister Monuments', emoji: '🕌', desc: 'Rani ki Vav shares its Maru-Gurjara architectural style with other Solanki-era landmarks, including the Modhera Sun Temple and the Vimalavasahi Temple at Mount Abu.' }
+  ];
+
+  const unescoData = [
+    'Inscribed as a UNESCO World Heritage Site on 22 June 2014.',
+    'Recognized as an exceptional example of technological development in groundwater resource management within a single architectural component.',
+    'Praised for its capacity to break large underground spaces into smaller, aesthetically proportioned volumes.'
+  ];
+
+  const factsData = [
+    'Rani ki Vav appears on the reverse of India\'s ₹100 banknote, introduced in 2019.',
+    'It was named India\'s "Cleanest Iconic Place" at the 2016 Indian Sanitation Conference (INDOSAN).',
+    'The flood that buried the stepwell for centuries is also what preserved its sculptures in near-pristine condition.',
+    'The stepwell is mentioned in a 14th-century Jain text, the Prabandha-Chintamani, written by the monk Merutunga in 1304.'
+  ];
+
+  const galleryData = [
+    { emoji: '🛕', alt: 'Illustration representing the inverted-temple design of Rani ki Vav\'s stepped corridor', caption: 'The inverted-temple stepped corridor' },
+    { emoji: '🗿', alt: 'Illustration representing sculpted panels of Vishnu\'s avatars along the stepwell walls', caption: 'Sculpted panels depicting Vishnu\'s avatars' },
+    { emoji: '🏛️', alt: 'Illustration representing the multi-storeyed pillared pavilions inside the stepwell', caption: 'Multi-storeyed pillared pavilions' },
+    { emoji: '💧', alt: 'Illustration representing the circular draw well at the rear of the stepwell', caption: 'The circular draw well at the rear of the structure' }
+  ];
+
+  // Render Functions
+  function renderCards(containerId, data) {
+    const grid = document.getElementById(containerId);
+    data.forEach(item => {
+      const card = document.createElement('div');
+      card.className = 'data-card';
+      card.setAttribute('role', 'listitem');
+      card.innerHTML = `<h3>${item.emoji} ${item.name}</h3><p>${item.desc}</p>`;
+      grid.appendChild(card);
+    });
+  }
+
+  function renderTimeline() {
+    const list = document.getElementById('timeline-list');
+    timelineData.forEach(item => {
+      const div = document.createElement('div');
+      div.className = 'timeline-entry';
+      div.setAttribute('role', 'listitem');
+      div.innerHTML = `<span class="year">${item.year}</span><span class="desc">${item.desc}</span>`;
+      list.appendChild(div);
+    });
+  }
+
+  function renderList(containerId, items) {
+    const list = document.getElementById(containerId);
+    items.forEach(text => {
+      const li = document.createElement('li');
+      li.textContent = text;
+      list.appendChild(li);
+    });
+  }
+
+  function renderGallery() {
+    const grid = document.getElementById('gallery-grid');
+    galleryData.forEach(item => {
+      const div = document.createElement('div');
+      div.className = 'gallery-item';
+      div.setAttribute('role', 'listitem');
+      div.innerHTML = `<div class="gallery-illustration" role="img" aria-label="${item.alt}">${item.emoji}</div><div class="gallery-caption">${item.caption}</div>`;
+      grid.appendChild(div);
+    });
+  }
+
+  // Initialize
+  document.addEventListener('DOMContentLoaded', () => {
+    renderCards('history-grid', historyData);
+    renderTimeline();
+    renderCards('architecture-grid', architectureData);
+    renderCards('water-grid', waterData);
+    renderCards('sculptures-grid', sculpturesData);
+    renderCards('solanki-grid', solankiData);
+    renderList('unesco-list', unescoData);
+    renderList('facts-list', factsData);
+    renderGallery();
+  });
+})();

--- a/frontend/rani-ki-vav-explorer/style.css
+++ b/frontend/rani-ki-vav-explorer/style.css
@@ -1,0 +1,271 @@
+/* =========================================
+   Rani ki Vav Explorer Styles
+   Supports Dark (default) and Light themes
+   ========================================= */
+
+:root {
+  --bg-primary: #14171a;
+  --bg-secondary: #1d2226;
+  --bg-alt: #262c31;
+  --text-primary: #f4f6f7;
+  --text-secondary: #b6c0c6;
+  --sandstone: #b98a4e;
+  --deep-blue: #2c6e8e;
+  --gold: #d9a441;
+  --card-bg: #1d2226;
+  --border-color: #333c42;
+  --shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+}
+
+body.light-theme {
+  --bg-primary: #f7f5f1;
+  --bg-secondary: #ffffff;
+  --bg-alt: #efe9df;
+  --text-primary: #1c1c1c;
+  --text-secondary: #5a5a52;
+  --sandstone: #8c6432;
+  --deep-blue: #1f5670;
+  --gold: #a3801f;
+  --card-bg: #ffffff;
+  --border-color: #e6e0d3;
+  --shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.site-header {
+  background-color: var(--bg-secondary);
+  padding: 1rem 2rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  box-shadow: var(--shadow);
+}
+
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.nav-logo {
+  color: var(--sandstone);
+  text-decoration: none;
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.theme-btn {
+  background: var(--bg-alt);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+
+.theme-btn:hover {
+  background: var(--border-color);
+}
+
+.vav-hero {
+  background: linear-gradient(135deg, var(--bg-secondary), var(--bg-primary));
+  padding: 5rem 2rem;
+  text-align: center;
+}
+
+.hero-content {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.hero-content h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  color: var(--sandstone);
+}
+
+.hero-subtitle {
+  font-size: 1.15rem;
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.hero-badges {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.badge {
+  background: var(--bg-alt);
+  border: 1px solid var(--border-color);
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+}
+
+.cta-button {
+  display: inline-block;
+  background: var(--sandstone);
+  color: #fff;
+  padding: 0.75rem 1.75rem;
+  border-radius: 0.5rem;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.cta-button:hover {
+  opacity: 0.9;
+}
+
+.content-section {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 4rem 2rem;
+}
+
+.content-section h2 {
+  font-size: 1.8rem;
+  margin-bottom: 0.5rem;
+  color: var(--sandstone);
+}
+
+.sub-heading {
+  font-size: 1.2rem;
+  margin-top: 2rem;
+  margin-bottom: 0.25rem;
+  color: var(--gold);
+}
+
+.section-desc {
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.alt-bg {
+  background: var(--bg-secondary);
+  border-radius: 1rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.data-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  box-shadow: var(--shadow);
+}
+
+.data-card h3 {
+  margin-bottom: 0.5rem;
+  color: var(--gold);
+}
+
+.data-card p {
+  color: var(--text-secondary);
+}
+
+.timeline-list {
+  margin-top: 1rem;
+  border-left: 3px solid var(--gold);
+  padding-left: 1.25rem;
+}
+
+.timeline-entry {
+  margin-bottom: 1rem;
+}
+
+.timeline-entry .year {
+  font-weight: 700;
+  color: var(--gold);
+  display: block;
+}
+
+.timeline-entry .desc {
+  color: var(--text-secondary);
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.gallery-item {
+  border-radius: 0.75rem;
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  background: var(--card-bg);
+}
+
+.gallery-illustration {
+  width: 100%;
+  height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.75rem;
+  background: linear-gradient(135deg, var(--bg-alt), var(--border-color));
+}
+
+.gallery-caption {
+  padding: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.facts-list {
+  list-style: none;
+  margin-top: 1.5rem;
+}
+
+.facts-list li {
+  background: var(--card-bg);
+  border-left: 4px solid var(--sandstone);
+  padding: 0.9rem 1.25rem;
+  margin-bottom: 0.75rem;
+  border-radius: 0.5rem;
+  color: var(--text-secondary);
+}
+
+.site-footer {
+  text-align: center;
+  padding: 2rem;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+}
+
+.site-footer a {
+  color: var(--sandstone);
+  margin-left: 0.5rem;
+}
+
+@media (max-width: 700px) {
+  .content-section {
+    padding: 3rem 1.25rem;
+  }
+}

--- a/frontend/victoria-memorial-explorer/index.html
+++ b/frontend/victoria-memorial-explorer/index.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore the Victoria Memorial in Kolkata — a white marble monument, museum, and garden complex that stands as one of India's finest examples of Indo-Saracenic architecture.">
+  <title>Victoria Memorial Explorer | Incredible India</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header class="site-header">
+    <nav class="navbar" aria-label="Main navigation">
+      <a href="../../index.html" class="nav-logo" aria-label="Go to homepage">Incredible India Explorer</a>
+      <button id="theme-toggle" class="theme-btn" aria-label="Toggle dark and light theme">🌓 Theme</button>
+    </nav>
+  </header>
+
+  <main>
+    <section class="victoria-hero" aria-labelledby="hero-title">
+      <div class="hero-content">
+        <h1 id="hero-title">Victoria Memorial Explorer</h1>
+        <p class="hero-subtitle">A white marble monument, museum, and 64-acre garden on the Maidan in central Kolkata, West Bengal — one of India's most visited heritage landmarks.</p>
+        <div class="hero-badges">
+          <span class="badge">📍 Kolkata, West Bengal</span>
+          <span class="badge">🏛️ Indo-Saracenic Style</span>
+          <span class="badge">🏛️ Museum & Gardens</span>
+        </div>
+        <a href="#history" class="cta-button">Start Exploring ↓</a>
+      </div>
+    </section>
+
+    <section id="history" class="content-section" aria-labelledby="history-title">
+      <h2 id="history-title">Historical Background</h2>
+      <p class="section-desc">Conceived as a tribute to Queen Victoria and built through public contribution, the memorial took fifteen years to complete.</p>
+      <div id="history-grid" class="card-grid" role="list"></div>
+      <h3 class="sub-heading">Timeline</h3>
+      <div id="timeline-list" class="timeline-list" role="list"></div>
+    </section>
+
+    <section id="architecture" class="content-section alt-bg" aria-labelledby="arch-title">
+      <h2 id="arch-title">Architecture</h2>
+      <p class="section-desc">Designed by William Emerson in the Indo-Saracenic revivalist style, blending British classical form with Mughal, Islamic, and Deccani influences.</p>
+      <div id="architecture-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="museum" class="content-section" aria-labelledby="museum-title">
+      <h2 id="museum-title">Museum</h2>
+      <p class="section-desc">Opened as a museum and art gallery in 1930, it remains one of the most-visited museums in India today.</p>
+      <div id="museum-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="art-collections" class="content-section alt-bg" aria-labelledby="art-title">
+      <h2 id="art-title">Art and Collections</h2>
+      <p class="section-desc">Twenty-five galleries house around 28,000 artefacts spanning paintings, portraits, arms, and manuscripts.</p>
+      <div id="collections-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="gardens" class="content-section" aria-labelledby="gardens-title">
+      <h2 id="gardens-title">Gardens</h2>
+      <p class="section-desc">The memorial sits within roughly 64 acres of landscaped gardens, as much a part of its identity as the marble building itself.</p>
+      <div id="gardens-grid" class="card-grid" role="list"></div>
+    </section>
+
+    <section id="heritage-significance" class="content-section alt-bg" aria-labelledby="heritage-title">
+      <h2 id="heritage-title">Heritage Significance</h2>
+      <ul id="heritage-list" class="facts-list" role="list"></ul>
+    </section>
+
+    <section id="interesting-facts" class="content-section" aria-labelledby="facts-title">
+      <h2 id="facts-title">Interesting Facts</h2>
+      <ul id="facts-list" class="facts-list" role="list"></ul>
+    </section>
+
+    <section id="gallery" class="content-section alt-bg" aria-labelledby="gallery-title">
+      <h2 id="gallery-title">Gallery</h2>
+      <div id="gallery-grid" class="gallery-grid" role="list"></div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>&copy; 2026 Incredible India Explorer. Educational purposes only.</p>
+    <a href="../../index.html">Back to Home</a>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/victoria-memorial-explorer/script.js
+++ b/frontend/victoria-memorial-explorer/script.js
@@ -1,0 +1,139 @@
+(function() {
+  'use strict';
+
+  // Theme toggle logic
+  const themeBtn = document.getElementById('theme-toggle');
+  const body = document.body;
+
+  if (localStorage.getItem('theme') === 'light') {
+    body.classList.add('light-theme');
+  }
+
+  themeBtn.addEventListener('click', () => {
+    body.classList.toggle('light-theme');
+    localStorage.setItem('theme', body.classList.contains('light-theme') ? 'light' : 'dark');
+  });
+
+  // Data
+  const historyData = [
+    { name: 'A Viceroy\'s Idea', emoji: '👑', desc: 'After Queen Victoria\'s death in 1901, Viceroy Lord Curzon proposed a grand memorial in her honor, to be built through public contributions from across British India.' },
+    { name: 'Building the Memorial', emoji: '🏗️', desc: 'Construction was carried out by Martin & Co. of Calcutta, founded by Sir Rajendranath Mukherjee and Thomas Acquin Martin, and took roughly fifteen years to complete.' },
+    { name: 'From Memorial to Museum', emoji: '🖼️', desc: 'The building opened to the public in 1921, and its museum and art gallery followed in 1930, transforming the monument into one of India\'s major cultural institutions.' }
+  ];
+
+  const timelineData = [
+    { year: '1901', desc: 'Queen Victoria dies; Lord Curzon proposes a memorial in her honor.' },
+    { year: '1906', desc: 'The Prince of Wales (later King George V) lays the foundation stone on 4 January.' },
+    { year: '1910', desc: 'Construction of the main superstructure begins.' },
+    { year: '1921', desc: 'The memorial is formally opened to the public on 28 December.' },
+    { year: '1930', desc: 'The museum and art gallery are inaugurated inside the building.' },
+    { year: '1935', desc: 'Declared an institution of national importance under the Government of India Act.' }
+  ];
+
+  const architectureData = [
+    { name: 'Indo-Saracenic Style', emoji: '🕌', desc: 'Architect William Emerson blended British civic classicism with Mughal, Egyptian, Venetian, Deccani, and Islamic architectural elements.' },
+    { name: 'Scale', emoji: '📐', desc: 'The building measures about 103 by 69 metres and rises to a height of roughly 56 metres (184 feet).' },
+    { name: 'The Angel of Victory', emoji: '👼', desc: 'A bronze figure nearly 5 metres tall stands atop the central dome, mounted on ball bearings so it turns gently with the wind.' },
+    { name: 'Allegorical Sculptures', emoji: '🗿', desc: 'Figures representing Art, Justice, Charity, Architecture, Learning, Motherhood, and Prudence decorate the exterior around the dome.' }
+  ];
+
+  const museumData = [
+    { name: 'A National Institution', emoji: '🏛️', desc: 'Declared an institution of national importance in 1935, the Victoria Memorial Hall is today an autonomous body under India\'s Ministry of Culture.' },
+    { name: 'Among India\'s Most Visited', emoji: '🎟️', desc: 'It regularly ranks as one of the most-visited museums in India, drawing millions of visitors to its galleries and gardens each year.' },
+    { name: 'Ongoing Exhibitions', emoji: '📅', desc: 'Beyond its permanent collection, the museum hosts temporary exhibitions throughout the year, including international collaborations.' }
+  ];
+
+  const collectionsData = [
+    { name: 'Royal Gallery', emoji: '🖼️', desc: 'Portraits of Queen Victoria and Prince Albert, alongside personal items such as Victoria\'s childhood pianoforte and writing desk.' },
+    { name: 'Calcutta Gallery', emoji: '🗺️', desc: 'Traces the city\'s history from its founding through paintings, photographs, maps, and documents, including a life-size diorama of 19th-century Chitpur Road.' },
+    { name: 'National Leaders Gallery', emoji: '🇮🇳', desc: 'Honors India\'s freedom fighters, including artefacts connected to Netaji Subhas Chandra Bose and the Indian National Army.' },
+    { name: 'Sculpture & Arms Galleries', emoji: '⚔️', desc: 'Displays of sculpture alongside historic weaponry, swords, and armour spanning the collection\'s roughly 28,000 artefacts across 25 galleries.' }
+  ];
+
+  const gardensData = [
+    { name: 'Landscape Design', emoji: '🌳', desc: 'The roughly 64-acre gardens were designed by Scottish botanist Sir David Prain and Lord Redesdale, with the garden gates and north bridge designed by Vincent Esch.' },
+    { name: 'Water Features', emoji: '⛲', desc: 'Lawns, pools, and fountains are joined by a lake used for boating, creating a calm counterpoint to the marble monument at its centre.' },
+    { name: 'A Sculpture Trail', emoji: '🗽', desc: 'Statues of Queen Victoria and various colonial-era figures, relocated here after 1947, are scattered throughout the grounds alongside a dedicated French Garden of marble busts.' }
+  ];
+
+  const heritageData = [
+    'The Victoria Memorial is considered the largest monument built anywhere in the world for a monarch.',
+    'It stands as both a reminder of colonial history and a symbol of Kolkata\'s civic identity, blending British and Indian architectural traditions.',
+    'Often nicknamed the "Taj of the Raj," it draws a direct visual link to the Taj Mahal through its use of white marble.',
+    'Post-independence additions, like the National Leaders Gallery, place India\'s freedom struggle alongside its colonial-era exhibits.'
+  ];
+
+  const factsData = [
+    'The marble was sourced from the same Makrana quarries in Rajasthan used to build the Taj Mahal.',
+    'The bronze Angel of Victory atop the dome rotates with the wind thanks to a ball-bearing mount.',
+    'Despite Kolkata\'s strategic importance during World War II, the memorial escaped damage from bombing.',
+    'The museum holds the world\'s largest collection of paintings by Thomas and William Daniell.'
+  ];
+
+  const galleryData = [
+    { type: 'image', src: '../../assets/Victoria_Memorial.png', alt: 'The white marble Victoria Memorial building with its central dome, set against Kolkata\'s Maidan gardens', caption: 'The white marble memorial building on Kolkata\'s Maidan' },
+    { type: 'icon', emoji: '👼', alt: 'Illustration representing the bronze Angel of Victory statue atop the central dome', caption: 'The Angel of Victory atop the central dome' },
+    { type: 'icon', emoji: '🖼️', alt: 'Illustration representing the Royal Gallery with portraits of Queen Victoria', caption: 'The Royal Gallery\'s portraits and royal memorabilia' },
+    { type: 'icon', emoji: '🌳', alt: 'Illustration representing the landscaped gardens surrounding the memorial', caption: 'The 64-acre gardens surrounding the memorial' }
+  ];
+
+  // Render Functions
+  function renderCards(containerId, data) {
+    const grid = document.getElementById(containerId);
+    data.forEach(item => {
+      const card = document.createElement('div');
+      card.className = 'data-card';
+      card.setAttribute('role', 'listitem');
+      card.innerHTML = `<h3>${item.emoji} ${item.name}</h3><p>${item.desc}</p>`;
+      grid.appendChild(card);
+    });
+  }
+
+  function renderTimeline() {
+    const list = document.getElementById('timeline-list');
+    timelineData.forEach(item => {
+      const div = document.createElement('div');
+      div.className = 'timeline-entry';
+      div.setAttribute('role', 'listitem');
+      div.innerHTML = `<span class="year">${item.year}</span><span class="desc">${item.desc}</span>`;
+      list.appendChild(div);
+    });
+  }
+
+  function renderList(containerId, items) {
+    const list = document.getElementById(containerId);
+    items.forEach(text => {
+      const li = document.createElement('li');
+      li.textContent = text;
+      list.appendChild(li);
+    });
+  }
+
+  function renderGallery() {
+    const grid = document.getElementById('gallery-grid');
+    galleryData.forEach(item => {
+      const div = document.createElement('div');
+      div.className = 'gallery-item';
+      div.setAttribute('role', 'listitem');
+      if (item.type === 'image') {
+        div.innerHTML = `<img src="${item.src}" alt="${item.alt}" loading="lazy"><div class="gallery-caption">${item.caption}</div>`;
+      } else {
+        div.innerHTML = `<div class="gallery-illustration" role="img" aria-label="${item.alt}">${item.emoji}</div><div class="gallery-caption">${item.caption}</div>`;
+      }
+      grid.appendChild(div);
+    });
+  }
+
+  // Initialize
+  document.addEventListener('DOMContentLoaded', () => {
+    renderCards('history-grid', historyData);
+    renderTimeline();
+    renderCards('architecture-grid', architectureData);
+    renderCards('museum-grid', museumData);
+    renderCards('collections-grid', collectionsData);
+    renderCards('gardens-grid', gardensData);
+    renderList('heritage-list', heritageData);
+    renderList('facts-list', factsData);
+    renderGallery();
+  });
+})();

--- a/frontend/victoria-memorial-explorer/style.css
+++ b/frontend/victoria-memorial-explorer/style.css
@@ -1,0 +1,278 @@
+/* =========================================
+   Victoria Memorial Explorer Styles
+   Supports Dark (default) and Light themes
+   ========================================= */
+
+:root {
+  --bg-primary: #14151a;
+  --bg-secondary: #1e2026;
+  --bg-alt: #262932;
+  --text-primary: #f6f6f8;
+  --text-secondary: #b8bac2;
+  --marble: #e8e2d6;
+  --burgundy: #8a2f3c;
+  --gold: #c9a441;
+  --card-bg: #1e2026;
+  --border-color: #34373f;
+  --shadow: 0 4px 6px rgba(0, 0, 0, 0.3);
+}
+
+body.light-theme {
+  --bg-primary: #f8f7f4;
+  --bg-secondary: #ffffff;
+  --bg-alt: #f0ece3;
+  --text-primary: #1c1c22;
+  --text-secondary: #565862;
+  --marble: #cfc6b3;
+  --burgundy: #6e2530;
+  --gold: #a3801f;
+  --card-bg: #ffffff;
+  --border-color: #e6e1d6;
+  --shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+  line-height: 1.6;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.site-header {
+  background-color: var(--bg-secondary);
+  padding: 1rem 2rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  box-shadow: var(--shadow);
+}
+
+.navbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.nav-logo {
+  color: var(--burgundy);
+  text-decoration: none;
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.theme-btn {
+  background: var(--bg-alt);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  padding: 0.5rem 1rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+}
+
+.theme-btn:hover {
+  background: var(--border-color);
+}
+
+.victoria-hero {
+  background: linear-gradient(135deg, var(--bg-secondary), var(--bg-primary));
+  padding: 5rem 2rem;
+  text-align: center;
+}
+
+.hero-content {
+  max-width: 800px;
+  margin: 0 auto;
+}
+
+.hero-content h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+  color: var(--burgundy);
+}
+
+.hero-subtitle {
+  font-size: 1.15rem;
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.hero-badges {
+  display: flex;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.badge {
+  background: var(--bg-alt);
+  border: 1px solid var(--border-color);
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+}
+
+.cta-button {
+  display: inline-block;
+  background: var(--burgundy);
+  color: #fff;
+  padding: 0.75rem 1.75rem;
+  border-radius: 0.5rem;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.cta-button:hover {
+  opacity: 0.9;
+}
+
+.content-section {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 4rem 2rem;
+}
+
+.content-section h2 {
+  font-size: 1.8rem;
+  margin-bottom: 0.5rem;
+  color: var(--burgundy);
+}
+
+.sub-heading {
+  font-size: 1.2rem;
+  margin-top: 2rem;
+  margin-bottom: 0.25rem;
+  color: var(--gold);
+}
+
+.section-desc {
+  color: var(--text-secondary);
+  margin-bottom: 1.5rem;
+}
+
+.alt-bg {
+  background: var(--bg-secondary);
+  border-radius: 1rem;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.data-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  box-shadow: var(--shadow);
+}
+
+.data-card h3 {
+  margin-bottom: 0.5rem;
+  color: var(--gold);
+}
+
+.data-card p {
+  color: var(--text-secondary);
+}
+
+.timeline-list {
+  margin-top: 1rem;
+  border-left: 3px solid var(--gold);
+  padding-left: 1.25rem;
+}
+
+.timeline-entry {
+  margin-bottom: 1rem;
+}
+
+.timeline-entry .year {
+  font-weight: 700;
+  color: var(--gold);
+  display: block;
+}
+
+.timeline-entry .desc {
+  color: var(--text-secondary);
+}
+
+.gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+  margin-top: 1.5rem;
+}
+
+.gallery-item {
+  border-radius: 0.75rem;
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  background: var(--card-bg);
+}
+
+.gallery-item img {
+  width: 100%;
+  height: 180px;
+  object-fit: cover;
+  display: block;
+}
+
+.gallery-illustration {
+  width: 100%;
+  height: 180px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.75rem;
+  background: linear-gradient(135deg, var(--bg-alt), var(--border-color));
+}
+
+.gallery-caption {
+  padding: 0.75rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.facts-list {
+  list-style: none;
+  margin-top: 1.5rem;
+}
+
+.facts-list li {
+  background: var(--card-bg);
+  border-left: 4px solid var(--burgundy);
+  padding: 0.9rem 1.25rem;
+  margin-bottom: 0.75rem;
+  border-radius: 0.5rem;
+  color: var(--text-secondary);
+}
+
+.site-footer {
+  text-align: center;
+  padding: 2rem;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+}
+
+.site-footer a {
+  color: var(--burgundy);
+  margin-left: 0.5rem;
+}
+
+@media (max-width: 700px) {
+  .content-section {
+    padding: 3rem 1.25rem;
+  }
+}


### PR DESCRIPTION
## What this PR does
Adds a new, dedicated Rani ki Vav page at `frontend/rani-ki-vav-explorer/`, covering:
- Hero section with location (Patan, Gujarat) and quick badges
- History: Queen Udayamati's memorial to King Bhima I, the stepwell's centuries under silt, and its rediscovery, plus a dedicated historical timeline
- Stepwell Architecture: the inverted-temple design, scale, and core structural elements
- Water Management: why stepwells were built and how they served both practical and social needs
- Sculptures and Carvings: the Dashavatara imagery and the link to Patan's Patola textile patterns
- Solanki Heritage: the Solanki (Chaulukya) dynasty's golden age and related Maru-Gurjara monuments
- UNESCO Recognition: World Heritage status (inscribed 2014) and the criteria behind it
- A dedicated Interesting Facts section
- An illustrated image gallery with descriptive alt text on every entry (no mismatched stock photo is used, since no verified Rani ki Vav image asset exists in the repository)
- Responsive layout (mobile-friendly grid and spacing)

## Files added
- `frontend/rani-ki-vav-explorer/index.html`
- `frontend/rani-ki-vav-explorer/style.css`
- `frontend/rani-ki-vav-explorer/script.js`

## Files changed
- None — this issue does not request landing-page integration, so no existing files were modified.

Closes #2738 

@Eshajha19 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.