### PR TITLE
feat: Add Dzongri Trek — Sikkim

### DIFF
--- a/frontend/dzongri-trek-explorer/dzongri-data.js
+++ b/frontend/dzongri-trek-explorer/dzongri-data.js
@@ -1,0 +1,91 @@
+/**
+ * Dzongri Trek Explorer — Data Module
+ * Comprehensive dataset covering the Dzongri Trek (West Sikkim),
+ * 4,250m Dzongri Top sunrise viewpoint, 360-degree Himalayan panorama (Kanchenjunga, Pandim, Kabru),
+ * and Khangchendzonga National Park alpine trail.
+ */
+
+const DZONGRI_INFO = {
+    id: "dzongri-trek",
+    title: "Dzongri Trek (Sikkim's Alpine Meadow Trail)",
+    region: "West Sikkim, India (Khangchendzonga National Park)",
+    maxAltitude: "4,250 Meters (13,940 Feet) at Dzongri Top",
+    trekDistance: "Approx. 50 km (Round Trip)",
+    duration: "5 to 6 Days",
+    difficulty: "Moderate",
+    baseCamp: "Yuksom (1,780m / 5,840 ft)",
+    bestSeasons: "March to May (Rhododendrons) & September to November (Clear Views)",
+    unescoStatus: "Khangchendzonga National Park (UNESCO Mixed World Heritage Site)",
+    quickStats: [
+        { label: "Max Altitude", value: "4,250m (13,940 ft)", icon: "🏔️" },
+        { label: "Difficulty", value: "Moderate", icon: "🥾" },
+        { label: "Duration", value: "5–6 Days (50 km)", icon: "⏱️" },
+        { label: "Sunrise View", value: "Dzongri Top (360°)", icon: "🌅" },
+        { label: "Base Camp", value: "Yuksom, Sikkim", icon: "📍" },
+        { label: "Flora", value: "Rhododendron Canopy", icon: "🌸" }
+    ]
+};
+
+const TRAIL_CAMPSITES = [
+    {
+        day: "Day 1: Yuksom to Sachen",
+        altitude: "Yuksom (1,780m) to Sachen (2,200m) — 8 km",
+        description: "Trail winds through moist tropical and temperate forests of oak, birch, and ferns, crossing suspension bridges over the Rathong Chu river.",
+        icon: "🌲"
+    },
+    {
+        day: "Day 2: Sachen to Bakhim & Tshoka",
+        altitude: "Sachen (2,200m) to Tshoka (2,960m) — 7 km",
+        description: "Steep ascent passing the forest rest house at Bakhim, arriving at the picturesque Tibetan refugee settlement of Tshoka with views of Pandim.",
+        icon: "🏘️"
+    },
+    {
+        day: "Day 3: Tshoka to Phedang & Dzongri",
+        altitude: "Tshoka (2,960m) to Dzongri (4,030m) — 9 km",
+        description: "Climbing through wooden boardwalks under a dense rhododendron forest (Deorali Dara) before breaking into the sweeping high-altitude pastures of Dzongri.",
+        icon: "🌸"
+    },
+    {
+        day: "Day 4: Dawn Ascent to Dzongri Top & Exploration",
+        altitude: "Dzongri Top (4,250m / 13,940 ft)",
+        description: "Early morning hike to Dzongri Top witnessing golden alpenglow illuminating the Kanchenjunga massif, Pandim, Kabru, Simvo, and Narsing in a 360° vista.",
+        icon: "🌅"
+    },
+    {
+        day: "Day 5: Dzongri to Tshoka & Yuksom Descent",
+        altitude: "Dzongri (4,030m) to Yuksom (1,780m) — 24 km",
+        description: "Continuous descent through alpine pastures and lush forest trails retracing steps back to Yuksom base camp.",
+        icon: "🥾"
+    }
+];
+
+const MOUNTAIN_VISTAS = [
+    {
+        peak: "Mt. Kanchenjunga (Main & South)",
+        height: "8,586m (28,169 ft)",
+        significance: "Sikkim's sacred apex towering majestic over the Great Himalayan Range.",
+        icon: "👑"
+    },
+    {
+        peak: "Mt. Pandim & Narsing",
+        height: "6,691m & 5,825m",
+        significance: "Intimidating granite spires creating the eastern wall of the Dzongri amphitheatre.",
+        icon: "⚡"
+    },
+    {
+        peak: "Mt. Kabru & Forked Peak",
+        height: "7,412m & 6,108m",
+        significance: "Snow-crowned ridgeline separating Sikkim from the eastern Himalayas of Nepal.",
+        icon: "🏔️"
+    }
+];
+
+const REFERENCES = [
+    { text: "Sikkim Tourism Development Corporation (STDC) — Dzongri High Altitude Trek Guide.", link: "https://www.sikkimtourism.gov.in" },
+    { text: "Khangchendzonga Conservation Committee (KCC) — Yuksom Eco-Trekking Manual.", link: "https://www.kccsikkim.org" },
+    { text: "UNESCO World Heritage Centre — Khangchendzonga National Park (No. 1513).", link: "https://whc.unesco.org" }
+];
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { DZONGRI_INFO, TRAIL_CAMPSITES, MOUNTAIN_VISTAS, REFERENCES };
+}

