### PR TITLE
feat(history): add Keladi Chennamma historical profile and Bednore defense explorer

### DIFF
--- a/frontend/keladi-chennamma-explorer/index.html
+++ b/frontend/keladi-chennamma-explorer/index.html
@@ -1,0 +1,110 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    if (document.body) {
+                        document.body.classList.add('light-theme');
+                    } else {
+                        document.documentElement.classList.add('light-theme');
+                    }
+                }
+            })();
+        </script>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Explore Keladi Chennamma (reign 1671–1696 CE) — The Queen Who Defended the Keladi Kingdom: shelter to Chhatrapati Rajaram, defiance of Aurangzeb's Mughal army, and coastal Karnataka heritage."
+        />
+        <title>Keladi Chennamma — The Queen Who Defended the Keladi Kingdom | Incredible India Explorer</title>
+
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+            rel="stylesheet"
+        />
+
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="keladi.css" />
+    </head>
+    <body class="keladi-main">
+        <header class="navbar scrolled" id="navbar">
+            <div class="nav-container">
+                <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </button>
+                <nav class="nav-menu" id="nav-menu">
+                    <a href="../../index.html#home" class="nav-link">Home</a>
+                    <a href="index.html" class="nav-link active" style="color: var(--accent-amber)">Keladi Chennamma</a>
+                    <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
+                        ☀️
+                    </button>
+                </nav>
+            </div>
+        </header>
+
+        <main>
+            <!-- Hero Section -->
+            <section class="keladi-hero" id="hero">
+                <div class="section-container">
+                    <div class="hero-badges-row">
+                        <span class="hero-pill">👑 1671 – 1696 CE</span>
+                        <span class="hero-pill">⚔️ Defier of Aurangzeb</span>
+                        <span class="hero-pill">🛡️ Protector of Rajaram</span>
+                    </div>
+                    <h1>Keladi Chennamma <span>The Queen Who Defended the Keladi Kingdom</span></h1>
+                    <p class="hero-subtitle">
+                        Discover the fearless governance, geopolitical courage, and military resilience of Rani Keladi Chennamma — sovereign monarch of the Keladi Nayakas who repelled Mughal imperial expansion and protected Maratha sovereignty.
+                    </p>
+                    <div id="stats-grid" class="stats-grid"></div>
+                </div>
+            </section>
+
+            <!-- Historical Chapters & Governance Analyses -->
+            <section class="keladi-content-section">
+                <div class="section-container">
+                    <h2>Historical Profile & Resistance Chapters</h2>
+                    <div class="cards-grid" id="sections-grid"></div>
+                </div>
+            </section>
+
+            <!-- Keladi Kingdom Territories Map -->
+            <section class="keladi-map-section">
+                <div class="section-container">
+                    <h2>Strategic Centers & Coastal Strongholds of the Keladi Realm</h2>
+                    <div class="map-grid" id="map-grid"></div>
+                </div>
+            </section>
+
+            <!-- Chronological Timeline -->
+            <section class="keladi-timeline-section">
+                <div class="section-container">
+                    <h2>Chronological Timeline</h2>
+                    <div class="timeline-container" id="timeline-container"></div>
+                </div>
+            </section>
+
+            <!-- Sources & Historical References -->
+            <section class="keladi-sources-section">
+                <div class="section-container">
+                    <h2>Reliable Historical References & Scholarly Sources</h2>
+                    <ul class="sources-list" id="sources-list"></ul>
+                </div>
+            </section>
+        </main>
+
+        <script src="keladi-data.js"></script>
+        <script src="keladi.js"></script>
+    </body>
+</html>

