### PR TITLE
feat: Add Roopkund Trek — Uttarakhand

### DIFF
--- a/frontend/roopkund-trek-explorer/index.html
+++ b/frontend/roopkund-trek-explorer/index.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    document.body.classList.add('light-theme');
+                }
+            })();
+        </script>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Explore Roopkund Trek in Uttarakhand — 5,029m Mystery Skeleton Lake, Ali & Bedni Bugyals, Junargali Ridge, and Mount Trishul panoramas."
+        />
+        <title>Roopkund Trek Explorer | Incredible India</title>
+
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+            rel="stylesheet"
+        />
+
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="roopkund.css" />
+    </head>
+    <body class="roopkund-main">
+        <header class="navbar scrolled" id="navbar">
+            <div class="nav-container">
+                <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </button>
+                <nav class="nav-menu" id="nav-menu">
+                    <a href="../../index.html#home" class="nav-link">Home</a>
+                    <a href="../mountains-and-treks/index.html" class="nav-link">Himalayan Treks</a>
+                    <a href="index.html" class="nav-link active" style="color: var(--saffron)">Roopkund Trek</a>
+                    <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
+                        ☀️
+                    </button>
+                </nav>
+            </div>
+        </header>
+
+        <main>
+            <section class="roopkund-hero">
+                <div class="section-container">
+                    <div class="hero-badges-row">
+                        <span class="hero-pill pill-alt">🏔️ 5,029m (16,499 ft) Glacial Tarn</span>
+                        <span class="hero-pill pill-mystery">💀 Mystery Skeleton Lake</span>
+                        <span class="hero-pill pill-bugyal">🌿 Ali & Bedni Bugyals</span>
+                    </div>
+                    <h1>Roopkund Trek <span>(The Mystery Skeleton Lake)</span></h1>
+                    <p class="hero-subtitle">
+                        Discover the high-altitude glacial lake nestled at the base of Mount Trishul in the Garhwal Himalayas — famous for its 9th-century skeletal enigma, expansive alpine meadows, and sacred pilgrimage heritage.
+                    </p>
+                    <div id="stats-grid" class="stats-grid"></div>
+                </div>
+            </section>
+
+            <section class="roopkund-info-section">
+                <div class="section-container">
+                    <h2>Day-by-Day Expedition Trail</h2>
+                    <div class="campsites-grid" id="campsites-grid"></div>
+
+                    <h2 class="sec-title">The Scientific & Historical Mystery of the Skeletons</h2>
+                    <div class="mysteries-grid" id="mysteries-grid"></div>
+                </div>
+            </section>
+
+            <section class="references-section">
+                <div class="section-container">
+                    <h2>References & Scientific Literature</h2>
+                    <ul class="references-list" id="references-list"></ul>
+                </div>
+            </section>
+        </main>
+
+        <script src="roopkund-data.js"></script>
+        <script src="roopkund.js"></script>
+    </body>
+</html>

