### PR TITLE
feat: add regional biryani explorer

### DIFF
--- a/frontend/Biryani/biryani.css
+++ b/frontend/Biryani/biryani.css
@@ -1,0 +1,486 @@
+:root {
+    --ink: #251d19;
+    --muted: #6c5e56;
+    --paper: #fffaf1;
+    --paper-2: #f5ead8;
+    --saffron: #c75b24;
+    --saffron-dark: #8d3515;
+    --gold: #d89a35;
+    --green: #315b45;
+    --line: rgba(76, 49, 32, 0.15);
+    --shadow: 0 18px 45px rgba(68, 42, 20, 0.12);
+    --radius: 22px;
+}
+* {
+    box-sizing: border-box;
+}
+html {
+    scroll-behavior: smooth;
+}
+body {
+    margin: 0;
+    color: var(--ink);
+    background: var(--paper);
+    font-family:
+        Inter,
+        ui-sans-serif,
+        system-ui,
+        -apple-system,
+        BlinkMacSystemFont,
+        'Segoe UI',
+        sans-serif;
+    line-height: 1.65;
+}
+a {
+    color: inherit;
+}
+.skip-link {
+    position: fixed;
+    left: 1rem;
+    top: -4rem;
+    z-index: 50;
+    padding: 0.7rem 1rem;
+    background: #fff;
+    border-radius: 8px;
+}
+.skip-link:focus {
+    top: 1rem;
+}
+.hero {
+    min-height: 76vh;
+    background:
+        radial-gradient(circle at 78% 20%, rgba(216, 154, 53, 0.32), transparent 28%),
+        radial-gradient(circle at 12% 80%, rgba(49, 91, 69, 0.28), transparent 30%),
+        linear-gradient(135deg, #2f211a, #7d351c 58%, #bd6428);
+    color: #fffaf1;
+    position: relative;
+    overflow: hidden;
+}
+.hero::after {
+    content: '🍚';
+    position: absolute;
+    right: 8%;
+    bottom: -5%;
+    font-size: clamp(10rem, 27vw, 24rem);
+    opacity: 0.09;
+    transform: rotate(-12deg);
+}
+.topbar {
+    max-width: 1180px;
+    margin: auto;
+    padding: 1.2rem 1.5rem;
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: center;
+    position: relative;
+    z-index: 2;
+}
+.topbar a {
+    text-decoration: none;
+    font-weight: 700;
+}
+.brand {
+    letter-spacing: 0.02em;
+}
+.hero-inner {
+    max-width: 980px;
+    margin: 0 auto;
+    padding: 8vh 1.5rem 10vh;
+    position: relative;
+    z-index: 2;
+}
+.eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.15em;
+    font-size: 0.78rem;
+    font-weight: 800;
+    margin: 0 0 0.6rem;
+    color: var(--gold);
+}
+.hero .eyebrow {
+    color: #ffd890;
+}
+h1 {
+    font-family: Georgia, serif;
+    font-size: clamp(4rem, 11vw, 8.5rem);
+    line-height: 0.85;
+    margin: 0;
+    letter-spacing: -0.055em;
+}
+.hero-title {
+    font:
+        700 clamp(1.35rem, 3vw, 2.1rem)/1.2 Georgia,
+        serif;
+    margin: 1.2rem 0 0.7rem;
+}
+.hero-copy {
+    max-width: 720px;
+    font-size: clamp(1rem, 2vw, 1.2rem);
+    color: #fff4df;
+}
+.hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.8rem;
+    margin-top: 2rem;
+}
+.button {
+    padding: 0.85rem 1.2rem;
+    border-radius: 999px;
+    text-decoration: none;
+    font-weight: 800;
+}
+.primary {
+    background: #fff;
+    color: var(--saffron-dark);
+}
+.secondary {
+    border: 1px solid rgba(255, 255, 255, 0.55);
+    color: #fff;
+}
+.section {
+    max-width: 1180px;
+    margin: auto;
+    padding: 6rem 1.5rem;
+}
+.section-heading {
+    max-width: 760px;
+    margin-bottom: 2rem;
+}
+h2 {
+    font:
+        700 clamp(2.1rem, 5vw, 3.6rem)/1.05 Georgia,
+        serif;
+    margin: 0 0 0.8rem;
+    letter-spacing: -0.035em;
+}
+h3 {
+    font-family: Georgia, serif;
+}
+.two-column,
+.map-layout,
+.split-section {
+    display: grid;
+    grid-template-columns: 1.25fr 0.75fr;
+    gap: 2rem;
+    align-items: start;
+}
+.intro {
+    border-bottom: 1px solid var(--line);
+}
+.fact-card,
+.region-panel,
+.food-card,
+.method-grid article,
+.source-grid a {
+    background: #fff;
+    border: 1px solid var(--line);
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+}
+.fact-card {
+    padding: 1.5rem;
+}
+.fact-icon {
+    font-size: 2.5rem;
+}
+.fact-card ul {
+    padding-left: 1.2rem;
+    color: var(--muted);
+}
+.map-section {
+    background: var(--paper-2);
+    max-width: none;
+}
+.map-section > * {
+    max-width: 1180px;
+    margin-left: auto;
+    margin-right: auto;
+}
+.map-layout {
+    align-items: center;
+}
+.india-map {
+    position: relative;
+    width: min(100%, 560px);
+    margin: auto;
+    filter: drop-shadow(0 18px 25px rgba(50, 35, 25, 0.15));
+}
+.india-map img {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+.map-pin {
+    position: absolute;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    border: 3px solid #fff;
+    background: var(--saffron);
+    color: #fff;
+    font-weight: 900;
+    cursor: pointer;
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.22);
+}
+.map-pin:hover,
+.map-pin:focus-visible,
+.map-pin.active {
+    background: var(--green);
+    transform: scale(1.08);
+}
+.north {
+    left: 49%;
+    top: 29%;
+}
+.east {
+    left: 67%;
+    top: 43%;
+}
+.west {
+    left: 31%;
+    top: 51%;
+}
+.south {
+    left: 51%;
+    top: 62%;
+}
+.southwest {
+    left: 38%;
+    top: 76%;
+}
+.southcentral {
+    left: 54%;
+    top: 76%;
+}
+.region-panel {
+    padding: 2rem;
+    min-height: 390px;
+}
+.panel-kicker {
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 0.72rem;
+    font-weight: 800;
+    color: var(--saffron);
+}
+.region-panel h3 {
+    font-size: clamp(2rem, 4vw, 3rem);
+    margin: 0.2rem 0;
+}
+.region-place {
+    color: var(--green);
+    font-weight: 800;
+    margin-top: 0;
+}
+.detail-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.8rem;
+    margin-top: 1.5rem;
+}
+.detail-grid div {
+    background: var(--paper-2);
+    padding: 0.85rem;
+    border-radius: 12px;
+}
+.detail-grid span {
+    display: block;
+    color: var(--muted);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+.detail-grid strong {
+    display: block;
+    margin-top: 0.2rem;
+    font-size: 0.9rem;
+}
+.region-links a {
+    color: var(--saffron-dark);
+    font-weight: 800;
+}
+.region-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    margin-top: 1.5rem;
+}
+.region-buttons button {
+    border: 1px solid var(--line);
+    background: #fff;
+    color: var(--ink);
+    padding: 0.7rem 1rem;
+    border-radius: 999px;
+    cursor: pointer;
+    font-weight: 800;
+}
+.region-buttons button:hover,
+.region-buttons button.active {
+    background: var(--green);
+    color: #fff;
+    border-color: var(--green);
+}
+.cards {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+}
+.food-card {
+    padding: 1.4rem;
+    box-shadow: none;
+}
+.food-card > span {
+    color: var(--saffron);
+    font-weight: 900;
+}
+.food-card h3 {
+    font-size: 1.45rem;
+    margin: 0.4rem 0;
+}
+.food-card p,
+.method-grid p,
+.source-grid span {
+    color: var(--muted);
+}
+.split-section {
+    background: var(--green);
+    color: #f8f2e5;
+    max-width: none;
+    padding-left: max(1.5rem, calc((100% - 1180px) / 2));
+    padding-right: max(1.5rem, calc((100% - 1180px) / 2));
+}
+.split-section .eyebrow {
+    color: #e5c77f;
+}
+.ingredient-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.7rem;
+}
+.ingredient-list span {
+    padding: 0.7rem 0.9rem;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 999px;
+}
+.method-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+}
+.method-grid article {
+    padding: 1.4rem;
+    box-shadow: none;
+}
+.method-grid h3 {
+    margin-top: 0;
+}
+.storyline {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+}
+.storyline li {
+    border-top: 4px solid var(--saffron);
+    padding-top: 1rem;
+}
+.storyline strong {
+    display: block;
+    font-family: Georgia, serif;
+    font-size: 1.25rem;
+}
+.storyline span {
+    display: block;
+    color: var(--muted);
+    margin-top: 0.5rem;
+}
+.sources {
+    border-top: 1px solid var(--line);
+}
+.source-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+}
+.source-grid a {
+    padding: 1.2rem;
+    text-decoration: none;
+    box-shadow: none;
+}
+.source-grid strong,
+.source-grid span {
+    display: block;
+}
+.source-grid strong {
+    color: var(--saffron-dark);
+    margin-bottom: 0.35rem;
+}
+.credit-note {
+    color: var(--muted);
+    font-size: 0.9rem;
+    margin-top: 1.2rem;
+}
+footer {
+    padding: 2rem 1.5rem;
+    background: #251d19;
+    color: #f8f2e5;
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+footer a {
+    font-weight: 800;
+}
+@media (max-width: 850px) {
+    .two-column,
+    .map-layout,
+    .split-section {
+        grid-template-columns: 1fr;
+    }
+    .cards {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    .method-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    .storyline {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+@media (max-width: 560px) {
+    .hero-inner {
+        padding-top: 5vh;
+    }
+    .section {
+        padding-top: 4rem;
+        padding-bottom: 4rem;
+    }
+    .cards,
+    .method-grid,
+    .storyline,
+    .source-grid,
+    .detail-grid {
+        grid-template-columns: 1fr;
+    }
+    .map-pin {
+        width: 2.1rem;
+        height: 2.1rem;
+    }
+    .topbar {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+}
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
+    .map-pin {
+        transition: none;
+    }
+}

--- a/frontend/Biryani/biryani.js
+++ b/frontend/Biryani/biryani.js
@@ -1,0 +1,104 @@
+const regions = {
+    hyderabad: {
+        name: 'Hyderabad',
+        place: 'Telangana · Deccan',
+        description:
+            'A celebrated Deccan tradition with both kachhi and pakki forms. The rice and meat are finished together under dum, allowing steam to carry the aroma through the pot.',
+        signature: 'Kachhi & pakki',
+        method: 'Dum / sealed pot',
+        ingredients: 'Rice, meat, cardamom, green chilli, ghee, saffron',
+        story: "The style sits within Hyderabad's layered Deccani culinary culture.",
+        source: 'https://www.incredibleindia.gov.in/en/telangana/hyderabad/food-and-cuisine.html'
+    },
+    lucknow: {
+        name: 'Awadh / Lucknow',
+        place: 'Uttar Pradesh · Awadh',
+        description:
+            'Lakhnavi biryani is associated with the culinary culture of Lucknow and the Nawabi era. Its rice is gently seasoned and cooked with stock before the final dum stage.',
+        signature: 'Lakhnavi / Awadhi',
+        method: 'Stock + dum',
+        ingredients: 'Rice, mutton, stock, saffron, rose water, aromatic spices',
+        story: "A courtly regional style that became part of Lucknow's wider food culture.",
+        source: 'https://www.prod.incredibleindia.gov.in/content/incredible-india-v2/en/destinations/lucknow/lakhnavi-biryani.html'
+    },
+    kolkata: {
+        name: 'Kolkata',
+        place: 'West Bengal · Eastern India',
+        description:
+            "Kolkata biryani has a recognizable combination of fragrant rice, meat and potato. The city's version is often connected to the migration of Awadhi culinary traditions to Bengal.",
+        signature: 'Potato + meat',
+        method: 'Pakki + dum',
+        ingredients: 'Rice, mutton, potato, saffron, whole spices',
+        story: "The potato became a defining local marker of the city's biryani tradition.",
+        source: 'https://www.incredibleindia.gov.in/en/west-bengal/kolkata/food-guide-a-culinary-journey-through-kolkata-s-best-restaurantsby'
+    },
+    malabar: {
+        name: 'Malabar',
+        place: 'Kerala · Northern Malabar Coast',
+        description:
+            'Northern Kerala has a distinct biryani culture shaped by coastal trade, Muslim food traditions and local ingredients. Many Malabar preparations use aromatic short-grain rice such as jeerakasala.',
+        signature: 'Malabar biryani',
+        method: 'Layering / dum',
+        ingredients: 'Jeerakasala rice, meat, fried onions, spices, ghee',
+        story: 'Coastal exchange and local rice traditions give Malabar biryani its own identity.',
+        source: 'https://www.keralatourism.org/kerala-articles/malabar-biryani/115/'
+    },
+    ambur: {
+        name: 'Ambur / Tamil Nadu',
+        place: 'Tamil Nadu · North Arcot region',
+        description:
+            'Ambur is strongly associated with a Tamil Nadu biryani style that uses seeraga samba rice and a distinctive chilli-and-meat base.',
+        signature: 'Ambur biryani',
+        method: 'One-pot / layering',
+        ingredients: 'Seeraga samba rice, meat, dried chillies, mint, coriander',
+        story: "A local rice and spice profile makes Ambur's version readily recognizable.",
+        source: 'https://www.tamilnadutourism.com/foods/ambur-biryani.php'
+    },
+    bombay: {
+        name: 'Mumbai',
+        place: 'Maharashtra · Western India',
+        description:
+            "Mumbai's biryani culture reflects a city where regional communities, traders and migrants brought different rice-and-meat traditions into a shared urban food landscape.",
+        signature: 'Mumbai-style biryani',
+        method: 'Layering / dum',
+        ingredients: 'Rice, meat or chicken, potatoes, spices, herbs',
+        story: "Its identity is best understood as part of Mumbai's plural culinary culture rather than a single canonical recipe.",
+        source: 'https://www.incredibleindia.gov.in/en/maharashtra/mumbai/food-and-cuisine'
+    }
+};
+
+const nameEl = document.getElementById('region-name');
+const placeEl = document.getElementById('region-place');
+const descriptionEl = document.getElementById('region-description');
+const signatureEl = document.getElementById('region-signature');
+const methodEl = document.getElementById('region-method');
+const ingredientsEl = document.getElementById('region-ingredients');
+const storyEl = document.getElementById('region-story');
+const linksEl = document.getElementById('region-links');
+
+function selectRegion(key) {
+    const region = regions[key];
+    if (!region) return;
+
+    nameEl.textContent = region.name;
+    placeEl.textContent = region.place;
+    descriptionEl.textContent = region.description;
+    signatureEl.textContent = region.signature;
+    methodEl.textContent = region.method;
+    ingredientsEl.textContent = region.ingredients;
+    storyEl.textContent = region.story;
+    linksEl.innerHTML = `<a href="${region.source}" target="_blank" rel="noopener noreferrer">View supporting source ↗</a>`;
+
+    document.querySelectorAll('[data-region]').forEach(button => {
+        button.classList.toggle('active', button.dataset.region === key);
+    });
+}
+
+document.querySelectorAll('[data-region]').forEach(button => {
+    button.addEventListener('click', () => {
+        selectRegion(button.dataset.region);
+        document.getElementById('region-name').scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    });
+});
+
+selectRegion('hyderabad');

--- a/frontend/Biryani/index.html
+++ b/frontend/Biryani/index.html
@@ -1,0 +1,350 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta
+            name="description"
+            content="Explore India's regional biryani traditions, ingredients, cooking methods and cultural stories through an interactive map."
+        />
+        <title>Biryani — India's Regional Food Stories | Incredible India Explorer</title>
+        <link rel="stylesheet" href="biryani.css" />
+    </head>
+    <body>
+        <a class="skip-link" href="#main-content">Skip to content</a>
+
+        <header class="hero">
+            <nav class="topbar" aria-label="Primary navigation">
+                <a href="../index.html" class="brand">Incredible India Explorer</a>
+                <a href="#regional-map">Explore the map</a>
+            </nav>
+            <div class="hero-inner">
+                <p class="eyebrow">B · Regional Food Stories</p>
+                <h1>Biryani</h1>
+                <p class="hero-title">One dish, many regional identities.</p>
+                <p class="hero-copy">
+                    From the layered, saffron-scented biryanis of Hyderabad and Lucknow to Kolkata's potato-and-meat
+                    combination and Kerala's Malabar traditions, biryani changes with place, pantry and cooking
+                    practice.
+                </p>
+                <div class="hero-actions">
+                    <a class="button primary" href="#regional-map">Discover a region</a>
+                    <a class="button secondary" href="#story">Read the story</a>
+                </div>
+            </div>
+        </header>
+
+        <main id="main-content">
+            <section id="story" class="section intro">
+                <div class="section-heading">
+                    <p class="eyebrow">The dish</p>
+                    <h2>What is biryani?</h2>
+                </div>
+                <div class="two-column">
+                    <div>
+                        <p>
+                            Biryani is a family of fragrant rice dishes in which rice is cooked with seasoned meat,
+                            fish, eggs, vegetables or a combination of ingredients. Regional traditions differ in how
+                            the rice is prepared, when the protein is added, how strongly the dish is spiced, and
+                            whether the pot is finished by <em>dum</em>, a sealed slow-cooking method.
+                        </p>
+                        <p>
+                            There is no single “original” regional recipe represented here. The map is designed to show
+                            how communities developed recognizable local styles rather than to rank one biryani above
+                            another.
+                        </p>
+                    </div>
+                    <aside class="fact-card">
+                        <span class="fact-icon" aria-hidden="true">🍚</span>
+                        <h3>Shared foundations</h3>
+                        <ul>
+                            <li>Long-grain or local rice varieties</li>
+                            <li>Whole and ground spices</li>
+                            <li>Layering, mixing or one-pot cooking</li>
+                            <li>Slow cooking in many traditional styles</li>
+                        </ul>
+                    </aside>
+                </div>
+            </section>
+
+            <section id="regional-map" class="section map-section" aria-labelledby="map-title">
+                <div class="section-heading">
+                    <p class="eyebrow">Interactive feature</p>
+                    <h2 id="map-title">Follow biryani across India</h2>
+                    <p>Select a region on the map or use the accessible region buttons below it.</p>
+                </div>
+
+                <div class="map-layout">
+                    <div
+                        class="india-map"
+                        role="img"
+                        aria-label="Schematic map of India with selectable biryani regions"
+                    >
+                        <img src="../Lassi/in.svg" alt="" aria-hidden="true" />
+                        <button
+                            class="map-pin north"
+                            type="button"
+                            data-region="lucknow"
+                            aria-label="Explore Awadh and Lucknow biryani"
+                        >
+                            1
+                        </button>
+                        <button
+                            class="map-pin east"
+                            type="button"
+                            data-region="kolkata"
+                            aria-label="Explore Kolkata biryani"
+                        >
+                            2
+                        </button>
+                        <button
+                            class="map-pin west"
+                            type="button"
+                            data-region="bombay"
+                            aria-label="Explore Mumbai biryani"
+                        >
+                            3
+                        </button>
+                        <button
+                            class="map-pin south"
+                            type="button"
+                            data-region="hyderabad"
+                            aria-label="Explore Hyderabad biryani"
+                        >
+                            4
+                        </button>
+                        <button
+                            class="map-pin southwest"
+                            type="button"
+                            data-region="malabar"
+                            aria-label="Explore Malabar biryani"
+                        >
+                            5
+                        </button>
+                        <button
+                            class="map-pin southcentral"
+                            type="button"
+                            data-region="ambur"
+                            aria-label="Explore Ambur and Tamil Nadu biryani"
+                        >
+                            6
+                        </button>
+                    </div>
+
+                    <div class="region-panel" aria-live="polite">
+                        <div class="panel-kicker">Selected region</div>
+                        <h3 id="region-name">Hyderabad</h3>
+                        <p id="region-place" class="region-place">Telangana · Deccan</p>
+                        <p id="region-description"></p>
+                        <div class="detail-grid">
+                            <div><span>Signature</span><strong id="region-signature"></strong></div>
+                            <div><span>Method</span><strong id="region-method"></strong></div>
+                            <div><span>Ingredients</span><strong id="region-ingredients"></strong></div>
+                            <div><span>Story</span><strong id="region-story"></strong></div>
+                        </div>
+                        <div class="region-links" id="region-links"></div>
+                    </div>
+                </div>
+
+                <div class="region-buttons" aria-label="Biryani regions">
+                    <button type="button" data-region="hyderabad">Hyderabad</button>
+                    <button type="button" data-region="lucknow">Awadh / Lucknow</button>
+                    <button type="button" data-region="kolkata">Kolkata</button>
+                    <button type="button" data-region="malabar">Malabar</button>
+                    <button type="button" data-region="ambur">Ambur / Tamil Nadu</button>
+                    <button type="button" data-region="bombay">Mumbai</button>
+                </div>
+            </section>
+
+            <section class="section" aria-labelledby="varieties-title">
+                <div class="section-heading">
+                    <p class="eyebrow">Regional varieties</p>
+                    <h2 id="varieties-title">Six traditions to explore</h2>
+                </div>
+                <div class="cards">
+                    <article class="food-card">
+                        <span>01</span>
+                        <h3>Hyderabadi</h3>
+                        <p>Kachhi and pakki traditions, dum cooking, aromatic spices, meat and basmati rice.</p>
+                    </article>
+                    <article class="food-card">
+                        <span>02</span>
+                        <h3>Lakhnavi / Awadhi</h3>
+                        <p>
+                            A refined courtly tradition associated with Lucknow, with stock-cooked rice and gentle
+                            aromatics.
+                        </p>
+                    </article>
+                    <article class="food-card">
+                        <span>03</span>
+                        <h3>Kolkata</h3>
+                        <p>A distinctive style known for fragrant rice, meat and the familiar presence of potato.</p>
+                    </article>
+                    <article class="food-card">
+                        <span>04</span>
+                        <h3>Malabar</h3>
+                        <p>
+                            Kerala's northern coast has its own rice, spice and meat traditions, often using short-grain
+                            rice such as jeerakasala.
+                        </p>
+                    </article>
+                    <article class="food-card">
+                        <span>05</span>
+                        <h3>Ambur</h3>
+                        <p>
+                            A Tamil Nadu tradition associated with Ambur, using seeraga samba rice and a distinctive
+                            chilli-forward profile.
+                        </p>
+                    </article>
+                    <article class="food-card">
+                        <span>06</span>
+                        <h3>Mumbai</h3>
+                        <p>
+                            Mumbai's biryani culture reflects the city's layered food history and the many communities
+                            that cook and eat it.
+                        </p>
+                    </article>
+                </div>
+            </section>
+
+            <section class="section split-section" aria-labelledby="ingredients-title">
+                <div>
+                    <p class="eyebrow">The pantry</p>
+                    <h2 id="ingredients-title">Ingredients change the identity</h2>
+                    <p>
+                        Rice is only the beginning. Regional biryanis can use mutton, chicken, fish, prawns, eggs or
+                        vegetables, alongside yogurt, stock, ghee, saffron, rose or kewra water, chillies, mint,
+                        coriander and different combinations of whole spices.
+                    </p>
+                </div>
+                <div class="ingredient-list">
+                    <span>Rice</span><span>Meat & seafood</span><span>Vegetables</span> <span>Yogurt</span
+                    ><span>Ghee</span><span>Saffron</span> <span>Mint</span><span>Coriander</span
+                    ><span>Whole spices</span>
+                </div>
+            </section>
+
+            <section class="section cooking" aria-labelledby="cooking-title">
+                <div class="section-heading">
+                    <p class="eyebrow">Cooking traditions</p>
+                    <h2 id="cooking-title">Different paths to the same pot</h2>
+                </div>
+                <div class="method-grid">
+                    <article>
+                        <h3>Kachhi</h3>
+                        <p>
+                            Marinated meat is cooked together with rice, as in a traditional Hyderabadi kachhi
+                            preparation.
+                        </p>
+                    </article>
+                    <article>
+                        <h3>Pakki</h3>
+                        <p>Cooked meat and partially cooked rice are layered before the final steaming stage.</p>
+                    </article>
+                    <article>
+                        <h3>Dum</h3>
+                        <p>
+                            A sealed vessel traps steam and aroma while the dish finishes slowly over controlled heat.
+                        </p>
+                    </article>
+                    <article>
+                        <h3>Local rice</h3>
+                        <p>
+                            Not every regional tradition depends on basmati; southern styles may favor smaller-grained
+                            aromatic rice.
+                        </p>
+                    </article>
+                </div>
+            </section>
+
+            <section class="section timeline" aria-labelledby="history-title">
+                <div class="section-heading">
+                    <p class="eyebrow">Cultural history</p>
+                    <h2 id="history-title">A dish shaped by movement</h2>
+                </div>
+                <ol class="storyline">
+                    <li>
+                        <strong>Persianate culinary influence</strong
+                        ><span
+                            >Rice, meat, aromatics and layered cooking traditions developed through long histories of
+                            cultural exchange across South and Central Asia.</span
+                        >
+                    </li>
+                    <li>
+                        <strong>Royal and urban kitchens</strong
+                        ><span
+                            >Courtly cuisines helped refine techniques and ingredients, while cities and trade routes
+                            carried recipes beyond palace kitchens.</span
+                        >
+                    </li>
+                    <li>
+                        <strong>Regional adaptation</strong
+                        ><span
+                            >Local rice, produce, spice preferences and cooking equipment turned shared ideas into
+                            distinct regional biryanis.</span
+                        >
+                    </li>
+                    <li>
+                        <strong>Living food heritage</strong
+                        ><span
+                            >Today biryani belongs to homes, restaurants, festivals and everyday food culture across
+                            many parts of India.</span
+                        >
+                    </li>
+                </ol>
+            </section>
+
+            <section class="section sources" aria-labelledby="sources-title">
+                <div class="section-heading">
+                    <p class="eyebrow">Evidence & attribution</p>
+                    <h2 id="sources-title">Food information properly sourced</h2>
+                </div>
+                <div class="source-grid">
+                    <a
+                        href="https://www.incredibleindia.gov.in/en/telangana/hyderabad/food-and-cuisine.html"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        <strong>Incredible India · Hyderabad</strong>
+                        <span>Hyderabadi biryani, kachhi/pakki methods and dum cooking.</span>
+                    </a>
+                    <a
+                        href="https://www.prod.incredibleindia.gov.in/content/incredible-india-v2/en/destinations/lucknow/lakhnavi-biryani.html"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        <strong>Incredible India · Lucknow</strong>
+                        <span>Lakhnavi biryani and its preparation traditions.</span>
+                    </a>
+                    <a
+                        href="https://www.incredibleindia.gov.in/en/west-bengal/kolkata/food-guide-a-culinary-journey-through-kolkata-s-best-restaurantsby"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        <strong>Incredible India · Kolkata</strong>
+                        <span>Kolkata's biryani culture and regional food context.</span>
+                    </a>
+                    <a
+                        href="https://www.incredibleindia.gov.in/en/telangana/hyderabad/the-best-local-foods-in-hyderabad"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        <strong>Incredible India · Hyderabad food guide</strong>
+                        <span>Dum cooking and the city's biryani tradition.</span>
+                    </a>
+                </div>
+                <p class="credit-note">
+                    Map artwork uses the repository's existing India SVG asset; no new third-party images were added.
+                    The map is a learning interface, not a claim that biryani styles stop at state boundaries.
+                </p>
+            </section>
+        </main>
+
+        <footer>
+            <a href="../index.html">Back to Incredible India Explorer</a>
+            <span>Built as part of the regional food stories collection.</span>
+        </footer>
+
+        <script src="biryani.js"></script>
+    </body>
+</html>


### PR DESCRIPTION
# Pull Request

## Description

Implemented #2918 by adding a dedicated interactive Biryani regional food explorer.

The feature documents biryani as a diverse family of regional rice dishes and allows users to explore six regional traditions through an interactive India map: Hyderabad, Awadh/Lucknow, Kolkata, Malabar, Ambur/Tamil Nadu, and Mumbai.

The page also covers ingredients, cooking traditions, cultural history, regional characteristics, and supporting sources.

## Type of Change

- [x] New Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Refactor
- [ ] Performance Improvement
- [ ] Security Improvement
- [ ] Other

## Related Issue

Closes #2918

## Testing

- [x] Tested locally
- [x] Existing functionality verified
- [x] No new warnings or errors

JavaScript syntax validated with `node --check`.


## Checklist

- [x] Code follows project conventions
- [x] Documentation updated where required
- [x] No unnecessary files included
- [x] Changes have been tested
- [x] Ready for review