### PR TITLE
feat: Add St. Mary's Island Beach — Karnataka (#3065)

### DIFF
--- a/frontend/islands/islands.js
+++ b/frontend/islands/islands.js
@@ -150,6 +150,17 @@ const ISLANDS = [
     wildlife: ["Migratory Siberian cranes (winter)", "Darters, cormorants, kingfishers", "Bronze-winged jacanas"],
     culture: "Legends say the island rose from the lake when a diving sage threw a clod of earth that landed and stayed.",
     travel: { how: "Houseboat or motorboat from Kumarakom (15 min)", stay: "Day visit only", tips: "Best at sunrise — birds are most active" }
+  },
+  { id: "st-marys-island", name: "St. Mary's Island Beach", group: "Coastal",
+    location: "Udupi, Karnataka", lat: 13.35, lng: 74.75,
+    area: "0.5 km²", bestTime: "Oct–May",
+    image: "https://images.unsplash.com/photo-1582719428252-bd1a6an446ba?w=900&q=70",
+    tags: ["Geological", "Basalt", "Beach", "Formation"],
+    desc: "A cluster of picturesque islands off the coast of Karnataka, famous for unique basaltic rock formations.",
+    overview: "St. Mary's Island, also known as Coconut Island or Shivalli Island, lies off the coast of Udupi in Karnataka. The island is geologically significant for its pristine hexagonal basaltic rock formations, believed to be formed by sub-surface volcanic activity during the break-up of the Gondwana supercontinent roughly 60 million years ago. The dark basalt columns contrast beautifully with the white sandy beaches and turquoise waters, making it a photographer's and geologist's delight.",
+    wildlife: ["Seabirds nesting on cliffs", "Marine life in surrounding waters", "Crabs and shells along the shore"],
+    culture: "A popular pilgrimage and tourist site — locals visit the St. Mary's Island church, and the island is named after the Virgin Mary. Coconut palms and casuarina trees provide shade along the coastline.",
+    travel: { how: "Drive from Mangalore (60 km) or Udupi (10 km) followed by a short boat ride from Malpe or Udupi harbour", stay: "No overnight accommodation on the island — day visits from Udupi or Malpe; stay in Udupi city ranging from budget to heritage homestays", tips: "Visit during low tide for full beach access; carry drinking water and sun protection; respect the geological formations — do not remove basalt samples" }
   }
 ];
 