--- a/frontend/keladi-chennamma-explorer/keladi-data.js
+++ b/frontend/keladi-chennamma-explorer/keladi-data.js
@@ -1,0 +1,194 @@
+/**
+ * Keladi Chennamma Explorer — Data Module
+ * Comprehensive historical dataset covering Rani Keladi Chennamma (reign 1671–1696 CE)
+ * of the Keladi Nayaka Dynasty (Ikkeri/Bednore), her shelter to Chhatrapati Rajaram,
+ * successful guerrilla resistance against Aurangzeb's Mughal army, coastal Karnataka administration,
+ * trade, timeline, kingdom map, and scholarly sources.
+ */
+
+const KELADI_CHENNAMMA_INFO = {
+    id: "keladi-chennamma",
+    title: "Keladi Chennamma — The Queen Who Defended the Keladi Kingdom",
+    subtitle: "Fearless Queen of Bednore, Protector of Rajaram & Defender of Karnataka",
+    reignPeriod: "1671 – 1696 CE (25-Year Reign)",
+    dynasty: "Keladi Nayaka Dynasty (Ikkeri / Bednore Kingdom)",
+    capital: "Bednore (Bidanur / Nagara) & Ikkeri (Shimoga, Karnataka)",
+    titles: "Rani of Keladi, Protector of Dharma, Defier of Aurangzeb",
+    realmExtent: "Malenadu, Coastal Kanara (Karwar to Kasaragod), Western Ghats",
+    quickStats: [
+        { label: "Reign as Queen", value: "1671 – 1696 CE (25 yrs)", icon: "👑" },
+        { label: "Dynastic Capital", value: "Bednore & Ikkeri", icon: "🏰" },
+        { label: "Historic Defense", value: "Defeated Mughals (1689–90)", icon: "⚔️" },
+        { label: "Chhatrapati Ally", value: "Sheltered Rajaram", icon: "🛡️" },
+        { label: "Maritime Coast", value: "Kanara Ports & Bekal", icon: "⚓" },
+        { label: "State Religion", value: "Veerashaivism & Pluralism", icon: "🕉️" }
+    ]
+};
+
+const KELADI_CHENNAMMA_SECTIONS = [
+    {
+        id: "who-was-chennamma",
+        title: "Who Was Keladi Chennamma?",
+        icon: "👑",
+        summary: "Daughter of Siddappa Setti of Kotepura; married King Somashekara Nayaka and rose to become one of South India's greatest warrior queens.",
+        details: [
+            "Born in the mid-17th century at Kotepura (near Kundapura in coastal Karnataka) into a Lingayat merchant family of Siddappa Setti.",
+            "Known for her exceptional intellect, martial training in archery, swordplay, horse-riding, and mastery of statecraft from an early age.",
+            "Married King Somashekara Nayaka of the Keladi Nayaka kingdom; actively co-ruled and studied political treaties, treasury management, and military garrisons."
+        ]
+    },
+    {
+        id: "keladi-kingdom",
+        title: "The Keladi Nayaka Kingdom & Realm",
+        icon: "🏰",
+        summary: "Successors to Vijayanagara authority in Malenadu and coastal Kanara, ruling a prosperous spice-trading empire.",
+        details: [
+            "The Keladi Nayakas (originally feudatories of the Vijayanagara Empire) established sovereign rule after Talikota, spanning the Sahyadri mountains (Shimoga, Chikmagalur) and coastal Kanara (Uttara Kannada, Dakshina Kannada, Udupi, and north Kerala).",
+            "Capitals shifted from Keladi to Ikkeri and finally to the impenetrable jungle fortress of Bednore (Bidanur/Nagara).",
+            "Maintained flourishing coastal ports at Honnavar, Bhatkal, Kundapura, and Mangalore, dominating the global black pepper, cardamom, and rice trade with Portuguese, Dutch, and Arab merchants."
+        ]
+    },
+    {
+        id: "rise-to-power",
+        title: "Rise to Sovereign Power & Regency",
+        icon: "⚖️",
+        summary: "Navigating dynastic intrigue following King Somashekara's death, overcoming corrupt ministers to secure the throne.",
+        details: [
+            "When King Somashekara was murdered in 1671 by conspiring court factions led by minister Thimmanna Nayaka, Chennamma acted with decisive bravery.",
+            "Crushed the court rebellion, eliminated the conspirators, and assumed supreme sovereign authority over the kingdom in 1671.",
+            "Adopted Basavappa Nayaka as her heir and educated him in administration, law, and military arts while personally governing the state."
+        ]
+    },
+    {
+        id: "political-leadership",
+        title: "Political Leadership & Internal Governance",
+        icon: "📜",
+        summary: "Administrative excellence, agricultural expansion, religious tolerance, and public infrastructure.",
+        details: [
+            "Instituted efficient revenue surveys, constructed check-posts, roads, and grain storage granaries across the rugged Western Ghats passes.",
+            "Patronized literature and arts; court scholar Shadaksharadeva composed renowned classical Kannada epics (Rajshekhara Vilasa, Vrishabhendra Vijaya).",
+            "Upheld pluralistic religious harmony, endowing Veerashaiva mathas (monasteries), Sringeri Sharada Peetham, Jain basadis, and allowing Christian and Muslim subjects freedom of worship and commerce."
+        ]
+    },
+    {
+        id: "mughal-resistance",
+        title: "Resistance Against Mughal Expansion & Shelter to Rajaram",
+        icon: "⚔️",
+        summary: "Courageously sheltering Maratha Chhatrapati Rajaram in 1689 and defeating Aurangzeb's invading army in the dense jungles of Bednore.",
+        details: [
+            "In 1689, following the execution of Chhatrapati Sambhaji by Aurangzeb, his brother Chhatrapati Rajaram escaped from Raigad heading toward Gingee Fort in Tamil Nadu.",
+            "Knowing the immense risk of Mughal wrath, Rani Chennamma granted Rajaram royal sanctuary and safe escort through her territory.",
+            "Mughal Emperor Aurangzeb dispatched a massive imperial army commanded by Matabar Khan and General Jan Nisar Khan to capture Rajaram and annex Bednore.",
+            "Chennamma deployed classic guerrilla tactics in the treacherous rain-soaked Sahyadri rainforests, cutting off Mughal supply lines and ambushing their forces at the Battle of Bednore.",
+            "The demoralized Mughal generals sued for peace, signing a treaty that recognized Keladi's independence, while Rajaram safely reached Gingee."
+        ]
+    },
+    {
+        id: "coastal-heritage",
+        title: "Coastal Karnataka Heritage & Maritime Power",
+        icon: "⚓",
+        summary: "Controlling Arabian Sea trade, coastal fortresses like Bekal and Mirjan, and diplomatic parity with European maritime powers.",
+        details: [
+            "Maintained strict oversight on European trading posts; regulated Portuguese factory treaties and Dutch spice quotas without yielding territorial sovereignty.",
+            "Strengthened coastal defenses across Mirjan Fort, Honnavar, and Bekal Fort, ensuring safe passage for domestic merchant fleets.",
+            "Documented in contemporary factory records of the English East India Company and Portuguese archives as a resolute and wise sovereign ruler."
+        ]
+    }
+];
+
+const KELADI_TERRITORY_MAP_SITES = [
+    {
+        name: "Bednore / Nagara (Imperial Capital)",
+        region: "Western Ghats, Shimoga, Karnataka",
+        role: "Impregnable Forest Citadel",
+        desc: "Capital of Rani Chennamma surrounded by deep jungles and hills, where the Mughal assault was crushed."
+    },
+    {
+        name: "Ikkeri & Keladi (Ancestral Seats)",
+        region: "Sagar, Shimoga, Karnataka",
+        role: "Dynastic Heartland & Temples",
+        desc: "Home to the magnificent Aghoreshwara Temple at Ikkeri and Rameshwara Temple at Keladi."
+    },
+    {
+        name: "Honnavar & Bhatkal (Maritime Ports)",
+        region: "Uttara Kannada Coast",
+        role: "International Spice Trade Hubs",
+        desc: "Major ocean ports trading black pepper and rice with Portuguese, Dutch, and Persian merchants."
+    },
+    {
+        name: "Mirjan & Bekal Forts",
+        region: "Coastal Karnataka & North Malabar",
+        role: "Coastal Strongholds",
+        desc: "Key fortifications safeguarding Keladi's southern and coastal frontiers from naval raids."
+    }
+];
+
+const KELADI_CHENNAMMA_TIMELINE = [
+    {
+        year: "c. 1650 CE",
+        title: "Birth at Kotepura",
+        desc: "Born to Siddappa Setti at Kotepura in coastal Karnataka; trained in martial arts and statecraft."
+    },
+    {
+        year: "1667 CE",
+        title: "Marriage to Somashekara Nayaka",
+        desc: "Enters the royal Keladi family as Queen Consort, co-administering state affairs."
+    },
+    {
+        year: "1671 CE",
+        title: "Accession to the Throne of Bednore",
+        desc: "Quells internal palace conspiracies following Somashekara's death and takes sovereign command as reigning Queen."
+    },
+    {
+        year: "1689 CE",
+        title: "Sheltering Chhatrapati Rajaram",
+        desc: "Grants safe asylum and armed escort to Rajaram during his escape from Aurangzeb's Mughal forces."
+    },
+    {
+        year: "1689 – 1690 CE",
+        title: "Defeat of the Mughal Army",
+        desc: "Deploys guerrilla warfare in the Western Ghats rainforests, repelling Aurangzeb's invasion and forcing a peace treaty."
+    },
+    {
+        year: "1696 CE",
+        title: "Peaceful Transition & Legacy",
+        desc: "Concludes 25 glorious years of reign, handing over a secure and prosperous kingdom to her adopted son Basavappa Nayaka I."
+    }
+];
+
+const KELADI_CHENNAMMA_SOURCES = [
+    {
+        author: "Linganna Kavi",
+        work: "Keladinripavijaya (Victory of the Keladi Kings)",
+        year: "c. 1763–1800",
+        note: "Primary classical Kannada champu kavya chronicle detailing the genealogy, administrative reigns, and military exploits of the Keladi Nayakas."
+    },
+    {
+        author: "K. D. Swaminathan",
+        work: "The Nayakas of Ikkeri",
+        year: "1957",
+        note: "Comprehensive scholarly monograph published by the P. Varadachary & Co., detailing administrative institutions and foreign relations."
+    },
+    {
+        author: "B. S. Shastry",
+        work: "Studies in Indo-Portuguese History",
+        year: "1981",
+        note: "Documents diplomatic treaties, naval policies, and commercial exchanges between the Keladi Nayaka court and Portuguese Goa."
+    },
+    {
+        author: "Stewart Gordon",
+        work: "The Marathas 1600–1818",
+        year: "1993",
+        note: "Covers the escape of Chhatrapati Rajaram to Gingee and Rani Chennamma's critical strategic intervention against Mughal armies."
+    }
+];
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        KELADI_CHENNAMMA_INFO,
+        KELADI_CHENNAMMA_SECTIONS,
+        KELADI_TERRITORY_MAP_SITES,
+        KELADI_CHENNAMMA_TIMELINE,
+        KELADI_CHENNAMMA_SOURCES
+    };
+}

