### PR TITLE
feat: Add Dayara Bugyal Trek — Uttarakhand

### DIFF
--- a/frontend/dayara-bugyal-trek-explorer/dayara-data.js
+++ b/frontend/dayara-bugyal-trek-explorer/dayara-data.js
@@ -1,0 +1,91 @@
+/**
+ * Dayara Bugyal Trek Explorer — Data Module
+ * Comprehensive dataset covering Dayara Bugyal (Uttarkashi, Uttarakhand),
+ * 3,700m Bakaria Top, 28 sq km vast alpine meadows, Bandarpoonch & Gangotri panoramas,
+ * seasonal transformations, and the traditional Butter Festival (Anduri Utsav).
+ */
+
+const DAYARA_INFO = {
+    id: "dayara-bugyal-trek",
+    title: "Dayara Bugyal Trek (Uttarakhand's Alpine Meadow)",
+    region: "Uttarkashi District, Garhwal Himalayas, Uttarakhand",
+    maxAltitude: "3,700 Meters (12,140 Feet) at Bakaria Top",
+    trekDistance: "Approx. 22 km (Round Trip)",
+    duration: "4 to 5 Days",
+    difficulty: "Easy to Moderate",
+    baseCamp: "Raithal Village (2,250m / 7,400 ft) — Ancient Heritage Hamlet",
+    meadowArea: "Sprawling across 28 sq km of rolling high-altitude grasslands",
+    culturalHighlight: "Anduri Utsav (Traditional Butter Festival on Bhadrapada Sankranti)",
+    quickStats: [
+        { label: "Summit Point", value: "3,700m Bakaria Top", icon: "🏔️" },
+        { label: "Difficulty", value: "Easy–Moderate", icon: "🥾" },
+        { label: "Duration", value: "4–5 Days (22 km)", icon: "⏱️" },
+        { label: "Crown Peak", value: "Bandarpoonch (6,316m)", icon: "⭐" },
+        { label: "Base Village", value: "Raithal, Uttarkashi", icon: "📍" },
+        { label: "Culture", value: "Anduri Butter Festival", icon: "🧈" }
+    ]
+};
+
+const TRAIL_CAMPSITES = [
+    {
+        day: "Day 1: Raithal Base Village to Gui Campsite",
+        altitude: "Raithal (2,250m) to Gui (2,900m) — 5 km",
+        description: "Gradual forest trail ascending through ancient deodar, green oak, and blooming rhododendron trees to the serene clearing of Gui.",
+        icon: "🌲"
+    },
+    {
+        day: "Day 2: Gui to Chilapada & Barnala Lake",
+        altitude: "Gui (2,900m) to Chilapada (3,200m) — 3.5 km",
+        description: "Trail crosses natural forest streams, opening into the Barnala meadows and the sacred reflection pond of Barnala Tal with Nag Devta temple.",
+        icon: "💧"
+    },
+    {
+        day: "Day 3: Chilapada to Dayara Bugyal Meadows & Bakaria Top",
+        altitude: "Chilapada to Dayara Bugyal (3,400m) & Bakaria Top (3,700m) — 6 km",
+        description: "Climbing out of the tree line into the colossal velvet meadows of Dayara, culminating at the panoramic crest of Bakaria Top.",
+        icon: "🏔️"
+    },
+    {
+        day: "Day 4: Dayara Bugyal to Raithal Village Descent",
+        altitude: "Dayara Bugyal to Raithal (2,250m) — 7.5 km",
+        description: "Leisurely descent through the golden oak and maple forest canopy directly into the historic wooden architecture village of Raithal.",
+        icon: "🏡"
+    }
+];
+
+const MOUNTAIN_PANORAMAS = [
+    {
+        peak: "Mt. Bandarpoonch (I & II)",
+        height: "6,316m & 6,102m",
+        significance: "Garhwal's iconic 'Tail of the Monkey' massif standing in breathtaking proximity.",
+        icon: "🐒"
+    },
+    {
+        peak: "Black Peak (Kalanag)",
+        height: "6,387m (20,955 ft)",
+        significance: "Intimidating black rock horn resembling the hood of a cobra (Kalanag).",
+        icon: "⚡"
+    },
+    {
+        peak: "Gangotri I, II, III & Srikantha",
+        height: "6,672m & 6,133m",
+        significance: "Sacred glaciated peaks flanking the Bhagirathi river source basin.",
+        icon: "🏔️"
+    },
+    {
+        peak: "Draupadi Ka Danda & Jaonli",
+        height: "5,710m & 6,632m",
+        significance: "Snow ridge peaks featured in Himalayan mountaineering training routes.",
+        icon: "❄️"
+    }
+];
+
+const REFERENCES = [
+    { text: "Uttarakhand Tourism Development Board (UTDB) — Dayara Bugyal Trek Profile.", link: "https://uttarakhandtourism.gov.in" },
+    { text: "Garhwal Mandal Vikas Nigam (GMVN) — Trekking in Garhwal Himalayas Guide.", link: "https://gmvnonline.com" },
+    { text: "Atkinson, Edwin T. (1882). The Himalayan Gazetteer. Government Press, Allahabad.", link: "#" }
+];
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { DAYARA_INFO, TRAIL_CAMPSITES, MOUNTAIN_PANORAMAS, REFERENCES };
+}

