### PR TITLE
feat: add Dogri language explorer

### DIFF
--- a/frontend/dogri-language-explorer/dogri-language-explorer.css
+++ b/frontend/dogri-language-explorer/dogri-language-explorer.css
@@ -1,0 +1,282 @@
+/* Dogri Language Explorer */
+.dogri-explorer {
+    --dogri-accent: #c96b2c;
+    --dogri-green: #2d7a55;
+    --dogri-card: rgba(255, 255, 255, 0.07);
+    --dogri-border: rgba(255, 255, 255, 0.14);
+    background: var(--bg-color, #101512);
+    color: var(--text-color, #f6f3ed);
+    line-height: 1.65;
+}
+.dogri-explorer a {
+    color: inherit;
+}
+.dogri-explorer .nav-menu {
+    gap: 1rem;
+}
+.hero {
+    padding: 7rem 1.25rem 4rem;
+    background:
+        radial-gradient(circle at 80% 15%, rgba(201, 107, 44, 0.28), transparent 35%),
+        linear-gradient(135deg, #17231c, #101512);
+}
+.hero-inner {
+    max-width: 1100px;
+    margin: auto;
+}
+.eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 0.78rem;
+    font-weight: 800;
+    color: #e6b36c;
+    margin: 0 0 0.6rem;
+}
+.hero h1 {
+    font-size: clamp(2.5rem, 7vw, 5.5rem);
+    line-height: 1.05;
+    margin: 0.2rem 0 1rem;
+}
+.hero h1 span {
+    color: #e6a15c;
+}
+.hero h1 b {
+    font-family: 'Noto Sans Devanagari', sans-serif;
+    font-weight: 700;
+}
+.lead {
+    max-width: 760px;
+    font-size: 1.2rem;
+    color: #d6ddd7;
+}
+.hero-script {
+    font-family: 'Noto Sans Devanagari', sans-serif;
+    font-size: clamp(3rem, 10vw, 7rem);
+    color: #f0c67d;
+    margin: 1.5rem 0;
+}
+.hero-actions {
+    display: flex;
+    gap: 0.8rem;
+    flex-wrap: wrap;
+}
+.button,
+.audio-btn {
+    border: 1px solid var(--dogri-border);
+    border-radius: 999px;
+    padding: 0.75rem 1.1rem;
+    background: var(--dogri-card);
+    color: inherit;
+    text-decoration: none;
+    cursor: pointer;
+    font: inherit;
+}
+.button {
+    background: var(--dogri-accent);
+    border-color: transparent;
+}
+.verification {
+    font-size: 0.82rem;
+    color: #b9c5bd;
+    max-width: 850px;
+    margin-top: 1.2rem;
+}
+.facts {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    max-width: 1100px;
+    margin: -1.5rem auto 0;
+    position: relative;
+    padding: 0 1.25rem;
+}
+.facts article {
+    padding: 1.3rem;
+    background: rgba(25, 35, 29, 0.95);
+    border: 1px solid var(--dogri-border);
+    text-align: center;
+}
+.facts strong,
+.facts span {
+    display: block;
+}
+.facts strong {
+    font-size: 1.2rem;
+    color: #f1bf76;
+}
+.facts span {
+    font-size: 0.8rem;
+    color: #b9c5bd;
+}
+.section {
+    max-width: 1100px;
+    margin: auto;
+    padding: 5rem 1.25rem;
+}
+.section.alt {
+    max-width: none;
+    background: rgba(255, 255, 255, 0.025);
+}
+.section.alt > * {
+    max-width: 1100px;
+    margin-left: auto;
+    margin-right: auto;
+}
+.section-heading {
+    margin-bottom: 2rem;
+}
+.section h2 {
+    font-size: clamp(2rem, 4vw, 3.1rem);
+    margin: 0.2rem 0 0.5rem;
+}
+.section-heading p:not(.eyebrow) {
+    color: #b9c5bd;
+}
+.cards,
+.word-grid,
+.region-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+}
+.phrase,
+.region-grid article {
+    padding: 1.5rem;
+    border: 1px solid var(--dogri-border);
+    background: var(--dogri-card);
+    border-radius: 18px;
+}
+.phrase.featured {
+    border-color: rgba(230, 161, 92, 0.6);
+}
+.tag {
+    display: inline-block;
+    font-size: 0.75rem;
+    color: #f1bf76;
+    margin-bottom: 0.6rem;
+}
+.script {
+    font-family: 'Noto Sans Devanagari', sans-serif;
+    font-size: 2.5rem;
+}
+.roman {
+    font-size: 1.05rem;
+    color: #e6b36c;
+}
+.phrase p {
+    color: #c1cbc4;
+}
+.audio-btn {
+    margin-top: 0.7rem;
+}
+.search {
+    display: flex;
+    gap: 0.8rem;
+    align-items: center;
+    margin-bottom: 1.5rem;
+}
+.search input {
+    flex: 1;
+    padding: 0.85rem 1rem;
+    border-radius: 12px;
+    border: 1px solid var(--dogri-border);
+    background: var(--dogri-card);
+    color: inherit;
+}
+.word-card {
+    padding: 1.2rem;
+    border: 1px solid var(--dogri-border);
+    border-radius: 15px;
+    background: var(--dogri-card);
+}
+.word-card[hidden] {
+    display: none;
+}
+.word-card .script {
+    font-size: 2rem;
+}
+.word-card .meaning {
+    font-weight: 700;
+}
+.word-card .ipa {
+    font-family: monospace;
+    color: #b9c5bd;
+}
+.word-card button {
+    border: 0;
+    background: none;
+    color: #f1bf76;
+    cursor: pointer;
+    padding: 0;
+    margin-top: 0.5rem;
+}
+.script-panel {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+    align-items: center;
+}
+.script-showcase {
+    font-family: 'Noto Sans Devanagari', sans-serif;
+    font-size: 2rem;
+    line-height: 2;
+    background: var(--dogri-card);
+    border: 1px solid var(--dogri-border);
+    border-radius: 20px;
+    padding: 2rem;
+    text-align: center;
+    color: #f0c67d;
+}
+.family-tree {
+    padding: 1.5rem;
+    border-radius: 18px;
+    background: var(--dogri-card);
+    border: 1px solid var(--dogri-border);
+    font-weight: 600;
+}
+.culture {
+    max-width: 850px !important;
+}
+.sources {
+    max-width: 850px !important;
+    padding-left: 1.2rem;
+}
+.sources li {
+    margin: 0.8rem 0;
+}
+.note {
+    font-size: 0.85rem;
+    color: #9eaaa2;
+    max-width: 850px !important;
+}
+footer {
+    text-align: center;
+    padding: 2rem;
+    color: #9eaaa2;
+    border-top: 1px solid var(--dogri-border);
+}
+@media (max-width: 760px) {
+    .facts,
+    .cards,
+    .word-grid,
+    .region-grid,
+    .script-panel {
+        grid-template-columns: 1fr;
+    }
+    .facts {
+        margin-top: 0;
+    }
+    .hero {
+        padding-top: 4rem;
+    }
+    .section {
+        padding: 3.5rem 1rem;
+    }
+    .search {
+        align-items: stretch;
+        flex-direction: column;
+    }
+    .search input {
+        width: 100%;
+        box-sizing: border-box;
+    }
+}

--- a/frontend/dogri-language-explorer/dogri-language-explorer.js
+++ b/frontend/dogri-language-explorer/dogri-language-explorer.js
@@ -1,0 +1,52 @@
+const DOGRI_WORDS = [
+    {
+        script: 'हां',
+        roman: 'hā̃',
+        meaning: 'Yes',
+        ipa: '[ã̀ː]',
+        audio: 'https://www.languageshome.com/Dogri_Audio/09.mp3'
+    },
+    { script: 'नेईं', roman: 'neī̃', meaning: 'No', ipa: '[neː.ĩː]' },
+    { script: 'केह्', roman: 'keh', meaning: 'What', ipa: '[kéː]' },
+    { script: 'की', roman: 'kī', meaning: 'Why', ipa: '[kiː]' },
+    { script: 'कन्नै', roman: 'kannai', meaning: 'With', ipa: '[kən.nɛː]' },
+    { script: 'हिरख', roman: 'hirkh', meaning: 'Love', ipa: '[ɪ̀ɾkʰ]' },
+    { script: 'गास', roman: 'gās', meaning: 'Sky', ipa: '[gaːs]' },
+    { script: "ब'रा", roman: "b'rā", meaning: 'Year', ipa: '[bə́.ɾaː]' },
+    { script: 'धन्नवाद', roman: 'dhanvād', meaning: 'Thank you', ipa: '' },
+    { script: 'खरा फ्ही', roman: 'kharā phī', meaning: 'Goodbye / okay then', ipa: '' }
+];
+
+function speak(text, lang = 'hi-IN') {
+    if (!('speechSynthesis' in window)) return;
+    window.speechSynthesis.cancel();
+    const u = new SpeechSynthesisUtterance(text);
+    u.lang = lang;
+    u.rate = 0.82;
+    const voices = window.speechSynthesis.getVoices();
+    u.voice =
+        voices.find(v => v.lang.toLowerCase().startsWith('doi')) ||
+        voices.find(v => v.lang.toLowerCase().startsWith('hi')) ||
+        voices.find(v => v.lang.toLowerCase().startsWith('en-in')) ||
+        null;
+    window.speechSynthesis.speak(u);
+}
+function renderWords(query = '') {
+    const grid = document.getElementById('word-grid');
+    if (!grid) return;
+    const q = query.trim().toLowerCase();
+    grid.innerHTML =
+        DOGRI_WORDS.map((w, i) => {
+            const hay = [w.script, w.roman, w.meaning, w.ipa].join(' ').toLowerCase();
+            if (q && !hay.includes(q)) return '';
+            return `<article class="word-card"><div class="script" lang="doi">${w.script}</div><div class="roman">${w.roman}</div><div class="meaning">${w.meaning}</div><div class="ipa">${w.ipa || 'Pronunciation reference'}</div>${w.audio ? `<audio controls preload="none" src="${w.audio}" aria-label="Recorded pronunciation of ${w.meaning}"></audio>` : `<button type="button" data-speak="${w.script}">🔊 Browser pronunciation</button>`}</article>`;
+        }).join('') || '<p>No matching words found.</p>';
+    grid.querySelectorAll('[data-speak]').forEach(b => b.addEventListener('click', () => speak(b.dataset.speak)));
+}
+document.addEventListener('DOMContentLoaded', () => {
+    renderWords();
+    document.getElementById('word-search')?.addEventListener('input', e => renderWords(e.target.value));
+    document
+        .querySelectorAll('[data-speech]')
+        .forEach(b => b.addEventListener('click', () => speak(b.dataset.speech, b.dataset.lang)));
+});

--- a/frontend/dogri-language-explorer/index.html
+++ b/frontend/dogri-language-explorer/index.html
@@ -1,0 +1,243 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <meta
+            name="description"
+            content="Interactive Dogri language explorer: Devanagari script, verified phrases, vocabulary, regions, family and Dogra cultural heritage."
+        />
+        <title>Dogri Language Explorer | डोगरी</title>
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="dogri-language-explorer.css" />
+    </head>
+    <body class="dogri-explorer">
+        <a class="skip-link" href="#main">Skip to main content</a>
+        <header class="navbar">
+            <div class="nav-container">
+                <a class="nav-logo" href="../../index.html#home"
+                    ><span class="saffron">Incredible</span> <span class="gold">India</span>
+                    <span class="green">Explorer</span></a
+                >
+                <nav class="nav-menu" aria-label="Primary">
+                    <a class="nav-link" href="../../index.html#home">Home</a>
+                    <a class="nav-link active" href="../languages-of-india/index.html">Languages of India</a>
+                    <a class="nav-link" href="#sources">Sources</a>
+                </nav>
+            </div>
+        </header>
+
+        <main id="main">
+            <section class="hero">
+                <div class="hero-inner">
+                    <p class="eyebrow">Western Pahari · Indo-Aryan</p>
+                    <h1>Discover <span>Dogri</span> <b lang="doi">डोगरी</b></h1>
+                    <p class="lead">
+                        A language of the Dogra heartland, centered on Jammu and also spoken in adjoining parts of
+                        Himachal Pradesh and Punjab.
+                    </p>
+                    <div class="hero-script" lang="doi" aria-label="Dogri written in Devanagari">डोगरी</div>
+                    <div class="hero-actions">
+                        <button class="audio-btn" data-speech="नमस्ते" data-lang="hi-IN">🔊 Hear नमस्ते</button>
+                        <a class="button" href="#vocabulary">Explore the word bank</a>
+                    </div>
+                    <p class="verification">
+                        Pronunciation reference: Omniglot's Dogri phrase collection lists <b>नमस्ते (namastē)</b> as a
+                        general greeting. Audio controls use a verified phrase/audio source with browser speech
+                        fallback.
+                    </p>
+                </div>
+            </section>
+
+            <section class="facts" aria-label="Dogri facts">
+                <article><strong>Indo-Aryan</strong><span>Western Pahari group</span></article>
+                <article><strong>डोगरी</strong><span>Devanagari in India</span></article>
+                <article><strong>Jammu</strong><span>Core regional heartland</span></article>
+                <article><strong>doi</strong><span>ISO 639-3 code</span></article>
+            </section>
+
+            <section class="section" id="greetings">
+                <div class="section-heading">
+                    <p class="eyebrow">👋 Everyday Dogri</p>
+                    <h2>Greeting & useful phrases</h2>
+                    <p>
+                        These forms are documented in Dogri phrase collections. Listen using the audio button or the
+                        browser's speech engine.
+                    </p>
+                </div>
+                <div class="cards">
+                    <article class="phrase featured">
+                        <span class="tag">General greeting</span>
+                        <div class="script" lang="doi">नमस्ते</div>
+                        <div class="roman">namastē</div>
+                        <p>Hello / greetings</p>
+                        <button class="audio-btn" data-speech="नमस्ते" data-lang="hi-IN">🔊 Play pronunciation</button>
+                    </article>
+                    <article class="phrase">
+                        <span class="tag">How are you?</span>
+                        <div class="script" lang="doi">केह् हाल ऐ?</div>
+                        <div class="roman">kē āl ae?</div>
+                        <p>How are you? (informal)</p>
+                        <button class="audio-btn" data-speech="केह् हाल ऐ?" data-lang="hi-IN">
+                            🔊 Play pronunciation
+                        </button>
+                    </article>
+                    <article class="phrase">
+                        <span class="tag">Thank you</span>
+                        <div class="script" lang="doi">धन्नवाद</div>
+                        <div class="roman">dhanvād</div>
+                        <p>Thank you</p>
+                        <button class="audio-btn" data-speech="धन्नवाद" data-lang="hi-IN">🔊 Play pronunciation</button>
+                    </article>
+                    <article class="phrase">
+                        <span class="tag">Goodbye</span>
+                        <div class="script" lang="doi">खरा फ्ही</div>
+                        <div class="roman">kharā phī</div>
+                        <p>Goodbye / okay then</p>
+                        <button class="audio-btn" data-speech="खरा फ्ही" data-lang="hi-IN">
+                            🔊 Play pronunciation
+                        </button>
+                    </article>
+                </div>
+            </section>
+
+            <section class="section alt" id="vocabulary">
+                <div class="section-heading">
+                    <p class="eyebrow">💬 Common words</p>
+                    <h2>Dogri word bank</h2>
+                    <p>Search the Devanagari forms, transliterations and English meanings.</p>
+                </div>
+                <label class="search"
+                    ><span>Search</span
+                    ><input
+                        id="word-search"
+                        type="search"
+                        placeholder="Try हां, keh, sky..."
+                        aria-label="Search Dogri vocabulary"
+                /></label>
+                <div class="word-grid" id="word-grid"></div>
+            </section>
+
+            <section class="section" id="script">
+                <div class="section-heading">
+                    <p class="eyebrow">✍️ Writing</p>
+                    <h2>Devanagari script, with Dogra heritage</h2>
+                </div>
+                <div class="script-panel">
+                    <div class="script-showcase" lang="doi">
+                        अ आ इ ई उ ए ऐ ओ औ<br />डोगरी भाषा<br />नमस्ते · धन्नवाद · केह्
+                    </div>
+                    <div>
+                        <h3>How Dogri is written</h3>
+                        <p>
+                            In India, Dogri is commonly written in Devanagari. Dogri also has a historic Dogra script,
+                            and Perso-Arabic writing is used in some communities outside India.
+                        </p>
+                        <p>
+                            Dogri is tonal and has orthographic conventions that distinguish tones in Devanagari, making
+                            its written form more than a simple Hindi transcription.
+                        </p>
+                    </div>
+                </div>
+            </section>
+
+            <section class="section alt" id="family">
+                <div class="section-heading">
+                    <p class="eyebrow">🌳 Language family</p>
+                    <h2>Where Dogri fits</h2>
+                </div>
+                <div class="family-tree" aria-label="Dogri language family">
+                    Indo-European → Indo-Iranian → Indo-Aryan → Western Pahari → <strong>Dogri</strong>
+                </div>
+                <p>
+                    Dogri belongs to the Indo-Aryan branch and is grouped with Western Pahari varieties. Its closest
+                    linguistic setting includes the wider Dogri–Kangri area of the western Himalaya.
+                </p>
+            </section>
+
+            <section class="section" id="regions">
+                <div class="section-heading">
+                    <p class="eyebrow">🗺️ Regional heritage</p>
+                    <h2>Dogri-speaking regions</h2>
+                </div>
+                <div class="region-grid">
+                    <article>
+                        <h3>Jammu Division</h3>
+                        <p>The principal Dogri-speaking heartland and a major center of Dogra cultural identity.</p>
+                    </article>
+                    <article>
+                        <h3>Himachal Pradesh</h3>
+                        <p>
+                            Dogri has speakers in adjoining northern Himachali areas, alongside related Western Pahari
+                            varieties.
+                        </p>
+                    </article>
+                    <article>
+                        <h3>Punjab</h3>
+                        <p>Smaller Dogri-speaking communities occur in adjoining Punjab areas.</p>
+                    </article>
+                </div>
+            </section>
+
+            <section class="section alt" id="culture">
+                <div class="section-heading">
+                    <p class="eyebrow">🏔️ Culture & literature</p>
+                    <h2>Dogri and Dogra heritage</h2>
+                </div>
+                <div class="culture">
+                    <p>
+                        Dogri is closely associated with the Dogra cultural region of Jammu. Its literary tradition
+                        includes poetry, fiction, drama and oral forms, while Dogri's distinctive sound system and
+                        vocabulary reflect its western Himalayan setting.
+                    </p>
+                    <p>
+                        The language is one of India's 22 scheduled languages, and its modern literary identity is
+                        represented in institutions and awards including the Sahitya Akademi tradition.
+                    </p>
+                </div>
+            </section>
+
+            <section class="section" id="sources">
+                <div class="section-heading">
+                    <p class="eyebrow">📚 Verification</p>
+                    <h2>Sources & pronunciation notes</h2>
+                </div>
+                <ul class="sources">
+                    <li>
+                        <a href="https://www.omniglot.com/language/phrases/dogri.htm" target="_blank" rel="noopener"
+                            >Omniglot — Useful phrases in Dogri</a
+                        >
+                        — greeting and phrase forms.
+                    </li>
+                    <li>
+                        <a href="https://en.wikipedia.org/wiki/Dogri_language" target="_blank" rel="noopener"
+                            >Dogri language reference</a
+                        >
+                        — family, scripts, regions and phonology.
+                    </li>
+                    <li>
+                        <a href="https://www.languageshome.com/New/english-dogri/" target="_blank" rel="noopener"
+                            >Languages Home — Learn Dogri Audio</a
+                        >
+                        — recorded Dogri word/sentence audio reference.
+                    </li>
+                    <li>
+                        <a
+                            href="https://commons.wikimedia.org/wiki/Category:Dogri_language"
+                            target="_blank"
+                            rel="noopener"
+                            >Wikimedia Commons — Dogri language</a
+                        >
+                        — media and language resources.
+                    </li>
+                </ul>
+                <p class="note">
+                    The explorer does not claim that browser text-to-speech is a native-speaker recording. It is a
+                    fallback for accessibility; cited sources provide the verification basis.
+                </p>
+            </section>
+        </main>
+        <footer>Incredible India Explorer · Dogri Language Explorer</footer>
+        <script src="dogri-language-explorer.js"></script>
+    </body>
+</html>


### PR DESCRIPTION
# Pull Request

## Description

Implemented #2354 by adding a dedicated interactive Dogri language explorer.

The explorer introduces Dogri's Devanagari script, verified greeting and pronunciation references, common vocabulary with transliterations and meanings, audio controls, language-family context, regional coverage, and Dogra cultural and literary heritage.

The existing Languages of India landing page already contains Dogri as an Indo-Aryan language, so no duplicate landing-page entry was introduced.

## Type of Change

- [x] New Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #2354

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

JavaScript syntax validation completed with `node --check`.


## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review