### PR TITLE
feat(surjit-hockey): add Surjit Hockey Tournament explorer with Punjab hockey timeline (#2527)

### DIFF
--- a/frontend/surjit-hockey-explorer/data.js
+++ b/frontend/surjit-hockey-explorer/data.js
@@ -1,0 +1,289 @@
+/**
+ * Surjit Hockey Explorer - Static data module (#2527)
+ * Exposes window.SURJIT_DATA with tournaments (winners), players and milestones.
+ * Sources: surjithockey.com, Surjit Hockey Society records, Wikipedia, The Tribune,
+ * HockeyPassion, Sports Board India.
+ */
+window.SURJIT_DATA = {
+    tournaments: [
+        {
+            year: 1984,
+            edition: '1st edition',
+            venue: 'Shri Guru Gobind Singh Stadium, Jalandhar',
+            champion: 'Western Command',
+            runnerUp: 'PSEB, Patiala',
+            india: null,
+            note: 'Inaugural memorial edition. The Surjit Hockey Society (formed 13 May 1984) staged the first tournament on the grass ground of Shri Guru Gobind Singh Stadium to keep Olympian Surjit Singh Randhawa\'s name alive.'
+        },
+        {
+            year: 1988,
+            edition: '5th edition',
+            venue: 'Jalandhar',
+            champion: 'Punjab & Sind Bank',
+            runnerUp: 'BSF Jalandhar',
+            note: 'Punjab & Sind Bank begin their love affair with the trophy - they would go on to win a record 11 titles.'
+        },
+        {
+            year: 1990,
+            edition: '7th edition',
+            venue: 'Jalandhar',
+            champion: 'Services XI',
+            runnerUp: 'RCF Kapurthala',
+            note: 'IndianOil comes aboard as title sponsor - a partnership that continues today under the "IndianOil Servo Surjit Hockey" banner.'
+        },
+        {
+            year: 1996,
+            edition: '13th edition',
+            venue: 'Jalandhar',
+            champion: 'Army-XI Delhi',
+            runnerUp: 'Punjab Police',
+            note: 'Services champions Army-XI edge Punjab Police in an all-institution final of the memorial tournament.'
+        },
+        {
+            year: 2002,
+            edition: '19th edition',
+            venue: 'Olympian Surjit Hockey Stadium, Burlton Park',
+            champion: 'Bharat Petroleum',
+            runnerUp: 'Punjab & Sind Bank',
+            note: 'BPCL open a strong run for the oil-sector giants at the tournament\'s permanent home, Burlton Park.'
+        },
+        {
+            year: 2005,
+            edition: '22nd edition',
+            venue: 'Olympian Surjit Hockey Stadium, Burlton Park',
+            champion: 'Indian Airlines, Delhi',
+            runnerUp: 'Indian Oil Corporation',
+            note: 'An all-airlines final - fitting tribute to Surjit Singh, who turned out for Indian Airlines during his playing days.'
+        },
+        {
+            year: 2007,
+            edition: '24th edition',
+            venue: 'Olympian Surjit Hockey Stadium, Burlton Park',
+            champion: 'Indian Oil Mumbai',
+            runnerUp: 'Indian Airlines, Delhi',
+            note: 'Indian Oil Mumbai lift the trophy for the first time - the start of a dynasty that would reach seven titles by 2025.'
+        },
+        {
+            year: 2008,
+            edition: '25th edition',
+            venue: 'Olympian Surjit Hockey Stadium, Burlton Park',
+            champion: 'Punjab & Sind Bank',
+            runnerUp: 'Javed Hockey Club, Gojra (Pakistan)',
+            note: 'A cross-border flavour in the silver-jubilee final as PSB defeat Pakistan\'s Javed Hockey Club of Gojra.'
+        },
+        {
+            year: 2019,
+            edition: '36th edition',
+            venue: 'Olympian Surjit Hockey Stadium, Burlton Park',
+            champion: 'Punjab & Sind Bank',
+            runnerUp: 'Indian Oil Mumbai',
+            note: 'PSB claim their record 11th Surjit title, stretching their lead at the top of the honours board.'
+        },
+        {
+            year: 2020,
+            edition: '',
+            venue: '-',
+            champion: 'Tournament not held',
+            runnerUp: '-',
+            note: 'The only year without a Surjit Hockey Tournament since its founding, amid the COVID-19 pandemic.'
+        },
+        {
+            year: 2021,
+            edition: '38th edition',
+            venue: 'Olympian Surjit Hockey Stadium, Burlton Park',
+            champion: 'Indian Railways',
+            runnerUp: 'Punjab & Sind Bank',
+            note: 'Railways return from the pandemic break to deny PSB a twelfth crown.'
+        },
+        {
+            year: 2023,
+            edition: '40th edition',
+            venue: 'Olympian Surjit Hockey Stadium, Burlton Park',
+            champion: 'Indian Oil Mumbai',
+            runnerUp: 'CAG New Delhi',
+            note: 'The ruby-jubilee edition ends with Indian Oil Mumbai back on top - the first leg of what becomes a hat-trick of titles.'
+        },
+        {
+            year: 2024,
+            edition: '41st edition',
+            venue: 'Olympian Surjit Hockey Stadium, Burlton Park',
+            champion: 'Indian Oil Mumbai',
+            runnerUp: 'Bharat Petroleum (BPCL)',
+            note: 'Indian Oil retain the trophy in an all-Maharashtra-oil-sector showdown with BPCL.'
+        },
+        {
+            year: 2025,
+            edition: '42nd edition',
+            venue: 'Olympian Surjit Hockey Stadium, Burlton Park',
+            champion: 'Indian Oil Mumbai',
+            runnerUp: 'Indian Railways Delhi',
+            note: 'Indian Oil Mumbai beat Indian Railways 2-1 in the final to complete a three-peat - their seventh Surjit crown overall.'
+        }
+    ],
+
+    players: [
+        {
+            name: 'Surjit Singh Randhawa',
+            initials: 'SS',
+            role: 'Right full-back \u00b7 Namesake',
+            era: '1951-1984',
+            highlight: '"Penalty corner da badshah" - World Cup winner 1975, captain at Bombay 1982, posthumous Arjuna Award 1998. The tournament is his living memorial.'
+        },
+        {
+            name: 'Balbir Singh Sr.',
+            initials: 'BS',
+            role: 'Centre-forward',
+            era: '1924-2020',
+            highlight: 'Born at Haripur Khalsa in Jalandhar district; triple Olympic gold medallist (1948, 1952, 1956) and independent India\'s greatest hockey icon.'
+        },
+        {
+            name: 'Ajit Pal Singh',
+            initials: 'AP',
+            role: 'Centre-half \u00b7 Captain',
+            era: '1970s-80s',
+            highlight: 'Son of Sansarpur, Jalandhar - captained India to their historic 1975 Kuala Lumpur World Cup triumph alongside Surjit Singh.'
+        },
+        {
+            name: 'Pargat Singh',
+            initials: 'PS',
+            role: 'Full-back \u00b7 Administrator',
+            era: '1980s-2000s',
+            highlight: 'Olympian (1988, 1992, 1996), Padma Shri awardee and MLA from Jalandhar Cantt - serves as Working President of the Surjit Hockey Society.'
+        },
+        {
+            name: 'Manpreet Singh',
+            initials: 'MS',
+            role: 'Half-back \u00b7 Captain',
+            era: '2011-present',
+            highlight: 'From Mithapur on Jalandhar\'s outskirts - led India to bronze at the Tokyo Olympics (2021) and won the Major Dhyan Chand Khel Ratna Award.'
+        },
+        {
+            name: 'Chanchal Randhawa',
+            initials: 'CR',
+            role: 'International player',
+            era: '1970s',
+            highlight: 'Surjit Singh\'s wife was an international hockeyer who led India in the 1970s - the family\'s sporting legacy spans generations.'
+        }
+    ],
+
+    teams: [
+        {
+            name: 'Punjab & Sind Bank',
+            category: 'Departmental',
+            note: 'The most decorated side in tournament history with a record 11 titles, from 1988 through 2019.'
+        },
+        {
+            name: 'Indian Oil Mumbai',
+            category: 'Departmental',
+            note: 'Seven titles including the 2023-25 hat-trick - the dominant force of the modern era.'
+        },
+        {
+            name: 'Indian Railways',
+            category: 'Departmental',
+            note: 'Champions in 2015 and again in 2021 after the pandemic break; beaten finalists in 2025.'
+        },
+        {
+            name: 'Bharat Petroleum (BPCL)',
+            category: 'Departmental',
+            note: 'Oil-sector giants who won three straight finals around 2002-09 and finished runners-up in 2024.'
+        },
+        {
+            name: 'Army-XI Delhi',
+            category: 'Services',
+            note: 'Two-time champions (1996, 2018) representing the services stream of Indian hockey.'
+        },
+        {
+            name: 'BSF Jalandhar',
+            category: 'Services',
+            note: 'The border force\'s home-town outfit lifted the trophy in 1986, 1998 and 1999.'
+        },
+        {
+            name: 'Punjab Police',
+            category: 'State police',
+            note: 'Surjit Singh\'s own department and perennial contenders with titles across 1985-2017.'
+        },
+        {
+            name: 'ONGC Delhi',
+            category: 'Departmental',
+            note: 'Regular semi-finalists and runners-up in 2017 behind a resurgent Punjab Police.'
+        },
+        {
+            name: 'RCF Kapurthala',
+            category: 'Departmental',
+            note: 'Punjab\'s railway-factory team and early-era finalist (1987, 1990).'
+        },
+        {
+            name: 'JCT Phagwara',
+            category: 'Club',
+            note: 'Legendary Punjab club of the 1970s-90s golden age, runner-up in the 1987 final.'
+        },
+        {
+            name: 'CAG New Delhi',
+            category: 'Departmental',
+            note: 'The auditors\' XI who stunned the circuit as finalists of the ruby-jubilee edition in 2023.'
+        }
+    ],
+
+    milestones: [
+        {
+            year: '1951',
+            title: 'A legend is born',
+            text: 'Surjit Singh Randhawa is born on 10 October in Batala (Gurdaspur district, Punjab); his family later settles around Jalandhar, where he learns his hockey.'
+        },
+        {
+            year: '1973',
+            title: 'Debut and the World XI',
+            text: 'Surjit debuts for India at the second World Cup in Amsterdam - emerging as one of the tournament\'s stars - and is named to the World Hockey XI.'
+        },
+        {
+            year: '1975',
+            title: 'World Cup glory at Kuala Lumpur',
+            text: 'Playing full-back beside captain Ajit Pal Singh, Surjit helps India win their first (and still only) men\'s Hockey World Cup, scoring India\'s opening goal of the campaign.'
+        },
+        {
+            year: '1976',
+            title: 'Montreal Olympics',
+            text: 'Surjit represents India at the Montreal Olympic Games, having already been acclaimed among the world\'s finest full-backs.'
+        },
+        {
+            year: '1984',
+            title: 'Tragedy and a society\'s pledge',
+            text: 'Surjit dies in a car accident near Kartarpur, Jalandhar, aged just 32. Within months - on 13 May 1984 - the Surjit Hockey Society is founded to keep his name alive.'
+        },
+        {
+            year: '1984',
+            title: 'First Surjit Hockey Tournament',
+            text: 'Western Command win the inaugural memorial tournament at the grassy Guru Gobind Singh Stadium, Jalandhar, defeating PSEB Patiala.'
+        },
+        {
+            year: '1990',
+            title: 'IndianOil partnership begins',
+            text: 'IndianOil steps in as title sponsor - the tournament becomes the "IndianOil Servo Surjit Hockey Tournament", a bond now spanning three decades-plus.'
+        },
+        {
+            year: '1998',
+            title: 'Posthumous Arjuna Award',
+            text: 'Fourteen years after his passing, the Government of India confers the Arjuna Award on Surjit Singh in recognition of his services to hockey.'
+        },
+        {
+            year: '2000',
+            title: 'A village renamed',
+            text: 'After persistent efforts of Surjit\'s family, his native village Dakhla is officially renamed "Surjit Singh Wala".'
+        },
+        {
+            year: '2012',
+            title: 'State support revived',
+            text: 'The Government of Punjab announces support for the Surjit Hockey Society and the Olympian Surjit Hockey Academy to revive the sport across the state.'
+        },
+        {
+            year: '2023',
+            title: 'Ruby jubilee - 40th edition',
+            text: 'The tournament celebrates its 40th running at the Olympian Surjit Hockey Stadium, with Indian Oil Mumbai beating CAG New Delhi for the title.'
+        },
+        {
+            year: '2025',
+            title: 'Three in a row for Indian Oil',
+            text: 'Indian Oil Mumbai defeat Indian Railways Delhi 2-1 in the 42nd final to claim a third consecutive title and seventh overall.'
+        }
+    ]
+};

--- a/frontend/surjit-hockey-explorer/index.html
+++ b/frontend/surjit-hockey-explorer/index.html
@@ -1,0 +1,382 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.documentElement.setAttribute('data-theme', 'light');
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Surjit Hockey Tournament Explorer - Discover Punjab's hockey heritage through the memorial tournament for Olympian Surjit Singh Randhawa at Jalandhar: the trophy, his profile, tournament history, winners, teams, notable players and an interactive Punjab hockey timeline.">
+    <title>Surjit Hockey Explorer | Incredible India Explorer</title>
+    <link rel="icon" href="data:,">
+
+    <!-- Preload Critical Fonts -->
+    <link rel="preload" href="../../assets/fonts/Outfit-400.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="../../assets/fonts/Outfit-700.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="../../assets/fonts/PlayfairDisplay-400.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="style.css">
+
+    <!-- Open Graph / Social Media Tags -->
+    <meta property="og:title" content="Surjit Hockey Explorer | Incredible India Explorer">
+    <meta property="og:description" content="Explore Punjab's hockey heritage - the Surjit Hockey Tournament honouring Olympian Surjit Singh Randhawa: trophy, history, winners, teams and an interactive timeline.">
+    <meta property="og:type" content="website">
+    <meta property="og:locale" content="en_IN">
+</head>
+
+<body class="sh-page-body">
+    <script>
+        (function() {
+            let theme = 'dark'; try { theme = JSON.parse(localStorage.getItem('iie_storage') || '{}').theme || 'dark'; } catch(e) {}
+            if (theme === 'light') {
+                document.body.classList.add('light-theme');
+            }
+        })();
+    </script>
+    <!-- Navbar Header -->
+    <header class="navbar" id="navbar">
+    <div class="nav-container">
+        <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+            <span class="saffron">Incredible</span>
+            <span class="gold">India</span>
+            <span class="green">Explorer</span>
+        </a>
+        <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+            <span class="bar"></span>
+            <span class="bar"></span>
+            <span class="bar"></span>
+        </button>
+        <nav class="nav-menu" id="nav-menu">
+            <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
+                    <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                    <a href="../../frontend/ancient-ports-explorer/index.html" class="dropdown-item">Ancient Ports of India</a>
+                    <a href="../../frontend/islands/islands.html" class="dropdown-item">Islands of India</a>
+                    <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    <a href="../../frontend/forts/forts.html" class="dropdown-item">Forts of India</a>
+                    <a href="../../frontend/route-planner/route-planner.html" class="dropdown-item">Route Planner</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+                    <a href="../../frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
+                    <a href="../../frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
+                    <a href="../../frontend/event-discovery/index.html" class="dropdown-item">Festival & Event Discovery</a>
+                    <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
+                    <a href="../../frontend/national-symbols-gallery/national-symbols-gallery.html" class="dropdown-item">National Symbols</a>
+                    <a href="../../frontend/cuisine-discovery-hub/index.html" class="dropdown-item">UP Cuisine</a>
+                    <a href="../../frontend/handicrafts-showcase/index.html" class="dropdown-item">UP Handicrafts</a>
+                    <a href="../../frontend/national-days-calendar/index.html" class="dropdown-item">National Days</a>
+                    <a href="../../frontend/ganga-ghats-experience/index.html" class="dropdown-item">Ganga Ghats</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Nature ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/national-parks-explorer/index.html" class="dropdown-item">National Parks</a>
+                    <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                    <a href="../../frontend/wildlife-rescue/wildlife-rescue.html" class="dropdown-item">Wildlife Rescue</a>
+                    <a href="../../frontend/endemic-flora-fauna-explorer/index.html" class="dropdown-item">Endemic Flora & Fauna</a>
+                    <a href="../../frontend/harike-wetland/harike-wetland.html" class="dropdown-item">Harike Wetland</a>
+                    <a href="../../frontend/wular-lake/wular-lake.html" class="dropdown-item">Wular Lake</a>
+                    <a href="../../frontend/crowd-density/index.html" class="dropdown-item">Crowd Density Predictor</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Games ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/passport-quest/passport-quest.html" class="dropdown-item">Passport Quest</a>
+                    <a href="../../frontend/culinary-game/culinary-game.html" class="dropdown-item">Culinary Challenge</a>
+                    <a href="../../frontend/monsoon-game/monsoon-game.html" class="dropdown-item">Monsoon Game</a>
+                    <a href="../../frontend/river-game/river-game.html" class="dropdown-item">River Explorer</a>
+                    <a href="../../frontend/geo-guesser-india/index.html" class="dropdown-item">GeoGuesser</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Community ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/contributors/contributors.html" class="dropdown-item">Contributors</a>
+                    <a href="../../frontend/world-records-india/index.html" class="dropdown-item">World Records</a>
+                </div>
+            </div>
+
+            <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+        </nav>
+    </div>
+</header>
+
+    <main class="sh-main">
+        <!-- Hero Banner -->
+        <section class="sh-hero">
+            <div class="sh-hero-bg" aria-hidden="true"></div>
+            <div class="sh-hero-overlay" aria-hidden="true"></div>
+            <div class="sh-hero-particles" aria-hidden="true">
+                <span></span><span></span><span></span><span></span><span></span><span></span>
+            </div>
+            <div class="sh-hero-content">
+                <p class="sh-kicker">Jalandhar &middot; Punjab &middot; Since 1984</p>
+                <h1>The <span class="gradient-text">Surjit Hockey</span> Explorer</h1>
+                <p class="sh-hero-sub">
+                    Punjab's festival of hockey - the annual memorial tournament for Olympian
+                    Surjit Singh Randhawa - told through the
+                    <span class="sh-type sh-type-accent" data-words='["Trophy","Legends","Winners","Timeline"]'>Trophy</span>
+                </p>
+                <div class="hero-stats" role="list" aria-label="Key Surjit Hockey numbers">
+                    <div class="hero-stat" role="listitem">
+                        <span class="number" id="stat-editions" data-target="42">0</span>
+                        <span class="label">Editions since 1984</span>
+                    </div>
+                    <div class="hero-stat" role="listitem">
+                        <span class="number" id="stat-psb" data-target="11">0</span>
+                        <span class="label">Record titles - Punjab &amp; Sind Bank</span>
+                    </div>
+                    <div class="hero-stat" role="listitem">
+                        <span class="number" id="stat-io" data-target="7">0</span>
+                        <span class="label">Titles for Indian Oil Mumbai</span>
+                    </div>
+                    <div class="hero-stat" role="listitem">
+                        <span class="number" id="stat-nations" data-target="9">0</span>
+                        <span class="label">Foreign nations have taken part</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Tab Navigation -->
+        <nav class="sh-tabs" aria-label="Surjit Hockey sections">
+            <button class="sh-tab active" data-tab="trophy">🏆 Trophy</button>
+            <button class="sh-tab" data-tab="namesake">🧑‍🏭 Namesake</button>
+            <button class="sh-tab" data-tab="history">📜 History</button>
+            <button class="sh-tab" data-tab="punjab-hockey">🌾 Punjab &amp; Hockey</button>
+            <button class="sh-tab" data-tab="teams">🛡️ Teams</button>
+            <button class="sh-tab" data-tab="winners">🏅 Winners</button>
+            <button class="sh-tab" data-tab="players">⭐ Notable Players</button>
+            <button class="sh-tab" data-tab="milestones">🚩 Milestones</button>
+            <button class="sh-tab" data-tab="timeline">🕰️ Timeline</button>
+            <button class="sh-tab" data-tab="sources">📚 Sources</button>
+        </nav>
+
+        <!-- Trophy -->
+        <section class="sh-section active" id="trophy" aria-labelledby="trophy-heading">
+            <h2 id="trophy-heading">The Surjit Trophy &amp; The Festival</h2>
+            <div class="sh-card-grid">
+                <article class="sh-card glass-card">
+                    <h3>A Memorial Prize</h3>
+                    <p>The champions lift a trophy dedicated to Olympian Surjit Singh Randhawa - instituted in 1984,
+                       months after the great full-back's death - so that every final keeps his name echoing across Jalandhar.</p>
+                </article>
+                <article class="sh-card glass-card">
+                    <h3>Free For The People</h3>
+                    <p>True to its community spirit, the Society charges no gate money. Thousands pack the stands each winter,
+                       with lucky draws adding Maruti Alto cars, motorcycles and appliances for spectators.</p>
+                </article>
+                <article class="sh-card glass-card">
+                    <h3>Olympian Surjit Hockey Stadium</h3>
+                    <p>Since its early days on the grass of Guru Gobind Singh Stadium, the event has found a permanent home at
+                       Burlton Park - renamed in Surjit's honour - complete with floodlights and international-grade turf.</p>
+                </article>
+                <article class="sh-card glass-card">
+                    <h3>Men &amp; Women Alike</h3>
+                    <p>The festival hosts both men's and women's competitions alongside coaching camps for children -
+                       the Society's way of "exploring a new Surjit" in every generation.</p>
+                </article>
+            </div>
+        </section>
+
+        <!-- Namesake -->
+        <section class="sh-section" id="namesake" aria-labelledby="namesake-heading">
+            <h2 id="namesake-heading">Olympian Surjit Singh Randhawa</h2>
+            <p class="sh-section-sub">(10 October 1951 - January 1984) &middot; Right full-back &middot; "Penalty corner da badshah"</p>
+            <div class="sh-content-card">
+                <p>Born in Batala and raised into hockey around Jalandhar, Surjit Singh studied at Lyallpur Khalsa College
+                   and starred for Guru Nanak Dev University before making his India debut at the 1973 Amsterdam World Cup.
+                   A member of the 1975 Kuala Lumpur World Cup-winning side - where he scored India's opening goal of the
+                   campaign - he also played the Montreal 1976 Olympics, the Tehran 1974 and Bangkok 1978 Asian Games, and
+                   captained India at the Bombay 1982 World Cup. Named to the World Hockey XI (1973) and All-Star XI (1974),
+                   this full-back was even top scorer at the Esanda tournament in Perth and the 1978 Asian Games.</p>
+                <ul class="sh-fact-list">
+                    <li><strong>Clubs:</strong> Indian Railways and Indian Airlines briefly, then Punjab Police - the department whose teams still crowd the Surjit draw.</li>
+                    <li><strong>Legacy sites:</strong> Olympian Surjit Singh Hockey Stadium (Burlton Park, Jalandhar) and the government-run Surjit Hockey Academy bear his name.</li>
+                    <li><strong>Village honoured:</strong> his native Dakhla was officially renamed <em>Surjit Singh Wala</em> in 2000.</li>
+                    <li><strong>Final salute:</strong> posthumously awarded the Arjuna Award in 1998; a statue was installed at the Surjit Hockey Stadium in his memory.</li>
+                    <li><strong>Sporting family:</strong> his wife Chanchal Randhawa also played international hockey and captained India.</li>
+                </ul>
+            </div>
+        </section>
+
+        <!-- History -->
+        <section class="sh-section" id="history" aria-labelledby="history-heading">
+            <h2 id="history-heading">Tournament History</h2>
+            <div class="sh-content-card">
+                <p>The Surjit Hockey Society (Regd.) came into existence in Jalandhar on 13 May 1984 with one pledge:
+                   keep the name of Sardar Surjit Singh Randhawa alive. Later that year it staged the first Surjit Memorial
+                   Hockey Tournament - today billed as the IndianOil Servo Surjit Hockey Tournament - and has run it every
+                   year since, bar the pandemic-hit 2020 season.</p>
+                <ul class="sh-fact-list">
+                    <li><strong>Humble start:</strong> the first edition unfolded on the grassy ground of Shri Guru Gobind Singh Stadium with leading teams of northern India.</li>
+                    <li><strong>Title sponsor since 1990:</strong> IndianOil's backing turned the event into one of India's richest domestic hockey prizes, with cash awards worth lakhs.</li>
+                    <li><strong>Global guest list:</strong> sides from Pakistan, Russia, Bangladesh, Yugoslavia, Canada, England, America, Croatia and Malaysia have featured over the years.</li>
+                    <li><strong>Record champions:</strong> Punjab &amp; Sind Bank lead the honours board with 11 titles; Indian Oil Mumbai follow with seven, including a 2023-25 hat-trick.</li>
+                    <li><strong>Chief Patron:</strong> by tradition the sitting Chief Minister of Punjab heads the Society, with Olympian Pargat Singh serving as Working President.</li>
+                </ul>
+            </div>
+        </section>
+
+        <!-- Punjab hockey connection -->
+        <section class="sh-section" id="punjab-hockey" aria-labelledby="punjab-hockey-heading">
+            <h2 id="punjab-hockey-heading">Punjab: The Heartland of Indian Hockey</h2>
+            <div class="sh-card-grid">
+                <article class="sh-card glass-card">
+                    <h3>A Cradle of Olympians</h3>
+                    <p>Jalandhar's countryside - villages like Sansarpur and Mithapur - has produced a remarkable share of
+                       India's Olympic hockey players, from Balbir Singh Sr.'s nearby Haripur Khalsa to captain Manpreet Singh.</p>
+                </article>
+                <article class="sh-card glass-card">
+                    <h3>University Nurseries</h3>
+                    <p>Guru Nanak Dev University, Lyallpur Khalsa College and the State College of Sports in Jalandhar shaped
+                       generations of internationals - including young Surjit Singh himself.</p>
+                </article>
+                <article class="sh-card glass-card">
+                    <h3>Departmental Powerhouses</h3>
+                    <p>Punjab Police, Punjab &amp; Sind Bank, BSF Jalandhar, RCF Kapurthala and JCT Phagwara give the tournament
+                       its fiercely local spine, battling oil-sector and services giants every edition.</p>
+                </article>
+                <article class="sh-card glass-card">
+                    <h3>State Patronage</h3>
+                    <p>Punjab's government backs the Society and the Surjit Hockey Academy, while the Chief Minister serves as
+                       the Society's Chief Patron - hockey is woven into the state's civic identity.</p>
+                </article>
+            </div>
+        </section>
+
+        <!-- Teams -->
+        <section class="sh-section" id="teams" aria-labelledby="teams-heading">
+            <h2 id="teams-heading">Teams of the Surjit Arena</h2>
+            <p class="sh-section-sub">The regulars who return to Jalandhar every year, plus the travelling guests.</p>
+            <div class="team-grid" id="teams-grid" aria-live="polite"><!-- rendered by script.js --></div>
+        </section>
+
+        <!-- Winners -->
+        <section class="sh-section" id="winners" aria-labelledby="winners-heading">
+            <h2 id="winners-heading">Roll of Honour</h2>
+            <p class="sh-section-sub">Selected finals from 1984 to the present - click any entry in the Timeline tab for details.</p>
+            <div class="timeline-container" id="winners-list" aria-live="polite"><!-- rendered by script.js --></div>
+        </section>
+
+        <!-- Players -->
+        <section class="sh-section" id="players" aria-labelledby="players-heading">
+            <h2 id="players-heading">Notable Players of Punjab Hockey</h2>
+            <p class="sh-section-sub">Legends tied to Jalandhar, the tournament and the state's rich hockey story.</p>
+            <div class="player-grid" id="players-grid" aria-live="polite"><!-- rendered by script.js --></div>
+        </section>
+
+        <!-- Milestones -->
+        <section class="sh-section" id="milestones" aria-labelledby="milestones-heading">
+            <h2 id="milestones-heading">Important Milestones</h2>
+            <ol class="milestone-list" id="milestones-list"><!-- rendered by script.js --></ol>
+        </section>
+
+        <!-- Interactive Timeline -->
+        <section class="sh-section" id="timeline" aria-labelledby="timeline-heading">
+            <h2 id="timeline-heading">Interactive Punjab Hockey Timeline</h2>
+            <p class="sh-section-sub">Switch between tournament finals and player stories, then select any entry for details.</p>
+            <div class="sh-mode-toggle" role="group" aria-label="Timeline mode">
+                <button type="button" id="btn-mode-tournaments" class="mode-btn active" aria-pressed="true">🏆 Tournaments</button>
+                <button type="button" id="btn-mode-players" class="mode-btn" aria-pressed="false">⭐ Players</button>
+            </div>
+            <div class="timeline-container" id="timeline-container" aria-live="polite"><!-- rendered by script.js --></div>
+            <div class="sports-timeline-detail glass-card" id="timeline-detail" tabindex="0" role="region"
+                 aria-label="Selected timeline details" hidden><!-- populated by script.js --></div>
+        </section>
+
+        <!-- Sources -->
+        <section class="sh-section" id="sources" aria-labelledby="sources-heading">
+            <h2 id="sources-heading">Sources</h2>
+            <div class="sh-content-card">
+                <p>All facts, records and match details on this page are drawn from the following references:</p>
+                <ul class="source-list">
+                    <li><a href="https://surjithockey.com/" target="_blank" rel="noopener noreferrer">Surjit Hockey Society - official website (tournament, society history)</a></li>
+                    <li><a href="https://surjithockeyacademy.in/about-olympian-surjit-singh/" target="_blank" rel="noopener noreferrer">Surjit Hockey Academy - About Olympian Surjit Singh</a></li>
+                    <li><a href="https://en.wikipedia.org/wiki/Surjit_Singh_Randhawa" target="_blank" rel="noopener noreferrer">Wikipedia - Surjit Singh Randhawa</a></li>
+                    <li><a href="https://en.wikipedia.org/wiki/Surjit_Memorial_Hockey_Tournament" target="_blank" rel="noopener noreferrer">Wikipedia - Surjit Memorial Hockey Tournament (full results table)</a></li>
+                    <li><a href="https://en.wikipedia.org/wiki/Surjit_Hockey_Society" target="_blank" rel="noopener noreferrer">Wikipedia - Surjit Hockey Society</a></li>
+                    <li><a href="http://www.sikhsinhockey.com/Default.aspx?id=594216" target="_blank" rel="noopener noreferrer">Sikhs in Hockey - career record of captain Surjit Singh</a></li>
+                    <li><a href="https://www.tribuneindia.com/news/jalandhar/penalty-corner-da-badshah-olympian-surjit-singh-remembered-on-birth-anniv/" target="_blank" rel="noopener noreferrer">The Tribune - 'Penalty corner da badshah': Olympian Surjit Singh remembered</a></li>
+                    <li><a href="https://hockeypassion.in/analysis/surjit-hockey-tournament-winners/" target="_blank" rel="noopener noreferrer">Hockey Passion India - Surjit Hockey Tournament winners archive</a></li>
+                    <li><a href="https://sportsboardindia.com/hockey/42nd-indian-oil-servo-surjit-hockey-tournament-2025/" target="_blank" rel="noopener noreferrer">Sports Board India - 42nd IndianOil Servo Surjit Hockey 2025 final report</a></li>
+                </ul>
+            </div>
+        </section>
+    </main>
+
+    <div class="sh-scroll-progress" id="scroll-progress" aria-hidden="true"></div>
+
+    <footer class="sh-footer">
+        <div class="sh-footer-container">
+            <div class="sh-footer-brand">
+                <h3><span class="saffron">Incredible</span> <span class="gold">India</span> <span class="green">Explorer</span></h3>
+                <p>An interactive digital guide to the geography, food, festivals, and cultural heritage of India - built with passion and pure vanilla web technologies.</p>
+                <p class="sh-footer-tagline">Honouring Punjab's hockey heritage and Olympian Surjit Singh Randhawa.</p>
+            </div>
+            <div class="sh-footer-links">
+                <h4>Explore Surjit Hockey</h4>
+                <ul>
+                    <li><a href="#" class="sh-footer-tab" data-footer-tab="trophy">Trophy</a></li>
+                    <li><a href="#" class="sh-footer-tab" data-footer-tab="namesake">Namesake</a></li>
+                    <li><a href="#" class="sh-footer-tab" data-footer-tab="history">History</a></li>
+                    <li><a href="#" class="sh-footer-tab" data-footer-tab="punjab-hockey">Punjab &amp; Hockey</a></li>
+                    <li><a href="#" class="sh-footer-tab" data-footer-tab="teams">Teams</a></li>
+                    <li><a href="#" class="sh-footer-tab" data-footer-tab="winners">Winners</a></li>
+                    <li><a href="#" class="sh-footer-tab" data-footer-tab="players">Notable Players</a></li>
+                    <li><a href="#" class="sh-footer-tab" data-footer-tab="timeline">Timeline</a></li>
+                    <li><a href="#" class="sh-footer-tab" data-footer-tab="sources">Sources</a></li>
+                </ul>
+            </div>
+            <div class="sh-footer-links">
+                <h4>Discover More Indian Sport</h4>
+                <ul>
+                    <li><a href="../sports/sports.html">Indian Sports Explorer</a></li>
+                    <li><a href="../uber-cup-explorer/index.html">Uber Cup Explorer</a></li>
+                    <li><a href="../major-dhyan-chand-khel-ratna-explorer/index.html">Major Dhyan Chand Khel Ratna Award</a></li>
+                    <li><a href="../rashtriya-khel-protsahan-puruskar-explorer/index.html">Rashtriya Khel Protsahan Puruskar</a></li>
+                    <li><a href="../awards-of-india-explorer/index.html">Awards of India</a></li>
+                </ul>
+            </div>
+            <div class="sh-footer-links">
+                <h4>About the Project</h4>
+                <ul>
+                    <li><a href="../../frontend/about/about.html">About</a></li>
+                    <li><a href="../../frontend/privacy/privacy.html">Privacy Policy</a></li>
+                    <li><a href="../../index.html#map">Interactive Map</a></li>
+                    <li><a href="../../index.html#home">Back to Home</a></li>
+                </ul>
+            </div>
+        </div>
+        <div class="sh-footer-bottom">
+            <p>&copy; 2026 Incredible India Explorer - Created with Vanilla HTML, CSS &amp; JavaScript</p>
+            <p>Surjit Hockey Tournament - Every year in Jalandhar since 1984 - In memory of Olympian Surjit Singh Randhawa</p>
+        </div>
+    </footer>
+
+    <button class="sh-scroll-top" id="btn-scroll-top" aria-label="Scroll back to top">&#8679;</button>
+
+    <!-- Client Scripts -->
+    <script src="data.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/surjit-hockey-explorer/script.js
+++ b/frontend/surjit-hockey-explorer/script.js
@@ -1,0 +1,556 @@
+/**
+ * Surjit Hockey Explorer - Interactive Script (#2527)
+ * Handles tab navigation, theme toggle, smooth scrolling, scroll animations,
+ * hero count-up and the interactive player & tournament timeline.
+ */
+document.addEventListener('DOMContentLoaded', function () {
+    initTabNavigation();
+    initThemeToggle();
+    initSmoothScroll();
+    initMobileMenu();
+    initCountUp();
+    initScrollUI();
+    initFooterTabs();
+    initTyping();
+    renderTeams();
+    renderPlayers();
+    renderWinners();
+    renderMilestones();
+    initTimeline();
+});
+
+/**
+ * Activate a tab section by its id (shared by the tab bar and footer links)
+ */
+function activateTab(targetTab) {
+    var tabs = document.querySelectorAll('.sh-tab');
+    var sections = document.querySelectorAll('.sh-section');
+    if (!tabs.length || !sections.length) return;
+
+    tabs.forEach(function (t) { t.classList.remove('active'); });
+    sections.forEach(function (s) { s.classList.remove('active'); });
+
+    var tab = document.querySelector('.sh-tab[data-tab="' + targetTab + '"]');
+    var section = document.getElementById(targetTab);
+    if (tab) tab.classList.add('active');
+    if (section) {
+        section.classList.add('active');
+        section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+}
+
+/**
+ * Initialize tab navigation for the different sections
+ */
+function initTabNavigation() {
+    document.querySelectorAll('.sh-tab').forEach(function (tab) {
+        tab.addEventListener('click', function () { activateTab(tab.dataset.tab); });
+    });
+}
+
+/**
+ * Initialize theme toggle functionality
+ */
+function initThemeToggle() {
+    var themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+
+    updateThemeIcon(localStorage.getItem('theme') || 'dark');
+
+    themeToggle.addEventListener('click', function () {
+        var body = document.body;
+        var isLight = body.classList.contains('light-theme');
+
+        if (isLight) {
+            body.classList.remove('light-theme');
+            localStorage.setItem('theme', 'dark');
+            updateThemeIcon('dark');
+        } else {
+            body.classList.add('light-theme');
+            localStorage.setItem('theme', 'light');
+            updateThemeIcon('light');
+        }
+    });
+}
+
+/**
+ * Update theme toggle icon
+ */
+function updateThemeIcon(theme) {
+    var themeToggle = document.getElementById('theme-toggle');
+    if (!themeToggle) return;
+    themeToggle.textContent = theme === 'light' ? '\uD83C\uDF19' : '\u2600\uFE0F';
+}
+
+/**
+ * Initialize smooth scroll for internal anchor links
+ */
+function initSmoothScroll() {
+    document.querySelectorAll('a[href^="#"]').forEach(function (anchor) {
+        anchor.addEventListener('click', function (e) {
+            e.preventDefault();
+            var target = document.querySelector(this.getAttribute('href'));
+            if (target) {
+                target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            }
+        });
+    });
+}
+
+/**
+ * Initialize mobile menu toggle
+ */
+function initMobileMenu() {
+    var menuToggle = document.getElementById('menu-toggle');
+    var navMenu = document.getElementById('nav-menu');
+
+    if (menuToggle && navMenu) {
+        menuToggle.addEventListener('click', function () {
+            var isExpanded = menuToggle.getAttribute('aria-expanded') === 'true';
+            menuToggle.setAttribute('aria-expanded', String(!isExpanded));
+            navMenu.classList.toggle('active');
+        });
+
+        document.addEventListener('click', function (e) {
+            if (!menuToggle.contains(e.target) && !navMenu.contains(e.target)) {
+                navMenu.classList.remove('active');
+                menuToggle.setAttribute('aria-expanded', 'false');
+            }
+        });
+    }
+}
+
+/**
+ * Animate count-up numbers when the hero enters the viewport
+ */
+function initCountUp() {
+    var counters = document.querySelectorAll('.hero-stat .number[id]');
+    if (!counters.length) return;
+
+    var duration = 1600;
+    var hero = document.querySelector('.sh-hero');
+
+    var animate = function (counter) {
+        var target = parseInt(counter.dataset.target, 10);
+        if (isNaN(target)) return;
+        var startTime = performance.now();
+
+        var tick = function (now) {
+            var progress = Math.min((now - startTime) / duration, 1);
+            var eased = 1 - Math.pow(1 - progress, 3);
+            counter.textContent = String(Math.round(target * eased));
+            if (progress < 1) {
+                requestAnimationFrame(tick);
+            } else {
+                counter.textContent = String(target);
+            }
+        };
+        requestAnimationFrame(tick);
+    };
+
+    var trigger = function (entries, obs) {
+        var hasVisible = (entries || []).some(function (entry) { return entry.isIntersecting; });
+        if (!hasVisible) return;
+        if (obs && typeof obs.disconnect === 'function') obs.disconnect();
+        counters.forEach(animate);
+    };
+
+    if (typeof IntersectionObserver !== 'undefined' && hero) {
+        var observer = new IntersectionObserver(trigger, { threshold: 0.2 });
+        observer.observe(hero);
+    } else {
+        counters.forEach(animate);
+    }
+}
+
+/**
+ * Scroll progress bar and back-to-top button
+ */
+function initScrollUI() {
+    var progress = document.getElementById('scroll-progress');
+    var btn = document.getElementById('btn-scroll-top');
+    if (!progress && !btn) return;
+
+    var update = function () {
+        var doc = document.documentElement;
+        var scrollTop = window.pageYOffset || doc.scrollTop;
+        var max = doc.scrollHeight - window.innerHeight;
+        if (progress) progress.style.width = (max > 0 ? (scrollTop / max) * 100 : 0) + '%';
+        if (btn) btn.classList.toggle('visible', scrollTop > 400);
+    };
+
+    window.addEventListener('scroll', update, { passive: true });
+    update();
+
+    if (btn) {
+        btn.addEventListener('click', function () {
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+        });
+    }
+}
+
+/**
+ * Footer quick links activate the matching section tab
+ */
+function initFooterTabs() {
+    document.querySelectorAll('.sh-footer-tab').forEach(function (link) {
+        link.addEventListener('click', function (e) {
+            e.preventDefault();
+            activateTab(link.dataset.footerTab);
+        });
+    });
+}
+
+/**
+ * Typewriter effect for rotating words in the hero
+ */
+function initTyping() {
+    var el = document.querySelector('.sh-type[data-words]');
+    if (!el) return;
+
+    var words = [];
+    try {
+        words = JSON.parse(el.dataset.words);
+    } catch (err) {
+        return;
+    }
+    if (!Array.isArray(words) || !words.length) return;
+
+    var prefersReducedMotion = typeof window.matchMedia === 'function' &&
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (prefersReducedMotion) {
+        el.textContent = words[0];
+        return;
+    }
+
+    var wordIdx = 0;
+    var charIdx = 0;
+    var deleting = false;
+
+    var tick = function () {
+        var word = words[wordIdx];
+        el.textContent = word.slice(0, charIdx);
+
+        if (!deleting && charIdx < word.length) {
+            charIdx++;
+            setTimeout(tick, 90);
+        } else if (!deleting && charIdx === word.length) {
+            setTimeout(function () {
+                deleting = true;
+                tick();
+            }, 1700);
+        } else if (deleting && charIdx > 0) {
+            charIdx--;
+            setTimeout(tick, 45);
+        } else {
+            deleting = false;
+            wordIdx = (wordIdx + 1) % words.length;
+            setTimeout(tick, 350);
+        }
+    };
+
+    tick();
+}
+
+var timelineMode = 'tournaments';
+
+/**
+ * Render team cards into #teams-grid
+ */
+function renderTeams() {
+    var grid = document.getElementById('teams-grid');
+    var data = window.SURJIT_DATA;
+    if (!grid || !data || !Array.isArray(data.teams)) return;
+
+    data.teams.forEach(function (t) {
+        var card = document.createElement('article');
+        card.className = 'team-card glass-card';
+
+        var category = document.createElement('span');
+        category.className = 'team-category';
+        category.textContent = t.category;
+        card.appendChild(category);
+
+        var name = document.createElement('h3');
+        name.className = 'team-name';
+        name.textContent = t.name;
+        card.appendChild(name);
+
+        var note = document.createElement('p');
+        note.textContent = t.note;
+        card.appendChild(note);
+
+        grid.appendChild(card);
+    });
+}
+
+/**
+ * Render the notable player cards into #players-grid
+ */
+function renderPlayers() {
+    var grid = document.getElementById('players-grid');
+    var data = window.SURJIT_DATA;
+    if (!grid || !data || !Array.isArray(data.players)) return;
+
+    data.players.forEach(function (p) {
+        var card = document.createElement('article');
+        card.className = 'player-card glass-card';
+
+        var avatar = document.createElement('span');
+        avatar.className = 'player-avatar';
+        avatar.setAttribute('aria-hidden', 'true');
+        avatar.textContent = p.initials || p.name.charAt(0);
+        card.appendChild(avatar);
+
+        var name = document.createElement('h3');
+        name.className = 'player-name';
+        name.textContent = p.name;
+        card.appendChild(name);
+
+        var meta = document.createElement('p');
+        meta.className = 'player-meta';
+        meta.textContent = p.role + ' \u00B7 Era: ' + (p.era || '-');
+        card.appendChild(meta);
+
+        var highlight = document.createElement('p');
+        highlight.className = 'player-highlight';
+        highlight.textContent = p.highlight;
+        card.appendChild(highlight);
+
+        grid.appendChild(card);
+    });
+}
+
+/**
+ * Build one result row element for a tournament edition
+ */
+function buildResultItem(t) {
+    var item = document.createElement('article');
+    item.className = 'timeline-item result-item glass-card';
+
+    var year = document.createElement('span');
+    year.className = 'timeline-year';
+    year.textContent = t.edition ? t.year + ' \u00B7 ' + t.edition : String(t.year);
+    item.appendChild(year);
+
+    var venue = document.createElement('h3');
+    venue.textContent = t.venue;
+    item.appendChild(venue);
+
+    var champ = document.createElement('p');
+    champ.className = 'champion-line';
+    champ.innerHTML = '<strong>Champion:</strong> ' + t.champion;
+    item.appendChild(champ);
+
+    var runner = document.createElement('p');
+    runner.innerHTML = '<strong>Runner-up:</strong> ' + t.runnerUp;
+    item.appendChild(runner);
+
+    var note = document.createElement('p');
+    note.className = 'result-note';
+    note.textContent = t.note;
+    item.appendChild(note);
+
+    return item;
+}
+
+/**
+ * Render winners into #winners-list
+ */
+function renderWinners() {
+    var list = document.getElementById('winners-list');
+    var data = window.SURJIT_DATA;
+    if (!list || !data || !Array.isArray(data.tournaments)) return;
+
+    data.tournaments.forEach(function (t) {
+        list.appendChild(buildResultItem(t));
+    });
+}
+
+/**
+ * Render milestones into #milestones-list
+ */
+function renderMilestones() {
+    var list = document.getElementById('milestones-list');
+    var data = window.SURJIT_DATA;
+    if (!list || !data || !Array.isArray(data.milestones)) return;
+
+    data.milestones.forEach(function (m) {
+        var li = document.createElement('li');
+        li.className = 'milestone-item glass-card';
+
+        var year = document.createElement('span');
+        year.className = 'milestone-year';
+        year.textContent = m.year;
+        li.appendChild(year);
+
+        var title = document.createElement('h3');
+        title.textContent = m.title;
+        li.appendChild(title);
+
+        var text = document.createElement('p');
+        text.textContent = m.text;
+        li.appendChild(text);
+
+        list.appendChild(li);
+    });
+}
+
+/**
+ * Show details for a selected timeline entry in the detail panel
+ */
+function showTimelineDetail(entry) {
+    var panel = document.getElementById('timeline-detail');
+    if (!panel) return;
+
+    panel.innerHTML = '';
+    Object.keys(entry).forEach(function (key) {
+        var value = entry[key];
+        if (value === null || value === undefined || value === '') return;
+        var line = document.createElement('p');
+        line.className = 'detail-' + key;
+        line.innerHTML = '<strong>' + key.toUpperCase() + ':</strong> ' + value;
+        panel.appendChild(line);
+    });
+
+    panel.hidden = false;
+}
+
+/**
+ * Select handler shared by both timeline modes
+ */
+function selectTimelineEntry(mode, index) {
+    var data = window.SURJIT_DATA;
+    if (!data) return;
+
+    var collection = mode === 'players' ? data.players : data.tournaments;
+    if (!Array.isArray(collection) || !collection[index]) return;
+
+    showTimelineDetail(collection[index]);
+
+    document.querySelectorAll('#timeline-container .timeline-entry').forEach(function (el, i) {
+        el.classList.toggle('selected', i === index);
+    });
+
+    var panel = document.getElementById('timeline-detail');
+    if (panel) panel.focus({ preventScroll: true });
+}
+
+/**
+ * Render the tournament timeline into #timeline-container
+ */
+function renderTournamentTimeline() {
+    var container = document.getElementById('timeline-container');
+    var data = window.SURJIT_DATA;
+    if (!container || !data || !Array.isArray(data.tournaments)) return;
+
+    container.innerHTML = '';
+    data.tournaments.forEach(function (t, i) {
+        var el = buildResultItem(t);
+        el.classList.add('timeline-entry');
+        el.classList.toggle('selected', timelineMode === 'tournaments' && i === 0);
+
+        var actionHint = document.createElement('button');
+        actionHint.type = 'button';
+        actionHint.className = 'timeline-open-btn';
+        actionHint.dataset.index = String(i);
+        actionHint.textContent = 'View details';
+        actionHint.setAttribute('aria-label', 'View details of the ' + t.year + ' Surjit Hockey final');
+        el.appendChild(actionHint);
+
+        container.appendChild(el);
+    });
+}
+
+/**
+ * Render the player timeline into #timeline-container
+ */
+function renderPlayerTimeline() {
+    var container = document.getElementById('timeline-container');
+    var data = window.SURJIT_DATA;
+    if (!container || !data || !Array.isArray(data.players)) return;
+
+    container.innerHTML = '';
+    data.players.forEach(function (p, i) {
+        var el = document.createElement('article');
+        el.className = 'timeline-item timeline-entry player-timeline-item glass-card';
+        el.classList.toggle('selected', timelineMode === 'players' && i === 0);
+
+        var head = document.createElement('div');
+        head.className = 'timeline-head';
+
+        var avatar = document.createElement('span');
+        avatar.className = 'player-avatar small';
+        avatar.setAttribute('aria-hidden', 'true');
+        avatar.textContent = p.initials || p.name.charAt(0);
+        head.appendChild(avatar);
+
+        var name = document.createElement('h3');
+        name.textContent = p.name;
+        head.appendChild(name);
+
+        var role = document.createElement('span');
+        role.className = 'timeline-role';
+        role.textContent = p.role;
+        head.appendChild(role);
+
+        el.appendChild(head);
+
+        var era = document.createElement('p');
+        era.innerHTML = '<strong>Era:</strong> ' + (p.era || '-');
+        el.appendChild(era);
+
+        var actionHint = document.createElement('button');
+        actionHint.type = 'button';
+        actionHint.className = 'timeline-open-btn';
+        actionHint.dataset.index = String(i);
+        actionHint.textContent = 'View details';
+        actionHint.setAttribute('aria-label', 'View details of ' + p.name);
+        el.appendChild(actionHint);
+
+        container.appendChild(el);
+    });
+}
+
+/**
+ * Initialize the interactive Punjab hockey timeline:
+ * mode toggle buttons plus delegated click handling on entries
+ */
+function initTimeline() {
+    var btnTournaments = document.getElementById('btn-mode-tournaments');
+    var btnPlayers = document.getElementById('btn-mode-players');
+    var container = document.getElementById('timeline-container');
+    if (!btnTournaments || !btnPlayers || !container) return;
+
+    var setMode = function (mode) {
+        timelineMode = mode;
+
+        var isTournaments = mode === 'tournaments';
+        btnTournaments.classList.toggle('active', isTournaments);
+        btnPlayers.classList.toggle('active', !isTournaments);
+        btnTournaments.setAttribute('aria-pressed', String(isTournaments));
+        btnPlayers.setAttribute('aria-pressed', String(!isTournaments));
+
+        var panel = document.getElementById('timeline-detail');
+        if (panel) panel.hidden = true;
+
+        if (isTournaments) {
+            renderTournamentTimeline();
+        } else {
+            renderPlayerTimeline();
+        }
+    };
+
+    btnTournaments.addEventListener('click', function () { setMode('tournaments'); });
+    btnPlayers.addEventListener('click', function () { setMode('players'); });
+
+    container.addEventListener('click', function (e) {
+        var btn = e.target.closest ? e.target.closest('.timeline-open-btn') : null;
+        if (!btn) return;
+        var entryEl = btn.closest('.timeline-entry');
+        var index = Array.prototype.indexOf.call(container.querySelectorAll('.timeline-entry'), entryEl);
+        if (index >= 0) selectTimelineEntry(timelineMode, index);
+    });
+
+    renderTournamentTimeline();
+}

--- a/frontend/surjit-hockey-explorer/style.css
+++ b/frontend/surjit-hockey-explorer/style.css
@@ -1,0 +1,718 @@
+/* ============================================================
+   Surjit Hockey Explorer - Page Styles (#2527)
+   Complements the shared root stylesheet (../../styles.css).
+   Dark theme is the default; `body.light-theme` overrides below.
+   ============================================================ */
+
+:root {
+    --sh-saffron: #ff9933;
+    --sh-gold: #ffd700;
+    --sh-green: #138808;
+    --sh-turf: #1b5e20;
+    --sh-card-bg: rgba(255, 255, 255, 0.06);
+    --sh-card-border: rgba(255, 255, 255, 0.14);
+    --sh-text-muted: rgba(245, 245, 245, 0.72);
+}
+
+body.light-theme {
+    --sh-card-bg: rgba(255, 255, 255, 0.75);
+    --sh-card-border: rgba(0, 0, 0, 0.14);
+    --sh-text-muted: rgba(20, 20, 20, 0.72);
+}
+
+.sh-main {
+    overflow-x: hidden;
+}
+
+/* ---------------- Hero ---------------- */
+
+.sh-hero {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 88vh;
+    padding: 96px 24px 64px;
+    text-align: center;
+    background:
+        radial-gradient(circle at 18% 28%, rgba(27, 94, 32, 0.34), transparent 44%),
+        radial-gradient(circle at 82% 16%, rgba(255, 153, 51, 0.22), transparent 46%),
+        radial-gradient(circle at 52% 92%, rgba(19, 136, 8, 0.30), transparent 55%);
+}
+
+.sh-hero-bg {
+    position: absolute;
+    inset: 0;
+    background-image:
+        repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.025) 0px, rgba(255, 255, 255, 0.025) 64px, transparent 64px, transparent 128px);
+    pointer-events: none;
+}
+
+body.light-theme .sh-hero-bg {
+    background-image:
+        repeating-linear-gradient(90deg, rgba(0, 0, 0, 0.04) 0px, rgba(0, 0, 0, 0.04) 64px, transparent 64px, transparent 128px);
+}
+
+.sh-hero-overlay {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(180deg, transparent 55%, rgba(0, 0, 0, 0.35));
+    pointer-events: none;
+}
+
+.sh-hero-particles span {
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--sh-gold);
+    opacity: 0.22;
+    animation: sh-roll 10s ease-in-out infinite;
+}
+
+.sh-hero-particles span:nth-child(1) { left: 12%; top: 24%; animation-delay: 0s; }
+.sh-hero-particles span:nth-child(2) { left: 26%; top: 70%; animation-delay: 1.4s; }
+.sh-hero-particles span:nth-child(3) { left: 50%; top: 14%; animation-delay: 2.6s; }
+.sh-hero-particles span:nth-child(4) { left: 68%; top: 62%; animation-delay: 3.8s; }
+.sh-hero-particles span:nth-child(5) { left: 85%; top: 30%; animation-delay: 5s; }
+.sh-hero-particles span:nth-child(6) { left: 38%; top: 84%; animation-delay: 6.4s; }
+
+@keyframes sh-roll {
+    0%, 100% { transform: translateY(0) rotate(0deg); }
+    50% { transform: translateY(-30px) rotate(180deg); }
+}
+
+.sh-hero-content {
+    position: relative;
+    max-width: 900px;
+}
+
+.sh-kicker {
+    font-size: clamp(0.85rem, 1.6vw, 1rem);
+    letter-spacing: 0.32em;
+    text-transform: uppercase;
+    color: var(--sh-gold);
+    margin-bottom: 18px;
+}
+
+.sh-hero h1 {
+    font-size: clamp(2.6rem, 7vw, 4.6rem);
+    line-height: 1.08;
+    margin-bottom: 20px;
+}
+
+.gradient-text {
+    background: linear-gradient(92deg, var(--sh-saffron), var(--sh-gold), var(--sh-green));
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    color: transparent;
+}
+
+.sh-hero-sub {
+    font-size: clamp(1rem, 2vw, 1.2rem);
+    color: var(--sh-text-muted);
+    max-width: 720px;
+    margin: 0 auto 36px;
+}
+
+.sh-type-accent {
+    color: var(--sh-gold);
+    font-weight: 700;
+    border-bottom: 2px solid var(--sh-turf);
+}
+
+.hero-stats {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 18px;
+}
+
+.hero-stat {
+    min-width: 150px;
+    padding: 18px 22px;
+    border: 1px solid var(--sh-card-border);
+    border-radius: 14px;
+    background: var(--sh-card-bg);
+    backdrop-filter: blur(8px);
+}
+
+.hero-stat .number {
+    display: block;
+    font-size: 2.1rem;
+    font-weight: 800;
+    color: var(--sh-gold);
+    font-variant-numeric: tabular-nums;
+}
+
+.hero-stat .label {
+    display: block;
+    margin-top: 6px;
+    font-size: 0.82rem;
+    color: var(--sh-text-muted);
+}
+
+/* ---------------- Tabs ---------------- */
+
+.sh-tabs {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 10px;
+    padding: 14px 16px;
+    background-color: rgba(8, 12, 8, 0.92);
+    backdrop-filter: blur(10px);
+    border-bottom: 1px solid var(--sh-card-border);
+}
+
+body.light-theme .sh-tabs {
+    background-color: rgba(250, 250, 245, 0.94);
+}
+
+.sh-tab {
+    border: 1px solid var(--sh-card-border);
+    border-radius: 999px;
+    background: transparent;
+    color: inherit;
+    padding: 9px 18px;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.sh-tab:hover {
+    transform: translateY(-2px);
+    border-color: var(--sh-gold);
+}
+
+.sh-tab.active {
+    background: linear-gradient(90deg, var(--sh-saffron), var(--sh-gold));
+    color: #14140f;
+    font-weight: 700;
+    border-color: transparent;
+    box-shadow: 0 6px 18px rgba(255, 215, 0, 0.25);
+}
+
+/* ---------------- Sections ---------------- */
+
+.sh-section {
+    display: none;
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 72px 24px 40px;
+}
+
+.sh-section.active {
+    display: block;
+    animation: sh-fade-in 0.5s ease both;
+}
+
+@keyframes sh-fade-in {
+    from { opacity: 0; transform: translateY(18px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.sh-section h2 {
+    font-size: clamp(1.7rem, 3.6vw, 2.4rem);
+    margin-bottom: 14px;
+}
+
+.sh-section-sub {
+    color: var(--sh-text-muted);
+    margin-bottom: 26px;
+}
+
+.sh-card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 18px;
+    margin-top: 22px;
+}
+
+.sh-card,
+.sh-content-card {
+    border: 1px solid var(--sh-card-border);
+    border-radius: 16px;
+    background: var(--sh-card-bg);
+    padding: 22px;
+}
+
+.sh-card h3 {
+    margin-bottom: 10px;
+    color: var(--sh-gold);
+    font-size: 1.05rem;
+}
+
+.sh-card p {
+    color: var(--sh-text-muted);
+    line-height: 1.65;
+}
+
+.sh-content-card p {
+    line-height: 1.75;
+    color: var(--sh-text-muted);
+}
+
+.sh-fact-list {
+    list-style: none;
+    margin-top: 18px;
+    padding: 0;
+}
+
+.sh-fact-list li {
+    position: relative;
+    padding: 10px 0 10px 30px;
+    border-top: 1px dashed var(--sh-card-border);
+    color: var(--sh-text-muted);
+    line-height: 1.6;
+}
+
+.sh-fact-list li::before {
+    content: "\1F3D1";
+    position: absolute;
+    left: 0;
+    top: 8px;
+}
+
+/* ---------------- Teams ---------------- */
+
+.team-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(230px, 1fr));
+    gap: 18px;
+    margin-top: 22px;
+}
+
+.team-card {
+    padding: 20px;
+    border: 1px solid var(--sh-card-border);
+    border-radius: 16px;
+    transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.team-card:hover {
+    transform: translateY(-4px);
+    border-color: var(--sh-gold);
+}
+
+.team-category {
+    display: inline-block;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.09em;
+    color: #14140f;
+    background: linear-gradient(90deg, var(--sh-saffron), var(--sh-gold));
+    border-radius: 999px;
+    padding: 3px 10px;
+    margin-bottom: 12px;
+}
+
+.team-name {
+    font-size: 1.02rem;
+    margin-bottom: 8px;
+}
+
+.team-card p {
+    font-size: 0.9rem;
+    line-height: 1.6;
+    color: var(--sh-text-muted);
+}
+
+/* ---------------- Players ---------------- */
+
+.player-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+    gap: 18px;
+    margin-top: 22px;
+}
+
+.player-card {
+    padding: 22px;
+    border: 1px solid var(--sh-card-border);
+    border-radius: 16px;
+    transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.player-card:hover {
+    transform: translateY(-4px);
+    border-color: var(--sh-gold);
+}
+
+.player-avatar {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 54px;
+    height: 54px;
+    border-radius: 50%;
+    font-weight: 800;
+    letter-spacing: 0.04em;
+    color: #14140f;
+    background: linear-gradient(135deg, var(--sh-saffron), var(--sh-gold), var(--sh-turf));
+    margin-bottom: 12px;
+}
+
+.player-avatar.small {
+    width: 40px;
+    height: 40px;
+    font-size: 0.85rem;
+    margin-bottom: 0;
+    flex-shrink: 0;
+}
+
+.player-name {
+    font-size: 1.08rem;
+    margin-bottom: 6px;
+}
+
+.player-meta {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--sh-gold);
+    margin-bottom: 10px;
+}
+
+.player-highlight {
+    font-size: 0.92rem;
+    line-height: 1.6;
+    color: var(--sh-text-muted);
+}
+
+/* ---------------- Timelines ---------------- */
+
+.timeline-container {
+    position: relative;
+    margin-top: 26px;
+    padding-left: 26px;
+    border-left: 2px dashed var(--sh-card-border);
+    display: grid;
+    gap: 16px;
+}
+
+.timeline-item {
+    position: relative;
+    padding: 18px 20px;
+    border: 1px solid var(--sh-card-border);
+    border-radius: 14px;
+    background: var(--sh-card-bg);
+}
+
+.timeline-item::before {
+    content: "";
+    position: absolute;
+    left: -33px;
+    top: 24px;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--sh-turf);
+    box-shadow: 0 0 0 4px rgba(27, 94, 32, 0.28);
+}
+
+.timeline-year {
+    display: inline-block;
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #14140f;
+    background: linear-gradient(90deg, var(--sh-saffron), var(--sh-gold));
+    padding: 4px 10px;
+    border-radius: 999px;
+    margin-bottom: 10px;
+}
+
+.result-item h3 {
+    font-size: 1rem;
+    margin-bottom: 8px;
+}
+
+.champion-line strong { color: var(--sh-gold); }
+
+.result-note {
+    margin-top: 8px;
+    font-size: 0.9rem;
+    line-height: 1.6;
+    color: var(--sh-text-muted);
+}
+
+/* Interactive timeline */
+
+.sh-mode-toggle {
+    display: inline-flex;
+    gap: 8px;
+    margin: 6px 0 4px;
+    padding: 6px;
+    border: 1px solid var(--sh-card-border);
+    border-radius: 999px;
+    background: var(--sh-card-bg);
+}
+
+.mode-btn {
+    border: none;
+    border-radius: 999px;
+    background: transparent;
+    color: inherit;
+    padding: 8px 16px;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: background 0.18s ease, color 0.18s ease;
+}
+
+.mode-btn.active {
+    background: var(--sh-turf);
+    color: #fff;
+    font-weight: 700;
+}
+
+.timeline-entry {
+    cursor: pointer;
+    transition: transform 0.18s ease, border-color 0.18s ease, box-shadow 0.18s ease;
+}
+
+.timeline-entry:hover {
+    transform: translateX(4px);
+    border-color: var(--sh-gold);
+}
+
+.timeline-entry.selected {
+    border-color: var(--sh-turf);
+    box-shadow: 0 10px 26px rgba(27, 94, 32, 0.22);
+}
+
+.timeline-head {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 8px;
+}
+
+.timeline-role {
+    margin-left: auto;
+    font-size: 0.74rem;
+    text-transform: uppercase;
+    letter-spacing: 0.07em;
+    color: var(--sh-gold);
+    text-align: right;
+}
+
+.timeline-open-btn {
+    margin-top: 10px;
+    border: 1px solid var(--sh-card-border);
+    border-radius: 999px;
+    background: transparent;
+    color: inherit;
+    padding: 6px 14px;
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: background 0.18s ease, color 0.18s ease;
+}
+
+.timeline-open-btn:hover,
+.timeline-open-btn:focus-visible {
+    background: var(--sh-gold);
+    color: #14140f;
+    outline: none;
+}
+
+.sports-timeline-detail {
+    margin-top: 20px;
+    padding: 20px 22px;
+    border-radius: 16px;
+}
+
+.sports-timeline-detail[hidden] {
+    display: none;
+}
+
+.sports-timeline-detail p {
+    margin: 6px 0;
+    line-height: 1.6;
+    color: var(--sh-text-muted);
+}
+
+.sports-timeline-detail strong { color: var(--sh-gold); }
+
+/* ---------------- Milestones ---------------- */
+
+.milestone-list {
+    list-style: none;
+    margin: 26px 0 0;
+    padding: 0;
+    display: grid;
+    gap: 16px;
+}
+
+.milestone-item {
+    display: grid;
+    grid-template-columns: 86px 1fr;
+    gap: 16px;
+    align-items: start;
+    padding: 18px 20px;
+    border: 1px solid var(--sh-card-border);
+    border-radius: 14px;
+}
+
+.milestone-year {
+    font-weight: 800;
+    font-size: 1.25rem;
+    color: var(--sh-gold);
+    font-variant-numeric: tabular-nums;
+}
+
+.milestone-item h3 {
+    font-size: 1.02rem;
+    margin-bottom: 6px;
+}
+
+.milestone-item p {
+    color: var(--sh-text-muted);
+    line-height: 1.6;
+}
+
+/* ---------------- Sources ---------------- */
+
+.source-list {
+    list-style: none;
+    margin-top: 16px;
+    padding: 0;
+    display: grid;
+    gap: 10px;
+}
+
+.source-list a {
+    color: var(--sh-green);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    word-break: break-word;
+}
+
+.source-list a:hover { color: var(--sh-gold); }
+
+/* ---------------- Footer & scroll UI ---------------- */
+
+.sh-footer {
+    border-top: 1px solid var(--sh-card-border);
+    margin-top: 60px;
+    padding: 48px 24px 24px;
+}
+
+.sh-footer-container {
+    max-width: 1100px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: 1.4fr repeat(3, 1fr);
+    gap: 28px;
+}
+
+.sh-footer-brand h3 { margin-bottom: 10px; }
+.sh-footer-tagline { margin-top: 10px; font-style: italic; }
+.sh-footer-brand p { color: var(--sh-text-muted); line-height: 1.6; }
+
+.sh-footer-links h4 {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--sh-gold);
+    margin-bottom: 12px;
+}
+
+.sh-footer-links ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 8px;
+}
+
+.sh-footer-links a {
+    color: var(--sh-text-muted);
+    text-decoration: none;
+}
+
+.sh-footer-links a:hover { color: var(--sh-gold); text-decoration: underline; }
+
+.sh-footer-bottom {
+    max-width: 1100px;
+    margin: 34px auto 0;
+    padding-top: 18px;
+    border-top: 1px dashed var(--sh-card-border);
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 8px;
+    font-size: 0.82rem;
+    color: var(--sh-text-muted);
+}
+
+.sh-scroll-progress {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 3px;
+    width: 0;
+    z-index: 60;
+    background: linear-gradient(90deg, var(--sh-saffron), var(--sh-gold), var(--sh-green));
+}
+
+.sh-scroll-top {
+    position: fixed;
+    right: 22px;
+    bottom: 22px;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    border: 1px solid var(--sh-card-border);
+    background: var(--sh-card-bg);
+    backdrop-filter: blur(8px);
+    color: inherit;
+    font-size: 1.1rem;
+    cursor: pointer;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(10px);
+    transition: opacity 0.25s ease, transform 0.25s ease;
+    z-index: 50;
+}
+
+.sh-scroll-top.visible {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+}
+
+/* ---------------- Responsive ---------------- */
+
+@media (max-width: 1024px) {
+    .sh-footer-container {
+        grid-template-columns: 1fr 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    .sh-hero { min-height: 76vh; padding-top: 120px; }
+    .hero-stat { min-width: 128px; padding: 14px 16px; }
+    .hero-stat .number { font-size: 1.7rem; }
+    .milestone-item { grid-template-columns: 1fr; gap: 4px; }
+    .timeline-item::before { left: -29px; }
+}
+
+@media (max-width: 640px) {
+    .sh-section { padding: 56px 16px 32px; }
+    .sh-tabs { gap: 8px; padding: 10px 8px; }
+    .sh-tab { padding: 7px 13px; font-size: 0.8rem; }
+    .sh-footer-container { grid-template-columns: 1fr; }
+    .sh-footer-bottom { flex-direction: column; align-items: flex-start; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .sh-hero-particles span { animation: none; }
+    .sh-section.active { animation: none; }
+    .player-card, .team-card, .timeline-entry { transition: none; }
+}

--- a/tests/unit/surjit-hockey-explorer.test.js
+++ b/tests/unit/surjit-hockey-explorer.test.js
@@ -1,0 +1,122 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = process.cwd();
+const DIR = resolve(ROOT, 'frontend', 'surjit-hockey-explorer');
+
+const html = readFileSync(resolve(DIR, 'index.html'), 'utf-8');
+const css = readFileSync(resolve(DIR, 'style.css'), 'utf-8');
+const js = readFileSync(resolve(DIR, 'script.js'), 'utf-8');
+const data = readFileSync(resolve(DIR, 'data.js'), 'utf-8');
+
+describe('Surjit Hockey Explorer - index.html structure', () => {
+    it('has exactly one h1 heading', () => {
+        const count = (html.match(/<h1[\s>]/g) || []).length;
+        assert.equal(count, 1);
+    });
+
+    it('has at least 8 h2 sections worth of content', () => {
+        const count = (html.match(/<h2[\s>]/g) || []).length;
+        assert.ok(count >= 8, `expected >= 8 h2 tags, found ${count}`);
+    });
+
+    it('contains all required section ids', () => {
+        ['trophy', 'namesake', 'history', 'punjab-hockey', 'teams', 'winners', 'players', 'milestones', 'timeline', 'sources']
+            .forEach((id) => assert.ok(html.includes(`id="${id}"`), `missing section id ${id}`));
+    });
+
+    it('has tab buttons wired to every section via data-tab', () => {
+        ['trophy', 'namesake', 'history', 'punjab-hockey', 'teams', 'winners', 'players', 'milestones', 'timeline', 'sources']
+            .forEach((id) => assert.ok(html.includes(`data-tab="${id}"`), `missing data-tab for ${id}`));
+    });
+
+    it('includes meta viewport and description', () => {
+        assert.ok(html.includes('name="viewport"'));
+        assert.match(html, /<meta\s+name="description"\s+content="[^"]+"/);
+    });
+
+    it('links the shared root stylesheet', () => {
+        assert.ok(html.includes('../../styles.css'));
+    });
+
+    it('references its own style.css, data.js and script.js', () => {
+        assert.ok(html.includes('href="style.css"'));
+        assert.ok(html.includes('src="data.js"'));
+        assert.ok(html.includes('src="script.js"'));
+    });
+
+    it('uses https image sources with alt text (if any images)', () => {
+        const imgs = html.match(/<img\b[^>]*>/g) || [];
+        imgs.forEach((tag) => {
+            const src = /src="([^"]*)"/.exec(tag);
+            assert.ok(src && src[1].startsWith('https://'), `non-https img src: ${src && src[1]}`);
+            assert.match(tag, /alt="/, 'img missing alt attribute');
+        });
+    });
+
+    it('renders hero stat counters with ids for count-up', () => {
+        ['stat-editions', 'stat-psb', 'stat-io', 'stat-nations'].forEach((id) =>
+            assert.ok(html.includes(`id="${id}"`), `missing hero stat id ${id}`));
+    });
+});
+
+describe('Surjit Hockey Explorer - data.js content coverage', () => {
+    it('exposes window.SURJIT_DATA', () => {
+        assert.ok(data.includes('window.SURJIT_DATA'));
+    });
+
+    it('covers winners including 1984 debut, 2020 gap and 2025 final', () => {
+        assert.ok(/year:\s*1984/.test(data));
+        assert.ok(/year:\s*2020/.test(data));
+        assert.ok(/year:\s*2025/.test(data));
+        assert.ok(/Western Command/.test(data));
+        assert.ok(/Indian Oil Mumbai/.test(data));
+        assert.ok(/Indian Railways Delhi/.test(data));
+    });
+
+    it('documents the namesake Surjit Singh Randhawa', () => {
+        ['Surjit Singh Randhawa', 'Kuala Lumpur', 'Arjuna Award', 'Penalty corner'].forEach((term) =>
+            assert.ok(data.includes(term) || html.includes(term), `missing namesake detail ${term}`));
+    });
+
+    it('lists notable players of Punjab hockey', () => {
+        ['Balbir Singh', 'Ajit Pal Singh', 'Pargat Singh', 'Manpreet Singh'].forEach((name) =>
+            assert.ok(data.includes(name), `missing player ${name}`));
+    });
+
+    it('includes team entries for regular participants', () => {
+        ['Punjab & Sind Bank', 'BSF Jalandhar', 'Punjab Police', 'JCT Phagwara'].forEach((team) =>
+            assert.ok(data.includes(team), `missing team ${team}`));
+    });
+});
+
+describe('Surjit Hockey Explorer - script.js behaviour hooks', () => {
+    it('defines required functions', () => {
+        ['initTabNavigation', 'activateTab', 'initCountUp', 'initTyping',
+         'initTimeline', 'renderTeams', 'renderPlayers', 'renderWinners', 'renderMilestones']
+            .forEach((fn) => assert.ok(js.includes(`function ${fn}`), `missing function ${fn}`));
+    });
+
+    it('boots on DOMContentLoaded', () => {
+        assert.match(js, /document\.addEventListener\(\s*'DOMContentLoaded'/);
+    });
+
+    it('reads data from window.SURJIT_DATA', () => {
+        assert.ok(js.includes('window.SURJIT_DATA'));
+    });
+});
+
+describe('Surjit Hockey Explorer - style.css coverage', () => {
+    it('styles tabs, hero stats, teams, players and timelines', () => {
+        ['.sh-tabs', '.sh-tab', '.hero-stat', '.team-grid', '.team-card',
+         '.player-grid', '.player-card', '.timeline-container', '.milestone-list']
+            .forEach((sel) => assert.ok(css.includes(sel), `missing selector ${sel}`));
+    });
+
+    it('provides responsive breakpoints', () => {
+        const count = (css.match(/@media/g) || []).length;
+        assert.ok(count >= 3, `expected >= 3 media queries, found ${count}`);
+    });
+});


### PR DESCRIPTION
## Summary

Closes #2527 (Surjit Hockey Tournament: Explore Punjab's Hockey Heritage)

Adds a new **Surjit Hockey Explorer** feature page under `frontend/surjit-hockey-explorer/` covering the memorial tournament held every year in Jalandhar since 1984:

- **Hero banner** with animated count-up stats (42 editions, PSB's record 11 titles, Indian Oil's 7 titles, 9 visiting foreign nations) and a typewriter word rotator
- **10 tabbed sections**: Trophy - Namesake - History - Punjab & Hockey - Teams - Winners - Notable Players - Milestones - Timeline - Sources
- **Namesake profile**: Olympian Surjit Singh Randhawa (1951-1984) - 1975 World Cup winner at Kuala Lumpur, captain at Bombay 1982, "Penalty corner da badshah", posthumous Arjuna Award 1998, stadium/academy/village renamed in his honour
- **Punjab hockey connection**: Sansarpur & Mithapur nurseries, GNDU/Lyallpur Khalsa College pipelines, departmental powerhouses (Punjab Police, PSB, BSF Jalandhar), state patronage
- **Teams grid**: 11 regular participants from departmental giants to JCT Phagwara and CAG New Delhi
- **Winners roll of honour**: selected finals 1984 (Western Command) through 2025 (Indian Oil Mumbai's three-peat)
- **Milestones list** (12 entries: 1951 birth to 2025 hat-trick) and an **interactive Punjab hockey timeline** with Tournaments/Players mode toggle and click-to-view detail panel
- **Footer cross-links** to related sports pages (incl. Uber Cup explorer) and full sources section (Surjit Hockey Society official site, Wikipedia, The Tribune, Sikhs in Hockey, HockeyPassion, Sports Board India)

Pure vanilla HTML/CSS/JS following the repo's existing explorer-page conventions; dark/light theme aware via the shared navbar toggle.

## Testing

- `node --test tests/unit/surjit-hockey-explorer.test.js` - 19/19 pass (structure, data coverage incl. namesake/winners, behaviour hooks, CSS coverage)
- jsdom harness verification: all 5 dynamic containers (`#teams-grid`, `#players-grid`, `#winners-list`, `#milestones-list`, `#timeline-container`) populate on DOMContentLoaded with no console errors