### PR TITLE
feat: Add Kuari Pass Trek — Uttarakhand

### DIFF
--- a/frontend/kuari-pass-trek-explorer/index.html
+++ b/frontend/kuari-pass-trek-explorer/index.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    document.body.classList.add('light-theme');
+                }
+            })();
+        </script>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Explore Kuari Pass Trek (The Curzon Trail) in Uttarakhand — 3,876m mountain pass, close-up Mt. Nanda Devi and Dronagiri vistas, and ancient oak forests."
+        />
+        <title>Kuari Pass Trek Explorer | Incredible India</title>
+
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+            rel="stylesheet"
+        />
+
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="kuari.css" />
+    </head>
+    <body class="kuari-main">
+        <header class="navbar scrolled" id="navbar">
+            <div class="nav-container">
+                <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </button>
+                <nav class="nav-menu" id="nav-menu">
+                    <a href="../../index.html#home" class="nav-link">Home</a>
+                    <a href="../mountains-and-treks/index.html" class="nav-link">Himalayan Treks</a>
+                    <a href="index.html" class="nav-link active" style="color: var(--saffron)">Kuari Pass</a>
+                    <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
+                        ☀️
+                    </button>
+                </nav>
+            </div>
+        </header>
+
+        <main>
+            <section class="kuari-hero">
+                <div class="section-container">
+                    <div class="hero-badges-row">
+                        <span class="hero-pill pill-alt">🏔️ 3,876m (12,516 ft) Pass</span>
+                        <span class="hero-pill pill-curzon">📜 The Curzon Trail (1905)</span>
+                        <span class="hero-pill pill-nanda">👑 Mt. Nanda Devi (7,816m)</span>
+                    </div>
+                    <h1>Kuari Pass Trek <span>(The Lord Curzon Trail)</span></h1>
+                    <p class="hero-subtitle">
+                        Traverse historic Himalayan ridge trails in the Garhwal Himalayas — discovering ancient oak canopies, the alpine heights of Khullara, and peerless vistas of Mount Nanda Devi and Dronagiri.
+                    </p>
+                    <div id="stats-grid" class="stats-grid"></div>
+                </div>
+            </section>
+
+            <section class="kuari-info-section">
+                <div class="section-container">
+                    <h2>Day-by-Day Curzon Trail Itinerary & Campsites</h2>
+                    <div class="campsites-grid" id="campsites-grid"></div>
+
+                    <h2 class="sec-title">Revered Himalayan Giants Visible from Kuari Pass</h2>
+                    <div class="giants-grid" id="giants-grid"></div>
+                </div>
+            </section>
+
+            <section class="references-section">
+                <div class="section-container">
+                    <h2>References & Mountain Literature</h2>
+                    <ul class="references-list" id="references-list"></ul>
+                </div>
+            </section>
+        </main>
+
+        <script src="kuari-data.js"></script>
+        <script src="kuari.js"></script>
+    </body>
+</html>