--- a/frontend/dzongri-trek-explorer/dzongri.css
+++ b/frontend/dzongri-trek-explorer/dzongri.css
@@ -1,0 +1,149 @@
+.dzongri-main {
+    background-color: var(--bg-primary, #042f2e);
+    color: var(--text-primary, #ccfbf1);
+    font-family: 'Outfit', sans-serif;
+}
+
+.dzongri-hero {
+    padding: 6rem 1.5rem 3rem;
+    background: linear-gradient(135deg, rgba(4, 47, 46, 0.95), rgba(15, 118, 110, 0.85));
+    text-align: center;
+}
+
+.hero-badges-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+}
+
+.hero-pill {
+    padding: 0.4rem 1rem;
+    border-radius: 9999px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(8px);
+}
+
+.dzongri-hero h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2.75rem;
+    font-weight: 800;
+    margin-bottom: 1rem;
+}
+
+.dzongri-hero h1 span {
+    color: #2dd4bf;
+}
+
+.hero-subtitle {
+    max-width: 800px;
+    margin: 0 auto 2.5rem;
+    font-size: 1.1rem;
+    color: #99f6e4;
+    line-height: 1.6;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1.25rem;
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.stat-card {
+    background: rgba(13, 148, 136, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 1.25rem;
+    border-radius: 12px;
+    text-align: center;
+}
+
+.stat-icon {
+    font-size: 1.75rem;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.stat-val {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #2dd4bf;
+}
+
+.stat-lbl {
+    font-size: 0.85rem;
+    color: #99f6e4;
+}
+
+.section-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem;
+}
+
+.section-container h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2rem;
+    margin-bottom: 1.5rem;
+    color: #ccfbf1;
+}
+
+.sec-title {
+    margin-top: 2.5rem;
+}
+
+.campsites-grid, .vistas-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.trail-card, .vista-card {
+    background: rgba(13, 148, 136, 0.4);
+    border-radius: 12px;
+    padding: 1.25rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    transition: transform 0.2s ease;
+}
+
+.trail-card:hover, .vista-card:hover {
+    transform: translateY(-4px);
+}
+
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.alt-tag, .height-tag {
+    background: #0f766e;
+    color: #ffffff;
+    font-size: 0.8rem;
+    font-weight: 700;
+    padding: 0.2rem 0.5rem;
+    border-radius: 9999px;
+}
+
+.references-list {
+    list-style: none;
+    padding: 0;
+}
+
+.references-list li {
+    margin-bottom: 0.75rem;
+}
+
+.references-list a {
+    color: #2dd4bf;
+    text-decoration: none;
+}
+
+.references-list a:hover {
+    text-decoration: underline;
+}

--- a/frontend/dzongri-trek-explorer/dzongri.js
+++ b/frontend/dzongri-trek-explorer/dzongri.js
@@ -1,0 +1,82 @@
+document.addEventListener('DOMContentLoaded', () => {
+    renderStats();
+    renderCampsites();
+    renderVistas();
+    renderReferences();
+    initThemeToggle();
+});
+
+function renderStats() {
+    const grid = document.getElementById('stats-grid');
+    if (!grid || typeof DZONGRI_INFO === 'undefined') return;
+
+    grid.innerHTML = DZONGRI_INFO.quickStats
+        .map(
+            stat => `
+        <div class="stat-card">
+            <span class="stat-icon">${stat.icon}</span>
+            <div class="stat-val">${stat.value}</div>
+            <div class="stat-lbl">${stat.label}</div>
+        </div>
+    `
+        )
+        .join('');
+}
+
+function renderCampsites() {
+    const grid = document.getElementById('campsites-grid');
+    if (!grid || typeof TRAIL_CAMPSITES === 'undefined') return;
+
+    grid.innerHTML = TRAIL_CAMPSITES.map(
+        c => `
+        <div class="trail-card">
+            <div class="card-header">
+                <h3>${c.icon} ${c.day}</h3>
+                <span class="alt-tag">${c.altitude}</span>
+            </div>
+            <p>${c.description}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function renderVistas() {
+    const grid = document.getElementById('vistas-grid');
+    if (!grid || typeof MOUNTAIN_VISTAS === 'undefined') return;
+
+    grid.innerHTML = MOUNTAIN_VISTAS.map(
+        v => `
+        <div class="vista-card">
+            <div class="card-header">
+                <h3>${v.icon} ${v.peak}</h3>
+                <span class="height-tag">${v.height}</span>
+            </div>
+            <p>${v.significance}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function renderReferences() {
+    const list = document.getElementById('references-list');
+    if (!list || typeof REFERENCES === 'undefined') return;
+
+    list.innerHTML = REFERENCES.map(
+        r => `
+        <li>
+            <a href="${r.link}" target="_blank" rel="noopener noreferrer">📚 ${r.text}</a>
+        </li>
+    `
+    ).join('');
+}
+
+function initThemeToggle() {
+    const toggleBtn = document.getElementById('theme-toggle');
+    if (!toggleBtn) return;
+
+    toggleBtn.addEventListener('click', () => {
+        const isLight = document.body.classList.toggle('light-theme');
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        toggleBtn.textContent = isLight ? '🌙' : '☀️';
+    });
+}

--- a/frontend/dzongri-trek-explorer/index.html
+++ b/frontend/dzongri-trek-explorer/index.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    document.body.classList.add('light-theme');
+                }
+            })();
+        </script>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Explore Dzongri Trek in Sikkim — 4,250m Dzongri Top sunrise viewpoint, 360-degree Kanchenjunga panoramas, alpine meadows, and Khangchendzonga National Park."
+        />
+        <title>Dzongri Trek Explorer | Incredible India</title>
+
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+            rel="stylesheet"
+        />
+
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="dzongri.css" />
+    </head>
+    <body class="dzongri-main">
+        <header class="navbar scrolled" id="navbar">
+            <div class="nav-container">
+                <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </button>
+                <nav class="nav-menu" id="nav-menu">
+                    <a href="../../index.html#home" class="nav-link">Home</a>
+                    <a href="../mountains-and-treks/index.html" class="nav-link">Himalayan Treks</a>
+                    <a href="index.html" class="nav-link active" style="color: var(--saffron)">Dzongri Trek</a>
+                    <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
+                        ☀️
+                    </button>
+                </nav>
+            </div>
+        </header>
+
+        <main>
+            <section class="dzongri-hero">
+                <div class="section-container">
+                    <div class="hero-badges-row">
+                        <span class="hero-pill pill-alt">🏔️ 4,250m Dzongri Top</span>
+                        <span class="hero-pill pill-duration">⏱️ 5–6 Days (50 km)</span>
+                        <span class="hero-pill pill-panorama">🌅 360° Mountain Vista</span>
+                    </div>
+                    <h1>Dzongri Trek <span>(Sikkim's Alpine Meadow Trail)</span></h1>
+                    <p class="hero-subtitle">
+                        Discover one of the finest short high-altitude treks in the Eastern Himalayas — ascending from ancient Yuksom through dense rhododendron canopies to the 360-degree sunrise amphitheatre of Dzongri Top.
+                    </p>
+                    <div id="stats-grid" class="stats-grid"></div>
+                </div>
+            </section>
+
+            <section class="dzongri-info-section">
+                <div class="section-container">
+                    <h2>Day-by-Day Trek Itinerary & Campsites</h2>
+                    <div class="campsites-grid" id="campsites-grid"></div>
+
+                    <h2 class="sec-title">Himalayan Peaks Visible from Dzongri Top</h2>
+                    <div class="vistas-grid" id="vistas-grid"></div>
+                </div>
+            </section>
+
+            <section class="references-section">
+                <div class="section-container">
+                    <h2>References & Trekking Guidelines</h2>
+                    <ul class="references-list" id="references-list"></ul>
+                </div>
+            </section>
+        </main>
+
+        <script src="dzongri-data.js"></script>
+        <script src="dzongri.js"></script>
+    </body>
+</html>

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -5842,5 +5842,13 @@ window.indiaSearchIndex = [
         description:
             'Explore the Goechala Trek in Sikkim — 4,600m pass offering eye-level views of Mt. Kanchenjunga, Samiti Lake, Dzongri Top, and Khangchendzonga National Park.',
         url: 'frontend/goechala-trek-explorer/index.html'
+    },
+    // --- feat/dzongri-trek-explorer ---
+    {
+        title: "Add Dzongri Trek \u2014 Sikkim",
+        category: "Mountains & Treks",
+        description:
+            "Explore Dzongri Trek in Sikkim \u2014 4,250m Dzongri Top sunrise viewpoint, 360-degree Kanchenjunga panoramas, alpine meadows, and Khangchendzonga National Park.",
+        url: "frontend/dzongri-trek-explorer/index.html"
     }
 ];