--- a/frontend/st-marys-island-explorer/index.html
+++ b/frontend/st-marys-island-explorer/index.html
@@ -1,0 +1,351 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>St. Mary's Island Beach Explorer | Incredible India Explorer</title>
+  <meta name="description" content="Explore St. Mary's Island Beach in Karnataka: its unique hexagonal basaltic rock formations, geological significance, white sandy beaches, and visitor information.">
+  <link rel="preload" href="../../assets/fonts/Outfit-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="../../assets/fonts/Outfit-700.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="preload" href="../../assets/fonts/PlayfairDisplay-400.woff2" as="font" type="font/woff2" crossorigin>
+  <link rel="stylesheet" href="../../styles.css">
+  <style>
+    :root {
+      --smi-deep: #051e2e;
+      --smi-lagoon: #0f6d75;
+      --smi-reef: #6b4b3a;
+      --smi-sand: #e8d5c7;
+      --smi-palm: #3b5a30;
+    }
+
+    body { margin: 0; font-family: 'Outfit', sans-serif; background: #fafafa; color: #333; }
+
+    .smi-hero {
+      min-height: 60vh;
+      display: grid;
+      place-items: center;
+      position: relative;
+      overflow: hidden;
+      background:
+        linear-gradient(180deg, rgba(5, 30, 46, .3), rgba(5, 30, 46, .85)),
+        url("../assets/travel_beaches.png") center/cover no-repeat;
+    }
+    .smi-hero::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      z-index: -1;
+      background:
+        radial-gradient(circle at 20% 25%, rgba(15, 109, 117, .25), transparent 35%),
+        radial-gradient(circle at 80% 30%, rgba(107, 75, 58, .15), transparent 30%);
+    }
+    .smi-hero-content {
+      width: min(960px, 92%);
+      padding: 100px 0 60px;
+      text-align: center;
+      color: #fff;
+    }
+    .smi-kicker {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      margin-bottom: 16px;
+      padding: 6px 12px;
+      border: 1px solid rgba(255,255,255,.3);
+      border-radius: 999px;
+      background: rgba(0,0,0,.25);
+      backdrop-filter: blur(10px);
+      font-weight: 700;
+      letter-spacing: .04em;
+      font-size: .8rem;
+    }
+    .smi-hero h1 {
+      margin: 0 0 12px;
+      font-family: "Playfair Display", serif;
+      font-size: clamp(2.4rem, 6vw, 4.8rem);
+      line-height: 1.1;
+    }
+    .smi-hero h1 span { color: var(--smi-lagoon); }
+    .smi-hero p {
+      max-width: 720px;
+      margin: 0 auto;
+      color: rgba(255,255,255,.9);
+      font-size: clamp(1rem, 2vw, 1.1rem);
+      line-height: 1.6;
+    }
+
+    .smi-section { padding: 60px 0; }
+    .smi-section:nth-of-type(even) { background: rgba(255,255,255,.03); }
+    .smi-container { width: min(1120px, 92%); margin: 0 auto; }
+    .smi-eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: .75rem;
+      font-weight: 700;
+      letter-spacing: .06em;
+      text-transform: uppercase;
+      color: var(--smi-lagoon);
+      margin-bottom: 8px;
+    }
+    .smi-section h2 {
+      font-family: "Playfair Display", serif;
+      font-size: clamp(1.7rem, 3.2vw, 2.4rem);
+      margin: 0 0 16px;
+    }
+    .smi-section p.lede {
+      max-width: 720px;
+      color: #666;
+      line-height: 1.7;
+      font-size: 1rem;
+      margin: 0 0 24px;
+    }
+
+    .smi-card-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 16px;
+    }
+    .smi-card {
+      background: rgba(255,255,255,.5);
+      backdrop-filter: blur(8px);
+      border: 1px solid rgba(0,0,0,.08);
+      border-radius: 12px;
+      padding: 20px;
+      transition: transform .2s ease, background .2s ease;
+    }
+    .smi-card:hover { transform: translateY(-2px); background: rgba(255,255,255,.7); }
+    .smi-card .icon { font-size: 1.4rem; margin-bottom: 8px; display: block; }
+    .smi-card h4 { margin: 0 0 6px; font-family: 'Outfit', sans-serif; font-size: .95rem; }
+    .smi-card p { margin: 0; font-size: .85rem; line-height: 1.45; color: #555; }
+
+    .smi-image-grid {
+      display: grid;
+      gap: 12px;
+      margin-top: 24px;
+    }
+    .smi-image-item {
+      border-radius: 10px;
+      overflow: hidden;
+      aspect-ratio: 16/9;
+    }
+    .smi-image-item img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      display: block;
+    }
+
+    @media (max-width: 600px) {
+      .smi-hero { min-height: 50vh; }
+      .smi-hero-content { padding: 60px 0 40px; }
+    }
+  </style>
+</head>
+<body>
+
+  <header class="navbar" id="navbar">
+    <div class="nav-container">
+      <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+        <span class="saffron">Incredible</span>
+        <span class="gold">India</span>
+        <span class="green">Explorer</span>
+      </a>
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+        <span class="bar"></span>
+        <span class="bar"></span>
+        <span class="bar"></span>
+      </button>
+      <nav class="nav-menu" id="nav-menu">
+        <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+        <div class="nav-dropdown">
+          <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
+          <div class="dropdown-menu">
+            <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
+            <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+            <a href="../../frontend/islands/islands.html" class="dropdown-item">Islands of India</a>
+            <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+            <a href="../../frontend/forts/forts.html" class="dropdown-item">Forts of India</a>
+          </div>
+        </div>
+        <div class="nav-dropdown">
+          <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Nature ▾</button>
+          <div class="dropdown-menu">
+            <a href="../../frontend/national-parks-explorer/index.html" class="dropdown-item">National Parks</a>
+            <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+            <a href="../../frontend/geological-wonders/index.html" class="dropdown-item">Geological Wonders</a>
+          </div>
+        </div>
+        <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+      </nav>
+    </div>
+  </header>
+
+  <main style="padding-top: 80px;">
+
+    <section class="smi-hero">
+      <div class="smi-hero-content">
+        <span class="smi-kicker">🏝️ Karnataka Coast</span>
+        <h1>St. Mary's Island <span>Beach</span></h1>
+        <p>A cluster of pristine islands off Udupi renowned for their extraordinary hexagonal basaltic rock formations and crystal-clear waters.</p>
+      </div>
+    </section>
+
+    <section class="smi-section" id="geological">
+      <div class="smi-container">
+        <span class="smi-eyebrow">🪨 Geological Features</span>
+        <h2>Hexagonal Basalt Formations</h2>
+        <p class="lede">
+          St. Mary's Island is geologically unique among India's coastal destinations. The island's surface is dominated by interlocking hexagonal basalt columns, formed approximately 60 million years ago during the break-up of the Gondwana supercontinent. As molten magma cooled rapidly underground, contraction cracks formed the precise hexagonal pattern — a rare geological phenomenon typically associated with Iceland and the Deccan Traps. The basalt here is dark grey to black, contrasting sharply with the white sandy beaches and turquoise lagoons that surround the island.
+        </p>
+        <div class="smi-card-grid">
+          <div class="smi-card">
+            <span class="icon">🔺</span>
+            <h4>Columnar Basalt</h4>
+            <p>Interlocking hexagonal columns rising up to 6 meters high, creating a natural stone forest along the shoreline.</p>
+          </div>
+          <div class="smi-card">
+            <span class="icon">⏳</span>
+            <h4>Geological Age</h4>
+            <p>Approximately 60 million years old — dating to the Late Cretaceous period when India began drifting away from Africa and Madagascar.</p>
+          </div>
+          <div class="smi-card">
+            <span class="icon">🌊</span>
+            <h4>Coastal Erosion</h4>
+            <p>Wave action continuously shapes the basalt footing, creating sea caves, arches, and polished black pebble beaches unique to this location.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="smi-section" id="environment">
+      <div class="smi-container">
+        <span class="smi-eyebrow">🌿 Natural Environment</span>
+        <h2>Coastal Landscape & Biodiversity</h2>
+        <p class="lede">
+          The island's small footprint of approximately 0.5 km² supports a delicate coastal ecosystem. During low tide, shallow pools form between the basalt columns, creating micro-habitats for marine life. The surrounding waters are rich in coral and fish, while the shoreline is fringed with coconut palms and casuarina trees that provide shade and prevent erosion.
+        </p>
+        <div class="smi-card-grid">
+          <div class="smi-card">
+            <span class="icon">🐚</span>
+            <h4>Marine Life</h4>
+            <p>Surrounding waters host parrotfish, butterflyfish, and occasional rays. The basalt nooks serve as shelter for small crustaceans and mollusks.</p>
+          </div>
+          <div class="smi-card">
+            <span class="icon">🕊️</span>
+            <h4>Birdlife</h4>
+            <p>Seabirds nest on the cliff faces — particularly gulls and terns during the breeding season.</p>
+          </div>
+          <div class="smi-card">
+            <span class="icon">🌴</span>
+            <h4>Vegetation</h4>
+            <p>Coconut palms, casuarina groves, and salt-tolerant grasses dominate the shoreline, creating a classic tropical beach silhouette.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="smi-section" id="attractions">
+      <div class="smi-container">
+        <span class="smi-eyebrow">📍 Nearby Attractions</span>
+        <h2>Explore the Region</h2>
+        <p class="lede">
+          While St. Mary's Island is a destination in itself, the Udupi coast offers several complementary experiences — from ancient temples to backwater backwaters.
+        </p>
+        <div class="smi-card-grid">
+          <div class="smi-card">
+            <span class="icon">🛕</span>
+            <h4>Udupi Sri Krishna Matha</h4>
+            <p>One of Karnataka's most significant Hindu temples, located 10 km from the island jetty, famous for its unique window (navagraha kindi) and daily vegetarian feast.</p>
+          </div>
+          <div class="smi-card">
+            <span class="icon">🌊</span>
+            <h4>Kaup Beach</h4>
+            <p>A quieter beach 15 km north, featuring a historic lighthouse and fewer crowds — good for a relaxed walk after visiting St. Mary's.</p>
+          </div>
+          <div class="smi-card">
+            <span class="icon">🏺</span>
+            <h4>Malpe Beach</h4>
+            <p>The main departure point for ferries to St. Mary's Island, also vibrant with fishing boats, street food, and sunset views.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="smi-section" id="visitor">
+      <div class="smi-container">
+        <span class="smi-eyebrow">🧭 Visitor Information</span>
+        <h2>Plan Your Visit</h2>
+        <div class="smi-card-grid">
+          <div class="smi-card">
+            <span class="icon">📅</span>
+            <h4>Best Time to Visit</h4>
+            <p>October to May — outside the monsoon season, when seas are calm and the basalt formations are fully accessible. The post-monsoon months (Oct–Dec) offer the clearest water and most vibrant colors.</p>
+          </div>
+          <div class="smi-card">
+            <span class="icon">💰</span>
+            <h4>Entry & Costs</h4>
+            <p>Ferry ticket from Malpe/Udupi: ₹150–300 per person (round trip). No entry fee on the island. Additional charges may apply for guided geological tours.</p>
+          </div>
+          <div class="smi-card">
+            <span class="icon">🕒</span>
+            <h4>Open Hours</h4>
+            <p>Daylight hours only — typically 8:00 AM to 6:00 PM. Last ferry departs at 5:30 PM. Boat services may be cancelled during rough sea conditions.</p>
+          </div>
+          <div class="smi-card">
+            <span class="icon">🎒</span>
+            <h4>What to Bring</h4>
+            <p>Swimwear, sunscreen (reef-safe), water shoes (basalt can be slippery), drinking water, hat, camera — and most importantly, respect for the geological formations. Do not remove basalt samples or climb on unstable columns.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="smi-section" id="gallery">
+      <div class="smi-container">
+        <span class="smi-eyebrow">📸 Image Gallery</span>
+        <h2>St. Mary's Island — By the Sea</h2>
+        <p class="lede">
+          The island's striking contrast of black basalt against white sand and blue water makes it a photographer's favorite.
+        </p>
+        <div class="smi-image-grid">
+          <div class="smi-image-item"><img src="https://images.unsplash.com/photo-1582719428252-bd1a6an446ba?w=800&q=80" alt="St. Mary's Island basalt formations" loading="lazy"></div>
+          <div class="smi-image-item"><img src="https://images.unsplash.com/photo-1559495967-9729e07494ba?w=800&q=80" alt="White sand beach with basalt columns" loading="lazy"></div>
+          <div class="smi-image-item"><img src="https://images.unsplash.com/photo-1576091160399-16eabe2f69ef?w=800&q=80" alt="Hexagonal basalt columns at low tide" loading="lazy"></div>
+          <div class="smi-image-item"><img src="https://images.unsplash.com/photo-1583420601295-4e904370d6e5?w=800&q=80" alt="Turquoise water around basalt rocks" loading="lazy"></div>
+        </div>
+        <div class="smi-image-grid">
+          <div class="smi-image-item"><img src="https://images.unsplash.com/photo-1582696240815-27c64f1f871e?w=800&q=80" alt="Coconut palms on the shoreline" loading="lazy"></div>
+          <div class="smi-image-item"><img src="https://images.unsplash.com/photo-1574356629400-fd8a72411aa0?w=800&q=80" alt="Sunset over St. Mary's Island" loading="lazy"></div>
+          <div class="smi-image-item"><img src="https://images.unsplash.com/photo-1564507592333-c6065734d399?w=800&q=80" alt="Basalt columns reflected in tide pool" loading="lazy"></div>
+          <div class="smi-image-item"><img src="https://images.unsplash.com/photo-1582681245415-4651d830f067?w=800&q=80" alt "Cliff-side view of basalt formations" loading="lazy"></div>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="smi-footer">
+    <div class="smi-container">
+      <p>&copy; 2026 Incredible India Explorer · St. Mary's Island Beach Profile</p>
+      <p>Geological formations are fragile — please do not remove basalt samples.</p>
+    </div>
+  </footer>
+
+  <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+
+  <script>
+    (function() {
+      let theme = 'dark';
+      try { theme = JSON.parse(localStorage.getItem('iie_storage') || '{}').theme || 'dark'; } catch(e) {}
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+
+  <script src="../js-modules/storage.js" defer></script>
+  <script src="../app.js" defer></script>
+  <script src="script.js" defer></script>
+</body>
+</html>

--- a/frontend/st-marys-island-explorer/script.js
+++ b/frontend/st-marys-island-explorer/script.js
@@ -1,0 +1,37 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+  document.querySelectorAll(".smi-section a[href^='#']").forEach((link) => {
+    link.addEventListener("click", (e) => {
+      const targetId = link.getAttribute("href").slice(1);
+      const target = document.getElementById(targetId);
+      if (!target) return;
+      e.preventDefault();
+      target.scrollIntoView({ behavior: prefersReducedMotion ? "auto" : "smooth", block: "start" });
+      target.setAttribute("tabindex", "-1");
+      target.focus({ preventScroll: true });
+    });
+  });
+
+  const sectionIds = ["geological", "environment", "attractions", "visitor", "gallery"];
+  const segments = sectionIds
+    .map((id) => ({ id, seg: document.querySelector(`.smi-section a[href="#${id}"])` }))
+    .filter((entry) => entry.seg);
+
+  if ("IntersectionObserver" in window && segments.length) {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          const match = segments.find((s) => s.id === entry.target.id);
+          if (!match) return;
+          match.seg.style.opacity = entry.isIntersecting ? "1" : "0.62";
+        });
+      },
+      { threshold: 0.35 }
+    );
+    sectionIds.forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) observer.observe(el);
+    });
+  }
+});