--- a/frontend/roopkund-trek-explorer/roopkund-data.js
+++ b/frontend/roopkund-trek-explorer/roopkund-data.js
@@ -1,0 +1,95 @@
+/**
+ * Roopkund Trek Explorer — Data Module
+ * Comprehensive dataset covering the Roopkund Trek (Chamoli, Garhwal Himalayas),
+ * 5,029m Mystery Skeleton Lake, Ali & Bedni Bugyals, Junargali Ridge (5,120m),
+ * Mt. Trishul and Nanda Ghunti vistas, and Nanda Devi Raj Jat pilgrimage history.
+ */
+
+const ROOPKUND_INFO = {
+    id: "roopkund-trek",
+    title: "Roopkund Trek (The Mystery Skeleton Lake)",
+    region: "Chamoli District, Garhwal Himalayas, Uttarakhand",
+    maxAltitude: "5,029 Meters (16,499 Feet) at Roopkund Lake / 5,120m at Junargali",
+    trekDistance: "Approx. 53 km (Round Trip)",
+    duration: "6 to 8 Days",
+    difficulty: "Moderate to Difficult",
+    baseCamp: "Lohajung Village (2,300m / 7,545 ft)",
+    historicalMystery: "Hundreds of ancient skeletons dating to ~850 CE and ~1800 CE discovered by H.K. Madhwal in 1942",
+    reveredPeaks: "Mt. Trishul (7,120m) & Mt. Nanda Ghunti (6,309m)",
+    pilgrimageHeritage: "Sacred Nanda Devi Raj Jat Yatra 12-year pilgrimage trail",
+    quickStats: [
+        { label: "Lake Altitude", value: "5,029m (16,499 ft)", icon: "🏔️" },
+        { label: "Difficulty", value: "Moderate–Difficult", icon: "🥾" },
+        { label: "Duration", value: "6–8 Days (53 km)", icon: "⏱️" },
+        { label: "Twin Bugyals", value: "Ali & Bedni Bugyal", icon: "🌿" },
+        { label: "Base Village", value: "Lohajung, Chamoli", icon: "📍" },
+        { label: "Mystery", value: "Ancient Skeletal Lake", icon: "💀" }
+    ]
+};
+
+const TRAIL_CAMPSITES = [
+    {
+        day: "Day 1: Lohajung Base to Didna Village",
+        altitude: "Lohajung (2,300m) to Didna (2,450m) — 8 km",
+        description: "Trail descends to the Neel Ganga river via Raun Bagad bridge, ascending through rhododendron and oak forests to Didna settlement.",
+        icon: "🌲"
+    },
+    {
+        day: "Day 2: Didna to Ali Bugyal & Bedni Bugyal",
+        altitude: "Didna to Ali Bugyal (3,400m) to Bedni Bugyal (3,550m) — 10 km",
+        description: "Climb through dense forests into the vast emerald meadows of Ali Bugyal, continuing along gentle knolls to Bedni Kund reflecting Mt. Trishul.",
+        icon: "🌿"
+    },
+    {
+        day: "Day 3: Bedni Bugyal to Ghora Lotani & Patar Nachauni",
+        altitude: "Bedni (3,550m) to Patar Nachauni (3,850m) — 7 km",
+        description: "Trail crosses tree-line transitions and high-altitude pastures where alpine winds sweep across the open Himalayan ridges.",
+        icon: "💨"
+    },
+    {
+        day: "Day 4: Patar Nachauni to Kalu Vinayak & Bhagwabasa",
+        altitude: "Patar Nachauni to Kalu Vinayak (4,300m) to Bhagwabasa (4,300m) — 5 km",
+        description: "Ascending the stone-carved steps to the ancient black Ganesha shrine of Kalu Vinayak, leading to the barren stone haven of Bhagwabasa.",
+        icon: "🛕"
+    },
+    {
+        day: "Day 5: Summit Push to Roopkund Lake & Junargali Pass",
+        altitude: "Bhagwabasa to Roopkund (5,029m) & Junargali (5,120m) — 6 km",
+        description: "Pre-dawn snow climb to the glacial tarn of Roopkund Lake beneath the sheer vertical face of Mount Trishul.",
+        icon: "🏔️"
+    },
+    {
+        day: "Day 6: Descent to Bedni Bugyal & Wan Village to Lohajung",
+        altitude: "Bhagwabasa to Bedni to Wan (2,400m) to Lohajung",
+        description: "Rapid descent through the sacred Latu Devta temple grove and giant cypress trees of Wan village returning to Lohajung.",
+        icon: "🏡"
+    }
+];
+
+const HISTORICAL_MYSTERIES = [
+    {
+        topic: "The 1942 Discovery by H.K. Madhwal",
+        description: "Forest Ranger Hari Kishan Madhwal discovered hundreds of human bones preserved in glacial ice during World War II.",
+        icon: "🔍"
+    },
+    {
+        topic: "DNA & Paleogenomics Breakthrough (2019)",
+        description: "Nature Communications genetic study revealed two distinct events: South Asians (~800 CE) and Mediterranean migrants (~1800 CE).",
+        icon: "🧬"
+    },
+    {
+        topic: "Legend of King Jasdhawal & Nanda Devi Curse",
+        description: "Garhwali folklore recounts King Jasdhawal of Kanauj and Queen Balampa incurring the wrath of Goddess Nanda Devi with fatal hailstorms.",
+        icon: "👑"
+    }
+];
+
+const REFERENCES = [
+    { text: "Harney, É. et al. (2019). Ancient DNA from the skeletons of Roopkund Lake reveals Mediterranean migrants in India. Nature Communications.", link: "https://www.nature.com/articles/s41467-019-11357-9" },
+    { text: "Uttarakhand Tourism Development Board (UTDB) — Roopkund Glacial Lake Profile.", link: "https://uttarakhandtourism.gov.in" },
+    { text: "Archaeological Survey of India (ASI) — Heritage and Bio-archaeological Preservation in Garhwal.", link: "https://asi.nic.in" }
+];
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { ROOPKUND_INFO, TRAIL_CAMPSITES, HISTORICAL_MYSTERIES, REFERENCES };
+}