--- a/frontend/kuari-pass-trek-explorer/kuari-data.js
+++ b/frontend/kuari-pass-trek-explorer/kuari-data.js
@@ -1,0 +1,97 @@
+/**
+ * Kuari Pass Trek Explorer — Data Module
+ * Comprehensive dataset covering Kuari Pass (Chamoli, Uttarakhand),
+ * 3,876m Curzon Trail, close-up Mt. Nanda Devi (India's 2nd highest peak) & Dronagiri vistas,
+ * pristine oak and deodar forest belts, and Tali-Khullara alpine campsites.
+ */
+
+const KUARI_INFO = {
+    id: "kuari-pass-trek",
+    title: "Kuari Pass Trek (The Lord Curzon Trail)",
+    region: "Chamoli District, Garhwal Himalayas, Uttarakhand",
+    maxAltitude: "3,876 Meters (12,516 Feet) at Kuari Pass Summit",
+    trekDistance: "Approx. 33 km (Round Trip)",
+    duration: "5 to 6 Days",
+    difficulty: "Moderate",
+    baseCamp: "Dhak Village / Joshimath (1,875m / 6,150 ft)",
+    historicalName: "The Curzon Trail (Explored by Lord Curzon in 1905)",
+    crownMountain: "Mt. Nanda Devi (7,816m — India's 2nd Highest Peak)",
+    quickStats: [
+        { label: "Pass Altitude", value: "3,876m (12,516 ft)", icon: "🏔️" },
+        { label: "Difficulty", value: "Moderate", icon: "🥾" },
+        { label: "Duration", value: "5–6 Days (33 km)", icon: "⏱️" },
+        { label: "Crown Peak", value: "Nanda Devi (7,816m)", icon: "👑" },
+        { label: "Base Town", value: "Joshimath / Dhak", icon: "📍" },
+        { label: "Historical Route", value: "The Curzon Trail (1905)", icon: "📜" }
+    ]
+};
+
+const TRAIL_CAMPSITES = [
+    {
+        day: "Day 1: Dhak Base Village to Gulling Top",
+        altitude: "Dhak (2,050m) to Gulling Top (2,900m) — 6 km",
+        description: "Trail winds past step farming terraces of Tugasi village, climbing into fragrant pine and silver birch forests.",
+        icon: "🌲"
+    },
+    {
+        day: "Day 2: Gulling Top to Tali Forest Campsite",
+        altitude: "Gulling Top (2,900m) to Tali (3,370m) — 5 km",
+        description: "Enchanting canopy walk through dense, ancient oak and rhododendron woodlands with crystal streams emerging at Tali.",
+        icon: "🍂"
+    },
+    {
+        day: "Day 3: Tali to Kuari Pass Summit & Khullara",
+        altitude: "Tali (3,370m) to Kuari Pass (3,876m) to Khullara (3,395m) — 8 km",
+        description: "Traversing the high-altitude ridge with sweeping vistas of Nanda Devi sanctuary, Dronagiri, and Kamet at the Kuari Pass crest.",
+        icon: "🏔️"
+    },
+    {
+        day: "Day 4: Khullara to Tali Lake & Auli Meadows",
+        altitude: "Khullara to Tali Lake (3,500m) to Auli (2,590m) — 8 km",
+        description: "Ridge trek past high alpine Tali lake descending into the world-famous bugyals and ski slopes of Auli overlooking Neelkanth.",
+        icon: "🎿"
+    },
+    {
+        day: "Day 5: Auli to Joshimath",
+        altitude: "Auli (2,590m) to Joshimath (1,875m) — 6 km / Cable Car",
+        description: "Descent into the sacred pilgrimage and mountaineering gateway hub of Joshimath.",
+        icon: "🏘️"
+    }
+];
+
+const HIMALAYAN_GIANTS = [
+    {
+        peak: "Mt. Nanda Devi & Nanda Devi East",
+        height: "7,816m & 7,434m",
+        significance: "India's highest peak located entirely within the country; the revered 'Bliss-Giving Goddess'.",
+        icon: "👑"
+    },
+    {
+        peak: "Mt. Dronagiri (Dunagiri)",
+        height: "7,066m (23,182 ft)",
+        significance: "The mythological herb mountain associated with the Sanjeevani booti in the Ramayana.",
+        icon: "🌿"
+    },
+    {
+        peak: "Mt. Kamet & Trishul",
+        height: "7,756m & 7,120m",
+        significance: "Colossal glaciated spires dominating the northern Zanskar and Garhwal horizon.",
+        icon: "⚡"
+    },
+    {
+        peak: "Hathi-Ghodi Parvat & Chaukhamba",
+        height: "6,727m & 7,138m",
+        significance: "Striking geological twin formations shaped like an elephant and a horse.",
+        icon: "🐘"
+    }
+];
+
+const REFERENCES = [
+    { text: "Uttarakhand Tourism Development Board (UTDB) — Kuari Pass Trek Profile.", link: "https://uttarakhandtourism.gov.in" },
+    { text: "Smythe, Frank S. (1938). The Valley of Flowers. Hodder & Stoughton, London.", link: "#" },
+    { text: "Nanda Devi Biosphere Reserve Management Plan — Forest Department of Uttarakhand.", link: "https://forest.uk.gov.in" }
+];
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { KUARI_INFO, TRAIL_CAMPSITES, HIMALAYAN_GIANTS, REFERENCES };
+}