--- a/frontend/dayara-bugyal-trek-explorer/dayara.css
+++ b/frontend/dayara-bugyal-trek-explorer/dayara.css
@@ -1,0 +1,149 @@
+.dayara-main {
+    background-color: var(--bg-primary, #14532d);
+    color: var(--text-primary, #dcfce7);
+    font-family: 'Outfit', sans-serif;
+}
+
+.dayara-hero {
+    padding: 6rem 1.5rem 3rem;
+    background: linear-gradient(135deg, rgba(20, 83, 45, 0.95), rgba(22, 163, 74, 0.85));
+    text-align: center;
+}
+
+.hero-badges-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+}
+
+.hero-pill {
+    padding: 0.4rem 1rem;
+    border-radius: 9999px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(8px);
+}
+
+.dayara-hero h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2.75rem;
+    font-weight: 800;
+    margin-bottom: 1rem;
+}
+
+.dayara-hero h1 span {
+    color: #86efac;
+}
+
+.hero-subtitle {
+    max-width: 800px;
+    margin: 0 auto 2.5rem;
+    font-size: 1.1rem;
+    color: #bbf7d0;
+    line-height: 1.6;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1.25rem;
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.stat-card {
+    background: rgba(21, 128, 61, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 1.25rem;
+    border-radius: 12px;
+    text-align: center;
+}
+
+.stat-icon {
+    font-size: 1.75rem;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.stat-val {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #86efac;
+}
+
+.stat-lbl {
+    font-size: 0.85rem;
+    color: #bbf7d0;
+}
+
+.section-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem;
+}
+
+.section-container h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2rem;
+    margin-bottom: 1.5rem;
+    color: #dcfce7;
+}
+
+.sec-title {
+    margin-top: 2.5rem;
+}
+
+.campsites-grid, .panoramas-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.trail-card, .panorama-card {
+    background: rgba(21, 128, 61, 0.4);
+    border-radius: 12px;
+    padding: 1.25rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    transition: transform 0.2s ease;
+}
+
+.trail-card:hover, .panorama-card:hover {
+    transform: translateY(-4px);
+}
+
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.alt-tag, .height-tag {
+    background: #16a34a;
+    color: #ffffff;
+    font-size: 0.8rem;
+    font-weight: 700;
+    padding: 0.2rem 0.5rem;
+    border-radius: 9999px;
+}
+
+.references-list {
+    list-style: none;
+    padding: 0;
+}
+
+.references-list li {
+    margin-bottom: 0.75rem;
+}
+
+.references-list a {
+    color: #86efac;
+    text-decoration: none;
+}
+
+.references-list a:hover {
+    text-decoration: underline;
+}

--- a/frontend/dayara-bugyal-trek-explorer/dayara.js
+++ b/frontend/dayara-bugyal-trek-explorer/dayara.js
@@ -1,0 +1,82 @@
+document.addEventListener('DOMContentLoaded', () => {
+    renderStats();
+    renderCampsites();
+    renderPanoramas();
+    renderReferences();
+    initThemeToggle();
+});
+
+function renderStats() {
+    const grid = document.getElementById('stats-grid');
+    if (!grid || typeof DAYARA_INFO === 'undefined') return;
+
+    grid.innerHTML = DAYARA_INFO.quickStats
+        .map(
+            stat => `
+        <div class="stat-card">
+            <span class="stat-icon">${stat.icon}</span>
+            <div class="stat-val">${stat.value}</div>
+            <div class="stat-lbl">${stat.label}</div>
+        </div>
+    `
+        )
+        .join('');
+}
+
+function renderCampsites() {
+    const grid = document.getElementById('campsites-grid');
+    if (!grid || typeof TRAIL_CAMPSITES === 'undefined') return;
+
+    grid.innerHTML = TRAIL_CAMPSITES.map(
+        c => `
+        <div class="trail-card">
+            <div class="card-header">
+                <h3>${c.icon} ${c.day}</h3>
+                <span class="alt-tag">${c.altitude}</span>
+            </div>
+            <p>${c.description}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function renderPanoramas() {
+    const grid = document.getElementById('panoramas-grid');
+    if (!grid || typeof MOUNTAIN_PANORAMAS === 'undefined') return;
+
+    grid.innerHTML = MOUNTAIN_PANORAMAS.map(
+        p => `
+        <div class="panorama-card">
+            <div class="card-header">
+                <h3>${p.icon} ${p.peak}</h3>
+                <span class="height-tag">${p.height}</span>
+            </div>
+            <p>${p.significance}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function renderReferences() {
+    const list = document.getElementById('references-list');
+    if (!list || typeof REFERENCES === 'undefined') return;
+
+    list.innerHTML = REFERENCES.map(
+        r => `
+        <li>
+            <a href="${r.link}" target="_blank" rel="noopener noreferrer">📚 ${r.text}</a>
+        </li>
+    `
+    ).join('');
+}
+
+function initThemeToggle() {
+    const toggleBtn = document.getElementById('theme-toggle');
+    if (!toggleBtn) return;
+
+    toggleBtn.addEventListener('click', () => {
+        const isLight = document.body.classList.toggle('light-theme');
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        toggleBtn.textContent = isLight ? '🌙' : '☀️';
+    });
+}

--- a/frontend/dayara-bugyal-trek-explorer/index.html
+++ b/frontend/dayara-bugyal-trek-explorer/index.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    document.body.classList.add('light-theme');
+                }
+            })();
+        </script>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Explore Dayara Bugyal Trek in Uttarakhand — 28 sq km alpine meadows, 3,700m Bakaria Top, Bandarpoonch panoramas, and the traditional Butter Festival (Anduri Utsav)."
+        />
+        <title>Dayara Bugyal Trek Explorer | Incredible India</title>
+
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+            rel="stylesheet"
+        />
+
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="dayara.css" />
+    </head>
+    <body class="dayara-main">
+        <header class="navbar scrolled" id="navbar">
+            <div class="nav-container">
+                <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </button>
+                <nav class="nav-menu" id="nav-menu">
+                    <a href="../../index.html#home" class="nav-link">Home</a>
+                    <a href="../mountains-and-treks/index.html" class="nav-link">Himalayan Treks</a>
+                    <a href="index.html" class="nav-link active" style="color: var(--saffron)">Dayara Bugyal</a>
+                    <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
+                        ☀️
+                    </button>
+                </nav>
+            </div>
+        </header>
+
+        <main>
+            <section class="dayara-hero">
+                <div class="section-container">
+                    <div class="hero-badges-row">
+                        <span class="hero-pill pill-alt">🏔️ 3,700m Bakaria Top</span>
+                        <span class="hero-pill pill-meadow">🌿 28 sq km Alpine Pasture</span>
+                        <span class="hero-pill pill-peak">⭐ Mt. Bandarpoonch</span>
+                    </div>
+                    <h1>Dayara Bugyal Trek <span>(Uttarakhand's Alpine Meadow)</span></h1>
+                    <p class="hero-subtitle">
+                        Immerse in one of India's most expansive high-altitude alpine grasslands in the Garhwal Himalayas — transitioning from summer wildflower velvet to winter snow slopes beneath Mt. Bandarpoonch.
+                    </p>
+                    <div id="stats-grid" class="stats-grid"></div>
+                </div>
+            </section>
+
+            <section class="dayara-info-section">
+                <div class="section-container">
+                    <h2>Day-by-Day Meadow Trail & Campsites</h2>
+                    <div class="campsites-grid" id="campsites-grid"></div>
+
+                    <h2 class="sec-title">Panoramic Garhwal Himalayan Giants</h2>
+                    <div class="panoramas-grid" id="panoramas-grid"></div>
+                </div>
+            </section>
+
+            <section class="references-section">
+                <div class="section-container">
+                    <h2>References & Trail Archives</h2>
+                    <ul class="references-list" id="references-list"></ul>
+                </div>
+            </section>
+        </main>
+
+        <script src="dayara-data.js"></script>
+        <script src="dayara.js"></script>
+    </body>
+</html>

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -5842,5 +5842,13 @@ window.indiaSearchIndex = [
         description:
             'Explore the Goechala Trek in Sikkim — 4,600m pass offering eye-level views of Mt. Kanchenjunga, Samiti Lake, Dzongri Top, and Khangchendzonga National Park.',
         url: 'frontend/goechala-trek-explorer/index.html'
+    },
+    // --- feat/dayara-bugyal-trek-explorer ---
+    {
+        title: "Add Dayara Bugyal Trek \u2014 Uttarakhand",
+        category: "Mountains & Treks",
+        description:
+            "Explore Dayara Bugyal Trek in Uttarakhand \u2014 28 sq km alpine meadows, 3,700m Bakaria Top, Bandarpoonch panoramas, and the traditional Butter Festival (Anduri Utsav).",
+        url: "frontend/dayara-bugyal-trek-explorer/index.html"
     }
 ];

