### PR TITLE
feat: add India's oldest sporting trophies age timeline

### DIFF
--- a/frontend/indias-oldest-sporting-trophies-timeline/index.html
+++ b/frontend/indias-oldest-sporting-trophies-timeline/index.html
@@ -1,0 +1,555 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>India's Oldest Sporting Trophies — An Age Timeline</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@500;600;700;900&family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400&family=Cutive+Mono&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --green-deep:#0e2b22;
+    --green-mid:#163a2d;
+    --green-line: #23483a;
+    --brass:#c9a24b;
+    --brass-bright:#e6c874;
+    --ivory:#f3ecda;
+    --ivory-dim:#cdc4a8;
+    --oxblood:#7a2430;
+    --patina:#6b9484;
+    --ink:#0b1512;
+    --shadow: 0 20px 50px rgba(0,0,0,0.45);
+  }
+
+  *{box-sizing:border-box;}
+
+  html{scroll-behavior:smooth;}
+
+  body{
+    margin:0;
+    background:
+      radial-gradient(1200px 700px at 15% -10%, rgba(201,162,75,0.10), transparent 60%),
+      radial-gradient(1000px 600px at 110% 10%, rgba(122,36,48,0.14), transparent 55%),
+      var(--green-deep);
+    color:var(--ivory);
+    font-family:'Cormorant Garamond', serif;
+    font-size:19px;
+    line-height:1.55;
+    -webkit-font-smoothing:antialiased;
+  }
+
+  h1,h2,h3,.eyebrow,.plaque-label{
+    font-family:'Cinzel', serif;
+    letter-spacing:0.04em;
+  }
+
+  .eyebrow{
+    font-family:'Cutive Mono', monospace;
+    text-transform:uppercase;
+    letter-spacing:0.28em;
+    font-size:0.72rem;
+    color:var(--brass);
+    opacity:0.9;
+  }
+
+  a{color:var(--brass-bright);}
+  a:hover{color:var(--ivory);}
+
+  /* ---------- textured rail background ---------- */
+  .rail-texture{
+    background-image:
+      repeating-linear-gradient(115deg, rgba(255,255,255,0.015) 0px, rgba(255,255,255,0.015) 1px, transparent 1px, transparent 3px);
+  }
+
+  /* ================= HERO ================= */
+  header.hero{
+    position:relative;
+    padding: 6.5rem 6vw 5rem;
+    text-align:center;
+    border-bottom:1px solid rgba(201,162,75,0.25);
+    overflow:hidden;
+  }
+  header.hero::before{
+    content:"";
+    position:absolute; inset:0;
+    background:
+      linear-gradient(180deg, rgba(0,0,0,0) 60%, var(--green-deep) 100%),
+      conic-gradient(from 180deg at 50% -20%, rgba(201,162,75,0.10), transparent 30%);
+    pointer-events:none;
+  }
+  .crest{
+    width:92px; height:92px; margin:0 auto 1.6rem;
+    opacity:0.95;
+    filter:drop-shadow(0 6px 14px rgba(0,0,0,0.5));
+  }
+  header.hero h1{
+    font-size:clamp(2.1rem, 5.4vw, 4.1rem);
+    margin:0 0 0.6rem;
+    color:var(--ivory);
+    text-shadow: 0 2px 0 rgba(0,0,0,0.4);
+    font-weight:700;
+  }
+  header.hero h1 span{color:var(--brass-bright);}
+  .hero-sub{
+    max-width:640px; margin:0 auto;
+    color:var(--ivory-dim);
+    font-size:1.28rem;
+    font-style:italic;
+  }
+  .hero-meta{
+    margin-top:2.4rem;
+    display:flex; gap:2.6rem; justify-content:center; flex-wrap:wrap;
+  }
+  .hero-meta div{ text-align:center; }
+  .hero-meta .num{
+    font-family:'Cinzel', serif; font-weight:700;
+    font-size:1.9rem; color:var(--brass-bright);
+    display:block;
+  }
+  .hero-meta .lbl{
+    font-family:'Cutive Mono', monospace;
+    font-size:0.66rem; letter-spacing:0.18em; text-transform:uppercase;
+    color:var(--ivory-dim);
+  }
+
+  section{ padding: 4.4rem 6vw; max-width:1180px; margin:0 auto; }
+  .section-head{ text-align:center; max-width:680px; margin:0 auto 3rem; }
+  .section-head h2{ font-size:clamp(1.5rem,3vw,2.1rem); color:var(--ivory); margin:0.5rem 0 0.8rem; }
+  .section-head p{ color:var(--ivory-dim); font-size:1.08rem; margin:0;}
+
+  /* ================= TIMELINE (signature element) ================= */
+  .timeline-wrap{
+    position:relative;
+    padding: 3.2rem 1rem 1rem;
+  }
+
+  .timeline-rail-outer{
+    position:relative;
+    height:180px;
+    margin: 0 1rem 0;
+  }
+
+  .timeline-baseline{
+    position:absolute;
+    left:0; right:0; top:50%;
+    height:3px;
+    background: linear-gradient(90deg, transparent, var(--brass) 6%, var(--brass) 94%, transparent);
+    box-shadow: 0 0 12px rgba(201,162,75,0.35);
+    transform:translateY(-50%);
+  }
+  .timeline-baseline::before, .timeline-baseline::after{
+    content:""; position:absolute; top:50%; transform:translateY(-50%);
+    width:10px; height:10px; border-radius:50%; background:var(--brass);
+  }
+  .timeline-baseline::before{ left:-2px; }
+  .timeline-baseline::after{ right:-2px; }
+
+  .tick{
+    position:absolute; top:50%; transform:translate(-50%,-50%);
+    display:flex; flex-direction:column; align-items:center; gap:0.5rem;
+    cursor:pointer;
+    background:none; border:none; padding:0;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .tick .year-label{
+    font-family:'Cutive Mono', monospace;
+    font-size:0.72rem; color:var(--ivory-dim);
+    letter-spacing:0.03em;
+    order:2;
+    white-space:nowrap;
+  }
+  .medallion{
+    width:52px; height:52px; border-radius:50%;
+    background: radial-gradient(circle at 32% 28%, #f1dca0, var(--brass) 46%, #8a6a24 100%);
+    border:2px solid rgba(255,255,255,0.35);
+    display:flex; align-items:center; justify-content:center;
+    box-shadow: 0 6px 16px rgba(0,0,0,0.5), inset 0 0 8px rgba(255,255,255,0.25);
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+    order:1;
+  }
+  .medallion svg{ width:26px; height:26px; }
+  .medallion svg *{ stroke:#3c2a08; fill:none; stroke-width:6; }
+
+  .tick:hover .medallion, .tick.active .medallion{
+    transform: translateY(-6px) scale(1.08);
+    box-shadow: 0 12px 26px rgba(0,0,0,0.55), 0 0 0 4px rgba(201,162,75,0.28), inset 0 0 8px rgba(255,255,255,0.35);
+  }
+  .tick.active .medallion{
+    background: radial-gradient(circle at 32% 28%, #fff1c4, var(--brass-bright) 46%, #a4801f 100%);
+  }
+  .tick.active .year-label{ color:var(--brass-bright); font-weight:600; }
+
+  .timeline-scroll-hint{
+    text-align:center; color:var(--ivory-dim); font-size:0.85rem; font-style:italic;
+    margin-top:1.6rem;
+  }
+
+  /* ================= DETAIL PLAQUE ================= */
+  .plaque{
+    margin-top: 2.6rem;
+    background: linear-gradient(180deg, rgba(255,255,255,0.03), rgba(0,0,0,0.15)), var(--green-mid);
+    border:1px solid rgba(201,162,75,0.35);
+    border-radius:10px;
+    box-shadow: var(--shadow);
+    padding: 2.6rem clamp(1.4rem, 4vw, 3rem);
+    display:grid;
+    grid-template-columns: 150px 1fr;
+    gap: 2.2rem;
+    align-items:start;
+    transition: opacity 0.25s ease;
+  }
+  @media (max-width:640px){
+    .plaque{ grid-template-columns: 1fr; text-align:left; }
+    .plaque-icon-wrap{ margin:0 auto; }
+  }
+  .plaque-icon-wrap{
+    width:130px; height:130px; border-radius:50%;
+    background: radial-gradient(circle at 34% 28%, #f1dca0, var(--brass) 46%, #8a6a24 100%);
+    border:3px solid rgba(255,255,255,0.4);
+    display:flex; align-items:center; justify-content:center;
+    box-shadow: 0 10px 24px rgba(0,0,0,0.5), inset 0 0 14px rgba(255,255,255,0.3);
+  }
+  .plaque-icon-wrap svg{ width:66px; height:66px; }
+  .plaque-icon-wrap svg *{ stroke:#3c2a08; fill:none; stroke-width:5.5; }
+
+  .plaque-label{
+    font-size:0.7rem; color:var(--patina); letter-spacing:0.24em; text-transform:uppercase;
+    font-family:'Cutive Mono', monospace;
+  }
+  .plaque h3{
+    font-size:clamp(1.5rem,2.6vw,2.1rem);
+    margin:0.35rem 0 0.2rem;
+    color:var(--brass-bright);
+  }
+  .plaque .subline{
+    color:var(--ivory-dim); font-style:italic; margin-bottom:1.2rem; font-size:1.05rem;
+  }
+  .plaque-grid{
+    display:grid; grid-template-columns: repeat(auto-fit,minmax(190px,1fr));
+    gap:1.1rem 1.8rem;
+    margin-bottom:1.3rem;
+  }
+  .plaque-grid dt{
+    font-family:'Cutive Mono', monospace; font-size:0.66rem; letter-spacing:0.16em;
+    text-transform:uppercase; color:var(--brass); margin-bottom:0.2rem;
+  }
+  .plaque-grid dd{ margin:0; color:var(--ivory); font-size:1.06rem; }
+
+  .plaque-body p{ color:var(--ivory-dim); margin:0 0 0.9rem; }
+  .status-pill{
+    display:inline-block; font-family:'Cutive Mono', monospace; font-size:0.68rem;
+    letter-spacing:0.12em; text-transform:uppercase;
+    padding:0.3rem 0.7rem; border-radius:999px; border:1px solid;
+  }
+  .status-active{ color:#bfe6cf; border-color:#3f6e54; background:rgba(63,110,84,0.18); }
+  .status-defunct{ color:#e3b3ac; border-color:#7a3a34; background:rgba(122,58,52,0.18); }
+
+  /* ================= GRID (all trophies) ================= */
+  .card-grid{
+    display:grid;
+    grid-template-columns: repeat(auto-fit, minmax(270px, 1fr));
+    gap:1.4rem;
+  }
+  .card{
+    background: linear-gradient(180deg, rgba(255,255,255,0.03), rgba(0,0,0,0.12)), var(--green-mid);
+    border:1px solid rgba(201,162,75,0.22);
+    border-radius:8px;
+    padding:1.5rem 1.5rem 1.7rem;
+    cursor:pointer;
+    transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    text-align:left;
+  }
+  .card:hover, .card:focus-visible{
+    transform:translateY(-4px);
+    border-color: var(--brass);
+    box-shadow: 0 14px 30px rgba(0,0,0,0.4);
+    outline:none;
+  }
+  .card .row1{ display:flex; align-items:center; gap:0.8rem; margin-bottom:0.7rem;}
+  .card .icon-sm{
+    width:40px; height:40px; border-radius:50%; flex:none;
+    background: radial-gradient(circle at 34% 28%, #f1dca0, var(--brass) 46%, #8a6a24 100%);
+    display:flex; align-items:center; justify-content:center;
+  }
+  .card .icon-sm svg{ width:20px; height:20px; }
+  .card .icon-sm svg *{ stroke:#3c2a08; fill:none; stroke-width:6; }
+  .card .yr{ font-family:'Cinzel', serif; font-weight:700; color:var(--brass-bright); font-size:1.35rem; }
+  .card h4{ margin:0 0 0.3rem; color:var(--ivory); font-size:1.25rem; font-family:'Cinzel', serif; font-weight:600;}
+  .card p.meta{ margin:0; color:var(--ivory-dim); font-size:0.95rem; }
+
+  /* ================= SOURCES ================= */
+  .sources{
+    border-top:1px solid rgba(201,162,75,0.25);
+  }
+  .sources ol{
+    columns: 2; column-gap:2.5rem;
+    padding-left:1.2rem; color:var(--ivory-dim); font-size:0.98rem;
+  }
+  @media(max-width:640px){ .sources ol{ columns:1; } }
+  .sources li{ margin-bottom:0.7rem; break-inside: avoid; }
+
+  footer{
+    text-align:center; padding:2.4rem 6vw 3rem; color:var(--ivory-dim);
+    font-size:0.85rem; border-top:1px solid rgba(201,162,75,0.15);
+  }
+
+  @media (prefers-reduced-motion: reduce){
+    *{ transition:none !important; scroll-behavior:auto !important; }
+  }
+</style>
+</head>
+<body class="rail-texture">
+
+<header class="hero">
+  <svg class="crest" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+    <circle cx="50" cy="50" r="46" fill="none" stroke="#c9a24b" stroke-width="2"/>
+    <circle cx="50" cy="50" r="38" fill="none" stroke="#c9a24b" stroke-width="1"/>
+    <path d="M50 18 L58 40 L82 40 L62 54 L70 76 L50 62 L30 76 L38 54 L18 40 L42 40 Z" fill="none" stroke="#c9a24b" stroke-width="2" stroke-linejoin="round"/>
+  </svg>
+  <p class="eyebrow">Est. 1880 — 1934 &nbsp;·&nbsp; A Living Heritage</p>
+  <h1>India's Oldest <span>Sporting Trophies</span></h1>
+  <p class="hero-sub">Seven trophies, forged in the colonial era, that still call players onto the field today — from a Calcutta polo ground in 1880 to a cricket pitch in Madras in 1934.</p>
+  <div class="hero-meta">
+    <div><span class="num">7</span><span class="lbl">Trophies</span></div>
+    <div><span class="num">4</span><span class="lbl">Sports</span></div>
+    <div><span class="num">54</span><span class="lbl">Years Span</span></div>
+    <div><span class="num">146</span><span class="lbl">Oldest Age Today</span></div>
+  </div>
+</header>
+
+<section id="timeline-section">
+  <div class="section-head">
+    <p class="eyebrow">Interactive</p>
+    <h2>An Age‑Based Timeline</h2>
+    <p>Positioned by the year each trophy was struck. Click a medallion to read its plaque.</p>
+  </div>
+
+  <div class="timeline-wrap">
+    <div class="timeline-rail-outer" id="rail" role="list" aria-label="Trophy timeline by founding year"></div>
+    <p class="timeline-scroll-hint">Tip: on a touch screen, tap a medallion — the plaque below updates instantly.</p>
+  </div>
+
+  <div class="plaque" id="plaque" role="region" aria-live="polite">
+    <!-- filled by JS -->
+  </div>
+</section>
+
+<section id="grid-section">
+  <div class="section-head">
+    <p class="eyebrow">The Full Roll</p>
+    <h2>All Seven, At a Glance</h2>
+    <p>Click any card to jump the timeline above straight to it.</p>
+  </div>
+  <div class="card-grid" id="cardGrid"></div>
+</section>
+
+<section class="sources">
+  <div class="section-head">
+    <p class="eyebrow">Verification</p>
+    <h2>Sources</h2>
+    <p>Every founding year, origin and status above was cross‑checked against these references.</p>
+  </div>
+  <ol id="sourceList"></ol>
+</section>
+
+<footer>
+  Built for GitHub issue “India's Oldest Sporting Trophies.” Historical details sourced from Wikipedia, Olympics.com, official tournament sites and heritage publications as of August 2026 — always double‑check original sources before citing in formal work.
+</footer>
+
+<script>
+const ICONS = {
+  polo: `<svg viewBox="0 0 40 40"><circle cx="14" cy="26" r="6"/><path d="M18 22 L34 6"/><path d="M30 6 L34 6 L34 10"/></svg>`,
+  football: `<svg viewBox="0 0 40 40"><circle cx="20" cy="20" r="15"/><path d="M20 9 L26 14 L24 21 L16 21 L14 14 Z"/><path d="M20 9 L20 5 M26 14 L31 12 M24 21 L28 27 M16 21 L12 27 M14 14 L9 12"/></svg>`,
+  hockey: `<svg viewBox="0 0 40 40"><circle cx="30" cy="30" r="4"/><path d="M12 6 L16 26 Q17 30 22 30"/></svg>`,
+  cricket: `<svg viewBox="0 0 40 40"><path d="M10 30 L26 12"/><path d="M24 10 L28 14"/><circle cx="31" cy="30" r="4"/><path d="M8 33 L12 29"/></svg>`
+};
+
+const TROPHIES = [
+  {
+    id:'ezra',
+    year:1880,
+    name:'Ezra Cup',
+    sport:'Polo',
+    sportKey:'polo',
+    origin:'Calcutta (Kolkata), hosted by the Calcutta Polo Club — the world\u2019s oldest polo club, founded in 1862',
+    significance:'Widely regarded as the world\u2019s oldest polo trophy. Named after Sir David Ezra, a Calcutta business patron of the sport, it predates every other polo cup still contested today, including the Carmichael Cup (1910) and Stewarts Cup (1932) that followed it at the same club.',
+    status:'active',
+    statusText:'Active — still contested at the Calcutta Polo Club, revived in 2006 after a period of dormancy.'
+  },
+  {
+    id:'durand',
+    year:1888,
+    name:'Durand Cup',
+    sport:'Football',
+    sportKey:'football',
+    origin:'Annandale, Shimla — founded by Sir Henry Mortimer Durand, Foreign Secretary of British India',
+    significance:'The oldest existing football tournament in Asia and one of the oldest in the world. Originally a tournament for army regiments, its first final was won by the Royal Scots Fusiliers. The original cup survived Partition after being smuggled out of a office in 1947 and kept safe by India\u2019s Defence Secretary.',
+    status:'active',
+    statusText:'Active — held annually; the 135th edition ran in 2026, organised by the Durand Football Tournament Society and AIFF.'
+  },
+  {
+    id:'rovers',
+    year:1891,
+    name:'Rovers Cup',
+    sport:'Football',
+    sportKey:'football',
+    origin:'Bombay (Mumbai)',
+    significance:'One of the three great early football tournaments of colonial India, alongside the Durand Cup and IFA Shield, drawing top clubs from across the country for decades.',
+    status:'defunct',
+    statusText:'Discontinued — no longer an active tournament, though it remains a landmark in Indian football history.'
+  },
+  {
+    id:'ifa',
+    year:1893,
+    name:'IFA Shield',
+    sport:'Football',
+    sportKey:'football',
+    origin:'Calcutta, organised by the Indian Football Association',
+    significance:'India\u2019s third‑oldest football tournament, after the Durand Cup and the Trades Cup, and among the oldest football competitions in the world. Unlike India\u2019s state‑team tournaments, it has always invited clubs from around the globe — past winners include Club Atl\u00e9tico Pe\u00f1arol of Uruguay (1985) and Bayern Munich II (2005).',
+    status:'active',
+    statusText:'Active — restructured in 2015 as an Under‑19 youth tournament.'
+  },
+  {
+    id:'beighton',
+    year:1895,
+    name:'Beighton Cup',
+    sport:'Field Hockey',
+    sportKey:'hockey',
+    origin:'Calcutta, donated by Judge Thomas Durant Beighton of the Indian Civil Service',
+    significance:'One of the oldest field hockey tournaments in the world, and the oldest still running. It continued through both World Wars without a break, and hockey legend Dhyan Chand called its 1933 final — between his Jhansi Heroes and Calcutta Customs — the best match of his career.',
+    status:'active',
+    statusText:'Active — organised today by Hockey Bengal, played annually in Kolkata.'
+  },
+  {
+    id:'agakhan',
+    year:1896,
+    name:'Aga Khan Tournament',
+    sport:'Field Hockey',
+    sportKey:'hockey',
+    origin:'Bombay Gymkhana, Bombay (Mumbai)',
+    significance:'Founded a year after the Beighton Cup, it quickly became hockey\u2019s other great early tournament, this time centred on western India, and helped cement Bombay Gymkhana as a home of Indian hockey.',
+    status:'active',
+    statusText:'Active in recent years under the Maharashtra Hockey Association, though its modern calendar has been less consistent than the Beighton Cup\u2019s.'
+  },
+  {
+    id:'ranji',
+    year:1934,
+    name:'Ranji Trophy',
+    sport:'Cricket',
+    sportKey:'cricket',
+    origin:'First match at Chepauk, Madras, between Madras and Mysore — trophy donated by Maharaja Bhupinder Singh of Patiala',
+    significance:'India\u2019s premier first‑class cricket championship, named in memory of Ranjitsinhji, the legendary Indian‑born England Test batsman. It has served for nine decades as the backbone of India\u2019s domestic cricket structure and the traditional route into the national team.',
+    status:'active',
+    statusText:'Active — India\u2019s flagship domestic first‑class cricket tournament, contested by state and regional teams every season.'
+  }
+];
+
+const SOURCES = [
+  { t:'Durand Cup — Wikipedia', u:'https://en.wikipedia.org/wiki/Durand_Cup' },
+  { t:'IFA Shield — Wikipedia', u:'https://en.wikipedia.org/wiki/IFA_Shield' },
+  { t:'Beighton Cup — Wikipedia', u:'https://en.wikipedia.org/wiki/Beighton_Cup' },
+  { t:'Beighton Cup: the oldest hockey tournament in India — Olympics.com', u:'https://www.olympics.com/en/news/beighton-cup-oldest-hockey-tournament-india-history-winners' },
+  { t:'Calcutta Hockey League — Wikipedia (Aga Khan / Beighton context)', u:'https://en.wikipedia.org/wiki/Calcutta_Hockey_League' },
+  { t:'Early hockey in India, tournaments are galore — Stick2Hockey', u:'https://stick2hockey.com/hockey-in-india-in-the-early-1900s/' },
+  { t:'Calcutta Polo Club — Wikipedia', u:'https://en.wikipedia.org/wiki/Calcutta_Polo_Club' },
+  { t:'Ezra Cup — Wikipedia', u:'https://en.wikipedia.org/wiki/Ezra_Cup' },
+  { t:'Kolkata has the world\u2019s oldest polo club, and polo cup — GetBengal', u:'https://www.getbengal.com/details/kolkata-has-the-worlds-oldest-polo-club-and-polo-cup-did-you-know-getbengal-story' },
+  { t:'The Durand Cup, Santosh Trophy and Rovers Cup — Prepp (Rovers Cup history)', u:'https://prepp.in/question/the-durand-cup-santosh-trophy-and-rovers-cup-are-r-6448e049267130feb1140b34' },
+  { t:'Football trophy in India: know all the tournaments — SportsAdda', u:'https://www.sportsadda.com/amp/football/features/football-trophy-names-india-tournaments-leagues' },
+  { t:'135th IndianOil Durand Cup Trophy Showcase — durandcup.in', u:'https://durandcup.in/trophy-showcase/' },
+  { t:'List of Sports Cups and Trophies — DataFlair (Ranji Trophy origin)', u:'https://data-flair.training/blogs/sports-cups-and-trophies/' },
+  { t:'List of All Important Sports Cups and Trophies — Adda247 (Ranji Trophy, first match)', u:'https://www.adda247.com/defence-jobs/sports-cups-and-trophies/' }
+];
+
+const rail = document.getElementById('rail');
+const plaque = document.getElementById('plaque');
+const cardGrid = document.getElementById('cardGrid');
+const sourceList = document.getElementById('sourceList');
+
+const minYear = 1875, maxYear = 1940;
+function yearToPercent(y){
+  return ((y - minYear) / (maxYear - minYear)) * 100;
+}
+
+TROPHIES.forEach((t, i) => {
+  const btn = document.createElement('button');
+  btn.className = 'tick';
+  btn.style.left = yearToPercent(t.year) + '%';
+  btn.setAttribute('role','listitem');
+  btn.setAttribute('aria-label', t.name + ', founded ' + t.year);
+  btn.dataset.id = t.id;
+  btn.innerHTML = `
+    <span class="medallion">${ICONS[t.sportKey]}</span>
+    <span class="year-label">${t.year}</span>
+  `;
+  btn.addEventListener('click', () => selectTrophy(t.id, true));
+  rail.appendChild(btn);
+});
+
+function renderPlaque(t){
+  plaque.style.opacity = 0;
+  setTimeout(() => {
+    plaque.innerHTML = `
+      <div class="plaque-icon-wrap">${ICONS[t.sportKey]}</div>
+      <div>
+        <p class="plaque-label">${t.sport} &nbsp;·&nbsp; Founded ${t.year}</p>
+        <h3>${t.name}</h3>
+        <p class="subline">${t.origin}</p>
+        <dl class="plaque-grid">
+          <div><dt>Sport</dt><dd>${t.sport}</dd></div>
+          <div><dt>Establishment Year</dt><dd>${t.year}</dd></div>
+          <div><dt>Age Today</dt><dd>${2026 - t.year} years</dd></div>
+          <div><dt>Current Status</dt><dd><span class="status-pill ${t.status === 'active' ? 'status-active' : 'status-defunct'}">${t.status === 'active' ? 'Active' : 'Discontinued'}</span></dd></div>
+        </dl>
+        <div class="plaque-body">
+          <p>${t.significance}</p>
+          <p>${t.statusText}</p>
+        </div>
+      </div>
+    `;
+    plaque.style.opacity = 1;
+  }, 120);
+}
+
+function selectTrophy(id, scrollIntoView){
+  document.querySelectorAll('.tick').forEach(el => {
+    el.classList.toggle('active', el.dataset.id === id);
+  });
+  const t = TROPHIES.find(x => x.id === id);
+  renderPlaque(t);
+  if(scrollIntoView){
+    document.getElementById('plaque').scrollIntoView({behavior:'smooth', block:'nearest'});
+  }
+}
+
+TROPHIES.forEach(t => {
+  const card = document.createElement('button');
+  card.className = 'card';
+  card.innerHTML = `
+    <div class="row1">
+      <span class="icon-sm">${ICONS[t.sportKey]}</span>
+      <span class="yr">${t.year}</span>
+    </div>
+    <h4>${t.name}</h4>
+    <p class="meta">${t.sport} &nbsp;·&nbsp; ${t.status === 'active' ? 'Active today' : 'Discontinued'}</p>
+  `;
+  card.addEventListener('click', () => {
+    selectTrophy(t.id, false);
+    document.getElementById('timeline-section').scrollIntoView({behavior:'smooth'});
+  });
+  cardGrid.appendChild(card);
+});
+
+SOURCES.forEach(s => {
+  const li = document.createElement('li');
+  li.innerHTML = `<a href="${s.u}" target="_blank" rel="noopener">${s.t}</a>`;
+  sourceList.appendChild(li);
+});
+
+// initial state: oldest trophy selected
+selectTrophy('ezra', false);
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## 🏆 India's Oldest Sporting Trophies

### 📌 Overview

Implemented an interactive collection showcasing some of **India's oldest surviving sporting trophies and competitions**, highlighting their origins, historical importance, and continued legacy in Indian sports.

### ✨ What I Added

* Added detailed trophy information including:

  * 🏆 Trophy name
  * ⚽ Sport
  * 📅 Establishment year
  * 📍 Origin
  * 📜 Historical significance
  * 🔄 Current status
* Added an **age-based interactive timeline** allowing users to explore trophies chronologically.
* Organized the collection to make historical comparisons easier.
* Added historical context for each trophy and competition.
* Included reliable **sources/references** for historical verification.
* Designed the section to be **responsive and accessible** across devices.
* Followed the existing project's structure and design conventions.

### 🕰️ Interactive Timeline

The timeline presents the trophies based on their establishment year, allowing users to explore India's sporting heritage from the oldest competitions to more recent ones.

### 🔎 Historical Verification

Historical details, establishment years, origins, and current status have been cross-checked against the referenced sources to improve accuracy and credibility.

### 🧪 Testing

* Tested the interactive timeline functionality.
* Verified trophy information and historical dates.
* Checked source/reference links.
* Tested responsive behavior across desktop and mobile layouts.
* Verified that existing pages and functionality remain unaffected.

### 📸 Screenshots

*Add screenshots/GIF of the completed interactive timeline and trophy collection here.*

### ✅ Acceptance Criteria

* [x] Trophies historically verified
* [x] Trophy details included
* [x] Age-based timeline implemented
* [x] Sources included
* [x] Responsive layout implemented

### 🔗 Related Issue

Closes #2554 