--- a/frontend/kuari-pass-trek-explorer/kuari.css
+++ b/frontend/kuari-pass-trek-explorer/kuari.css
@@ -1,0 +1,149 @@
+.kuari-main {
+    background-color: var(--bg-primary, #1e1b4b);
+    color: var(--text-primary, #e0e7ff);
+    font-family: 'Outfit', sans-serif;
+}
+
+.kuari-hero {
+    padding: 6rem 1.5rem 3rem;
+    background: linear-gradient(135deg, rgba(30, 27, 75, 0.95), rgba(67, 56, 202, 0.85));
+    text-align: center;
+}
+
+.hero-badges-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+}
+
+.hero-pill {
+    padding: 0.4rem 1rem;
+    border-radius: 9999px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(8px);
+}
+
+.kuari-hero h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2.75rem;
+    font-weight: 800;
+    margin-bottom: 1rem;
+}
+
+.kuari-hero h1 span {
+    color: #a5b4fc;
+}
+
+.hero-subtitle {
+    max-width: 800px;
+    margin: 0 auto 2.5rem;
+    font-size: 1.1rem;
+    color: #c7d2fe;
+    line-height: 1.6;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1.25rem;
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.stat-card {
+    background: rgba(55, 48, 163, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 1.25rem;
+    border-radius: 12px;
+    text-align: center;
+}
+
+.stat-icon {
+    font-size: 1.75rem;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.stat-val {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #a5b4fc;
+}
+
+.stat-lbl {
+    font-size: 0.85rem;
+    color: #c7d2fe;
+}
+
+.section-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem;
+}
+
+.section-container h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2rem;
+    margin-bottom: 1.5rem;
+    color: #e0e7ff;
+}
+
+.sec-title {
+    margin-top: 2.5rem;
+}
+
+.campsites-grid, .giants-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.trail-card, .giant-card {
+    background: rgba(55, 48, 163, 0.4);
+    border-radius: 12px;
+    padding: 1.25rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    transition: transform 0.2s ease;
+}
+
+.trail-card:hover, .giant-card:hover {
+    transform: translateY(-4px);
+}
+
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.alt-tag, .height-tag {
+    background: #4f46e5;
+    color: #ffffff;
+    font-size: 0.8rem;
+    font-weight: 700;
+    padding: 0.2rem 0.5rem;
+    border-radius: 9999px;
+}
+
+.references-list {
+    list-style: none;
+    padding: 0;
+}
+
+.references-list li {
+    margin-bottom: 0.75rem;
+}
+
+.references-list a {
+    color: #a5b4fc;
+    text-decoration: none;
+}
+
+.references-list a:hover {
+    text-decoration: underline;
+}

--- a/frontend/kuari-pass-trek-explorer/kuari.js
+++ b/frontend/kuari-pass-trek-explorer/kuari.js
@@ -1,0 +1,82 @@
+document.addEventListener('DOMContentLoaded', () => {
+    renderStats();
+    renderCampsites();
+    renderGiants();
+    renderReferences();
+    initThemeToggle();
+});
+
+function renderStats() {
+    const grid = document.getElementById('stats-grid');
+    if (!grid || typeof KUARI_INFO === 'undefined') return;
+
+    grid.innerHTML = KUARI_INFO.quickStats
+        .map(
+            stat => `
+        <div class="stat-card">
+            <span class="stat-icon">${stat.icon}</span>
+            <div class="stat-val">${stat.value}</div>
+            <div class="stat-lbl">${stat.label}</div>
+        </div>
+    `
+        )
+        .join('');
+}
+
+function renderCampsites() {
+    const grid = document.getElementById('campsites-grid');
+    if (!grid || typeof TRAIL_CAMPSITES === 'undefined') return;
+
+    grid.innerHTML = TRAIL_CAMPSITES.map(
+        c => `
+        <div class="trail-card">
+            <div class="card-header">
+                <h3>${c.icon} ${c.day}</h3>
+                <span class="alt-tag">${c.altitude}</span>
+            </div>
+            <p>${c.description}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function renderGiants() {
+    const grid = document.getElementById('giants-grid');
+    if (!grid || typeof HIMALAYAN_GIANTS === 'undefined') return;
+
+    grid.innerHTML = HIMALAYAN_GIANTS.map(
+        g => `
+        <div class="giant-card">
+            <div class="card-header">
+                <h3>${g.icon} ${g.peak}</h3>
+                <span class="height-tag">${g.height}</span>
+            </div>
+            <p>${g.significance}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function renderReferences() {
+    const list = document.getElementById('references-list');
+    if (!list || typeof REFERENCES === 'undefined') return;
+
+    list.innerHTML = REFERENCES.map(
+        r => `
+        <li>
+            <a href="${r.link}" target="_blank" rel="noopener noreferrer">📚 ${r.text}</a>
+        </li>
+    `
+    ).join('');
+}
+
+function initThemeToggle() {
+    const toggleBtn = document.getElementById('theme-toggle');
+    if (!toggleBtn) return;
+
+    toggleBtn.addEventListener('click', () => {
+        const isLight = document.body.classList.toggle('light-theme');
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        toggleBtn.textContent = isLight ? '🌙' : '☀️';
+    });
+}

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -5842,5 +5842,13 @@ window.indiaSearchIndex = [
         description:
             'Explore the Goechala Trek in Sikkim — 4,600m pass offering eye-level views of Mt. Kanchenjunga, Samiti Lake, Dzongri Top, and Khangchendzonga National Park.',
         url: 'frontend/goechala-trek-explorer/index.html'
+    },
+    // --- feat/kuari-pass-trek-explorer ---
+    {
+        title: "Add Kuari Pass Trek \u2014 Uttarakhand",
+        category: "Mountains & Treks",
+        description:
+            "Explore Kuari Pass Trek (The Curzon Trail) in Uttarakhand \u2014 3,876m mountain pass, close-up Mt. Nanda Devi and Dronagiri vistas, and ancient oak forests.",
+        url: "frontend/kuari-pass-trek-explorer/index.html"
     }
 ];

--- a/frontend/tests/unit/kuari-pass-trek-explorer.test.js
+++ b/frontend/tests/unit/kuari-pass-trek-explorer.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadKuariData() {
+    const code = readFileSync(
+        resolve(__dirname, '../../kuari-pass-trek-explorer/kuari-data.js'),
+        'utf-8'
+    );
+    const fn = new Function(
+        code + '\nreturn { KUARI_INFO, TRAIL_CAMPSITES, HIMALAYAN_GIANTS, REFERENCES };'
+    );
+    return fn();
+}
+
+describe('Kuari Pass Trek Explorer — Data Tests', () => {
+    let data;
+
+    beforeAll(() => {
+        data = loadKuariData();
+    });
+
+    describe('KUARI_INFO metadata', () => {
+        it('contains correct Kuari Pass metadata and altitude 3,876m', () => {
+            expect(data.KUARI_INFO.id).toBe('kuari-pass-trek');
+            expect(data.KUARI_INFO.title).toContain('Kuari Pass');
+            expect(data.KUARI_INFO.region).toContain('Uttarakhand');
+            expect(data.KUARI_INFO.maxAltitude).toContain('3,876 Meters');
+        });
+
+        it('has quickStats array with 6 items', () => {
+            expect(Array.isArray(data.KUARI_INFO.quickStats)).toBe(true);
+            expect(data.KUARI_INFO.quickStats.length).toBe(6);
+        });
+    });
+
+    describe('TRAIL_CAMPSITES & NANDA DEVI VISTA', () => {
+        it('contains Dhak, Tali, Kuari Pass, and Mt. Nanda Devi', () => {
+            expect(Array.isArray(data.TRAIL_CAMPSITES)).toBe(true);
+            expect(data.TRAIL_CAMPSITES.length).toBeGreaterThanOrEqual(4);
+
+            const pass = data.TRAIL_CAMPSITES.find(c => c.day.includes('Kuari Pass'));
+            expect(pass).toBeDefined();
+
+            expect(Array.isArray(data.HIMALAYAN_GIANTS)).toBe(true);
+            const nanda = data.HIMALAYAN_GIANTS.find(g => g.peak.includes('Nanda Devi'));
+            expect(nanda).toBeDefined();
+        });
+    });
+
+    describe('REFERENCES', () => {
+        it('contains tourism board and mountain literature citations', () => {
+            expect(Array.isArray(data.REFERENCES)).toBe(true);
+            expect(data.REFERENCES.length).toBeGreaterThanOrEqual(2);
+        });
+    });
+});


### PR DESCRIPTION
## Title

feat: Add Kuari Pass Trek — Uttarakhand

## Description

Create a dedicated Kuari Pass Trek profile (The Curzon Trail) in Chamoli, Uttarakhand — highlighting the 3,876m mountain pass, close-up vistas of Mt. Nanda Devi (India's 2nd highest peak) and Mt. Dronagiri, ancient oak-deodar forest canopies, and Tali-Khullara alpine campsites.

## Included
- Trek Overview & Statistics (3,876m altitude, 33 km, 5–6 days, Dhak / Joshimath base)
- Day-by-Day Curzon Trail Itinerary (Dhak, Gulling Top, Tali Forest, Kuari Pass, Khullara, Auli)
- Himalayan Giants Panorama (Nanda Devi, Dronagiri, Kamet, Trishul, Hathi-Ghodi Parvat)
- Lord Curzon Trail 1905 Historical Context
- Search Index Registration in frontend/search-index.js
- 100% Vitest Unit Test Suite Coverage

Closes #3158