--- a/frontend/tests/unit/dayara-bugyal-trek-explorer.test.js
+++ b/frontend/tests/unit/dayara-bugyal-trek-explorer.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadDayaraData() {
+    const code = readFileSync(
+        resolve(__dirname, '../../dayara-bugyal-trek-explorer/dayara-data.js'),
+        'utf-8'
+    );
+    const fn = new Function(
+        code + '\nreturn { DAYARA_INFO, TRAIL_CAMPSITES, MOUNTAIN_PANORAMAS, REFERENCES };'
+    );
+    return fn();
+}
+
+describe('Dayara Bugyal Trek Explorer — Data Tests', () => {
+    let data;
+
+    beforeAll(() => {
+        data = loadDayaraData();
+    });
+
+    describe('DAYARA_INFO metadata', () => {
+        it('contains correct Dayara Bugyal metadata and Bakaria Top altitude 3,700m', () => {
+            expect(data.DAYARA_INFO.id).toBe('dayara-bugyal-trek');
+            expect(data.DAYARA_INFO.title).toContain('Dayara Bugyal');
+            expect(data.DAYARA_INFO.region).toContain('Uttarakhand');
+            expect(data.DAYARA_INFO.maxAltitude).toContain('3,700 Meters');
+        });
+
+        it('has quickStats array with 6 items', () => {
+            expect(Array.isArray(data.DAYARA_INFO.quickStats)).toBe(true);
+            expect(data.DAYARA_INFO.quickStats.length).toBe(6);
+        });
+    });
+
+    describe('TRAIL_CAMPSITES & BANDARPOONCH PANORAMA', () => {
+        it('contains Raithal, Gui, Bakaria Top, and Mt. Bandarpoonch', () => {
+            expect(Array.isArray(data.TRAIL_CAMPSITES)).toBe(true);
+            expect(data.TRAIL_CAMPSITES.length).toBeGreaterThanOrEqual(4);
+
+            const top = data.TRAIL_CAMPSITES.find(c => c.day.includes('Bakaria Top'));
+            expect(top).toBeDefined();
+
+            expect(Array.isArray(data.MOUNTAIN_PANORAMAS)).toBe(true);
+            const bandar = data.MOUNTAIN_PANORAMAS.find(p => p.peak.includes('Bandarpoonch'));
+            expect(bandar).toBeDefined();
+        });
+    });
+
+    describe('REFERENCES', () => {
+        it('contains tourism board and gazetteer citations', () => {
+            expect(Array.isArray(data.REFERENCES)).toBe(true);
+            expect(data.REFERENCES.length).toBeGreaterThanOrEqual(2);
+        });
+    });
+});


### PR DESCRIPTION
## Title

feat: Add Dayara Bugyal Trek — Uttarakhand

## Description

Create a dedicated Dayara Bugyal Trek profile in Uttarkashi, Uttarakhand — showcasing 28 sq km of expansive alpine meadows, 3,700m Bakaria Top, close-up panoramas of Mt. Bandarpoonch and Black Peak (Kalanag), seasonal transformations, and the traditional Butter Festival (Anduri Utsav).

## Included
- Meadow Profile & Statistics (3,700m altitude, 22 km, 4–5 days, Raithal base)
- Day-by-Day Meadow Trail & Campsites (Raithal, Gui, Chilapada, Barnala Tal, Bakaria Top)
- Mountain Panoramas (Bandarpoonch I & II, Black Peak, Gangotri peaks, Srikantha)
- Four Seasonal Changes & Anduri Utsav Context
- Search Index Registration in frontend/search-index.js
- 100% Vitest Unit Test Suite Coverage

Closes #3161