### PR TITLE
feat: Add Rewa Ghat — Royal Riverfront Legacy page (#3295)

### DIFF
--- a/frontend/rewa-ghat/index.html
+++ b/frontend/rewa-ghat/index.html
@@ -1,0 +1,278 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Rewa Ghat | A Royal Riverfront Legacy of Varanasi</title>
+    <meta name="description" content="Explore Rewa Ghat in Varanasi: its origin as Lala Mishir Ghat, its 1879 purchase by the Maharaja of Rewa, the sandstone Rewa Kothi palace, its neighbouring temples and ghats, and its present life as a Banaras Hindu University arts hostel.">
+
+    <!-- Preload Critical Fonts -->
+    <link rel="preload" href="../../assets/fonts/Outfit-400.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="../../assets/fonts/Outfit-700.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" href="../../assets/fonts/PlayfairDisplay-400.woff2" as="font" type="font/woff2" crossorigin>
+
+    <link rel="stylesheet" href="../pages-common.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="rewa-ghat-page">
+    <header class="rewa-minimal-header">
+        <div class="rewa-minimal-header-inner">
+            <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+            <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+        </div>
+    </header>
+
+    <main class="page-container" id="main-view">
+
+        <!-- Hero Section -->
+        <section class="hero-section" aria-labelledby="hero-heading" id="hero">
+            <div class="hero-content">
+                <div class="badge-container">
+                    <span class="category-badge">Royal Riverfront Heritage</span>
+                    <span class="culture-badge">Varanasi, Uttar Pradesh</span>
+                </div>
+                <h1 id="hero-heading">Rewa Ghat</h1>
+                <p class="subtitle">A Royal Riverfront Legacy on the Ganges</p>
+                <p class="hero-desc">Tucked quietly between Assi Ghat and Tulsi Ghat, Rewa Ghat carries the layered history of a priest's endowment, a Punjab king's court, and a Baghela Maharaja's patronage. Once known as Lala Mishir Ghat, it was bought by the royal house of Rewa in 1879 and rebuilt in sandstone as the Rewa Kothi — a palace that today, quietly and fittingly, houses the music and art students of Banaras Hindu University.</p>
+                <table class="geo-table" aria-label="Rewa Ghat location summary">
+                    <tbody>
+                        <tr>
+                            <th>Location</th>
+                            <td>West bank of the Ganges, between Assi Ghat and Tulsi Ghat, Varanasi, Uttar Pradesh</td>
+                        </tr>
+                        <tr>
+                            <th>River</th>
+                            <td>Ganges (Ganga) — near its confluence with the Assi River</td>
+                        </tr>
+                        <tr>
+                            <th>Nearest Landmark</th>
+                            <td>~5 km from Varanasi Junction (Cantt.) Railway Station; close to Banaras Hindu University</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <!-- Section 1: History — Origin of the Ghat -->
+        <section class="info-section full-width" id="history" aria-labelledby="history-heading">
+            <h2 id="history-heading">📜 Origin &amp; History</h2>
+            <div class="content-grid">
+                <div class="info-card">
+                    <h3>Lala Mishir Ghat, the Earliest Name</h3>
+                    <p>Rewa Ghat did not begin as a royal riverfront at all. It was first built by <strong>Lala Mishir</strong> (Lala Misir), the family priest (purohit) of Maharaja Ranjit Singh of Punjab — founder of the Sikh Empire and known as the "Lion of Punjab." In its earliest years the ghat carried his name: <strong>Lala Mishir Ghat</strong>.</p>
+                </div>
+                <div class="info-card">
+                    <h3>A Second Name: Leelaram Ghat</h3>
+                    <p>Before its royal transformation, the ghat passed through another identity as <strong>Leelaram (Lilaram) Ghat</strong>. Its position was originally understood as part of the wider stretch of <strong>Assi Ghat</strong>, the southern anchor of Varanasi's riverfront, rather than a distinct site in its own right.</p>
+                </div>
+                <div class="info-card">
+                    <h3>From Priest's Endowment to Princely Estate</h3>
+                    <p>The shift from a priest's modest riverfront foundation to a full princely estate came in <strong>1879</strong>, when the ghat and its mansion were purchased outright by the royal house of Rewa — the moment that gives the ghat its present name and its enduring architectural character.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Section 2: Rewa Royal Heritage -->
+        <section class="info-section full-width" id="royal-heritage" aria-labelledby="heritage-heading">
+            <h2 id="heritage-heading">👑 Rewa Royal Heritage</h2>
+            <div class="content-grid">
+                <div class="info-card">
+                    <h3>The Maharaja of Rewa (1879)</h3>
+                    <p>In 1879, the ghat was purchased by the <strong>Maharaja of Rewa</strong>, ruler of the Rewa princely state in present-day Madhya Pradesh. The reigning Baghela-dynasty monarch at that date was <strong>Maharaja Raghuraj Singh</strong> (r. 1854–1880), a patron known across Kashi for endowing riverfront property in the sacred city, as many princely houses did to secure merit and a permanent presence at Varanasi.</p>
+                </div>
+                <div class="info-card">
+                    <h3>The Baghela Dynasty of Rewa</h3>
+                    <p>Rewa State was the seat of the <strong>Baghela dynasty</strong>, rulers of the Baghelkhand region for centuries from their capital at Rewa (Madhya Pradesh). Like many princely houses of the era, the Rewa court invested in temples, ghats, and dharamshalas in Varanasi as an expression of piety and prestige, well beyond their own territory.</p>
+                </div>
+                <div class="info-card">
+                    <h3>Renamed in the Royal House's Honour</h3>
+                    <p>Following the purchase, the site was renamed after its new patrons — recorded variously in local sources as <strong>Rewa Ghat</strong> or <strong>Rewan Ghat</strong> — and repairs and reconstruction were carried out under the Rewa court's direction, replacing the earlier priest's endowment with a formal princely riverfront residence.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Section 3: Interactive Explorer — Palace Architecture / Cultural Life / Nearby Ghats -->
+        <section class="info-section full-width" aria-labelledby="hub-heading">
+            <h2 id="hub-heading">🏛️ Explore Rewa Ghat</h2>
+            <div class="tabs-container">
+                <div class="tabs-header" role="tablist" aria-label="Rewa Ghat exploration tabs">
+                    <button class="tab-btn active" data-tab="tab-architecture" role="tab" aria-selected="true">
+                        <span>🏛️</span> Palace Architecture
+                    </button>
+                    <button class="tab-btn" data-tab="tab-culture" role="tab" aria-selected="false">
+                        <span>🎨</span> Cultural Importance
+                    </button>
+                    <button class="tab-btn" data-tab="tab-nearby" role="tab" aria-selected="false">
+                        <span>🗺️</span> Nearby Ghats
+                    </button>
+                </div>
+
+                <!-- Tab 1: Palace Architecture -->
+                <div class="tab-content active" id="tab-architecture" role="tabpanel">
+                    <div class="tab-pane-content">
+                        <div class="tab-pane-text">
+                            <h3>Rewa Kothi: A Sandstone Riverfront Palace</h3>
+                            <p>The palace built by the Rewa court, known locally as the <strong>Rewa Kothi</strong>, stands at the top of the stairs on the northern edge of Ganga Mahal — immediately recognisable by the royal insignia carved above the gate facing the river.</p>
+                            <ul class="key-highlights-list">
+                                <li><strong>Sandstone Construction:</strong> Built almost entirely in dressed sandstone, in keeping with the riverfront palace tradition of Varanasi's princely ghats.</li>
+                                <li><strong>Two Linked Structures:</strong> The complex comprises a main palace block and an auxiliary house, connected by covered northern and southern porches resting on joined stone pillars.</li>
+                                <li><strong>Ardhstambhs in the Coastline Wall:</strong> A collection of <em>ardhstambhs</em> (half-pillars), salvaged and reused, forms part of the palace's riverside retaining wall — a distinctive structural signature of the site.</li>
+                            </ul>
+                        </div>
+                        <div class="tab-pane-box">
+                            <h4>🏛️ Architectural Note</h4>
+                            <p>Unlike the colonnaded grandeur of some neighbouring princely ghats, Rewa Kothi's architecture is comparatively restrained — solid sandstone masonry built for residence and administration rather than public ceremony.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Tab 2: Cultural Importance -->
+                <div class="tab-content" id="tab-culture" role="tabpanel">
+                    <div class="tab-pane-content">
+                        <div class="tab-pane-text">
+                            <h3>From Royal Residence to Arts Hostel</h3>
+                            <p>In the second half of the 20th century, the Maharaja of Rewa ("Rewa Naresh") donated the Rewa Kothi to <strong>Banaras Hindu University</strong> (then referred to as Kashi Hindu Vishwavidyalaya). The university converted the palace into a hostel for students of its <strong>Drishya Kala</strong> (Visual Arts) and <strong>Sangeet Kala</strong> (Music) faculties — a transformation that continues to shape the ghat's identity today.</p>
+                            <ul class="key-highlights-list">
+                                <li><strong>A Living Arts Community:</strong> Rewa Ghat is still known locally as a favourite haunt of musicians and painters, many of whom arrive in the early morning to sketch and paint the riverfront's changing light.</li>
+                                <li><strong>Quiet Among Kashi's Riverfront:</strong> Set away from the crowds of Dashashwamedh and Assi, it is often described as one of Varanasi's cleanest and calmest ghats — valued for reflection as much as for its history.</li>
+                                <li><strong>A Rare Continuity:</strong> Few princely riverfront estates in Varanasi remain in continuous, active use; Rewa Ghat's life as a functioning student hostel is an unusually direct link between its royal past and its present.</li>
+                            </ul>
+                        </div>
+                        <div class="tab-pane-box">
+                            <h4>🎨 Cultural Highlight</h4>
+                            <p>A palace endowed by a Punjab court priest, purchased by a Madhya Pradesh royal house, and now home to Varanasi's own art and music students — Rewa Ghat's story crosses three regions of India in one riverfront address.</p>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Tab 3: Nearby Ghats -->
+                <div class="tab-content" id="tab-nearby" role="tabpanel">
+                    <div class="tab-pane-content">
+                        <div class="tab-pane-text">
+                            <h3>Its Place in the Riverfront Chain</h3>
+                            <p>Rewa Ghat sits inside one of the most historically dense stretches of Varanasi's riverfront, immediately south of the city's most famous southern anchor point.</p>
+                            <ul class="key-highlights-list">
+                                <li><strong>Assi Ghat (south end of the chain):</strong> Rewa Ghat was originally considered part of Assi Ghat, where the Assi River meets the Ganges — one of the city's most auspicious bathing points.</li>
+                                <li><strong>Ganga Mahal Ghat (immediate neighbour):</strong> Named for a former Maharaja's palace of its own, Ganga Mahal Ghat sits directly beside Rewa Ghat, with the Rewa Kothi standing at its northern edge.</li>
+                                <li><strong>Tulsi Ghat (just north):</strong> A short walk away, Tulsi Ghat marks the site associated with Goswami Tulsidas, who is said to have composed the <em>Ramcharitmanas</em> nearby and founded a Hanuman shrine just above the ghat.</li>
+                            </ul>
+                        </div>
+                        <div class="tab-pane-box">
+                            <h4>🗺️ Orientation Tip</h4>
+                            <p>Visitors walking the riverfront from Assi Ghat northward toward Dashashwamedh Ghat pass Rewa Ghat within the first few minutes — easy to miss, but worth the pause.</p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Section 4: Temples -->
+        <section class="info-section full-width" id="temples" aria-labelledby="temples-heading">
+            <h2 id="temples-heading">🛕 Temples &amp; Sacred Surroundings</h2>
+            <div class="content-grid">
+                <div class="info-card">
+                    <h3>A Riverfront of Residence, Not Ritual</h3>
+                    <p>Rewa Ghat itself is not built around a single grand temple, unlike some of Varanasi's more famous ghats — its story is one of a priest's endowment and a royal palace rather than a public shrine. Its sacred character instead comes from the temples that frame it on either side along the riverfront.</p>
+                </div>
+                <div class="info-card">
+                    <h3>Tulsi Ghat's Hanuman Shrine</h3>
+                    <p>Just north of Rewa Ghat, <strong>Tulsi Ghat</strong> carries one of the most literarily significant sacred sites on the river: the monastery and Hanuman temple founded by <strong>Goswami Tulsidas</strong>, the saint-poet who composed the Awadhi Ramcharitmanas in this stretch of Kashi.</p>
+                </div>
+                <div class="info-card">
+                    <h3>Kedar Ghat's Kedareshwar Temple</h3>
+                    <p>A short distance further along the riverfront, <strong>Kedar Ghat</strong> is home to the <strong>Kedareshwar Temple</strong>, one of the significant Shiva shrines of Varanasi and a popular pilgrimage stop for visitors walking this southern stretch of ghats.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Section 5: Interesting Facts -->
+        <section class="info-section full-width" id="facts" aria-labelledby="facts-heading">
+            <h2 id="facts-heading">💡 Interesting Facts</h2>
+            <div class="tabs-container">
+                <ul class="key-highlights-list facts-list">
+                    <li><strong>Three names, one ghat:</strong> Before becoming Rewa Ghat in 1879, it was known first as Lala Mishir Ghat and later as Leelaram (Lilaram) Ghat.</li>
+                    <li><strong>Built by a court priest, not a king:</strong> The original ghat was endowed by Lala Mishir, priest to Maharaja Ranjit Singh of Punjab — the founder of the Sikh Empire — long before any connection to Rewa existed.</li>
+                    <li><strong>A palace made partly of salvaged pillars:</strong> The Rewa Kothi's riverside retaining wall incorporates a collection of ardhstambhs (half-pillars), a distinctive construction detail rarely seen elsewhere on the riverfront.</li>
+                    <li><strong>Donated, not sold, to its present use:</strong> The Maharaja of Rewa gifted the palace to Banaras Hindu University rather than selling it — an act that kept the site in continuous public use.</li>
+                    <li><strong>A working arts hostel today:</strong> Rewa Kothi houses BHU's Visual Arts (Drishya Kala) and Music (Sangeet Kala) students, making it one of the few princely ghat-palaces in Varanasi still in active daily use.</li>
+                    <li><strong>About 5 km from Varanasi Junction:</strong> Close enough to the city's main railway station for an easy visit, yet the ghat remains one of the quietest stretches of the riverfront.</li>
+                </ul>
+            </div>
+        </section>
+
+        <!-- Section 6: Visual Heritage Gallery -->
+        <section class="gallery-section" id="gallery" aria-labelledby="gallery-heading">
+            <h2 class="section-title" id="gallery-heading">Visual Heritage Gallery</h2>
+            <div class="gallery-grid">
+                <div class="gallery-card">
+                    <div class="gallery-img-box" style="background-image: linear-gradient(to top, rgba(0,0,0,0.8), rgba(0,0,0,0.2)), url('https://images.unsplash.com/photo-1763994199920-8a519740fe93?fm=jpg&q=70&w=800&auto=format&fit=crop');">
+                        <div class="gallery-caption">
+                            <h4>Rewa Kothi Facade</h4>
+                            <p>The sandstone palace built for the Rewa royal house on the Ganges riverfront.</p>
+                        </div>
+                    </div>
+                    <div class="gallery-card-body">
+                        The palace's sandstone facade, its northern porch, and the royal insignia at the gate mark Rewa Kothi as one of Varanasi's quieter princely residences.
+                        <span class="attribution-tag">Photo: Zoshua Colah / Unsplash — red sandstone archway, Indian monument (illustrative)</span>
+                    </div>
+                </div>
+
+                <div class="gallery-card">
+                    <div class="gallery-img-box" style="background-image: linear-gradient(to top, rgba(0,0,0,0.8), rgba(0,0,0,0.2)), url('https://images.unsplash.com/photo-1713922622737-8aadb956c0f0?fm=jpg&q=70&w=800&auto=format&fit=crop');">
+                        <div class="gallery-caption">
+                            <h4>The Stone Steps at Dawn</h4>
+                            <p>Early morning light on Rewa Ghat's quiet stone stairway.</p>
+                        </div>
+                    </div>
+                    <div class="gallery-card-body">
+                        Painters and music students from Banaras Hindu University are often found here in the early hours, sketching the ghat before the city wakes.
+                        <span class="attribution-tag">Photo: Diwakar Singh / Unsplash — Assi Ghat, Varanasi (illustrative, neighbouring ghat)</span>
+                    </div>
+                </div>
+
+                <div class="gallery-card">
+                    <div class="gallery-img-box" style="background-image: linear-gradient(to top, rgba(0,0,0,0.8), rgba(0,0,0,0.2)), url('https://images.unsplash.com/photo-1763767457329-05e04aecfe69?fm=jpg&q=70&w=800&auto=format&fit=crop');">
+                        <div class="gallery-caption">
+                            <h4>Between Ganga Mahal and Tulsi Ghat</h4>
+                            <p>Rewa Ghat's position within Varanasi's dense southern riverfront chain.</p>
+                        </div>
+                    </div>
+                    <div class="gallery-card-body">
+                        Flanked by Ganga Mahal Ghat and Tulsi Ghat, Rewa Ghat forms part of one of the most historically layered stretches of the Varanasi waterfront.
+                        <span class="attribution-tag">Photo: Zoshua Colah / Unsplash — red sandstone arches, Indian building (illustrative)</span>
+                    </div>
+                </div>
+
+                <div class="gallery-card">
+                    <div class="gallery-img-box" style="background-image: linear-gradient(to top, rgba(0,0,0,0.8), rgba(0,0,0,0.2)), url('https://images.unsplash.com/photo-1713922622737-8aadb956c0f0?fm=jpg&q=70&w=800&h=500&auto=format&fit=crop&crop=bottom');">
+                        <div class="gallery-caption">
+                            <h4>The Ganges from Rewa Ghat</h4>
+                            <p>A quiet, uncrowded view of the river, away from Varanasi's busiest ghats.</p>
+                        </div>
+                    </div>
+                    <div class="gallery-card-body">
+                        Away from the bustle of Dashashwamedh and Assi Ghats, Rewa Ghat remains one of the calmest points to watch the Ganges flow.
+                        <span class="attribution-tag">Photo: Diwakar Singh / Unsplash — Assi Ghat, Varanasi (illustrative, neighbouring ghat)</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Footer -->
+        <footer class="page-footer">
+            <a href="../ganga-ghats-experience/index.html" class="back-to-ghats-btn">
+                <span>←</span> Back to Virtual Ganga Ghats Experience
+            </a>
+            <p>© 2026 Incredible India Explorer. Dedicated to celebrating India's rich cultural, spiritual, and architectural heritage.</p>
+        </footer>
+
+    </main>
+
+    <script src="../pages-common.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/rewa-ghat/script.js
+++ b/frontend/rewa-ghat/script.js
@@ -1,0 +1,54 @@
+/* ==========================================================================
+   REWA GHAT — INTERACTIVE SCRIPT
+   Handles interactive exploration tabs (Palace Architecture / Cultural
+   Importance / Nearby Ghats) and theme switching logic.
+   ========================================================================== */
+
+document.addEventListener('DOMContentLoaded', () => {
+    initTabs();
+    initThemeToggle();
+});
+
+/* ---------- 1. Interactive Tabs ---------- */
+function initTabs() {
+    const tabBtns = document.querySelectorAll('.tab-btn');
+    const tabContents = document.querySelectorAll('.tab-content');
+
+    if (!tabBtns.length) return;
+
+    tabBtns.forEach(btn => {
+        btn.addEventListener('click', () => {
+            const targetId = btn.getAttribute('data-tab');
+
+            tabBtns.forEach(b => {
+                b.classList.remove('active');
+                b.setAttribute('aria-selected', 'false');
+            });
+            tabContents.forEach(c => c.classList.remove('active'));
+
+            btn.classList.add('active');
+            btn.setAttribute('aria-selected', 'true');
+
+            const targetContent = document.getElementById(targetId);
+            if (targetContent) {
+                targetContent.classList.add('active');
+            }
+        });
+    });
+}
+
+/* ---------- 2. Theme Toggle Support ---------- */
+function initThemeToggle() {
+    const themeBtn = document.getElementById('theme-toggle');
+    if (!themeBtn) return;
+
+    const isLight = document.body.classList.contains('light-theme');
+    themeBtn.textContent = isLight ? '🌙' : '☀️';
+
+    themeBtn.addEventListener('click', () => {
+        document.body.classList.toggle('light-theme');
+        const nowLight = document.body.classList.contains('light-theme');
+        themeBtn.textContent = nowLight ? '🌙' : '☀️';
+        localStorage.setItem('theme', nowLight ? 'light' : 'dark');
+    });
+}

--- a/frontend/rewa-ghat/style.css
+++ b/frontend/rewa-ghat/style.css
@@ -1,0 +1,549 @@
+/* ==========================================================================
+   REWA GHAT — STYLESHEET
+   Dedicated page showcasing Rewa Ghat's royal patronage history,
+   Rewa Kothi palace architecture, temples, and riverfront heritage.
+   ========================================================================== */
+
+:root {
+    --primary-color: #9f1239; /* Royal Maroon */
+    --primary-dark: #7f1d3f;
+    --accent-color: #ca8a04;  /* Baghela Gold */
+    --hero-bg: #fff1f2;       /* Soft Rose Cream */
+    --card-bg: #ffffff;
+    --card-hover-bg: #fffbf5;
+    --text-color: #334155;
+    --heading-color: #1e293b;
+    --border-color: #fbcfe8;
+    --badge-bg: #ffe4e6;
+    --badge-text: #881337;
+    --royal-gold: #b45309;
+    --shadow-sm: 0 4px 6px -1px rgba(159, 18, 57, 0.08);
+    --shadow-md: 0 10px 25px -5px rgba(159, 18, 57, 0.14);
+}
+
+/* Dark Theme Variables */
+body:not(.light-theme) {
+    --primary-color: #fb7185; /* Rose Glow */
+    --primary-dark: #9f1239;
+    --accent-color: #eab308;
+    --hero-bg: #2c0a1c;       /* Royal Twilight Maroon */
+    --card-bg: #170b12;
+    --card-hover-bg: #26121b;
+    --text-color: #cbd5e1;
+    --heading-color: #f8fafc;
+    --border-color: #7f1d3f;
+    --badge-bg: #4c0519;
+    --badge-text: #fecdd3;
+    --royal-gold: #eab308;
+    --shadow-sm: 0 4px 6px -1px rgba(0, 0, 0, 0.4);
+    --shadow-md: 0 10px 25px -5px rgba(0, 0, 0, 0.6);
+}
+
+/* Page-wide background */
+body.rewa-ghat-page {
+    margin: 0;
+    min-height: 100vh;
+    background: radial-gradient(ellipse 900px 500px at 15% 0%, rgba(159, 18, 57, 0.18), transparent 60%),
+                radial-gradient(ellipse 700px 450px at 100% 20%, rgba(202, 138, 4, 0.12), transparent 55%),
+                #0d0508;
+    color: var(--text-color);
+    font-family: 'Outfit', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+body.rewa-ghat-page.light-theme {
+    background: radial-gradient(ellipse 900px 500px at 15% 0%, rgba(255, 228, 230, 0.9), transparent 60%),
+                radial-gradient(ellipse 700px 450px at 100% 20%, rgba(254, 249, 195, 0.7), transparent 55%),
+                #fffbf5;
+}
+
+/* Minimal Header (logo + theme toggle only) */
+.rewa-minimal-header {
+    padding: 1.25rem 2rem;
+    border-bottom: 1px solid var(--border-color);
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    background: rgba(13, 5, 8, 0.85);
+    backdrop-filter: blur(8px);
+}
+
+body.rewa-ghat-page.light-theme .rewa-minimal-header {
+    background: rgba(255, 251, 245, 0.9);
+}
+
+.rewa-minimal-header-inner {
+    max-width: 1200px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.rewa-minimal-header .nav-logo {
+    font-family: 'Playfair Display', Georgia, serif;
+    font-weight: 700;
+    font-size: 1.15rem;
+    text-decoration: none;
+}
+
+.rewa-minimal-header .saffron { color: #f97316; }
+.rewa-minimal-header .gold { color: var(--royal-gold); }
+.rewa-minimal-header .green { color: #16a34a; }
+
+.rewa-minimal-header .btn-theme-toggle {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 50%;
+    width: 2.4rem;
+    height: 2.4rem;
+    font-size: 1.1rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.2s ease, background-color 0.2s ease;
+}
+
+.rewa-minimal-header .btn-theme-toggle:hover {
+    transform: scale(1.08);
+    background: var(--badge-bg);
+}
+
+.page-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+    font-family: 'Outfit', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.section-title {
+    color: var(--primary-color);
+    text-align: center;
+    margin-bottom: 2rem;
+    font-size: 2.2rem;
+    font-family: 'Playfair Display', Georgia, serif;
+    border-bottom: 2px solid var(--accent-color);
+    display: inline-block;
+    padding-bottom: 0.5rem;
+}
+
+.text-center {
+    text-align: center;
+}
+
+/* Hero Section */
+.hero-section {
+    background-color: var(--hero-bg);
+    border: 2px solid var(--accent-color);
+    border-radius: 20px;
+    padding: 4rem 2rem;
+    text-align: center;
+    margin-bottom: 4rem;
+    position: relative;
+    overflow: hidden;
+    box-shadow: var(--shadow-md);
+}
+
+.badge-container {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
+}
+
+.category-badge, .culture-badge {
+    display: inline-block;
+    background: var(--badge-bg);
+    color: var(--badge-text);
+    padding: 0.5rem 1.2rem;
+    border-radius: 20px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    border: 1px solid var(--border-color);
+}
+
+.culture-badge {
+    background: var(--royal-gold);
+    color: #ffffff;
+    border: none;
+}
+
+body:not(.light-theme) .culture-badge {
+    background: #ca8a04;
+    color: #1c1917;
+}
+
+.hero-content h1 {
+    font-size: 3.8rem;
+    color: var(--primary-color);
+    margin: 0 0 0.75rem;
+    font-family: 'Playfair Display', Georgia, serif;
+    font-weight: 700;
+    letter-spacing: -0.5px;
+}
+
+.subtitle {
+    font-size: 1.5rem;
+    color: var(--heading-color);
+    margin-bottom: 1.8rem;
+    font-weight: 500;
+}
+
+.hero-desc {
+    max-width: 850px;
+    margin: 0 auto 2rem;
+    font-size: 1.15rem;
+    color: var(--text-color);
+    line-height: 1.8;
+}
+
+/* Hero Geo Summary Table */
+.geo-table {
+    width: 100%;
+    max-width: 850px;
+    margin: 0 auto;
+    border-collapse: collapse;
+    text-align: left;
+    background: var(--card-bg);
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: var(--shadow-sm);
+}
+
+.geo-table th, .geo-table td {
+    padding: 0.85rem 1.1rem;
+    border-bottom: 1px solid var(--border-color);
+    font-size: 0.98rem;
+}
+
+.geo-table tr:last-child th, .geo-table tr:last-child td {
+    border-bottom: none;
+}
+
+.geo-table th {
+    width: 32%;
+    color: var(--primary-color);
+    font-weight: 700;
+    background: var(--hero-bg);
+}
+
+.geo-table td {
+    color: var(--text-color);
+}
+
+/* Grids & Cards */
+.content-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 2.5rem;
+    margin-bottom: 4rem;
+}
+
+.full-width {
+    grid-column: 1 / -1;
+    margin-bottom: 3rem;
+}
+
+.info-section h2 {
+    color: var(--primary-color);
+    border-bottom: 2px solid var(--accent-color);
+    padding-bottom: 0.5rem;
+    margin-bottom: 1.5rem;
+    font-size: 1.8rem;
+    font-family: 'Playfair Display', Georgia, serif;
+}
+
+.info-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 16px;
+    padding: 2rem;
+    box-shadow: var(--shadow-sm);
+    height: 100%;
+    color: var(--text-color);
+    line-height: 1.75;
+    font-size: 1.05rem;
+    transition: transform 0.25s ease, box-shadow 0.25s ease, background-color 0.25s ease;
+}
+
+.info-card:hover {
+    transform: translateY(-4px);
+    box-shadow: var(--shadow-md);
+    background: var(--card-hover-bg);
+}
+
+.info-card h3 {
+    color: var(--primary-color);
+    font-size: 1.35rem;
+    margin-top: 0;
+    margin-bottom: 0.75rem;
+    font-family: 'Playfair Display', Georgia, serif;
+}
+
+/* Interactive Tabs Section */
+.tabs-container {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 16px;
+    padding: 2rem;
+    box-shadow: var(--shadow-sm);
+    margin-bottom: 1rem;
+}
+
+.tabs-header {
+    display: flex;
+    gap: 1rem;
+    border-bottom: 2px solid var(--border-color);
+    margin-bottom: 2rem;
+    overflow-x: auto;
+    padding-bottom: 0.5rem;
+}
+
+.tab-btn {
+    background: transparent;
+    border: none;
+    padding: 0.8rem 1.4rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-color);
+    cursor: pointer;
+    border-radius: 10px;
+    transition: all 0.2s ease;
+    white-space: nowrap;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.tab-btn:hover {
+    background: var(--badge-bg);
+    color: var(--badge-text);
+}
+
+.tab-btn.active {
+    background: var(--primary-color);
+    color: #ffffff;
+    box-shadow: 0 4px 12px rgba(159, 18, 57, 0.35);
+}
+
+.tab-content {
+    display: none;
+    animation: fadeIn 0.3s ease-in-out;
+}
+
+.tab-content.active {
+    display: block;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(6px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+.tab-pane-content {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+    align-items: center;
+}
+
+@media (max-width: 768px) {
+    .tab-pane-content {
+        grid-template-columns: 1fr;
+    }
+}
+
+.tab-pane-text h3 {
+    color: var(--primary-color);
+    font-size: 1.6rem;
+    margin-top: 0;
+    font-family: 'Playfair Display', Georgia, serif;
+}
+
+.tab-pane-text p {
+    line-height: 1.8;
+    color: var(--text-color);
+    font-size: 1.05rem;
+}
+
+.key-highlights-list {
+    list-style: none;
+    padding: 0;
+    margin: 1.5rem 0 0 0;
+}
+
+.key-highlights-list li {
+    position: relative;
+    padding-left: 1.8rem;
+    margin-bottom: 0.8rem;
+    color: var(--text-color);
+    line-height: 1.6;
+}
+
+.key-highlights-list li::before {
+    content: "🏛️";
+    position: absolute;
+    left: 0;
+    font-size: 1rem;
+}
+
+.facts-list {
+    margin-top: 0;
+}
+
+.facts-list li::before {
+    content: "💡";
+}
+
+.tab-pane-box {
+    background: var(--hero-bg);
+    border: 1px dashed var(--accent-color);
+    border-radius: 14px;
+    padding: 1.8rem;
+}
+
+.tab-pane-box h4 {
+    color: var(--primary-dark);
+    margin-top: 0;
+    font-size: 1.2rem;
+}
+
+body:not(.light-theme) .tab-pane-box h4 {
+    color: var(--accent-color);
+}
+
+/* Gallery Section */
+.gallery-section {
+    margin-bottom: 4rem;
+}
+
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.8rem;
+}
+
+.gallery-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 14px;
+    overflow: hidden;
+    box-shadow: var(--shadow-sm);
+    transition: transform 0.25s, box-shadow 0.25s;
+}
+
+.gallery-card:hover {
+    transform: translateY(-5px);
+    box-shadow: var(--shadow-md);
+}
+
+.gallery-img-box {
+    height: 220px;
+    position: relative;
+    display: flex;
+    align-items: flex-end;
+    padding: 1.2rem;
+    color: #ffffff;
+    box-sizing: border-box;
+    background-size: cover;
+    background-position: center;
+}
+
+.gallery-img-box::before {
+    content: "";
+    position: absolute;
+    top: 0; left: 0; right: 0; bottom: 0;
+    background: linear-gradient(to top, rgba(0,0,0,0.85) 0%, rgba(0,0,0,0.2) 60%, transparent 100%);
+}
+
+.gallery-caption {
+    position: relative;
+    z-index: 2;
+}
+
+.gallery-caption h4 {
+    margin: 0 0 0.3rem 0;
+    font-size: 1.25rem;
+    font-family: 'Playfair Display', Georgia, serif;
+    color: #ffffff;
+}
+
+.gallery-caption p {
+    margin: 0;
+    font-size: 0.9rem;
+    line-height: 1.4;
+    color: #e2e8f0;
+}
+
+.gallery-card-body {
+    padding: 1.2rem;
+    font-size: 0.95rem;
+    color: var(--text-color);
+    line-height: 1.6;
+}
+
+.attribution-tag {
+    display: block;
+    margin-top: 0.6rem;
+    font-size: 0.78rem;
+    color: var(--accent-color);
+    font-style: italic;
+}
+
+/* Footer & Back Link */
+.page-footer {
+    text-align: center;
+    padding: 3rem 1rem;
+    border-top: 1px solid var(--border-color);
+    margin-top: 4rem;
+    color: var(--text-color);
+}
+
+.back-to-ghats-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: var(--primary-color);
+    color: #ffffff;
+    padding: 0.8rem 1.6rem;
+    border-radius: 30px;
+    text-decoration: none;
+    font-weight: 600;
+    margin-bottom: 2rem;
+    transition: transform 0.2s, background-color 0.2s;
+    box-shadow: var(--shadow-sm);
+}
+
+.back-to-ghats-btn:hover {
+    transform: translateY(-2px);
+    background: var(--primary-dark);
+}
+
+@media (max-width: 768px) {
+    .hero-content h1 {
+        font-size: 2.6rem;
+    }
+    .subtitle {
+        font-size: 1.2rem;
+    }
+    .page-container {
+        padding: 1rem;
+    }
+    .hero-section {
+        padding: 2.5rem 1rem;
+    }
+    .geo-table th, .geo-table td {
+        display: block;
+        width: 100%;
+    }
+    .geo-table th {
+        border-bottom: none;
+        padding-bottom: 0.25rem;
+    }
+    .geo-table td {
+        padding-top: 0.25rem;
+    }
+}

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -10,6 +10,13 @@ window.indiaSearchIndex = [
         description:
             'Explore Naya Ghat in Varanasi: its historical development from 18th-century Phota Ghat, 19th-century sandstone masonry renewal, spacious bathing terraces, boat docking culture, riverfront Shiva and Hanuman shrines, and Dev Deepawali glow.',
         url: 'frontend/naya-ghat/index.html'},
+    {
+        title: 'Rewa Ghat — Varanasi Royal Riverfront Legacy Profile',
+        category: 'Heritage & Architecture',
+        description:
+            'Explore Rewa Ghat in Varanasi: its origin as Lala Mishir Ghat, 1879 purchase and renaming by the Baghela Maharaja of Rewa, the sandstone Rewa Kothi palace and its ardhstambh retaining wall, neighbouring Tulsi and Kedar Ghat temples, and its present life as a Banaras Hindu University arts hostel.',
+        url: 'frontend/rewa-ghat/index.html'
+    },
   {
         title: 'Causatthi Ghat — Varanasi Sixty-Four Yoginis & Shakta Heritage Profile',
         category: 'Heritage & Pilgrimage',
@@ -22,6 +29,7 @@ window.indiaSearchIndex = [
         description:
             'Explore Munshi Ghat in Varanasi: its 1912 construction by Sridhara Narayana Munshi (Finance Minister of Nagpur), royal Darbhanga Palace lineage, fusion of Greco-Roman colonnades and Maratha stone masonry, carved jharokhas, and Dev Deepawali illumination.',
         url: 'frontend/munshi-ghat/index.html'},
+
   {
         title: 'Daraganj Ghat — Prayagraj Historic Riverfront & Sangam Profile',
         category: 'Heritage & Pilgrimage',

--- a/tests/unit/rewa-ghat.test.js
+++ b/tests/unit/rewa-ghat.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function readFile(file) {
+    return readFileSync(
+        resolve(__dirname, '../../frontend/rewa-ghat', file),
+        'utf-8'
+    );
+}
+
+describe('Rewa Ghat — Page Structure & Content (#3295)', () => {
+    let html;
+
+    beforeAll(() => {
+        html = readFile('index.html');
+    });
+
+    it('contains hero section with location and river information', () => {
+        expect(html).toContain('id="hero"');
+        expect(html).toContain('<h1 id="hero-heading">Rewa Ghat</h1>');
+        expect(html).toContain('Varanasi');
+        expect(html).toContain('Ganges');
+        expect(html).toContain('class="geo-table"');
+    });
+
+    it('contains all suggested content sections', () => {
+        expect(html).toContain('id="history"');
+        expect(html).toContain('id="royal-heritage"');
+        expect(html).toContain('id="temples"');
+        expect(html).toContain('id="facts"');
+        expect(html).toContain('id="gallery"');
+    });
+
+    it('explains the origin and history of the ghat', () => {
+        expect(html).toContain('Lala Mishir');
+        expect(html).toContain('Leelaram');
+        expect(html).toContain('1879');
+    });
+
+    it('introduces the connection with the Maharaja of Rewa', () => {
+        expect(html).toContain('Maharaja of Rewa');
+        expect(html).toContain('Baghela');
+        expect(html).toContain('Raghuraj Singh');
+    });
+
+    it('describes the palace and architectural structures', () => {
+        expect(html).toContain('Rewa Kothi');
+        expect(html).toContain('sandstone');
+        expect(html).toContain('Ardhstambhs');
+    });
+
+    it('highlights important nearby temples', () => {
+        expect(html).toContain('Tulsi Ghat');
+        expect(html).toContain('Kedareshwar Temple');
+        expect(html).toContain('Goswami Tulsidas');
+    });
+
+    it('explains cultural heritage and role in Varanasi', () => {
+        expect(html).toContain('Banaras Hindu University');
+        expect(html).toContain('Sangeet Kala');
+        expect(html).toContain('Drishya Kala');
+    });
+
+    it('describes relationship with neighbouring ghats', () => {
+        expect(html).toContain('Assi Ghat');
+        expect(html).toContain('Ganga Mahal Ghat');
+    });
+
+    it('includes historical facts and a visual gallery with credits', () => {
+        expect(html).toContain('id="facts"');
+        expect(html).toContain('class="gallery-grid"');
+        expect(html).toContain('attribution-tag');
+    });
+
+    it('uses accessible, semantic markup for responsive design', () => {
+        expect(html).toContain('aria-labelledby="hero-heading"');
+        expect(html).toContain('role="tablist"');
+        expect(html).toContain('role="tabpanel"');
+        expect(html).toContain('name="viewport"');
+    });
+});
+
+describe('Rewa Ghat — Scripts & Styles', () => {
+    it('style.css defines hero, tabs, and gallery components', () => {
+        const css = readFile('style.css');
+        expect(css).toContain('.hero-section');
+        expect(css).toContain('.tabs-container');
+        expect(css).toContain('.gallery-grid');
+        expect(css).toContain('.geo-table');
+    });
+
+    it('script.js wires interactive tabs and theme switching', () => {
+        const js = readFile('script.js');
+        expect(js).toContain('initTabs');
+        expect(js).toContain('data-tab');
+        expect(js).toContain('theme-toggle');
+    });
+});


### PR DESCRIPTION
## Summary
Adds a dedicated page for **Rewa Ghat** in Varanasi, covering its royal patronage, architecture, temples, and role in the city's riverfront heritage — as requested in #3295.

Closes #3295

## What's included
- **Hero** — location, river (Ganges), distance from Varanasi Junction
- **History** — origin as Lala Mishir Ghat → Leelaram Ghat → Rewa Ghat (1879)
- **Rewa Royal Heritage** — Maharaja Raghuraj Singh, Baghela dynasty patronage
- **Palace Architecture** — Rewa Kothi, sandstone construction, ardhstambh retaining wall (interactive tab)
- **Temples** — honestly scoped: neighbouring Tulsi Ghat (Hanuman shrine, Tulsidas) and Kedar Ghat (Kedareshwar Temple), since Rewa Ghat itself is not built around a standalone temple
- **Cultural Importance** — donated to Banaras Hindu University, now a Sangeet Kala / Drishya Kala student hostel (interactive tab)
- **Nearby Ghats** — Assi Ghat, Ganga Mahal Ghat, Tulsi Ghat (interactive tab)
- **Interesting Facts** — 6-point list
- **Gallery** — 4 cards with photographer credit + Unsplash attribution

## Design
- Follows the existing ghat-page pattern (`munshi-ghat` template) for consistency with the rest of the site
- Royal maroon/gold colour palette (Baghela-dynasty inspired), distinct from other ghat pages
- Fully responsive, semantic markup, ARIA roles on tabs/sections for accessibility
- Registered in `frontend/search-index.js`

## Testing
- Added `tests/unit/rewa-ghat.test.js` — 12 tests covering structure, required content sections, and interactivity
- `npx vitest run tests/unit/rewa-ghat.test.js` → **12 passed**
- Manually verified in browser (desktop) — navigation tabs, theme toggle, and gallery images all load correctly

## Sources
Historical facts (1879 purchase, Baghela dynasty, BHU donation, ardhstambh construction) drawn from published Varanasi heritage guides referenced during research; cross-checked across multiple independent sources for consistency.
<img width="1440" height="852" alt="Screenshot 2026-08-24 095714" src="https://github.com/user-attachments/assets/b7925acf-1b35-4a0f-8726-b48d6fae46b0" />
<img width="1440" height="852" alt="Screenshot 2026-08-24 100435" src="https://github.com/user-attachments/assets/95950589-fa05-4b6b-9b5c-04d1a1819d71" />
<img width="1440" height="852" alt="Screenshot 2026-08-24 095729" src="https://github.com/user-attachments/assets/baace04e-17fa-448c-8faa-6b3df4b450da" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a responsive Rewa Ghat heritage page with historical, royal, architectural, and cultural information.
  * Added interactive tabs for architecture, culture, and nearby ghats.
  * Added dark-mode support with saved theme preferences.
  * Added temple details, key facts, a visual gallery, and navigation back to the Ganga Ghats experience.
  * Added Rewa Ghat to site search results.

* **Accessibility**
  * Added accessible tab controls and responsive page structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->