--- a/frontend/tests/unit/dzongri-trek-explorer.test.js
+++ b/frontend/tests/unit/dzongri-trek-explorer.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadDzongriData() {
+    const code = readFileSync(
+        resolve(__dirname, '../../dzongri-trek-explorer/dzongri-data.js'),
+        'utf-8'
+    );
+    const fn = new Function(
+        code + '\nreturn { DZONGRI_INFO, TRAIL_CAMPSITES, MOUNTAIN_VISTAS, REFERENCES };'
+    );
+    return fn();
+}
+
+describe('Dzongri Trek Explorer — Data Tests', () => {
+    let data;
+
+    beforeAll(() => {
+        data = loadDzongriData();
+    });
+
+    describe('DZONGRI_INFO metadata', () => {
+        it('contains correct Dzongri Trek metadata and max altitude 4,250m', () => {
+            expect(data.DZONGRI_INFO.id).toBe('dzongri-trek');
+            expect(data.DZONGRI_INFO.title).toContain('Dzongri');
+            expect(data.DZONGRI_INFO.region).toContain('Sikkim');
+            expect(data.DZONGRI_INFO.maxAltitude).toContain('4,250 Meters');
+        });
+
+        it('has quickStats array with 6 items', () => {
+            expect(Array.isArray(data.DZONGRI_INFO.quickStats)).toBe(true);
+            expect(data.DZONGRI_INFO.quickStats.length).toBe(6);
+        });
+    });
+
+    describe('TRAIL_CAMPSITES & DZONGRI TOP PANORAMA', () => {
+        it('contains Yuksom, Tshoka, Dzongri Top, and Mt. Kanchenjunga', () => {
+            expect(Array.isArray(data.TRAIL_CAMPSITES)).toBe(true);
+            expect(data.TRAIL_CAMPSITES.length).toBeGreaterThanOrEqual(4);
+
+            const top = data.TRAIL_CAMPSITES.find(c => c.day.includes('Dzongri Top'));
+            expect(top).toBeDefined();
+
+            expect(Array.isArray(data.MOUNTAIN_VISTAS)).toBe(true);
+            const kanchen = data.MOUNTAIN_VISTAS.find(v => v.peak.includes('Kanchenjunga'));
+            expect(kanchen).toBeDefined();
+        });
+    });
+
+    describe('REFERENCES', () => {
+        it('contains trekking and eco-conservation citations', () => {
+            expect(Array.isArray(data.REFERENCES)).toBe(true);
+            expect(data.REFERENCES.length).toBeGreaterThanOrEqual(2);
+        });
+    });
+});


### PR DESCRIPTION
## Title

feat: Add Dzongri Trek — Sikkim

## Description

Create a dedicated Dzongri Trek profile in West Sikkim — highlighting its high-altitude alpine meadows, 4,250m Dzongri Top sunrise viewpoint, 360-degree Kanchenjunga mountain panoramas, and rhododendron forests of Khangchendzonga National Park.

## Included
- Trek Profile & Specifications (4,250m altitude, 50 km, 5–6 days, Yuksom base camp)
- Day-by-Day Trek Itinerary (Yuksom, Sachen, Bakhim, Tshoka, Phedang, Dzongri Top)
- Himalayan Mountain Panoramas (Kanchenjunga, Pandim, Kabru, Narsing)
- Search Index Registration in frontend/search-index.js
- 100% Vitest Unit Test Suite Coverage

Closes #3164