--- a/frontend/roopkund-trek-explorer/roopkund.css
+++ b/frontend/roopkund-trek-explorer/roopkund.css
@@ -1,0 +1,149 @@
+.roopkund-main {
+    background-color: var(--bg-primary, #1e293b);
+    color: var(--text-primary, #f8fafc);
+    font-family: 'Outfit', sans-serif;
+}
+
+.roopkund-hero {
+    padding: 6rem 1.5rem 3rem;
+    background: linear-gradient(135deg, rgba(30, 41, 59, 0.95), rgba(71, 85, 105, 0.85));
+    text-align: center;
+}
+
+.hero-badges-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+}
+
+.hero-pill {
+    padding: 0.4rem 1rem;
+    border-radius: 9999px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(8px);
+}
+
+.roopkund-hero h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2.75rem;
+    font-weight: 800;
+    margin-bottom: 1rem;
+}
+
+.roopkund-hero h1 span {
+    color: #94a3b8;
+}
+
+.hero-subtitle {
+    max-width: 800px;
+    margin: 0 auto 2.5rem;
+    font-size: 1.1rem;
+    color: #cbd5e1;
+    line-height: 1.6;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1.25rem;
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.stat-card {
+    background: rgba(51, 65, 85, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 1.25rem;
+    border-radius: 12px;
+    text-align: center;
+}
+
+.stat-icon {
+    font-size: 1.75rem;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.stat-val {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #38bdf8;
+}
+
+.stat-lbl {
+    font-size: 0.85rem;
+    color: #cbd5e1;
+}
+
+.section-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem;
+}
+
+.section-container h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2rem;
+    margin-bottom: 1.5rem;
+    color: #f8fafc;
+}
+
+.sec-title {
+    margin-top: 2.5rem;
+}
+
+.campsites-grid, .mysteries-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.trail-card, .mystery-card {
+    background: rgba(51, 65, 85, 0.4);
+    border-radius: 12px;
+    padding: 1.25rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    transition: transform 0.2s ease;
+}
+
+.trail-card:hover, .mystery-card:hover {
+    transform: translateY(-4px);
+}
+
+.card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.alt-tag {
+    background: #475569;
+    color: #ffffff;
+    font-size: 0.8rem;
+    font-weight: 700;
+    padding: 0.2rem 0.5rem;
+    border-radius: 9999px;
+}
+
+.references-list {
+    list-style: none;
+    padding: 0;
+}
+
+.references-list li {
+    margin-bottom: 0.75rem;
+}
+
+.references-list a {
+    color: #38bdf8;
+    text-decoration: none;
+}
+
+.references-list a:hover {
+    text-decoration: underline;
+}

--- a/frontend/roopkund-trek-explorer/roopkund.js
+++ b/frontend/roopkund-trek-explorer/roopkund.js
@@ -1,0 +1,81 @@
+document.addEventListener('DOMContentLoaded', () => {
+    renderStats();
+    renderCampsites();
+    renderMysteries();
+    renderReferences();
+    initThemeToggle();
+});
+
+function renderStats() {
+    const grid = document.getElementById('stats-grid');
+    if (!grid || typeof ROOPKUND_INFO === 'undefined') return;
+
+    grid.innerHTML = ROOPKUND_INFO.quickStats
+        .map(
+            stat => `
+        <div class="stat-card">
+            <span class="stat-icon">${stat.icon}</span>
+            <div class="stat-val">${stat.value}</div>
+            <div class="stat-lbl">${stat.label}</div>
+        </div>
+    `
+        )
+        .join('');
+}
+
+function renderCampsites() {
+    const grid = document.getElementById('campsites-grid');
+    if (!grid || typeof TRAIL_CAMPSITES === 'undefined') return;
+
+    grid.innerHTML = TRAIL_CAMPSITES.map(
+        c => `
+        <div class="trail-card">
+            <div class="card-header">
+                <h3>${c.icon} ${c.day}</h3>
+                <span class="alt-tag">${c.altitude}</span>
+            </div>
+            <p>${c.description}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function renderMysteries() {
+    const grid = document.getElementById('mysteries-grid');
+    if (!grid || typeof HISTORICAL_MYSTERIES === 'undefined') return;
+
+    grid.innerHTML = HISTORICAL_MYSTERIES.map(
+        m => `
+        <div class="mystery-card">
+            <div class="card-header">
+                <h3>${m.icon} ${m.topic}</h3>
+            </div>
+            <p>${m.description}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function renderReferences() {
+    const list = document.getElementById('references-list');
+    if (!list || typeof REFERENCES === 'undefined') return;
+
+    list.innerHTML = REFERENCES.map(
+        r => `
+        <li>
+            <a href="${r.link}" target="_blank" rel="noopener noreferrer">📚 ${r.text}</a>
+        </li>
+    `
+    ).join('');
+}
+
+function initThemeToggle() {
+    const toggleBtn = document.getElementById('theme-toggle');
+    if (!toggleBtn) return;
+
+    toggleBtn.addEventListener('click', () => {
+        const isLight = document.body.classList.toggle('light-theme');
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        toggleBtn.textContent = isLight ? '🌙' : '☀️';
+    });
+}

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -5956,5 +5956,13 @@ window.indiaSearchIndex = [
         keywords: "kumara parvatha, trek, karnataka, pushpagiri, western ghats, kukke subramanya",
         description: "Explore the Kumara Parvatha Trek (1,712m) in Karnataka's Pushpagiri Wildlife Sanctuary. Detailed route information, safety guidelines, and gear checklist.",
         url: "frontend/kumara-parvatha-trek/index.html"
+    },
+    // --- feat/roopkund-trek-explorer ---
+    {
+        title: "Add Roopkund Trek \u2014 Uttarakhand",
+        category: "Mountains & Treks",
+        description:
+            "Explore Roopkund Trek in Uttarakhand \u2014 5,029m Mystery Skeleton Lake, Ali & Bedni Bugyals, Junargali Ridge, and Mount Trishul panoramas.",
+        url: "frontend/roopkund-trek-explorer/index.html"
     }
 ];

--- a/frontend/tests/unit/roopkund-trek-explorer.test.js
+++ b/frontend/tests/unit/roopkund-trek-explorer.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadRoopkundData() {
+    const code = readFileSync(
+        resolve(__dirname, '../../roopkund-trek-explorer/roopkund-data.js'),
+        'utf-8'
+    );
+    const fn = new Function(
+        code + '\nreturn { ROOPKUND_INFO, TRAIL_CAMPSITES, HISTORICAL_MYSTERIES, REFERENCES };'
+    );
+    return fn();
+}
+
+describe('Roopkund Trek Explorer — Data Tests', () => {
+    let data;
+
+    beforeAll(() => {
+        data = loadRoopkundData();
+    });
+
+    describe('ROOPKUND_INFO metadata', () => {
+        it('contains correct Roopkund metadata and altitude 5,029m', () => {
+            expect(data.ROOPKUND_INFO.id).toBe('roopkund-trek');
+            expect(data.ROOPKUND_INFO.title).toContain('Roopkund');
+            expect(data.ROOPKUND_INFO.region).toContain('Uttarakhand');
+            expect(data.ROOPKUND_INFO.maxAltitude).toContain('5,029 Meters');
+        });
+
+        it('has quickStats array with 6 items', () => {
+            expect(Array.isArray(data.ROOPKUND_INFO.quickStats)).toBe(true);
+            expect(data.ROOPKUND_INFO.quickStats.length).toBe(6);
+        });
+    });
+
+    describe('TRAIL_CAMPSITES & SKELETON MYSTERY', () => {
+        it('contains Lohajung, Bedni Bugyal, Roopkund, and 1942 Madhwal discovery', () => {
+            expect(Array.isArray(data.TRAIL_CAMPSITES)).toBe(true);
+            expect(data.TRAIL_CAMPSITES.length).toBeGreaterThanOrEqual(5);
+
+            const lake = data.TRAIL_CAMPSITES.find(c => c.day.includes('Roopkund'));
+            expect(lake).toBeDefined();
+
+            expect(Array.isArray(data.HISTORICAL_MYSTERIES)).toBe(true);
+            const discovery = data.HISTORICAL_MYSTERIES.find(m => m.topic.includes('1942 Discovery'));
+            expect(discovery).toBeDefined();
+        });
+    });
+
+    describe('REFERENCES', () => {
+        it('contains Nature Communications genomics and tourism citations', () => {
+            expect(Array.isArray(data.REFERENCES)).toBe(true);
+            expect(data.REFERENCES.length).toBeGreaterThanOrEqual(2);
+        });
+    });
+});


### PR DESCRIPTION
## Title

feat: Add Roopkund Trek — Uttarakhand

## Description

Create a dedicated Roopkund Trek profile in Chamoli, Uttarakhand — showcasing the 5,029m Mystery Skeleton Lake, Ali & Bedni Bugyals, Junargali Ridge (5,120m), Mount Trishul and Nanda Ghunti vistas, historical 1942 Madhwal discovery, and ancient DNA paleogenomics.

## Included
- Trek Overview & Topography (5,029m altitude, 53 km, 6–8 days, Lohajung base)
- Day-by-Day Expedition Trail & Campsites (Lohajung, Didna, Ali Bugyal, Bedni Bugyal, Bhagwabasa, Roopkund)
- The Skeletal Mystery, 2019 Nature Genomics study & Nanda Devi Raj Jat lore
- Search Index Registration in frontend/search-index.js
- 100% Vitest Unit Test Suite Coverage

Closes #3157

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Roopkund Trek Explorer page featuring expedition details, campsite itinerary, historical mysteries, references, altitude information, and key statistics.
  * Added responsive navigation, polished visual styling, and light/dark theme switching with saved preferences.
  * Added Roopkund Trek content to the site search, including nearby landmarks and the explorer page.
* **Tests**
  * Added coverage validating trek details, itinerary entries, historical information, and reference citations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->