--- a/frontend/keladi-chennamma-explorer/keladi.css
+++ b/frontend/keladi-chennamma-explorer/keladi.css
@@ -1,0 +1,315 @@
+:root {
+    --primary-color: #065f46;
+    --primary-gradient: linear-gradient(135deg, #064e3b 0%, #047857 50%, #059669 100%);
+    --accent-gold: #f59e0b;
+    --accent-amber: #fbbf24;
+    --card-bg: rgba(6, 78, 59, 0.45);
+    --card-border: rgba(251, 191, 36, 0.25);
+    --text-light: #ecfdf5;
+    --text-muted: #a7f3d0;
+}
+
+body.keladi-main {
+    background-color: #022c22;
+    color: var(--text-light);
+    font-family: 'Outfit', sans-serif;
+    margin: 0;
+    padding: 0;
+    line-height: 1.6;
+}
+
+body.keladi-main.light-theme {
+    background-color: #f0fdf4;
+    color: #022c22;
+    --card-bg: rgba(255, 255, 255, 0.92);
+    --card-border: rgba(4, 120, 87, 0.25);
+    --text-light: #064e3b;
+    --text-muted: #047857;
+}
+
+.keladi-hero {
+    padding: 6.5rem 1.5rem 3.5rem;
+    background: var(--primary-gradient);
+    text-align: center;
+    position: relative;
+    border-bottom: 2px solid var(--accent-gold);
+}
+
+.hero-badges-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+}
+
+.hero-pill {
+    padding: 0.4rem 1.1rem;
+    border-radius: 9999px;
+    font-size: 0.875rem;
+    font-weight: 600;
+    background: rgba(0, 0, 0, 0.3);
+    border: 1px solid var(--accent-amber);
+    color: #fff;
+    backdrop-filter: blur(8px);
+}
+
+.keladi-hero h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2.85rem;
+    font-weight: 800;
+    margin-bottom: 0.5rem;
+    color: #ffffff;
+    text-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.keladi-hero h1 span {
+    color: var(--accent-amber);
+    display: block;
+    font-size: 1.75rem;
+    font-weight: 600;
+    margin-top: 0.25rem;
+}
+
+.hero-subtitle {
+    max-width: 860px;
+    margin: 0 auto 2.5rem;
+    font-size: 1.15rem;
+    color: var(--text-muted);
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1.25rem;
+    max-width: 1050px;
+    margin: 0 auto;
+}
+
+.stat-card {
+    background: rgba(2, 44, 34, 0.65);
+    border: 1px solid var(--card-border);
+    padding: 1.25rem 1rem;
+    border-radius: 14px;
+    text-align: center;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.18);
+    transition: transform 0.2s ease;
+}
+
+.stat-card:hover {
+    transform: translateY(-3px);
+}
+
+.stat-icon {
+    font-size: 1.8rem;
+    margin-bottom: 0.4rem;
+    display: block;
+}
+
+.stat-val {
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: var(--accent-amber);
+    margin-bottom: 0.2rem;
+}
+
+.stat-lbl {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+}
+
+.section-container {
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: 3.5rem 1.5rem;
+}
+
+.section-container h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2.15rem;
+    margin-bottom: 1.75rem;
+    color: var(--accent-amber);
+    border-bottom: 2px solid var(--card-border);
+    padding-bottom: 0.5rem;
+}
+
+.cards-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1.75rem;
+}
+
+.info-card {
+    background: var(--card-bg);
+    border-radius: 14px;
+    padding: 1.6rem;
+    border: 1px solid var(--card-border);
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.12);
+    transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.info-card:hover {
+    transform: translateY(-4px);
+    border-color: var(--accent-amber);
+}
+
+.info-card h3 {
+    font-size: 1.35rem;
+    color: var(--accent-amber);
+    margin-top: 0;
+    margin-bottom: 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.card-summary {
+    font-size: 0.95rem;
+    color: #ffffff;
+    font-style: italic;
+    margin-bottom: 1rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 1px dashed rgba(251, 191, 36, 0.2);
+}
+
+.light-theme .card-summary {
+    color: #065f46;
+}
+
+.card-details-list {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+}
+
+.card-details-list li {
+    position: relative;
+    padding-left: 1.35rem;
+    margin-bottom: 0.65rem;
+    font-size: 0.95rem;
+}
+
+.card-details-list li::before {
+    content: "🛡️";
+    position: absolute;
+    left: 0;
+    font-size: 0.75rem;
+    top: 0.2rem;
+}
+
+/* Map sites */
+.map-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+}
+
+.map-card {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 12px;
+    padding: 1.4rem;
+    border-left: 4px solid var(--accent-gold);
+}
+
+.map-card h3 {
+    color: var(--accent-amber);
+    margin: 0 0 0.25rem 0;
+}
+
+.map-region {
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: var(--accent-gold);
+    margin-bottom: 0.5rem;
+}
+
+.map-role {
+    font-weight: 600;
+    font-size: 0.9rem;
+    margin-bottom: 0.5rem;
+}
+
+/* Timeline */
+.timeline-container {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.timeline-card {
+    display: flex;
+    gap: 1.5rem;
+    background: var(--card-bg);
+    padding: 1.35rem;
+    border-radius: 12px;
+    border: 1px solid var(--card-border);
+    border-left: 4px solid var(--accent-amber);
+}
+
+.timeline-year {
+    font-weight: 800;
+    color: var(--accent-amber);
+    min-width: 150px;
+    font-size: 1.05rem;
+}
+
+.timeline-content h3 {
+    margin: 0 0 0.4rem 0;
+    font-size: 1.15rem;
+}
+
+.timeline-content p {
+    margin: 0;
+    font-size: 0.95rem;
+}
+
+/* Sources */
+.sources-list {
+    list-style: none;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 1.25rem;
+}
+
+.source-item {
+    background: var(--card-bg);
+    padding: 1.25rem;
+    border-radius: 10px;
+    border: 1px solid var(--card-border);
+}
+
+.source-title {
+    font-weight: 700;
+    color: var(--accent-amber);
+    font-size: 1.05rem;
+    margin-bottom: 0.25rem;
+}
+
+.source-meta {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    margin-bottom: 0.5rem;
+}
+
+.source-note {
+    font-size: 0.9rem;
+}
+
+@media (max-width: 768px) {
+    .keladi-hero h1 {
+        font-size: 2.1rem;
+    }
+    .keladi-hero h1 span {
+        font-size: 1.35rem;
+    }
+    .timeline-card {
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+    .timeline-year {
+        min-width: unset;
+    }
+}

--- a/frontend/keladi-chennamma-explorer/keladi.js
+++ b/frontend/keladi-chennamma-explorer/keladi.js
@@ -1,0 +1,102 @@
+document.addEventListener('DOMContentLoaded', () => {
+    renderStats();
+    renderSections();
+    renderMapSites();
+    renderTimeline();
+    renderSources();
+    initThemeToggle();
+});
+
+function renderStats() {
+    const grid = document.getElementById('stats-grid');
+    if (!grid || typeof KELADI_CHENNAMMA_INFO === 'undefined') return;
+
+    grid.innerHTML = KELADI_CHENNAMMA_INFO.quickStats
+        .map(
+            stat => `
+        <div class="stat-card">
+            <span class="stat-icon">${stat.icon}</span>
+            <div class="stat-val">${stat.value}</div>
+            <div class="stat-lbl">${stat.label}</div>
+        </div>
+    `
+        )
+        .join('');
+}
+
+function renderSections() {
+    const grid = document.getElementById('sections-grid');
+    if (!grid || typeof KELADI_CHENNAMMA_SECTIONS === 'undefined') return;
+
+    grid.innerHTML = KELADI_CHENNAMMA_SECTIONS.map(
+        sec => `
+        <div class="info-card" id="${sec.id}">
+            <h3>${sec.icon} ${sec.title}</h3>
+            <div class="card-summary">${sec.summary}</div>
+            <ul class="card-details-list">
+                ${sec.details.map(d => `<li>${d}</li>`).join('')}
+            </ul>
+        </div>
+    `
+    ).join('');
+}
+
+function renderMapSites() {
+    const grid = document.getElementById('map-grid');
+    if (!grid || typeof KELADI_TERRITORY_MAP_SITES === 'undefined') return;
+
+    grid.innerHTML = KELADI_TERRITORY_MAP_SITES.map(
+        site => `
+        <div class="map-card">
+            <h3>📍 ${site.name}</h3>
+            <div class="map-region">${site.region}</div>
+            <div class="map-role">${site.role}</div>
+            <p>${site.desc}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function renderTimeline() {
+    const container = document.getElementById('timeline-container');
+    if (!container || typeof KELADI_CHENNAMMA_TIMELINE === 'undefined') return;
+
+    container.innerHTML = KELADI_CHENNAMMA_TIMELINE.map(
+        item => `
+        <div class="timeline-card">
+            <div class="timeline-year">${item.year}</div>
+            <div class="timeline-content">
+                <h3>${item.title}</h3>
+                <p>${item.desc}</p>
+            </div>
+        </div>
+    `
+    ).join('');
+}
+
+function renderSources() {
+    const list = document.getElementById('sources-list');
+    if (!list || typeof KELADI_CHENNAMMA_SOURCES === 'undefined') return;
+
+    list.innerHTML = KELADI_CHENNAMMA_SOURCES.map(
+        src => `
+        <li class="source-item">
+            <div class="source-title">📖 ${src.work}</div>
+            <div class="source-meta"><strong>Author:</strong> ${src.author} (${src.year})</div>
+            <div class="source-note">${src.note}</div>
+        </li>
+    `
+    ).join('');
+}
+
+function initThemeToggle() {
+    const toggle = document.getElementById('theme-toggle');
+    if (!toggle) return;
+
+    toggle.addEventListener('click', () => {
+        document.body.classList.toggle('light-theme');
+        const currentTheme = document.body.classList.contains('light-theme') ? 'light' : 'dark';
+        localStorage.setItem('theme', currentTheme);
+        toggle.textContent = currentTheme === 'light' ? '🌙' : '☀️';
+    });
+}

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -6022,8 +6022,7 @@ window.indiaSearchIndex = [
         description:
             "Explore Kalsubai Peak Trek (1,646m) in Maharashtra: detailed route, Kalsubai Temple summit details, steel ladders climbing, monsoon waterfalls, gear checklist, and duration estimator.",
         url: "frontend/kalsubai-trek/index.html"
->>>>>>
-        url: "frontend/kheerganga-trek/index.html"},
+    },
     // --- feat/tarsar-marsar-trek ---
     {
         title: "Tarsar Marsar Trek — Twin Alpine Lakes of Kashmir",
@@ -6031,5 +6030,13 @@ window.indiaSearchIndex = [
         description:
             "Explore Tarsar Marsar Trek (4,100m) in Kashmir: detailed route steps, Aru Valley base, Lidderwat meadows, Sundersar, and the twin almond-shaped glacial lakes of Tarsar and Marsar.",
         url: "frontend/tarsar-marsar-trek/index.html"
+    },
+    // --- Keladi Chennamma Explorer ---
+    {
+        title: "Keladi Chennamma — The Queen Who Defended the Keladi Kingdom Explorer",
+        category: "History & Royalty",
+        description:
+            "Explore Keladi Chennamma (reign 1671–1696 CE) — Queen of Bednore: shelter to Chhatrapati Rajaram, defiance of Aurangzeb's Mughal army, and coastal Karnataka heritage.",
+        url: "frontend/keladi-chennamma-explorer/index.html"
     }
 ];

--- a/frontend/tests/unit/keladi-chennamma-explorer.test.js
+++ b/frontend/tests/unit/keladi-chennamma-explorer.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadKeladiData() {
+    const code = readFileSync(
+        resolve(__dirname, '../../keladi-chennamma-explorer/keladi-data.js'),
+        'utf-8'
+    );
+    const fn = new Function(
+        code + '\nreturn { KELADI_CHENNAMMA_INFO, KELADI_CHENNAMMA_SECTIONS, KELADI_TERRITORY_MAP_SITES, KELADI_CHENNAMMA_TIMELINE, KELADI_CHENNAMMA_SOURCES };'
+    );
+    return fn();
+}
+
+describe('Keladi Chennamma Explorer — Data & Content Tests', () => {
+    let data;
+
+    beforeAll(() => {
+        data = loadKeladiData();
+    });
+
+    describe('KELADI_CHENNAMMA_INFO metadata', () => {
+        it('contains correct Keladi Chennamma title, dynasty, and capital data', () => {
+            expect(data.KELADI_CHENNAMMA_INFO.id).toBe('keladi-chennamma');
+            expect(data.KELADI_CHENNAMMA_INFO.title).toContain('Keladi Chennamma');
+            expect(data.KELADI_CHENNAMMA_INFO.dynasty).toContain('Keladi');
+            expect(data.KELADI_CHENNAMMA_INFO.capital).toContain('Bednore');
+        });
+
+        it('has quickStats array with 6 relevant items', () => {
+            expect(Array.isArray(data.KELADI_CHENNAMMA_INFO.quickStats)).toBe(true);
+            expect(data.KELADI_CHENNAMMA_INFO.quickStats.length).toBe(6);
+        });
+    });
+
+    describe('KELADI_CHENNAMMA_SECTIONS historical topics', () => {
+        it('contains all 6 required historical and administrative topics', () => {
+            expect(Array.isArray(data.KELADI_CHENNAMMA_SECTIONS)).toBe(true);
+            expect(data.KELADI_CHENNAMMA_SECTIONS.length).toBe(6);
+
+            const sectionIds = data.KELADI_CHENNAMMA_SECTIONS.map(s => s.id);
+            expect(sectionIds).toContain('who-was-chennamma');
+            expect(sectionIds).toContain('keladi-kingdom');
+            expect(sectionIds).toContain('rise-to-power');
+            expect(sectionIds).toContain('political-leadership');
+            expect(sectionIds).toContain('mughal-resistance');
+            expect(sectionIds).toContain('coastal-heritage');
+        });
+
+        it('ensures each section has title, icon, summary, and non-empty details array', () => {
+            data.KELADI_CHENNAMMA_SECTIONS.forEach(sec => {
+                expect(sec.title).toBeTruthy();
+                expect(sec.icon).toBeTruthy();
+                expect(sec.summary).toBeTruthy();
+                expect(Array.isArray(sec.details)).toBe(true);
+                expect(sec.details.length).toBeGreaterThanOrEqual(3);
+            });
+        });
+    });
+
+    describe('KELADI_TERRITORY_MAP_SITES & KELADI_CHENNAMMA_TIMELINE', () => {
+        it('contains key territory centers: Bednore, Ikkeri, Honnavar, and Mirjan/Bekal Forts', () => {
+            expect(Array.isArray(data.KELADI_TERRITORY_MAP_SITES)).toBe(true);
+            expect(data.KELADI_TERRITORY_MAP_SITES.length).toBeGreaterThanOrEqual(4);
+
+            const names = data.KELADI_TERRITORY_MAP_SITES.map(s => s.name);
+            expect(names.some(n => n.includes('Bednore'))).toBe(true);
+            expect(names.some(n => n.includes('Ikkeri'))).toBe(true);
+            expect(names.some(n => n.includes('Bekal'))).toBe(true);
+        });
+
+        it('contains chronological timeline covering c. 1650 to 1696 CE', () => {
+            expect(Array.isArray(data.KELADI_CHENNAMMA_TIMELINE)).toBe(true);
+            expect(data.KELADI_CHENNAMMA_TIMELINE.length).toBe(6);
+            expect(data.KELADI_CHENNAMMA_TIMELINE[0].year).toContain('1650');
+            expect(data.KELADI_CHENNAMMA_TIMELINE[data.KELADI_CHENNAMMA_TIMELINE.length - 1].year).toContain('1696');
+        });
+    });
+
+    describe('KELADI_CHENNAMMA_SOURCES historical references', () => {
+        it('cites Linganna Kavi (Keladinripavijaya), Swaminathan, Shastry, and Stewart Gordon', () => {
+            expect(Array.isArray(data.KELADI_CHENNAMMA_SOURCES)).toBe(true);
+            expect(data.KELADI_CHENNAMMA_SOURCES.length).toBeGreaterThanOrEqual(4);
+
+            const authors = data.KELADI_CHENNAMMA_SOURCES.map(s => s.author);
+            expect(authors.some(a => a.includes('Linganna'))).toBe(true);
+            expect(authors.some(a => a.includes('Swaminathan'))).toBe(true);
+            expect(authors.some(a => a.includes('Gordon'))).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
# Pull Request

## Description

Create a dedicated historical profile for **Keladi Chennamma** (reign 1671–1696 CE), the 17th-century sovereign queen of the Keladi Nayaka kingdom in present-day Karnataka, celebrating her defense against Mughal expansion and shelter to Chhatrapati Rajaram.

Fixes #3400

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Tested locally in browser
- [x] Tested in both dark and light themes
- [x] Tested at mobile viewport widths
- [x] Verified no console errors

## Checklist

- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)

## Screenshots (if applicable)

N/A
