### PR TITLE
feat: Add Nongriat Trek — Meghalaya #3169

### DIFF
--- a/frontend/nongriat-trek/index.html
+++ b/frontend/nongriat-trek/index.html
@@ -1,0 +1,360 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.documentElement.setAttribute('data-theme', 'light');
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Nongriat Trek in Meghalaya — descend 3,500 stone steps into a rainforest gorge to the Double-Decker Living Root Bridge, swim in turquoise natural pools, and trek on to Rainbow Falls in the East Khasi Hills.">
+    <title>Nongriat Trek — Meghalaya | Incredible India Explorer</title>
+    <link rel="icon" href="data:,">
+
+    <!-- Preload Critical Fonts -->
+    <link rel="preload" href="../../assets/fonts/Outfit-400.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="../../assets/fonts/Outfit-700.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="../../assets/fonts/PlayfairDisplay-400.woff2" as="font" type="font/woff2" crossorigin>
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="style.css">
+
+    <meta property="og:title" content="Nongriat Trek — Meghalaya | Incredible India Explorer">
+    <meta property="og:description" content="Descend into the rainforest gorges of the East Khasi Hills to Nongriat village — home of the Umshiang Double-Decker Living Root Bridge, turquoise natural pools and Rainbow Falls.">
+    <meta property="og:image" content="https://upload.wikimedia.org/wikipedia/commons/thumb/0/07/Umshiang_Double-Decker_Root_Bridge_01.jpg/1280px-Umshiang_Double-Decker_Root_Bridge_01.jpg">
+    <meta property="og:type" content="website">
+</head>
+
+<body>
+    <header class="navbar" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+
+                <div class="nav-dropdown">
+                    <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Nature ▾</button>
+                    <div class="dropdown-menu">
+                        <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
+                        <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                        <a href="../../frontend/mawryngkhang-trek/index.html" class="dropdown-item">Mawryngkhang Trek — Meghalaya</a>
+                        <a href="../../frontend/nongriat-trek/index.html" class="dropdown-item">Nongriat Trek — Meghalaya</a>
+                        <a href="../../frontend/nohkalikai-falls-explorer/index.html" class="dropdown-item">Nohkalikai Falls Explorer</a>
+                        <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                    </div>
+                </div>
+
+                <div class="nav-dropdown">
+                    <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
+                    <div class="dropdown-menu">
+                        <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+                        <a href="../../frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
+                        <a href="../../frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
+                        <a href="../../frontend/event-discovery/index.html" class="dropdown-item">Festival & Event Discovery</a>
+                        <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
+                        <a href="../../frontend/khasi-language-explorer/index.html" class="dropdown-item">Khasi Language Explorer</a>
+                    </div>
+                </div>
+
+                <div class="nav-dropdown">
+                    <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Games ▾</button>
+                    <div class="dropdown-menu">
+                        <a href="../../frontend/passport-quest/passport-quest.html" class="dropdown-item">Passport Quest</a>
+                        <a href="../../frontend/culinary-game/culinary-game.html" class="dropdown-item">Culinary Challenge</a>
+                        <a href="../../frontend/monsoon-game/monsoon-game.html" class="dropdown-item">Monsoon Game</a>
+                        <a href="../../frontend/river-game/river-game.html" class="dropdown-item">River Explorer</a>
+                        <a href="../../frontend/geo-guesser-india/index.html" class="dropdown-item">GeoGuesser</a>
+                    </div>
+                </div>
+
+                <div class="nav-dropdown">
+                    <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Community ▾</button>
+                    <div class="dropdown-menu">
+                        <a href="../../frontend/contributors/contributors.html" class="dropdown-item">Contributors</a>
+                        <a href="../../frontend/world-records-india/index.html" class="dropdown-item">World Records</a>
+                    </div>
+                </div>
+
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+            </nav>
+        </div>
+    </header>
+
+    <main class="ngt-page">
+        <!-- Hero Banner -->
+        <section class="ngt-hero" id="top">
+            <img
+                class="ngt-hero-bg"
+                src="https://upload.wikimedia.org/wikipedia/commons/thumb/0/07/Umshiang_Double-Decker_Root_Bridge_01.jpg/1280px-Umshiang_Double-Decker_Root_Bridge_01.jpg"
+                alt="The Umshiang Double-Decker Living Root Bridge spanning its stream in the forested gorge of Nongriat, Meghalaya"
+                fetchpriority="high"
+            />
+            <div class="ngt-hero-overlay" aria-hidden="true"></div>
+            <div class="ngt-hero-content">
+                <span class="hero-kicker anim-fade-down">Meghalaya • East Khasi Hills • Max Alt ~1,125 m (valley floor)</span>
+                <h1 class="hero-title anim-fade-up delay-1">Nongriat <span>Trek</span></h1>
+                <p class="hero-subtitle anim-fade-up delay-2">A staircase of 3,500 steps drops from the Sohra plateau into a rainforest gorge where living root bridges span turquoise streams — Khasi engineering grown, not built.</p>
+
+                <div class="hero-stats-bar anim-fade-up delay-3">
+                    <div class="stat-chip">
+                        <span class="stat-num" data-count="3500">0</span>
+                        <span class="stat-lbl">Stone Steps Down From Tyrna</span>
+                    </div>
+                    <div class="stat-chip">
+                        <span class="stat-num">6–8</span>
+                        <span class="stat-lbl">Km Round Trip To The Village</span>
+                    </div>
+                    <div class="stat-chip">
+                        <span class="stat-num">4–6</span>
+                        <span class="stat-lbl">Hours Typical Duration</span>
+                    </div>
+                    <div class="stat-chip">
+                        <span class="stat-num">Mod–Hard</span>
+                        <span class="stat-lbl">Difficulty Grade</span>
+                    </div>
+                </div>
+
+                <a href="#overview" class="hero-cta anim-fade-up delay-4">Explore the Trek ↓</a>
+            </div>
+        </section>
+
+        <!-- Overview Section -->
+        <section class="section-block" id="overview">
+            <div class="section-heading reveal">
+                <span class="section-badge">Trek Overview</span>
+                <h2 class="section-title">The Gorge of Growing Bridges</h2>
+                <p class="section-subtext">Below the rain-soaked plateau of Cherrapunji, the trail descends into one of the wettest inhabited valleys on Earth — a subtropical jungle threaded by streams that the Khasi people have learned to cross with trees.</p>
+            </div>
+
+            <div class="overview-grid">
+                <article class="overview-card reveal">
+                    <h3>📍 Trek Location</h3>
+                    <p>Nongriat is a small Khasi village in the East Khasi Hills district of Meghalaya, about 15 km south of Cherrapunji (Sohra) and roughly 55 km from Shillong. It sits deep in a gorge of the Umngot river basin at around 25.25° N, 91.67° E, surrounded by dense evergreen forest and crossed by clear jungle streams.</p>
+                </article>
+                <article class="overview-card reveal delay-1">
+                    <h3>🚩 Starting Point</h3>
+                    <p>The trek begins at Tyrna village, the last roadhead on the Sohra–Laitkynsew road about 30–45 minutes by taxi from Cherrapunji. From Tyrna's gate, roughly 3,500 concrete steps plunge toward the valley floor, crossing wire suspension bridges before reaching Nongriat.</p>
+                </article>
+                <article class="overview-card reveal delay-2">
+                    <h3>🌳 Forest Landscape</h3>
+                    <p>The descent passes through layered subtropical evergreen forest — betel nut gardens, bay leaf and jackfruit trees, wild bananas and moss-draped ficus giants. Cicadas hum through the canopy, kingfishers patrol the pools, and the humid air smells of rain even in the dry season.</p>
+                </article>
+                <article class="overview-card reveal delay-3">
+                    <h3>🌉 Living Root Heritage</h3>
+                    <p>For centuries the Khasi people have trained the aerial roots of Ficus elastica (rubber fig) across streams to grow into bridges — jingkieng jri. Nongriat's Umshiang Double-Decker Root Bridge is the most celebrated of them all: two stacked spans, matured over some 200 years, still alive and growing stronger every year.</p>
+                </article>
+            </div>
+        </section>
+
+        <!-- Facts Section -->
+        <section class="section-block" id="facts">
+            <div class="section-heading reveal">
+                <span class="section-badge">Trek Profile</span>
+                <h2 class="section-title">Nongriat Trek at a Glance</h2>
+            </div>
+            <div class="facts-grid" id="facts-grid">
+                <!-- Injected by script.js -->
+            </div>
+        </section>
+
+        <!-- Living Root Bridges Section -->
+        <section class="section-block" id="bridges">
+            <div class="section-heading reveal">
+                <span class="section-badge">Living Root Bridges</span>
+                <h2 class="section-title">Bridges That Are Alive</h2>
+                <p class="section-subtext">Jingkieng jri are not built but grown — Ficus elastica roots guided across streams on hollowed trunks for 15–30 years until they carry people alone. A mature bridge can hold dozens of walkers and outlast any steel structure, strengthening rather than decaying with age.</p>
+            </div>
+            <div class="features-grid" id="bridges-grid">
+                <!-- Injected by script.js -->
+            </div>
+        </section>
+
+        <!-- Waterfalls & Natural Pools Section -->
+        <section class="section-block" id="waterfalls">
+            <div class="section-heading reveal">
+                <span class="section-badge">Waterfalls & Pools</span>
+                <h2 class="section-title">The Wettest Valley on Earth</h2>
+                <p class="section-subtext">Cherrapunji's legendary rainfall feeds everything here — streams run turquoise between smooth boulders, and waterfalls pour over every cliff around the gorge.</p>
+            </div>
+            <div class="viewpoints-grid" id="waterfalls-grid">
+                <!-- Injected by script.js -->
+            </div>
+        </section>
+
+        <!-- Route Information Section -->
+        <section class="section-block" id="route">
+            <div class="section-heading reveal">
+                <span class="section-badge">Route Highlights</span>
+                <h2 class="section-title">Tyrna to Nongriat and Rainbow Falls — Stage by Stage</h2>
+                <p class="section-subtext">The classic day walk descends from Tyrna to the Double-Decker Bridge, continues to the Blue Lagoon and Rainbow Falls, then climbs back out the same way. An overnight in the village turns it into a relaxed two-day journey.</p>
+            </div>
+            <div class="routes-grid" id="routes-grid">
+                <!-- Injected by script.js -->
+            </div>
+        </section>
+
+        <!-- Nearby Destinations Section -->
+        <section class="section-block" id="nearby">
+            <div class="section-heading reveal">
+                <span class="section-badge">Nearby Attractions</span>
+                <h2 class="section-title">Extend Your Journey</h2>
+                <p class="section-subtext">The Sohra plateau and the Khasi Hills around the gorge pack in waterfalls, caves and viewpoints — pair your trek with these nearby highlights.</p>
+            </div>
+            <div class="nearby-grid" id="nearby-grid">
+                <!-- Injected by script.js -->
+            </div>
+        </section>
+
+        <!-- Map Section -->
+        <section class="section-block" id="map">
+            <div class="section-heading reveal">
+                <span class="section-badge">Trek Map</span>
+                <h2 class="section-title">Where the Gorge Lies</h2>
+                <p class="section-subtext">The trail runs from Tyrna on the plateau rim down to Nongriat on the valley floor, and onward to Rainbow Falls deeper in the gorge near the Bangladesh border.</p>
+            </div>
+            <div class="map-card reveal">
+                <iframe
+                    class="map-frame"
+                    title="OpenStreetMap — Nongriat Trek between Tyrna village, the Double-Decker Root Bridge and Rainbow Falls"
+                    src="https://www.openstreetmap.org/export/embed.html?bbox=91.63%2C25.22%2C91.72%2C25.29&layer=mapnik&marker=25.2510%2C91.6714"
+                    loading="lazy"
+                    referrerpolicy="no-referrer-when-downgrade"
+                ></iframe>
+                <div class="map-meta">
+                    <span class="coords">Nongriat · 25.2510° N · 91.6714° E</span>
+                    <a href="https://www.openstreetmap.org/?mlat=25.2510&mlon=91.6714#map=14/25.2510/91.6714" target="_blank" rel="noopener noreferrer">View larger map ↗</a>
+                </div>
+            </div>
+        </section>
+
+        <!-- Gallery Section -->
+        <section class="section-block" id="gallery">
+            <div class="section-heading reveal">
+                <span class="section-badge">Image Gallery</span>
+                <h2 class="section-title">Visual Story of the Gorge</h2>
+                <p class="section-subtext">Photographs of the root bridges, falls, pools and forests of Nongriat — click any image to view it larger. Each photo is credited to its source.</p>
+            </div>
+            <div class="gallery-grid" id="gallery-grid">
+                <!-- Injected by script.js -->
+            </div>
+        </section>
+
+        <!-- Permits & Safety Section -->
+        <section class="section-block" id="permits">
+            <div class="section-heading reveal">
+                <span class="section-badge">Permits & Responsible Travel</span>
+                <h2 class="section-title">Plan With Safety and Respect</h2>
+            </div>
+
+            <div class="permit-grid">
+                <article class="permit-card reveal">
+                    <h3>🎟️ Entry Fees & Timing</h3>
+                    <p>A modest entry fee is collected at the Tyrna gate for maintaining the steps and bridges, with small additional camera charges and a parking fee at the roadhead. The trail is generally open from early morning to late afternoon; note that access has at times been closed on Sundays — check locally before setting out.</p>
+                </article>
+                <article class="permit-card reveal delay-1">
+                    <h3>🥾 Fitness & Footwear</h3>
+                    <p>The climb out of the gorge is the hardest part — thousands of uneven, often damp steps. Wear grippy shoes, start early, carry at least 1.5 litres of water, and allow 2–3 hours for the ascent. Those with knee issues should consider trekking poles; overnighting in Nongriat splits the effort comfortably.</p>
+                </article>
+                <article class="permit-card reveal delay-2">
+                    <h3>🌧️ Weather Sense</h3>
+                    <p>October to April is safest and driest; post-monsoon months show the falls at full thunder. During heavy monsoon rain the steps turn slick and streams rise fast — avoid crossing suspension bridges or swimming in the pools when flows are high, and never enter the water after storms.</p>
+                </article>
+                <article class="permit-card reveal delay-3">
+                    <h3>🌿 Walk Lightly</h3>
+                    <p>The bridges are sacred, living structures — never climb on their railings, cut or pull the roots. Carry all plastic waste back up to Tyrna, keep noise low in the forest, hire local guides and stay in village homestays so tourism income stays with the community that grows these bridges.</p>
+                </article>
+            </div>
+
+            <div class="safety-box reveal">
+                <h3>⚠️ Trail Safety Notice</h3>
+                <p>This page is for educational exploration only. The Nongriat Trek involves steep staircases, swaying wire bridges and swift monsoon streams — always confirm current conditions, fees and access rules with local guides, the village council or Meghalaya Tourism before planning any real-world trekking decisions.</p>
+            </div>
+        </section>
+
+        <!-- Image Credits Section -->
+        <section class="section-block credits-section" id="image-credits">
+            <div class="section-heading reveal">
+                <span class="section-badge">Attribution</span>
+                <h2 class="section-title">Image Credits</h2>
+                <p class="section-subtext">Gallery photographs are hosted on Wikimedia Commons under Creative Commons licenses. Full license details are available on each linked file page.</p>
+            </div>
+            <ul class="credits-list reveal" id="credits-list">
+                <!-- Injected by script.js -->
+            </ul>
+        </section>
+    </main>
+
+    <!-- Image Lightbox -->
+    <div class="ngt-lightbox" id="ngt-lightbox" role="dialog" aria-modal="true" aria-label="Image viewer" hidden>
+        <button class="ngt-lightbox-close" id="ngt-lightbox-close" aria-label="Close image viewer">×</button>
+        <button class="ngt-lightbox-nav prev" id="ngt-lightbox-prev" aria-label="Previous image">‹</button>
+        <figure class="ngt-lightbox-figure">
+            <img id="ngt-lightbox-image" src="" alt="">
+            <figcaption>
+                <strong id="ngt-lightbox-title"></strong>
+                <span id="ngt-lightbox-caption"></span>
+                <a id="ngt-lightbox-credit" href="#" target="_blank" rel="noopener noreferrer" aria-label="View image source and license on Wikimedia Commons"></a>
+            </figcaption>
+        </figure>
+        <button class="ngt-lightbox-nav next" id="ngt-lightbox-next" aria-label="Next image">›</button>
+    </div>
+
+    <!-- Footer -->
+    <footer class="site-footer">
+        <div class="footer-container">
+            <div class="footer-brand">
+                <a href="../../index.html#home" class="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <p>Dedicated trek profile for the Nongriat Trek — documenting the living root bridges of the Khasi Hills, the waterfalls and pools of the Sohra gorge, and one of the world's great examples of bio-engineering in Meghalaya.</p>
+            </div>
+            <div class="footer-links">
+                <h4>Trek Sections</h4>
+                <a href="#overview">Trek Overview</a>
+                <a href="#facts">Trek Profile</a>
+                <a href="#bridges">Living Root Bridges</a>
+                <a href="#waterfalls">Waterfalls & Pools</a>
+                <a href="#route">Route Highlights</a>
+            </div>
+            <div class="footer-links">
+                <h4>Plan & Explore</h4>
+                <a href="#nearby">Nearby Attractions</a>
+                <a href="#map">Trek Map</a>
+                <a href="#gallery">Image Gallery</a>
+                <a href="#permits">Permits & Responsible Travel</a>
+                <a href="#image-credits">Image Credits</a>
+            </div>
+            <div class="footer-links">
+                <h4>More Meghalaya</h4>
+                <a href="../../frontend/mawryngkhang-trek/index.html">Mawryngkhang Bamboo Trek</a>
+                <a href="../../frontend/nohkalikai-falls-explorer/index.html">Nohkalikai Falls Explorer</a>
+                <a href="../../frontend/nohsngithiang-falls-explorer/index.html">Nohsngithiang Falls Explorer</a>
+                <a href="../../frontend/MeghalayaTraditionalHouses/index.html">Meghalaya Traditional Houses</a>
+            </div>
+        </div>
+        <div class="footer-bottom">
+            <p>&copy; 2026 Incredible India Explorer · Part of the <a href="../../index.html">Incredible India Explorer</a> project. Trek information is educational; always verify fees, access rules and conditions locally.</p>
+        </div>
+    </footer>
+
+    <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+
+    <script type="module" src="../app.js"></script>
+    <script type="module" src="script.js"></script>
+</body>
+</html>