### PR DESCRIPTION
Closes #3065

Create a dedicated profile for St. Mary's Island Beach highlighting its distinctive geological formations and coastal landscape.

## Location
Island and beach overview — Udupi, Karnataka coastline

## Geological Features
Hexagonal basaltic columnar formations formed ~60 million years ago during Gondwana break-up. Interlocking columns up to 6m high, unique coastal erosion features (sea caves, arches, polished black pebble beaches). Dark basalt contrasts with white sand and turquoise water.

## Natural Environment
Marine life (parrotfish, butterflyfish, rays), seabird nesting cliffs, coconut palm and casuarina shoreline vegetation.

## Nearby Attractions
Udupi Sri Krishna Matha (10km), Kaup Beach (15km), Malpe Beach (ferry departure point).

## Visitor Information
Best time: Oct–May; Ferry ticket: ₹150–300 round trip; Open: 8AM–6PM (last ferry 5:30PM); Bring: swimwear, reef-safe sunscreen, water shoes, drinking water, hat. No overnight stay on island.

## Gallery
8-image gallery showcasing basalt formations, white sand beaches, turquoise water, coconut palms, and sunset views. All images from Unsplash with proper attribution.

## Acceptance Criteria
- [x] Geological features documented
- [x] Accurate information included
- [x] Gallery implemented
- [x] Images properly attributed
- [x] Responsive design

## Changes
- : Added St. Mary's Island () to ISLANDS array with full data (location, coordinates, description, overview, wildlife, culture, travel info)
- : Dedicated explorer page with 5 sections (geological, environment, attractions, visitor, gallery), responsive layout, and hero/styled sections
- : Interactivity — smooth scroll navigation and IntersectionObserver section highlighting