--- a/frontend/nongriat-trek/script.js
+++ b/frontend/nongriat-trek/script.js
@@ -1,0 +1,562 @@
+export const NGRIAT_TREK_DATA = {
+    name: "Nongriat Trek",
+    title: "Nongriat Trek — Meghalaya",
+    state: "Meghalaya",
+    region: "East Khasi Hills — forested gorge below Cherrapunji (Sohra), near the Umngot river basin",
+    startingPoint: "Tyrna village (~3,500 steps above Nongriat)",
+    maxAltitude: "Valley floor at ~1,125 m, descending from the ~1,600 m Sohra plateau rim",
+    distance: "~6–8 km round trip to the village; ~10–11 km with Rainbow Falls",
+    duration: "4–6 hours round trip; a relaxed 1–2 days with an overnight in Nongriat",
+    difficulty: "Moderate to Difficult — steep staircases and swaying wire bridges",
+    bestSeason: "October–April; post-monsoon months show waterfalls at their fullest",
+    permits: "Small entry fee at the Tyrna gate plus camera charges; access has at times been closed on Sundays",
+
+    overview: {
+        location: "Nongriat is a small Khasi village in the East Khasi Hills district of Meghalaya, about 15 km south of Cherrapunji (Sohra) and roughly 55 km from Shillong. It sits deep in a forested gorge of the Umngot river basin at around 25.25° N, 91.67° E, threaded by clear jungle streams.",
+        landscape: "The descent passes through layered subtropical evergreen forest — betel nut gardens, bay leaf and jackfruit trees, wild bananas and moss-draped ficus giants. Cicadas hum through the canopy, kingfishers patrol the pools, and the humid air smells of rain even in the dry season.",
+        heritage: "For centuries the Khasi people have trained the aerial roots of Ficus elastica across streams to grow into bridges known as jingkieng jri. Nongriat's Umshiang Double-Decker Root Bridge is the most celebrated of them all: two stacked spans matured over some 200 years, still alive and growing stronger every year.",
+    },
+
+    facts: [
+        {
+            title: "Trek Location",
+            value: "East Khasi Hills",
+            description: "Nongriat village lies about 15 km from Cherrapunji (Sohra) in Meghalaya, deep in a rainforest gorge near the Bangladesh border.",
+            icon: "📍"
+        },
+        {
+            title: "Difficulty",
+            value: "Moderate–Difficult",
+            description: "Around 3,500 concrete steps descend to the valley floor — easy going down, demanding on the climb back out. No technical skill required, only steady knees.",
+            icon: "🧗"
+        },
+        {
+            title: "Distance",
+            value: "~6–8 km Round Trip",
+            description: "Roughly 3–4 km one way from Tyrna to Nongriat. Extending the walk to Rainbow Falls brings the total to about 10–11 km for the day.",
+            icon: "🥾"
+        },
+        {
+            title: "Duration",
+            value: "4–6 Hours",
+            description: "Most visitors complete the return trip in half a day. Staying overnight in a village homestay turns it into a relaxed two-day journey.",
+            icon: "🗓️"
+        },
+        {
+            title: "Best Season",
+            value: "October–April",
+            description: "Dry-season months offer safe, grippy steps. Post-monsoon October and November show the falls roaring while trails have dried out.",
+            icon: "🌤️"
+        },
+        {
+            title: "Starting Point",
+            value: "Tyrna Village",
+            description: "The last roadhead on the Sohra–Laitkynsew road, about 30–45 minutes by taxi from Cherrapunji, marks the top of the staircase descent.",
+            icon: "🚩"
+        },
+        {
+            title: "Living Root Bridges",
+            value: "Double-Decker & More",
+            description: "The village has three functional root bridges, including the famous two-tiered Umshiang Double-Decker, plus a rare root-and-wire hybrid upstream.",
+            icon: "🌉"
+        },
+        {
+            title: "Fees & Access",
+            value: "Gate Fee + Camera",
+            description: "A small entry fee at Tyrna maintains the steps and bridges, with modest camera charges and parking fees. Check locally — Sunday closures apply at times.",
+            icon: "🎟️"
+        }
+    ],
+
+    rootBridges: [
+        {
+            title: "Umshiang Double-Decker Bridge",
+            text: "The star of Nongriat: two bridges stacked one above the other where two streams meet beneath the village. Believed to be around two centuries old, it is often called the only bridge of its kind in the world, and mature roots can carry up to fifty walkers at a time."
+        },
+        {
+            title: "How Bridges Are Grown",
+            text: "Khasi growers plant Ficus elastica saplings on opposite banks, then guide aerial roots across hollowed-out betel trunks and bamboo scaffolding. In 15–30 years the roots fuse into a self-strengthening span — no nails, no cement, a structure that repairs itself as it grows."
+        },
+        {
+            title: "Ritymmen — The Longest Single Span",
+            text: "About 45 minutes down the trail, a fork leads to the 30-metre Ritymmen root bridge at Nongthymmai, the longest known single-decker living root bridge — a worthwhile detour before reaching Nongriat."
+        },
+        {
+            title: "Mawsaw Bridge & Pools",
+            text: "A further 20–30 minutes beyond the Double-Decker lies the Mawsaw root bridge beside beautiful natural swimming pools carved into blue-green rock — inviting in dry season, dangerous when monsoon flows rise."
+        },
+        {
+            title: "The Root-and-Wire Hybrid",
+            text: "Upstream from Nongriat grows a rare hybrid bridge where living ficus roots are interwoven with steel wire cables — a fascinating experiment showing tradition and modern engineering cooperating rather than competing."
+        },
+        {
+            title: "Jingkieng Jri Heritage",
+            text: "Meghalaya's living root bridges were added to UNESCO's tentative World Heritage list as 'Jingkieng Jri: Living Root Bridge Cultural Landscapes' — recognition that these bridges are both infrastructure and a living bond between community and forest."
+        }
+    ],
+
+    waterfalls: [
+        {
+            name: "Rainbow Falls",
+            detail: "Two hours beyond the village, the Umngot river plunges nearly 300 m over a cliff face. On sunny mornings a permanent rainbow arcs through its mist — the finest reward in the gorge and the classic reason to overnight in Nongriat."
+        },
+        {
+            name: "The Blue Lagoon",
+            detail: "Just past the Double-Decker Bridge, a broad pool of transparent turquoise water collects between smooth boulders. Trekkers swim here in the dry season while small fish nibble at their feet."
+        },
+        {
+            name: "Mawsaw Natural Pools",
+            detail: "Beside the Mawsaw root bridge, the stream slides over terraces of blue-green stone into swimmable pools ringed by hanging vines — the prettiest picnic spot close to the village."
+        },
+        {
+            name: "Wire-Bridge Crossings",
+            detail: "Two long wire-rope suspension bridges sway high above turquoise streams on the way into the gorge — thrilling crossings that give the trek its signature adrenaline moment."
+        },
+        {
+            name: "Ka Likai Viewpoint",
+            detail: "From the neighbouring village of Laitkynsew, the great Ka Likai cascade can be seen thundering through autumn-monsoon greenery — part of the same waterfall system that feeds the gorge below."
+        },
+        {
+            name: "Monsoon Thunderfalls",
+            detail: "In the wet season dozens of temporary waterfalls pour off every ledge around the valley. Spectacular from shelter, they also swell the streams — the reason monsoon crossings demand real caution."
+        }
+    ],
+
+    routeStages: [
+        {
+            step: 1,
+            stage: "Tyrna Gate → The Long Descent",
+            altitude: "~1,600 m → ~1,300 m · ~2 km of stone steps",
+            description: "From the Tyrna gate the trail drops immediately onto steep concrete staircases through betel-nut gardens. Roughly 1,500 steps down, the first wire suspension bridge swings into view high above a turquoise stream.",
+            keyHighlight: "Your first swaying wire-bridge crossing above impossibly green water."
+        },
+        {
+            step: 2,
+            stage: "The Fork → Ritymmen Root Bridge (Detour)",
+            altitude: "~1,250 m · optional ~1.5 km detour",
+            description: "A signed fork diverts left to the Ritymmen bridge at Nongthymmai — at 30 metres the longest single-decker living root bridge known. The main path continues right, contouring through forest toward the valley floor.",
+            keyHighlight: "Walking the longest living root bridge in the Khasi Hills before most crowds arrive."
+        },
+        {
+            step: 3,
+            stage: "Second Wire Bridge → Nongriat Village → Double-Decker Bridge",
+            altitude: "~1,125 m · ~3.5–4 km total from Tyrna",
+            description: "Another dramatic wire bridge leads to Nongriat's cluster of homestays. A short walk below the village brings you to the Umshiang Double-Decker Root Bridge — two stacked tiers of living ficus roots spanning the stream junction.",
+            keyHighlight: "Standing on a 200-year-old bridge that is still alive, growing thicker every year."
+        },
+        {
+            step: 4,
+            stage: "Blue Lagoon → Mawsaw Pools → Rainbow Falls",
+            altitude: "~1,100 m · ~2 km one way beyond the bridge",
+            description: "Past the Double-Decker lie the Blue Lagoon swimming hole and the Mawsaw root bridge with its natural pools. The trail then climbs gently upstream for 1.5–2 hours to Rainbow Falls, where the Umngot drops nearly 300 m through permanent rainbow mist.",
+            keyHighlight: "Swimming in turquoise jungle pools, then watching a rainbow hang inside a waterfall's spray."
+        },
+        {
+            step: 5,
+            stage: "Return Climb → Tyrna Gate",
+            altitude: "~1,125 m → ~1,600 m · ~3.5–4 km back up",
+            description: "The way out reverses the descent — thousands of steps reclaimed over 2–3 hours of steady climbing. Start early, pace the stairs, and reward yourself with tea at the stalls near the gate.",
+            keyHighlight: "Looking down from the plateau rim at the forest canopy hiding the bridges you just crossed."
+        }
+    ],
+
+    nearbyDestinations: [
+        {
+            title: "Cherrapunji (Sohra)",
+            text: "The rain capital of the world and your base camp — famous for its limestone caves, orange honey, waterfalls and viewpoints over the Bangladesh plains, just 15 km from the trailhead."
+        },
+        {
+            title: "Nohkalikai Falls",
+            text: "India's tallest plunge waterfall at 340 m, dropping off the Sohra plateau a short drive from Tyrna — best combined with the trek on the same day from Cherrapunji."
+        },
+        {
+            title: "Nohsngithiang (Seven Sisters) Falls",
+            text: "Seven ribbons of water pouring off the plateau escarpment near Mawsmai, spectacular in the wet season and easily paired with the cave visits below."
+        },
+        {
+            title: "Mawsmai & Arwah Caves",
+            text: "Walk-in limestone caves with fossil chambers and naturally lit passages on the Sohra plateau — an easy add-on before or after the trek."
+        },
+        {
+            title: "Wei Sawdong Falls",
+            text: "A trio of turquoise terraced pools reached by bamboo ladders near Sohra, among the most photogenic cascades in Meghalaya."
+        },
+        {
+            title: "Shillong",
+            text: "Meghalaya's charming hill capital, about 55 km away — music cafés, Police Bazar, Umiam Lake views and connections to the rest of Northeast India."
+        }
+    ],
+
+    gallery: [
+        {
+            title: "Umshiang Double-Decker Root Bridge",
+            caption: "Two stacked tiers of living ficus roots spanning the stream junction below Nongriat village.",
+            image: "https://upload.wikimedia.org/wikipedia/commons/thumb/0/07/Umshiang_Double-Decker_Root_Bridge_01.jpg/960px-Umshiang_Double-Decker_Root_Bridge_01.jpg",
+            credit: "Photo: Ganesh Mohan T / Wikimedia Commons (CC BY-SA 4.0)",
+            sourceUrl: "https://commons.wikimedia.org/wiki/File:Umshiang_Double-Decker_Root_Bridge_01.jpg"
+        },
+        {
+            title: "Double-Decker From Below",
+            caption: "Looking up at the Double-Decker Living Root Bridge from the boulders of the stream it crosses.",
+            image: "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a4/Double_decker_living_root_bridge_01.jpg/960px-Double_decker_living_root_bridge_01.jpg",
+            credit: "Photo: Chiranjeeb Baul / Wikimedia Commons (CC BY-SA 4.0)",
+            sourceUrl: "https://commons.wikimedia.org/wiki/File:Double_decker_living_root_bridge_01.jpg"
+        },
+        {
+            title: "Root Bridges of Nongriat",
+            caption: "A living root bridge carrying its vine-draped span across a clear jungle stream in the gorge.",
+            image: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/52/Living_root_bridges%2C_Nongriat_village%2C_Meghalaya.jpg/960px-Living_root_bridges%2C_Nongriat_village%2C_Meghalaya.jpg",
+            credit: "Photo: Arshiya Urveeja Bose / Wikimedia Commons (CC BY 2.0)",
+            sourceUrl: "https://commons.wikimedia.org/wiki/File:Living_root_bridges,_Nongriat_village,_Meghalaya.jpg"
+        },
+        {
+            title: "Rainbow Falls, Nongriat",
+            caption: "The Umngot river plunging into rainbow mist deep in the gorge beyond the village.",
+            image: "https://upload.wikimedia.org/wikipedia/commons/thumb/4/42/SaurabhSawant_RainbowFalls_Nongriat_MG_2913.jpg/960px-SaurabhSawant_RainbowFalls_Nongriat_MG_2913.jpg",
+            credit: "Photo: Saurabhsawantphoto / Wikimedia Commons (CC BY-SA 4.0)",
+            sourceUrl: "https://commons.wikimedia.org/wiki/File:SaurabhSawant_RainbowFalls_Nongriat_MG_2913.jpg"
+        },
+        {
+            title: "Natural Pool Near the Bridges",
+            caption: "Turquoise water gathering between smooth boulders beside the root bridges — the trek's famous swimming holes.",
+            image: "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f8/Natural_Pool_Near_Living_Roots_Bridge.jpg/960px-Natural_Pool_Near_Living_Roots_Bridge.jpg",
+            credit: "Photo: Sai Avinash / Wikimedia Commons (CC BY-SA 4.0)",
+            sourceUrl: "https://commons.wikimedia.org/wiki/File:Natural_Pool_Near_Living_Roots_Bridge.jpg"
+        },
+        {
+            title: "Nohkalikai Falls",
+            caption: "India's tallest plunge waterfall dropping 340 m off the Sohra plateau above the Nongriat gorge.",
+            image: "https://upload.wikimedia.org/wikipedia/commons/thumb/7/78/NohKaLikai_Falls_V2_Wiki.jpg/960px-NohKaLikai_Falls_V2_Wiki.jpg",
+            credit: "Photo: Vikramjit Kakati / Wikimedia Commons (CC BY-SA 4.0)",
+            sourceUrl: "https://commons.wikimedia.org/wiki/File:NohKaLikai_Falls_V2_Wiki.jpg"
+        },
+        {
+            title: "Seven Sisters Waterfalls",
+            caption: "The seven ribbons of Nohsngithiang Falls pouring off the plateau escarpment near Mawsmai.",
+            image: "https://upload.wikimedia.org/wikipedia/commons/thumb/3/30/Seven_Sister_Falls_View.jpg/960px-Seven_Sister_Falls_View.jpg",
+            credit: "Photo: Arindambasu2 / Wikimedia Commons (CC BY-SA 4.0)",
+            sourceUrl: "https://commons.wikimedia.org/wiki/File:Seven_Sister_Falls_View.jpg"
+        },
+        {
+            title: "Forest Trail in the Gorge",
+            caption: "Moss-lined stone steps winding through subtropical forest on the descent toward Nongriat.",
+            image: "https://upload.wikimedia.org/wikipedia/commons/thumb/9/99/Living_root_bridges_of_Nongriat_village_in_East_Khasi_Hills_district%2C_Meghalaya_JEG7387.jpg/960px-Living_root_bridges_of_Nongriat_village_in_East_Khasi_Hills_district%2C_Meghalaya_JEG7387.jpg",
+            credit: "Photo: PJeganathan / Wikimedia Commons (CC BY-SA 4.0)",
+            sourceUrl: "https://commons.wikimedia.org/wiki/File:Living_root_bridges_of_Nongriat_village_in_East_Khasi_Hills_district,_Meghalaya_JEG7387.jpg"
+        }
+    ]
+};
+
+const FALLBACK_IMAGE = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0MDAiIGhlaWdodD0iMjUwIiB2aWV3Qm94PSIwIDAgMTAwIDEwMCI+PHJlY3Qgd2lkdGg9IjEwMCUiIGhlaWdodD0iMTAwJSIgZmlsbD0iIzFlMjkzYiIvPjx0ZXh0IHg9IjUwJSIgeT0iNTUlIiBmb250LXNpemU9IjI0IiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjMzRkMzk5Ij7wn6Kp77iPPC90ZXh0Pjwvc3ZnPg==';
+
+function escapeHtml(value) {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+
+export function renderTrekFacts(facts, container) {
+    if (!container || !Array.isArray(facts)) return;
+
+    container.innerHTML = facts.map(fact => `
+        <article class="fact-card">
+            <div class="fact-icon">${escapeHtml(fact.icon)}</div>
+            <div class="fact-value">${escapeHtml(fact.value)}</div>
+            <h3 class="fact-title">${escapeHtml(fact.title)}</h3>
+            <p class="fact-desc">${escapeHtml(fact.description)}</p>
+        </article>
+    `).join('');
+}
+
+export function renderRootBridges(bridges, container) {
+    if (!container || !Array.isArray(bridges)) return;
+
+    container.innerHTML = bridges.map(bridge => `
+        <article class="feature-card">
+            <div class="feature-icon" aria-hidden="true">🌉</div>
+            <h3>${escapeHtml(bridge.title)}</h3>
+            <p>${escapeHtml(bridge.text)}</p>
+        </article>
+    `).join('');
+}
+
+export function renderWaterfalls(waterfalls, container) {
+    if (!container || !Array.isArray(waterfalls)) return;
+
+    container.innerHTML = waterfalls.map(fall => `
+        <article class="viewpoint-card">
+            <div class="viewpoint-marker" aria-hidden="true">💧</div>
+            <h3>${escapeHtml(fall.name)}</h3>
+            <p>${escapeHtml(fall.detail)}</p>
+        </article>
+    `).join('');
+}
+
+export function renderRouteStages(stages, container) {
+    if (!container || !Array.isArray(stages)) return;
+
+    container.innerHTML = stages.map(stage => `
+        <div class="route-step-card" data-step="${stage.step}">
+            <div class="step-badge">Stage ${stage.step}</div>
+            <h3 class="step-stage">${escapeHtml(stage.stage)}</h3>
+            <div class="step-altitude">📍 Altitude & Distance: ${escapeHtml(stage.altitude)}</div>
+            <p class="step-desc">${escapeHtml(stage.description)}</p>
+            <div class="step-highlight">✨ <strong>Highlight:</strong> ${escapeHtml(stage.keyHighlight)}</div>
+        </div>
+    `).join('');
+}
+
+export function renderNearbyDestinations(destinations, container) {
+    if (!container || !Array.isArray(destinations)) return;
+
+    container.innerHTML = destinations.map(destination => `
+        <article class="nearby-card">
+            <h3>${escapeHtml(destination.title)}</h3>
+            <p>${escapeHtml(destination.text)}</p>
+        </article>
+    `).join('');
+}
+
+export function renderGallery(gallery, container) {
+    if (!container || !Array.isArray(gallery)) return;
+
+    container.innerHTML = gallery.map((item, index) => `
+        <figure class="gallery-card" data-index="${index}" role="button" tabindex="0" aria-label="View larger image: ${escapeHtml(item.title)}">
+            <div class="gallery-img-wrapper">
+                <img
+                    src="${escapeHtml(item.image)}"
+                    alt="${escapeHtml(item.title)}"
+                    class="gallery-img"
+                    loading="lazy"
+                />
+            </div>
+            <figcaption class="gallery-caption">
+                <h4>${escapeHtml(item.title)}</h4>
+                <p>${escapeHtml(item.caption)}</p>
+                <a class="gallery-credit" href="${escapeHtml(item.sourceUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(item.credit)}</a>
+            </figcaption>
+        </figure>
+    `).join('');
+
+    container.querySelectorAll('.gallery-img').forEach((img) => {
+        img.addEventListener('error', () => {
+            img.src = FALLBACK_IMAGE;
+        }, { once: true });
+    });
+}
+
+export function renderImageCredits(gallery, container) {
+    if (!container || !Array.isArray(gallery)) return;
+
+    container.innerHTML = gallery.map(item => `
+        <li>
+            <a href="${escapeHtml(item.sourceUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(item.title)}</a>
+            — ${escapeHtml(item.credit)}.
+        </li>
+    `).join('');
+}
+
+export function prefersReducedMotion() {
+    return typeof window !== 'undefined'
+        && typeof window.matchMedia === 'function'
+        && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+export function initStatCounters() {
+    if (typeof document === 'undefined') return;
+
+    const counters = document.querySelectorAll('.stat-num[data-count]');
+    if (!counters.length) return;
+
+    const formatNumber = value => {
+        try {
+            return value.toLocaleString('en-IN');
+        } catch {
+            return String(value);
+        }
+    };
+
+    const runCounter = el => {
+        const target = parseInt(el.dataset.count, 10);
+        if (Number.isNaN(target)) return;
+        const prefix = el.dataset.prefix || '';
+        const suffix = el.dataset.suffix || '';
+
+        if (prefersReducedMotion() || typeof requestAnimationFrame !== 'function' || typeof performance === 'undefined') {
+            el.textContent = `${prefix}${formatNumber(target)}${suffix}`;
+            return;
+        }
+
+        const duration = 1600;
+        const startTime = performance.now();
+        const tick = now => {
+            const progress = Math.min((now - startTime) / duration, 1);
+            const eased = 1 - Math.pow(1 - progress, 3);
+            el.textContent = `${prefix}${formatNumber(Math.round(target * eased))}${suffix}`;
+            if (progress < 1) requestAnimationFrame(tick);
+        };
+        requestAnimationFrame(tick);
+    };
+
+    if (typeof IntersectionObserver === 'undefined') {
+        counters.forEach(runCounter);
+        return;
+    }
+
+    const counterObserver = new IntersectionObserver((entries, obs) => {
+        entries.forEach(entry => {
+            if (!entry.isIntersecting) return;
+            runCounter(entry.target);
+            obs.unobserve(entry.target);
+        });
+    }, { threshold: 0.4 });
+
+    counters.forEach(counter => counterObserver.observe(counter));
+}
+
+export function initScrollReveal() {
+    if (typeof document === 'undefined') return;
+
+    const targets = document.querySelectorAll(
+        '.reveal, .fact-card, .feature-card, .viewpoint-card, .route-step-card, .nearby-card, .gallery-card'
+    );
+    if (!targets.length) return;
+
+    if (prefersReducedMotion() || typeof IntersectionObserver === 'undefined') {
+        targets.forEach(el => el.classList.add('revealed'));
+        return;
+    }
+
+    const observer = new IntersectionObserver((entries, obs) => {
+        entries.forEach(entry => {
+            if (!entry.isIntersecting) return;
+            const el = entry.target;
+            el.classList.add('revealed');
+            el.addEventListener('transitionend', () => { el.style.transitionDelay = ''; }, { once: true });
+            obs.unobserve(el);
+        });
+    }, { threshold: 0.15, rootMargin: '0px 0px -40px 0px' });
+
+    targets.forEach(el => {
+        const parent = el.parentElement;
+        if (parent) {
+            const group = Array.from(parent.children).filter(child =>
+                child.classList.contains('reveal')
+                || child.classList.contains('fact-card')
+                || child.classList.contains('feature-card')
+                || child.classList.contains('viewpoint-card')
+                || child.classList.contains('route-step-card')
+                || child.classList.contains('nearby-card')
+                || child.classList.contains('gallery-card')
+            );
+            const position = Math.max(group.indexOf(el), 0);
+            el.style.transitionDelay = `${Math.min(position, 7) * 90}ms`;
+        }
+        observer.observe(el);
+    });
+}
+
+export function initLightbox(gallery = NGRIAT_TREK_DATA.gallery) {
+    if (typeof document === 'undefined') return null;
+
+    const lightbox = document.getElementById('ngt-lightbox');
+    const grid = document.getElementById('gallery-grid');
+    if (!lightbox || !grid || !Array.isArray(gallery) || !gallery.length) return null;
+
+    const imageEl = document.getElementById('ngt-lightbox-image');
+    const titleEl = document.getElementById('ngt-lightbox-title');
+    const captionEl = document.getElementById('ngt-lightbox-caption');
+    const creditEl = document.getElementById('ngt-lightbox-credit');
+    const closeBtn = document.getElementById('ngt-lightbox-close');
+    const prevBtn = document.getElementById('ngt-lightbox-prev');
+    const nextBtn = document.getElementById('ngt-lightbox-next');
+
+    let currentIndex = 0;
+    let hideTimer = null;
+
+    const showItem = index => {
+        currentIndex = (index + gallery.length) % gallery.length;
+        const item = gallery[currentIndex];
+        imageEl.src = item.image;
+        imageEl.alt = item.title;
+        titleEl.textContent = item.title;
+        captionEl.textContent = item.caption;
+        creditEl.textContent = item.credit;
+        creditEl.href = item.sourceUrl;
+    };
+
+    const openLightbox = index => {
+        clearTimeout(hideTimer);
+        showItem(index);
+        lightbox.hidden = false;
+        if (typeof requestAnimationFrame === 'function') {
+            requestAnimationFrame(() => lightbox.classList.add('open'));
+        } else {
+            lightbox.classList.add('open');
+        }
+        document.body.style.overflow = 'hidden';
+        closeBtn.focus();
+    };
+
+    const closeLightbox = () => {
+        lightbox.classList.remove('open');
+        document.body.style.overflow = '';
+        hideTimer = setTimeout(() => { lightbox.hidden = true; }, 280);
+    };
+
+    grid.addEventListener('click', event => {
+        const card = event.target.closest('.gallery-card');
+        if (!card || event.target.closest('.gallery-credit')) return;
+        openLightbox(parseInt(card.dataset.index, 10) || 0);
+    });
+
+    grid.addEventListener('keydown', event => {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        const card = event.target.closest('.gallery-card');
+        if (!card) return;
+        event.preventDefault();
+        openLightbox(parseInt(card.dataset.index, 10) || 0);
+    });
+
+    closeBtn.addEventListener('click', closeLightbox);
+    prevBtn.addEventListener('click', () => showItem(currentIndex - 1));
+    nextBtn.addEventListener('click', () => showItem(currentIndex + 1));
+
+    lightbox.addEventListener('click', event => {
+        if (event.target === lightbox) closeLightbox();
+    });
+
+    document.addEventListener('keydown', event => {
+        if (lightbox.hidden) return;
+        if (event.key === 'Escape') closeLightbox();
+        if (event.key === 'ArrowLeft') showItem(currentIndex - 1);
+        if (event.key === 'ArrowRight') showItem(currentIndex + 1);
+    });
+
+    return { openLightbox, closeLightbox, showItem };
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const factsGrid = document.getElementById('facts-grid');
+    const bridgesGrid = document.getElementById('bridges-grid');
+    const waterfallsGrid = document.getElementById('waterfalls-grid');
+    const routesGrid = document.getElementById('routes-grid');
+    const nearbyGrid = document.getElementById('nearby-grid');
+    const galleryGrid = document.getElementById('gallery-grid');
+    const creditsList = document.getElementById('credits-list');
+
+    if (factsGrid) renderTrekFacts(NGRIAT_TREK_DATA.facts, factsGrid);
+    if (bridgesGrid) renderRootBridges(NGRIAT_TREK_DATA.rootBridges, bridgesGrid);
+    if (waterfallsGrid) renderWaterfalls(NGRIAT_TREK_DATA.waterfalls, waterfallsGrid);
+    if (routesGrid) renderRouteStages(NGRIAT_TREK_DATA.routeStages, routesGrid);
+    if (nearbyGrid) renderNearbyDestinations(NGRIAT_TREK_DATA.nearbyDestinations, nearbyGrid);
+    if (galleryGrid) renderGallery(NGRIAT_TREK_DATA.gallery, galleryGrid);
+    if (creditsList) renderImageCredits(NGRIAT_TREK_DATA.gallery, creditsList);
+
+    initScrollReveal();
+    initLightbox();
+    initStatCounters();
+});

--- a/frontend/nongriat-trek/style.css
+++ b/frontend/nongriat-trek/style.css
@@ -1,0 +1,1157 @@
+/* ============================================================
+    Nongriat Trek — Meghalaya Page Styles
+    Animations · Full-screen Hero · Lightbox · Map · Footer
+    ============================================================ */
+
+:root {
+    --ngt-emerald: #059669;
+    --ngt-pine: #0d9488;
+    --ngt-gold: #f59e0b;
+    --saffron: #dc2626;
+
+    --bg-page: #0f172a;
+    --bg-card: #1e293b;
+    --border-color: rgba(255, 255, 255, 0.1);
+    --text-primary: #f8fafc;
+    --text-secondary: #94a3b8;
+    --shadow-card: 0 10px 25px -5px rgba(0, 0, 0, 0.3), 0 8px 10px -6px rgba(0, 0, 0, 0.3);
+}
+
+[data-theme="light"] {
+    --bg-page: #f8fafc;
+    --bg-card: #ffffff;
+    --border-color: rgba(0, 0, 0, 0.08);
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --shadow-card: 0 10px 25px -5px rgba(0, 0, 0, 0.08), 0 8px 10px -6px rgba(0, 0, 0, 0.05);
+}
+
+/* ---------- KEYFRAME ANIMATIONS ---------- */
+@keyframes ngtFadeInUp {
+    from { opacity: 0; transform: translateY(30px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ngtFadeInDown {
+    from { opacity: 0; transform: translateY(-20px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes ngtKenBurns {
+    0% { transform: scale(1) translateY(0); }
+    100% { transform: scale(1.12) translateY(-2.5%); }
+}
+
+@keyframes ngtShimmer {
+    0% { background-position: -200% center; }
+    100% { background-position: 200% center; }
+}
+
+@keyframes ngtFloat {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-6px); }
+}
+
+@keyframes ngtPulseGlow {
+    0%, 100% { box-shadow: 0 0 18px rgba(16, 185, 129, 0.25); }
+    50% { box-shadow: 0 0 32px rgba(16, 185, 129, 0.5); }
+}
+
+/* ---------- HERO ENTRY ANIMATIONS ---------- */
+.anim-fade-up {
+    opacity: 0;
+    animation: ngtFadeInUp 0.9s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.anim-fade-down {
+    opacity: 0;
+    animation: ngtFadeInDown 0.8s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.delay-1 { animation-delay: 0.15s; }
+.delay-2 { animation-delay: 0.3s; }
+.delay-3 { animation-delay: 0.45s; }
+.delay-4 { animation-delay: 0.6s; }
+
+/* ---------- SCROLL REVEAL SYSTEM ---------- */
+.reveal {
+    opacity: 0;
+    transform: translateY(30px);
+    transition:
+        opacity 0.7s cubic-bezier(0.16, 1, 0.3, 1),
+        transform 0.7s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.reveal.revealed {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.ngt-page {
+    padding: 0 20px 60px;
+    font-family: 'Outfit', sans-serif;
+    color: var(--text-primary);
+    overflow-x: hidden;
+}
+
+/* ---------- HERO SECTION (full-bleed) ---------- */
+.ngt-hero {
+    position: relative;
+    min-height: 92vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    margin-bottom: 50px;
+    inset: 0;
+    width: 100%;
+    overflow: hidden;
+    isolation: isolate;
+}
+
+.ngt-hero-bg {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    z-index: -2;
+    animation: ngtKenBurns 22s ease-in-out infinite alternate;
+    will-change: transform;
+}
+
+.ngt-hero-bg.broken {
+    background: var(--bg-card);
+}
+
+.ngt-hero-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: -1;
+    background:
+        radial-gradient(circle at 20% 25%, rgba(16, 185, 129, 0.16), transparent 42%),
+        radial-gradient(circle at 82% 20%, rgba(245, 158, 11, 0.12), transparent 38%),
+        linear-gradient(180deg, rgba(15, 23, 42, 0.55) 0%, rgba(15, 23, 42, 0.72) 55%, rgba(15, 23, 42, 0.92) 100%);
+}
+
+.ngt-hero-content {
+    position: relative;
+    z-index: 1;
+    padding: 90px 24px;
+    max-width: 900px;
+}
+
+.hero-kicker {
+    display: inline-block;
+    padding: 6px 16px;
+    background: rgba(16, 185, 129, 0.18);
+    color: var(--ngt-emerald);
+    border: 1px solid rgba(16, 185, 129, 0.35);
+    border-radius: 20px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin-bottom: 16px;
+    letter-spacing: 0.5px;
+    backdrop-filter: blur(8px);
+}
+
+.hero-title {
+    font-family: 'Playfair Display', serif;
+    font-size: 3.6rem;
+    font-weight: 700;
+    margin: 0 0 16px 0;
+    line-height: 1.15;
+    color: #fff;
+    text-shadow: 0 4px 30px rgba(0, 0, 0, 0.45);
+}
+
+.hero-title span {
+    background: linear-gradient(135deg, var(--ngt-emerald), #6ee7b7 40%, var(--ngt-gold));
+    background-size: 200% auto;
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    animation: ngtShimmer 5s linear infinite;
+}
+
+.hero-subtitle {
+    font-size: 1.15rem;
+    color: rgba(255, 255, 255, 0.9);
+    max-width: 760px;
+    margin: 0 auto 30px;
+    line-height: 1.65;
+    text-shadow: 0 2px 14px rgba(0, 0, 0, 0.5);
+}
+
+.hero-stats-bar {
+    display: flex;
+    justify-content: center;
+    gap: 18px;
+    flex-wrap: wrap;
+    margin-bottom: 28px;
+}
+
+.stat-chip {
+    background: rgba(15, 23, 42, 0.62);
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    padding: 14px 26px;
+    border-radius: 14px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    backdrop-filter: blur(10px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+    transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.stat-chip:hover {
+    transform: translateY(-4px);
+    border-color: rgba(16, 185, 129, 0.55);
+}
+
+.stat-num {
+    font-size: 1.5rem;
+    font-weight: 800;
+    color: var(--ngt-emerald);
+    line-height: 1;
+    margin-bottom: 4px;
+}
+
+.stat-lbl {
+    font-size: 0.82rem;
+    color: rgba(255, 255, 255, 0.78);
+    font-weight: 500;
+}
+
+.hero-cta {
+    display: inline-block;
+    background: linear-gradient(135deg, var(--ngt-emerald), var(--ngt-pine));
+    color: #06281e;
+    font-weight: 800;
+    padding: 13px 34px;
+    border-radius: 30px;
+    text-decoration: none;
+    letter-spacing: 0.02em;
+    animation: ngtPulseGlow 2.6s ease-in-out infinite;
+    transition: transform 0.25s ease, filter 0.25s ease;
+}
+
+.hero-cta:hover {
+    transform: translateY(-3px) scale(1.03);
+    filter: brightness(1.12);
+}
+
+/* ---------- SECTIONS GENERAL ---------- */
+.section-block {
+    margin-bottom: 64px;
+}
+
+.section-heading {
+    text-align: center;
+    margin-bottom: 36px;
+}
+
+.section-badge {
+    display: inline-block;
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: var(--ngt-emerald);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    margin-bottom: 6px;
+}
+
+.section-title {
+    font-family: 'Playfair Display', serif;
+    font-size: 2.2rem;
+    margin: 0 0 10px 0;
+    color: var(--text-primary);
+}
+
+.section-subtext {
+    font-size: 1rem;
+    color: var(--text-secondary);
+    max-width: 720px;
+    margin: 0 auto;
+}
+
+/* ---------- OVERVIEW SECTION ---------- */
+.overview-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 24px;
+}
+
+.overview-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    padding: 24px;
+    border-radius: 18px;
+    box-shadow: var(--shadow-card);
+    transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.overview-card:hover {
+    transform: translateY(-6px);
+    border-color: rgba(16, 185, 129, 0.45);
+    box-shadow: 0 16px 34px -8px rgba(16, 185, 129, 0.28);
+}
+
+.overview-card h3 {
+    font-size: 1.25rem;
+    color: var(--ngt-emerald);
+    margin: 0 0 12px 0;
+}
+
+.overview-card p {
+    font-size: 0.95rem;
+    color: var(--text-secondary);
+    line-height: 1.65;
+    margin: 0;
+}
+
+/* ---------- FACTS SECTION ---------- */
+.facts-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 20px;
+}
+
+.fact-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    padding: 24px;
+    border-radius: 18px;
+    box-shadow: var(--shadow-card);
+    opacity: 0;
+    transform: translateY(26px);
+    transition:
+        opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+        transform 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+        border-color 0.3s ease,
+        box-shadow 0.3s ease;
+}
+
+.fact-card.revealed {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.fact-card:hover {
+    transform: translateY(-5px);
+    border-color: var(--ngt-gold);
+    box-shadow: 0 16px 34px -8px rgba(245, 158, 11, 0.22);
+}
+
+.fact-icon {
+    font-size: 2.2rem;
+    margin-bottom: 12px;
+    display: inline-block;
+    animation: ngtFloat 4.5s ease-in-out infinite;
+}
+
+.fact-value {
+    font-size: 1.4rem;
+    font-weight: 800;
+    color: var(--ngt-gold);
+    margin-bottom: 4px;
+}
+
+.fact-title {
+    font-size: 1.1rem;
+    margin: 0 0 8px 0;
+    color: var(--text-primary);
+}
+
+.fact-desc {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    line-height: 1.5;
+    margin: 0;
+}
+
+/* ---------- NATURAL FEATURES SECTION ---------- */
+.features-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 20px;
+}
+
+.feature-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-left: 4px solid var(--ngt-emerald);
+    padding: 22px;
+    border-radius: 18px;
+    box-shadow: var(--shadow-card);
+    opacity: 0;
+    transform: translateX(-30px);
+    transition:
+        opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+        transform 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+        border-color 0.3s ease,
+        box-shadow 0.3s ease;
+}
+
+.feature-card:nth-child(even) {
+    transform: translateX(30px);
+}
+
+.feature-card.revealed {
+    opacity: 1;
+    transform: translateX(0);
+}
+
+.feature-card:hover {
+    border-left-color: var(--ngt-pine);
+    box-shadow: 0 14px 30px -8px rgba(13, 148, 136, 0.3);
+}
+
+.feature-card h3 {
+    font-size: 1.1rem;
+    margin: 0 0 8px 0;
+    color: var(--ngt-emerald);
+}
+
+.feature-card p {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    margin: 0;
+}
+
+/* ---------- VIEWPOINTS SECTION ---------- */
+.viewpoints-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 20px;
+}
+
+.viewpoint-card {
+    position: relative;
+    background:
+        linear-gradient(160deg, var(--bg-card), var(--bg-page));
+    border: 1px solid var(--border-color);
+    padding: 24px 22px 22px;
+    border-radius: 18px;
+    box-shadow: var(--shadow-card);
+    overflow: hidden;
+    opacity: 0;
+    transform: translateY(30px);
+    transition:
+        opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+        transform 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+        border-color 0.3s ease,
+        box-shadow 0.3s ease;
+}
+
+.viewpoint-card.revealed {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.viewpoint-card::after {
+    content: '';
+    position: absolute;
+    inset: auto -20% -60% -20%;
+    height: 70%;
+    background: radial-gradient(closest-side, rgba(16, 185, 129, 0.12), transparent);
+    pointer-events: none;
+}
+
+.viewpoint-card:hover {
+    border-color: rgba(16, 185, 129, 0.45);
+    box-shadow: 0 16px 34px -8px rgba(16, 185, 129, 0.25);
+}
+
+.viewpoint-marker {
+    font-size: 1.5rem;
+    margin-bottom: 10px;
+    display: inline-block;
+    filter: drop-shadow(0 0 8px rgba(16, 185, 129, 0.45));
+}
+
+.viewpoint-card h3 {
+    font-size: 1.05rem;
+    margin: 0 0 8px 0;
+    color: var(--ngt-emerald);
+}
+
+.viewpoint-card p {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    line-height: 1.65;
+    margin: 0;
+}
+
+/* ---------- NEARBY DESTINATIONS SECTION ---------- */
+.nearby-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 20px;
+}
+
+.nearby-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-top: 4px solid var(--ngt-gold);
+    padding: 22px;
+    border-radius: 18px;
+    box-shadow: var(--shadow-card);
+    opacity: 0;
+    transform: translateY(26px);
+    transition:
+        opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+        transform 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+        border-color 0.3s ease,
+        box-shadow 0.3s ease;
+}
+
+.nearby-card.revealed {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.nearby-card:hover {
+    border-top-color: var(--ngt-emerald);
+    box-shadow: 0 14px 30px -8px rgba(16, 185, 129, 0.28);
+}
+
+.nearby-card h3 {
+    font-size: 1.05rem;
+    margin: 0 0 8px 0;
+    color: var(--text-primary);
+}
+
+.nearby-card p {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    margin: 0;
+}
+
+/* ---------- MAP SECTION ---------- */
+.map-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: 20px;
+    overflow: hidden;
+    box-shadow: var(--shadow-card);
+}
+
+.map-frame {
+    display: block;
+    width: 100%;
+    height: 420px;
+    border: 0;
+    filter: saturate(0.92);
+}
+
+[data-theme="dark"] .map-frame {
+    filter: invert(0.88) hue-rotate(185deg) saturate(0.75) brightness(0.95);
+}
+
+.map-meta {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: 10px;
+    padding: 14px 18px;
+    border-top: 1px solid var(--border-color);
+    font-size: 0.85rem;
+}
+
+.map-meta .coords {
+    color: var(--text-secondary);
+    letter-spacing: 0.03em;
+}
+
+.map-meta a {
+    color: var(--ngt-emerald);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.map-meta a:hover {
+    text-decoration: underline;
+}
+
+/* ---------- ROUTE SECTION ---------- */
+.routes-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 20px;
+}
+
+.route-step-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    padding: 22px;
+    border-radius: 18px;
+    box-shadow: var(--shadow-card);
+    position: relative;
+    overflow: hidden;
+    opacity: 0;
+    transform: translateY(34px) scale(0.97);
+    transition:
+        opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+        transform 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+        border-color 0.3s ease,
+        box-shadow 0.3s ease;
+}
+
+.route-step-card::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, var(--ngt-emerald), var(--ngt-pine));
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform 0.45s ease;
+}
+
+.route-step-card.revealed {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+}
+
+.route-step-card:hover {
+    border-color: rgba(16, 185, 129, 0.45);
+    box-shadow: 0 16px 34px -8px rgba(16, 185, 129, 0.3);
+}
+
+.route-step-card:hover::before {
+    transform: scaleX(1);
+}
+
+.step-badge {
+    display: inline-block;
+    background: linear-gradient(135deg, var(--ngt-emerald), var(--ngt-pine));
+    color: #06281e;
+    font-weight: 800;
+    font-size: 0.75rem;
+    padding: 4px 12px;
+    border-radius: 12px;
+    margin-bottom: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.step-stage {
+    font-size: 1.1rem;
+    margin: 0 0 6px 0;
+    color: var(--text-primary);
+}
+
+.step-altitude {
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: var(--ngt-gold);
+    margin-bottom: 10px;
+}
+
+.step-desc {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    line-height: 1.5;
+    margin: 0 0 12px 0;
+}
+
+.step-highlight {
+    font-size: 0.85rem;
+    background: rgba(16, 185, 129, 0.08);
+    border-left: 3px solid var(--ngt-emerald);
+    padding: 8px 10px;
+    border-radius: 0 8px 8px 0;
+    color: var(--text-secondary);
+}
+
+/* ---------- GALLERY SECTION ---------- */
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 24px;
+}
+
+.gallery-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: 18px;
+    overflow: hidden;
+    margin: 0;
+    box-shadow: var(--shadow-card);
+    cursor: zoom-in;
+    opacity: 0;
+    transform: translateY(30px) scale(0.96);
+    transition:
+        opacity 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+        transform 0.6s cubic-bezier(0.16, 1, 0.3, 1),
+        border-color 0.3s ease,
+        box-shadow 0.3s ease;
+}
+
+.gallery-card.revealed {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+}
+
+.gallery-card:hover {
+    border-color: rgba(16, 185, 129, 0.5);
+    box-shadow: 0 18px 38px -10px rgba(16, 185, 129, 0.35);
+}
+
+.gallery-img-wrapper {
+    overflow: hidden;
+    position: relative;
+}
+
+.gallery-img {
+    display: block;
+    width: 100%;
+    height: 230px;
+    object-fit: cover;
+    transition: transform 0.6s cubic-bezier(0.16, 1, 0.3, 1), filter 0.4s ease;
+}
+
+.gallery-card:hover .gallery-img {
+    transform: scale(1.08);
+    filter: brightness(1.08);
+}
+
+.gallery-caption {
+    padding: 16px 20px;
+}
+
+.gallery-caption h4 {
+    font-size: 1.05rem;
+    margin: 0 0 4px 0;
+    color: var(--text-primary);
+}
+
+.gallery-caption p {
+    font-size: 0.88rem;
+    color: var(--text-secondary);
+    margin: 0 0 8px 0;
+    line-height: 1.5;
+}
+
+.gallery-credit {
+    font-size: 0.78rem;
+    color: var(--ngt-emerald);
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.gallery-credit:hover {
+    text-decoration: underline;
+}
+
+/* ---------- LIGHTBOX ---------- */
+.ngt-lightbox {
+    position: fixed;
+    inset: 0;
+    z-index: 9999;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    padding: 24px;
+    background: rgba(4, 10, 18, 0.92);
+    backdrop-filter: blur(10px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+}
+
+.ngt-lightbox.open {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.ngt-lightbox[hidden] {
+    display: none;
+}
+
+.ngt-lightbox-figure {
+    margin: 0;
+    max-width: min(920px, 88vw);
+    text-align: center;
+}
+
+.ngt-lightbox-figure img {
+    max-width: 100%;
+    max-height: 74vh;
+    border-radius: 14px;
+    box-shadow: 0 24px 70px rgba(0, 0, 0, 0.6);
+    animation: ngtFadeInUp 0.35s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.ngt-lightbox-figure figcaption {
+    margin-top: 14px;
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 0.92rem;
+    line-height: 1.55;
+}
+
+.ngt-lightbox-figure figcaption strong {
+    display: block;
+    color: #fff;
+    font-size: 1.05rem;
+    margin-bottom: 2px;
+}
+
+.ngt-lightbox-figure figcaption span {
+    display: block;
+    color: rgba(255, 255, 255, 0.66);
+    font-size: 0.85rem;
+    margin-bottom: 6px;
+}
+
+.ngt-lightbox-figure figcaption a {
+    color: var(--ngt-emerald);
+    font-weight: 600;
+    text-decoration: none;
+    font-size: 0.82rem;
+}
+
+.ngt-lightbox-figure figcaption a:hover {
+    text-decoration: underline;
+}
+
+.ngt-lightbox-close,
+.ngt-lightbox-nav {
+    flex-shrink: 0;
+    width: 46px;
+    height: 46px;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background: rgba(15, 23, 42, 0.7);
+    color: #fff;
+    font-size: 1.6rem;
+    line-height: 1;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.25s ease, transform 0.25s ease, border-color 0.25s ease;
+}
+
+.ngt-lightbox-close {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+}
+
+.ngt-lightbox-close:hover,
+.ngt-lightbox-nav:hover {
+    background: rgba(16, 185, 129, 0.28);
+    border-color: var(--ngt-emerald);
+    transform: scale(1.08);
+}
+
+/* ---------- PERMITS SECTION ---------- */
+.permit-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 20px;
+    margin-bottom: 40px;
+}
+
+.permit-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    padding: 22px;
+    border-radius: 18px;
+    box-shadow: var(--shadow-card);
+    transition: transform 0.3s ease, border-color 0.3s ease;
+}
+
+.permit-card:hover {
+    transform: translateY(-5px);
+    border-color: rgba(16, 185, 129, 0.4);
+}
+
+.permit-card h3 {
+    font-size: 1.1rem;
+    color: var(--ngt-emerald);
+    margin: 0 0 10px 0;
+}
+
+.permit-card p {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    line-height: 1.6;
+    margin: 0;
+}
+
+.safety-box {
+    background: rgba(220, 38, 38, 0.08);
+    border: 1px solid rgba(220, 38, 38, 0.3);
+    border-radius: 18px;
+    padding: 24px;
+    text-align: center;
+}
+
+.safety-box h3 {
+    color: var(--saffron);
+    margin: 0 0 8px 0;
+}
+
+.safety-box p {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    max-width: 800px;
+    margin: 0 auto;
+    line-height: 1.6;
+}
+
+/* ---------- IMAGE CREDITS SECTION ---------- */
+.credits-section .credits-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 auto;
+    max-width: 860px;
+    display: grid;
+    gap: 10px;
+}
+
+.credits-section .credits-list li {
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 12px 18px;
+    font-size: 0.88rem;
+    color: var(--text-secondary);
+    line-height: 1.55;
+    transition: border-color 0.25s ease, transform 0.25s ease;
+}
+
+.credits-section .credits-list li:hover {
+    border-color: rgba(16, 185, 129, 0.4);
+    transform: translateX(4px);
+}
+
+.credits-section .credits-list a {
+    color: var(--ngt-emerald);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.credits-section .credits-list a:hover {
+    text-decoration: underline;
+}
+
+/* ---------- FOOTER ---------- */
+.site-footer {
+    background: hsl(222, 47%, 4%);
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+    padding: 60px 24px 30px;
+}
+
+.site-footer .footer-container {
+    max-width: 1200px;
+    margin: 0 auto 40px;
+    display: grid;
+    grid-template-columns: 1.5fr 1fr 1fr 1fr;
+    gap: 40px;
+}
+
+.site-footer .footer-brand .nav-logo {
+    display: inline-flex;
+    gap: 6px;
+    font-family: 'Playfair Display', serif;
+    font-weight: 700;
+    font-size: 1.3rem;
+    margin-bottom: 14px;
+    text-decoration: none;
+}
+
+.site-footer .footer-brand .nav-logo .saffron { color: #ff9933; }
+.site-footer .footer-brand .nav-logo .gold { color: #f6c453; }
+.site-footer .footer-brand .nav-logo .green { color: #34d399; }
+
+.site-footer .footer-brand p {
+    color: #94a3b8;
+    font-size: 0.9rem;
+    line-height: 1.65;
+    max-width: 300px;
+    margin: 0;
+}
+
+.site-footer .footer-links {
+    display: flex;
+    flex-direction: column;
+}
+
+.site-footer .footer-links h4 {
+    font-size: 1rem;
+    font-weight: 700;
+    color: #e2e8f0;
+    margin: 0 0 16px 0;
+    text-align: left;
+}
+
+.site-footer .footer-links a {
+    color: #94a3b8;
+    text-decoration: none;
+    font-size: 0.88rem;
+    padding: 5px 0;
+    transition: color 0.2s ease, padding-left 0.2s ease;
+    display: block;
+}
+
+.site-footer .footer-links a:hover {
+    color: var(--ngt-emerald);
+    padding-left: 6px;
+}
+
+.site-footer .footer-bottom {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding-top: 24px;
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+    text-align: center;
+}
+
+.site-footer .footer-bottom p {
+    color: #94a3b8;
+    font-size: 0.82rem;
+    line-height: 1.6;
+    margin: 0;
+}
+
+.site-footer .footer-bottom a {
+    color: var(--ngt-emerald);
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.site-footer .footer-bottom a:hover {
+    text-decoration: underline;
+}
+
+[data-theme="light"] .site-footer {
+    background: #f1f5f9;
+    border-top-color: #e2e8f0;
+}
+
+[data-theme="light"] .site-footer .footer-brand p,
+[data-theme="light"] .site-footer .footer-links a,
+[data-theme="light"] .site-footer .footer-bottom p {
+    color: #475569;
+}
+
+[data-theme="light"] .site-footer .footer-links h4 {
+    color: #0f172a;
+}
+
+/* ---------- SCROLL TO TOP ---------- */
+.btn-scroll-top {
+    position: fixed;
+    bottom: 26px;
+    right: 26px;
+    z-index: 900;
+    width: 46px;
+    height: 46px;
+    border-radius: 50%;
+    border: 1px solid rgba(16, 185, 129, 0.4);
+    background: rgba(15, 23, 42, 0.85);
+    color: var(--ngt-emerald);
+    font-size: 1.2rem;
+    cursor: pointer;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(14px);
+    transition: opacity 0.3s ease, transform 0.3s ease, visibility 0.3s ease, background 0.3s ease;
+    backdrop-filter: blur(8px);
+}
+
+.btn-scroll-top.visible {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0);
+}
+
+.btn-scroll-top:hover {
+    background: rgba(16, 185, 129, 0.25);
+}
+
+/* ---------- REDUCED MOTION ---------- */
+@media (prefers-reduced-motion: reduce) {
+    .anim-fade-up,
+    .anim-fade-down,
+    .ngt-hero-bg,
+    .hero-title span,
+    .fact-icon,
+    .hero-cta {
+        animation: none !important;
+        opacity: 1 !important;
+    }
+
+    .reveal,
+    .fact-card,
+    .feature-card,
+    .route-step-card,
+    .gallery-card {
+        opacity: 1 !important;
+        transform: none !important;
+        transition: none !important;
+    }
+}
+
+/* ---------- RESPONSIVE ---------- */
+@media screen and (max-width: 768px) {
+    .hero-title {
+        font-size: 2.4rem;
+    }
+
+    .section-title {
+        font-size: 1.8rem;
+    }
+
+    .hero-stats-bar {
+        gap: 12px;
+    }
+
+    .stat-chip {
+        width: calc(50% - 12px);
+        padding: 10px 14px;
+    }
+
+    .ngt-hero {
+        min-height: 70vh;
+    }
+
+    .ngt-hero-content {
+        padding: 70px 18px;
+    }
+
+    .map-frame {
+        height: 300px;
+    }
+
+    .site-footer .footer-container {
+        grid-template-columns: 1fr;
+        gap: 28px;
+    }
+
+    .ngt-lightbox {
+        flex-direction: column;
+    }
+
+    .ngt-lightbox-nav.prev {
+        order: 2;
+    }
+
+    .ngt-lightbox-nav.next {
+        order: 3;
+    }
+
+    .ngt-lightbox-figure {
+        order: 1;
+    }
+}

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -5958,6 +5958,13 @@ window.indiaSearchIndex = [
         description: "Explore the Mawryngkhang Trek in Meghalaya. Known as the scariest trek in Meghalaya, it features bamboo bridges, dramatic rock formations, and dense forest ecosystems.",
         url: "frontend/mawryngkhang-trek/index.html"},
   
+    // --- Nongriat Trek Explorer ---
+    {
+        title: "Nongriat Trek",
+        keywords: "nongriat, trek, meghalaya, double decker, living root bridge, jingkieng jri, rainbow falls, tyrna, cherrapunji, sohra",
+        description: "Explore the Nongriat Trek in Meghalaya — descend 3,500 steps from Tyrna to the Double-Decker Living Root Bridge, turquoise natural pools and Rainbow Falls in the East Khasi Hills.",
+        url: "frontend/nongriat-trek/index.html"},
+
     // --- Kumara Parvatha Trek Explorer ---
     {
         title: "Kumara Parvatha Trek",

--- a/frontend/tests/unit/nongriat-trek.test.js
+++ b/frontend/tests/unit/nongriat-trek.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { JSDOM } from 'jsdom';
+
+const dom = new JSDOM('<!DOCTYPE html><html><body></body></html>', { url: 'http://localhost/' });
+global.document = dom.window.document;
+global.window = dom.window;
+
+const {
+    NGRIAT_TREK_DATA,
+    renderTrekFacts,
+    renderRootBridges,
+    renderWaterfalls,
+    renderRouteStages,
+    renderNearbyDestinations,
+    renderGallery,
+    renderImageCredits
+} = await import('../../nongriat-trek/script.js');
+
+describe('NGRIAT_TREK_DATA', () => {
+    it('has core trek identity fields', () => {
+        expect(NGRIAT_TREK_DATA.name).toBe('Nongriat Trek');
+        expect(NGRIAT_TREK_DATA.state).toBe('Meghalaya');
+        expect(NGRIAT_TREK_DATA.startingPoint).toContain('Tyrna');
+        expect(NGRIAT_TREK_DATA.difficulty).toMatch(/Moderate/i);
+        expect(NGRIAT_TREK_DATA.bestSeason).toContain('October');
+    });
+
+    it('includes eight trek facts covering issue requirements', () => {
+        expect(NGRIAT_TREK_DATA.facts).toHaveLength(8);
+        const titles = NGRIAT_TREK_DATA.facts.map(f => f.title);
+        expect(titles).toContain('Trek Location');
+        expect(titles).toContain('Difficulty');
+        expect(titles).toContain('Distance');
+        expect(titles).toContain('Duration');
+        expect(titles).toContain('Best Season');
+        expect(titles).toContain('Starting Point');
+    });
+
+    it('describes six living root bridge features including the Double-Decker', () => {
+        expect(NGRIAT_TREK_DATA.rootBridges).toHaveLength(6);
+        const titles = NGRIAT_TREK_DATA.rootBridges.map(b => b.title);
+        expect(titles.some(t => t.includes('Double-Decker'))).toBe(true);
+        expect(titles).toContain('Jingkieng Jri Heritage');
+    });
+
+    it('lists waterfalls and natural pools including Rainbow Falls', () => {
+        expect(NGRIAT_TREK_DATA.waterfalls.length).toBeGreaterThanOrEqual(4);
+        const names = NGRIAT_TREK_DATA.waterfalls.map(w => w.name);
+        expect(names.some(n => n.includes('Rainbow Falls'))).toBe(true);
+    });
+
+    it('defines five route stages in ascending order starting at Tyrna', () => {
+        const steps = NGRIAT_TREK_DATA.routeStages.map(s => s.step);
+        expect(steps).toEqual([1, 2, 3, 4, 5]);
+        expect(NGRIAT_TREK_DATA.routeStages[0].stage).toContain('Tyrna');
+        expect(NGRIAT_TREK_DATA.routeStages.at(-1).stage).toContain('Return');
+    });
+
+    it('suggests nearby attractions', () => {
+        expect(NGRIAT_TREK_DATA.nearbyDestinations.length).toBeGreaterThanOrEqual(4);
+        const titles = NGRIAT_TREK_DATA.nearbyDestinations.map(d => d.title);
+        expect(titles).toContain('Cherrapunji (Sohra)');
+        expect(titles).toContain('Nohkalikai Falls');
+    });
+
+    it('provides eight credited gallery images over HTTPS', () => {
+        expect(NGRIAT_TREK_DATA.gallery).toHaveLength(8);
+        for (const item of NGRIAT_TREK_DATA.gallery) {
+            expect(item.image.startsWith('https://')).toBe(true);
+            expect(item.credit).toContain('Wikimedia Commons');
+            expect(item.sourceUrl.startsWith('https://commons.wikimedia.org/')).toBe(true);
+        }
+    });
+});
+
+function createContainer() {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    return container;
+}
+
+describe('render functions', () => {
+    let container;
+
+    beforeEach(() => {
+        container?.remove();
+        container = createContainer();
+    });
+
+    it('renders one fact card per fact', () => {
+        renderTrekFacts(NGRIAT_TREK_DATA.facts, container);
+        expect(container.querySelectorAll('.fact-card')).toHaveLength(8);
+        expect(container.textContent).toContain('East Khasi Hills');
+    });
+
+    it('renders root bridge cards with title and text', () => {
+        renderRootBridges(NGRIAT_TREK_DATA.rootBridges, container);
+        expect(container.querySelectorAll('.feature-card')).toHaveLength(6);
+        expect(container.textContent).toContain('Double-Decker');
+    });
+
+    it('renders waterfall cards with names and details', () => {
+        renderWaterfalls(NGRIAT_TREK_DATA.waterfalls, container);
+        expect(container.querySelectorAll('.viewpoint-card')).toHaveLength(NGRIAT_TREK_DATA.waterfalls.length);
+        expect(container.textContent).toContain('Rainbow Falls');
+    });
+
+    it('renders route stage cards with badges and highlights', () => {
+        renderRouteStages(NGRIAT_TREK_DATA.routeStages, container);
+        expect(container.querySelectorAll('.route-step-card')).toHaveLength(5);
+        expect(container.querySelector('[data-step="3"] .step-stage').textContent).toContain('Double-Decker');
+    });
+
+    it('renders nearby destination cards', () => {
+        renderNearbyDestinations(NGRIAT_TREK_DATA.nearbyDestinations, container);
+        const expected = NGRIAT_TREK_DATA.nearbyDestinations.length;
+        expect(container.querySelectorAll('.nearby-card')).toHaveLength(expected);
+        expect(container.textContent).toContain('Cherrapunji');
+    });
+
+    it('renders gallery figures with images, captions, and credits', () => {
+        renderGallery(NGRIAT_TREK_DATA.gallery, container);
+        expect(container.querySelectorAll('.gallery-card')).toHaveLength(8);
+        expect(container.querySelectorAll('img.gallery-img')).toHaveLength(8);
+        expect(container.querySelectorAll('.gallery-credit')).toHaveLength(8);
+    });
+
+    it('renders image credit list items with source links', () => {
+        renderImageCredits(NGRIAT_TREK_DATA.gallery, container);
+        expect(container.querySelectorAll('li')).toHaveLength(8);
+        expect(container.querySelectorAll('a[target="_blank"]')).toHaveLength(8);
+    });
+
+    it('escapes HTML in rendered content', () => {
+        renderTrekFacts([{ title: '<script>alert(1)</script>', value: 'x & y', description: '"quoted"', icon: '📍' }], container);
+        expect(container.innerHTML).not.toContain('<script>');
+        expect(container.innerHTML).toContain('&lt;script&gt;');
+        expect(container.innerHTML).toContain('&amp;');
+    });
+});


### PR DESCRIPTION
## Summary

Implements **ONLY** GitHub Issue #3169 — a dedicated Nongriat Trek profile for Meghalaya, following the repository's existing trek-profile architecture (modeled on the newest trek pages such as `singalila-ridge-trek`).

Closes #3169

## What was added

### New files
- `frontend/nongriat-trek/index.html` — semantic, accessible page with hero + stats bar and sections for Overview, Trek Profile facts, Living Root Bridges, Waterfalls & Pools, Route Highlights, Nearby Attractions, OpenStreetMap embed (Nongriat · 25.2510° N · 91.6714° E), Image Gallery, Permits & Responsible Travel, and Image Credits
- `frontend/nongriat-trek/style.css` — self-contained theme (`ngt-` prefix), dark/light support, fully responsive at the project's standard breakpoints (desktop / tablet / mobile)
- `frontend/nongriat-trek/script.js` — vanilla JS module with `NGRIAT_TREK_DATA`, XSS-safe render functions, image lightbox (keyboard + ARIA), scroll reveal, and stat counters
- `frontend/tests/unit/nongriat-trek.test.js` — 15 vitest unit tests covering all issue requirements and render functions

### Modified files
- `frontend/search-index.js` — one entry registering "Nongriat Trek" in the client-side search index (+7 lines)

## Issue requirements coverage

| Requirement | Where |
|---|---|
| Location | Overview card + fact ("East Khasi Hills, ~15 km from Cherrapunji") |
| Difficulty | Fact card ("Moderate–Difficult") + Permits section |
| Distance | Fact card (~6–8 km round trip; ~10–11 km with Rainbow Falls) |
| Duration | Fact card (4–6 hours; 1–2 days overnight) |
| Best season | Fact card (October–April) |
| Starting point | Overview card + fact (Tyrna village) |
| Living root bridges | Dedicated section — Umshiang Double-Decker, how bridges are grown, Ritymmen, Mawsaw, root-wire hybrid, Jingkieng Jri UNESCO tentative heritage |
| Waterfalls | Rainbow Falls, Blue Lagoon, Mawsaw pools, Ka Likai viewpoint, monsoon falls |
| Forest landscape | Overview + route stage descriptions of subtropical evergreen forest |
| Nearby attractions | Cherrapunji, Nohkalikai Falls, Seven Sisters Falls, Mawsmai & Arwah caves, Wei Sawdong, Shillong |
| Image gallery | 8-image gallery with lightbox navigation |
| Image credits | Per-photo credit links + dedicated "Image Credits" attribution section |

All 8 gallery images are hosted on Wikimedia Commons under Creative Commons licenses (CC BY-SA / CC BY). Every image URL was verified to return HTTP 200 before inclusion.

## Validation completed

- [x] `npx vitest run frontend/tests/unit/nongriat-trek.test.js` → **15/15 pass**
- [x] Full unit suite compared with and without this change on latest `main` → identical pre-existing failures (56); this change adds only new passing tests (+15)
- [x] `npm run build` (minify) → completes successfully; unrelated pre-existing `.min` churn not included in this PR (consistent with newest trek PRs which ship source files only)
- [x] `npm run a11y` → zero accessibility violations on the new page (repo-wide count unchanged)
- [x] `npm run generate:check` drift verified as pre-existing on pristine upstream `main` (unrelated `dist/` states) — untouched
- [x] jsdom runtime smoke test — all sections render, lightbox opens
- [x] `git diff --check` passes; no conflict markers; no secrets; no dependency/lockfile changes; no unrelated files touched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated Nongriat Trek exploration page with route details, trek facts, living root bridges, waterfalls, nearby destinations, maps, safety guidance, permits, and image credits.
  - Added responsive layouts, light/dark themes, animated statistics, scroll effects, and reduced-motion support.
  - Added an interactive photo gallery with lightbox navigation and fallback images.
  - Added Nongriat Trek content to site search.

- **Tests**
  - Added coverage for trek content, page rendering, and safe handling of displayed text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->