### PR TITLE
feat: Add Scindia Ghat — The Partially Submerged Shiva Temple page (#3283)

### DIFF
--- a/frontend/scindia-ghat/index.html
+++ b/frontend/scindia-ghat/index.html
@@ -1,0 +1,294 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Scindia Ghat — The Partially Submerged Shiva Temple | Incredible India Explorer</title>
+    <meta name="description" content="Explore Scindia Ghat in Varanasi — its Maratha royal heritage, the famously tilted and partially submerged Ratneshwar Mahadev Temple, architecture, and religious significance.">
+
+    <meta property="og:title" content="Scindia Ghat — The Partially Submerged Shiva Temple">
+    <meta property="og:description" content="A Maratha-built ghat on the Ganges, home to the leaning Ratneshwar Mahadev Temple — tilted more sharply than the Tower of Pisa and slowly sinking into the river.">
+    <meta property="og:type" content="article">
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="../pages-common.css">
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+          integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+          crossorigin="" />
+
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "TouristAttraction",
+        "name": "Scindia Ghat",
+        "description": "A riverfront ghat in Varanasi built by the Maratha Scindia dynasty, famous for the partially submerged, tilted Ratneshwar Mahadev Temple.",
+        "address": {
+            "@type": "PostalAddress",
+            "addressLocality": "Varanasi",
+            "addressRegion": "Uttar Pradesh",
+            "addressCountry": "IN"
+        },
+        "geo": {
+            "@type": "GeoCoordinates",
+            "latitude": 25.3138,
+            "longitude": 83.0106
+        }
+    }
+    </script>
+</head>
+<body class="scindia-page">
+
+    <header class="site-header" id="site-header">
+        <div class="header-inner">
+            <a href="../../index.html" class="logo">Incredible India Explorer</a>
+            <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation menu" aria-expanded="false">☰</button>
+            <nav id="nav-menu" class="nav-menu">
+                <a href="../../index.html">Home</a>
+            </nav>
+            <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme">🌓</button>
+        </div>
+    </header>
+
+    <main class="page-container">
+
+        <!-- Hero -->
+        <section class="hero-section scindia-hero">
+            <div class="badge-container">
+                <span class="hero-badge badge-teal">Varanasi Ghats</span>
+                <span class="hero-badge badge-gold">Maratha Heritage</span>
+                <span class="hero-badge badge-sand">Ganges River</span>
+            </div>
+            <div class="hero-content">
+                <h1>Scindia Ghat <span class="accent">— The Leaning Temple of the Ganges</span></h1>
+                <p class="subtitle">Also known as Shinde Ghat</p>
+                <p class="hero-desc">
+                    Built by the Maratha Scindia (Shinde) dynasty on the western bank of the Ganges, Scindia Ghat is
+                    one of Varanasi's most photographed riverfront sites — not for grandeur, but for a quiet architectural
+                    mystery. Just offshore, the Ratneshwar Mahadev Temple leans dramatically into the river, partially
+                    submerged for over 150 years, sinking a little further with each passing decade.
+                </p>
+            </div>
+            <div class="hero-stats-ribbon">
+                <div class="stat-item"><span class="stat-label">Location</span><span class="stat-val">Varanasi, Uttar Pradesh</span></div>
+                <div class="stat-item"><span class="stat-label">River</span><span class="stat-val">Ganges (Ganga)</span></div>
+                <div class="stat-item"><span class="stat-label">Built</span><span class="stat-val">c. 1830–1835</span></div>
+                <div class="stat-item"><span class="stat-label">Temple Tilt</span><span class="stat-val">~9°, more than the Tower of Pisa</span></div>
+            </div>
+        </section>
+
+        <div class="content-grid">
+
+            <!-- History -->
+            <section class="info-card" id="history">
+                <h2>📜 History</h2>
+                <div class="grid-2col">
+                    <div>
+                        <p>
+                            The site of Scindia Ghat has been rebuilt more than once. Local heritage records note that an
+                            earlier ghat here — then called <strong>Vadeshwar Ghat</strong> — was reconstructed around
+                            1780 under the patronage of <strong>Ahilyabai Holkar</strong> of Indore, one of the great
+                            royal builders of Varanasi's riverfront.
+                        </p>
+                        <p>
+                            The ghat took its present name and form in the 1830s, when it was rebuilt by
+                            <strong>Rani Baija Bai Scindia</strong>, widow of Maharaja Daulat Rao Scindia of Gwalior.
+                            Sources place the construction between 1830 and 1835. The ghat was further repaired and
+                            remodelled by <strong>Maharaja Daulatrao Scindia</strong> in 1937, reflecting the family's
+                            continued investment in the site across a century.
+                        </p>
+                    </div>
+                    <div class="callout-box">
+                        <h3>A Sacred Origin Story</h3>
+                        <p>
+                            According to Hindu mythology, Scindia Ghat is believed to be the birthplace of
+                            <strong>Agni</strong>, the god of fire — one of many legends that give Varanasi's individual
+                            ghats their own distinct spiritual identity within the wider sacred riverfront.
+                        </p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Scindia Heritage -->
+            <section class="info-card" id="scindia-heritage">
+                <h2>👑 The Scindia (Maratha) Connection</h2>
+                <p>
+                    The Scindias (also spelled Shinde) were one of the most powerful ruling families of the Maratha
+                    Confederacy, governing the princely state of Gwalior. Like several other Maratha and Rajput royal
+                    houses — the Holkars, the Peshwas, the Bhonsales — the Scindias invested heavily in the religious
+                    infrastructure of Kashi (Varanasi), viewing ghat-building as both an act of piety and a public
+                    display of dynastic prestige.
+                </p>
+                <ul class="feature-list">
+                    <li>Rebuilt in the 1830s under Rani Baija Bai Scindia, queen consort of Gwalior.</li>
+                    <li>Further repaired in 1937 by Maharaja Daulatrao Scindia, showing sustained royal patronage.</li>
+                    <li>Part of a broader pattern of Maratha ghat-building in Varanasi, alongside Ahilyabai Holkar's works and the nearby Bajirao Ghat, built by the Peshwas.</li>
+                    <li>The ghat's popular name — Scindia or "Shinde" Ghat — directly honours the family that shaped it.</li>
+                </ul>
+            </section>
+
+            <!-- Submerged Temple -->
+            <section class="info-card" id="submerged-temple">
+                <h2>🛕 The Partially Submerged Shiva Temple</h2>
+                <div class="grid-2col">
+                    <div>
+                        <p>
+                            The ghat's defining landmark is the <strong>Ratneshwar Mahadev Temple</strong>, popularly
+                            called the "Leaning Shiva Temple." Dedicated to Lord Shiva, the temple has tilted and sunk
+                            into the Ganges for more than 150 years, and remains only partially visible above the
+                            waterline — more so in the drier months when the river level drops.
+                        </p>
+                        <p>
+                            Structural surveys have found the temple leans at roughly <strong>9 degrees</strong> — noticeably
+                            more than the famous Leaning Tower of Pisa's lean of about 4 degrees. The commonly cited
+                            explanation is that the temple's foundation could not bear the immense weight of the
+                            surrounding ghat masonry, causing it to gradually subside and tilt into the riverbed.
+                        </p>
+                    </div>
+                    <div class="callout-box">
+                        <h3>The "Matru Rin" Legend</h3>
+                        <p>
+                            Locally, the temple is also known as <strong>Matru Rin</strong> ("debt to the mother"). Folklore
+                            holds it was built by a son to repay a debt to his mother, and that the temple is cursed —
+                            a story residents offer alongside the structural explanation for why the temple continues
+                            to sink further each year.
+                        </p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Religious Significance -->
+            <section class="info-card" id="religious-significance">
+                <h2>🕉️ Religious Significance</h2>
+                <p>
+                    Scindia Ghat sits within the <strong>Siddha Kshetra</strong> ("Field of Fulfilment"), a tightly
+                    packed maze of alleys behind the ghat that holds several of Kashi's most revered shrines. The area
+                    is considered spiritually potent, and pilgrims combine a visit to the ghat itself with darshan at
+                    these neighbouring temples. As the believed birthplace of Agni, and given its direct proximity to
+                    Manikarnika Ghat — the primary cremation ghat associated with moksha (liberation) — Scindia Ghat
+                    carries deep ritual weight within the wider sacred geography of the Ganges riverfront.
+                </p>
+            </section>
+
+            <!-- Architecture -->
+            <section class="info-card" id="architecture">
+                <h2>🏛️ Architecture</h2>
+                <p>
+                    Scindia Ghat is built in a distinctive three-tier style of stone turrets known locally as
+                    <strong>marhis</strong>. The uppermost row has two large corner turrets, the tallest and most
+                    massive of the structure; a middle row has six turrets, and a lower row has five — all connected
+                    by stone walls and stairways. Locals traditionally use these turrets as shaded seating after
+                    bathing in the river. The sheer weight of this dense stone masonry is the same factor most often
+                    blamed for the neighbouring Ratneshwar temple's subsidence into the riverbed.
+                </p>
+            </section>
+
+            <!-- Nearby Heritage -->
+            <section class="hub-section" id="nearby-heritage">
+                <h2>🗺️ Nearby Heritage & Its Relationship with Manikarnika Ghat</h2>
+                <div class="hub-tabs" role="tablist">
+                    <button class="hub-tab-btn active" data-tab="manikarnika" role="tab" aria-selected="true">Manikarnika Ghat</button>
+                    <button class="hub-tab-btn" data-tab="shrines" role="tab" aria-selected="false">Siddha Kshetra Shrines</button>
+                    <button class="hub-tab-btn" data-tab="map" role="tab" aria-selected="false">Map</button>
+                </div>
+
+                <div class="hub-panel active" id="panel-manikarnika">
+                    <p>
+                        Scindia Ghat sits directly beside <strong>Manikarnika Ghat</strong> to its south — Varanasi's
+                        principal cremation ghat, where funeral pyres burn continuously. The two ghats are physically
+                        contiguous, and their proximity shapes how each is experienced: Manikarnika's constant activity
+                        and smoke are visible from Scindia's steps, while Scindia itself offers a relatively quieter
+                        spot for reflection, photography, and worship, just steps away from one of Hinduism's most
+                        sacred cremation grounds.
+                    </p>
+                </div>
+
+                <div class="hub-panel" id="panel-shrines" hidden>
+                    <p>
+                        Behind Scindia Ghat lies a dense network of lanes holding numerous small temples and shrines,
+                        collectively part of the Siddha Kshetra. Pilgrims often combine their visit to the ghat and
+                        the leaning temple with darshan at these surrounding shrines, making the area a compact but
+                        significant stop on a longer Varanasi ghat pilgrimage — sitting roughly 1.2 km from
+                        Dashashwamedh Ghat along the riverfront.
+                    </p>
+                </div>
+
+                <div class="hub-panel" id="panel-map" hidden>
+                    <div id="scindia-map" style="height: 320px; border-radius: 0.75rem;"></div>
+                </div>
+            </section>
+
+            <!-- Facts -->
+            <section class="info-card" id="facts">
+                <h2>💡 Interesting Historical Facts</h2>
+                <ul class="feature-list">
+                    <li>The ghat's earlier name was Vadeshwar Ghat, reconstructed around 1780 by Ahilyabai Holkar.</li>
+                    <li>Rebuilt in its current form in the 1830s by Rani Baija Bai Scindia of Gwalior.</li>
+                    <li>Repaired again in 1937 by Maharaja Daulatrao Scindia, over a century after the original construction.</li>
+                    <li>The Ratneshwar Mahadev Temple leans about 9°, more than double the Leaning Tower of Pisa's tilt.</li>
+                    <li>An 1833 lithograph by Thomas Shotter Boys, "Hindoo Temples at Benares," recorded the ghat's temple clusters in its early years.</li>
+                    <li>The temple becomes more visible in summer, when the Ganges' water level drops.</li>
+                </ul>
+            </section>
+
+            <!-- Gallery -->
+            <section class="gallery-section" id="gallery">
+                <h2>📸 Image Gallery</h2>
+                <div class="gallery-grid" id="scindia-gallery">
+                    <div class="gallery-card-item" tabindex="0" role="button" aria-label="View Scindia Ghat stone turrets along the Ganges">
+                        <img src="https://images.unsplash.com/photo-1561361058-c24cecae35ca?fm=jpg&q=60&w=1200&auto=format&fit=crop" alt="Stone ghat steps and turrets along the Ganges River, Varanasi" loading="lazy">
+                        <div class="gallery-caption-overlay">
+                            <h4>Ghat Turrets (Marhis)</h4>
+                            <p>The three-tier stone turret structure typical of Varanasi's riverfront ghats.</p>
+                            <span class="attribution-tag">Photo: Srivatsan Balaji / Unsplash</span>
+                        </div>
+                    </div>
+                    <div class="gallery-card-item" tabindex="0" role="button" aria-label="View Varanasi riverfront silhouette at dawn">
+                        <img src="https://images.unsplash.com/photo-1596097825168-c9b773f404ff?fm=jpg&q=60&w=1200&auto=format&fit=crop" alt="Silhouette of a boat and people on the Ganges at Varanasi during sunrise" loading="lazy">
+                        <div class="gallery-caption-overlay">
+                            <h4>Riverfront at Dawn</h4>
+                            <p>The Ganges riverfront near Manikarnika and Scindia Ghat in early morning light.</p>
+                            <span class="attribution-tag">Photo: Amit Gaur / Unsplash</span>
+                        </div>
+                    </div>
+                    <div class="gallery-card-item" tabindex="0" role="button" aria-label="View boats along the Ganges near Varanasi ghats and temples">
+                        <img src="https://images.unsplash.com/photo-1561359313-0639aad49ca6?fm=jpg&q=60&w=1200&auto=format&fit=crop" alt="Boats on the Ganges river before stone ghats and temples in Varanasi" loading="lazy">
+                        <div class="gallery-caption-overlay">
+                            <h4>Boats Along the Ganga</h4>
+                            <p>Traditional boats moored near the ghats, a common sight along this stretch of the river.</p>
+                            <span class="attribution-tag">Photo: Srivatsan Balaji / Unsplash</span>
+                        </div>
+                    </div>
+                    <div class="gallery-card-item" tabindex="0" role="button" aria-label="View narrow lanes near Varanasi temple complex">
+                        <img src="https://images.unsplash.com/photo-1608412525537-662195e817c5?fm=jpg&q=60&w=1200&auto=format&fit=crop" alt="People walking through narrow lanes near a stone building in Varanasi's old city" loading="lazy">
+                        <div class="gallery-caption-overlay">
+                            <h4>Siddha Kshetra Lanes</h4>
+                            <p>The maze of alleys behind the ghat, home to numerous smaller shrines and temples.</p>
+                            <span class="attribution-tag">Photo: Ashish Singh / Unsplash</span>
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+        </div>
+    </main>
+
+    <!-- Lightbox Modal -->
+    <div class="lightbox-modal" id="lightbox-modal" role="dialog" aria-modal="true" aria-label="Expanded image viewer with attribution" hidden>
+        <div class="lightbox-content">
+            <button class="lightbox-close" id="lightbox-close-btn" aria-label="Close image modal">&times;</button>
+            <img id="lightbox-img" alt="">
+            <div class="lightbox-details">
+                <h3 id="lightbox-title"></h3>
+                <p id="lightbox-desc"></p>
+                <p class="lightbox-attribution" id="lightbox-attr"></p>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+            integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+            crossorigin=""></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/scindia-ghat/script.js
+++ b/frontend/scindia-ghat/script.js
@@ -1,0 +1,151 @@
+/**
+ * Scindia Ghat Profile Interactive Features
+ * Handles Tab Navigation, Leaflet Map Initialization,
+ * Lightbox Gallery, Theme Switching, and Accessibility.
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    // 1. Theme Toggle
+    // NOTE: Match this to the site-wide IIEStorage / theme persistence
+    // pattern used elsewhere in the codebase before merging.
+    const themeBtn = document.getElementById('theme-toggle');
+    if (themeBtn) {
+        themeBtn.addEventListener('click', () => {
+            const isLight = document.body.classList.toggle('light-theme');
+            if (isLight) {
+                document.documentElement.setAttribute('data-theme', 'light');
+            } else {
+                document.documentElement.removeAttribute('data-theme');
+            }
+            localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        });
+    }
+
+    // 2. Mobile Menu Toggle
+    const menuToggle = document.getElementById('menu-toggle');
+    const navMenu = document.getElementById('nav-menu');
+    if (menuToggle && navMenu) {
+        menuToggle.addEventListener('click', () => {
+            const isExpanded = menuToggle.getAttribute('aria-expanded') === 'true';
+            menuToggle.setAttribute('aria-expanded', !isExpanded);
+            navMenu.classList.toggle('active');
+        });
+    }
+
+    // 3. Hub Tab Switching
+    const tabBtns = document.querySelectorAll('.hub-tab-btn');
+    const tabPanels = document.querySelectorAll('.hub-panel');
+    let mapInitialized = false;
+    let mapInitPending = false;
+
+    tabBtns.forEach(btn => {
+        btn.addEventListener('click', () => {
+            tabBtns.forEach(b => {
+                b.classList.remove('active');
+                b.setAttribute('aria-selected', 'false');
+            });
+            tabPanels.forEach(p => {
+                p.classList.remove('active');
+                p.hidden = true;
+            });
+
+            btn.classList.add('active');
+            btn.setAttribute('aria-selected', 'true');
+
+            const tabKey = btn.getAttribute('data-tab');
+            const targetPanel = document.getElementById(`panel-${tabKey}`);
+            if (targetPanel) {
+                targetPanel.classList.add('active');
+                targetPanel.hidden = false;
+            }
+
+            if (tabKey === 'map' && !mapInitialized && !mapInitPending) {
+                mapInitPending = true;
+                setTimeout(() => {
+                    initMap();
+                    mapInitialized = true;
+                    mapInitPending = false;
+                }, 100);
+            }
+        });
+    });
+
+    // 4. Leaflet Map Initialization
+    function initMap() {
+        if (!window.L) return;
+        const mapEl = document.getElementById('scindia-map');
+        if (!mapEl) return;
+
+        const map = L.map('scindia-map', { scrollWheelZoom: false }).setView([25.3138, 83.0106], 16);
+
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '© OpenStreetMap contributors',
+            maxZoom: 19
+        }).addTo(map);
+
+        L.marker([25.3138, 83.0106])
+            .addTo(map)
+            .bindPopup('<strong>Scindia Ghat</strong><br>Home of the leaning Ratneshwar Mahadev Temple')
+            .openPopup();
+
+        L.marker([25.3117, 83.0111])
+            .addTo(map)
+            .bindPopup('<strong>Manikarnika Ghat</strong><br>Primary cremation ghat, directly to the south');
+    }
+
+    // 5. Gallery Lightbox Modal
+    const galleryItems = document.querySelectorAll('.gallery-card-item');
+    const modal = document.getElementById('lightbox-modal');
+    const modalImg = document.getElementById('lightbox-img');
+    const modalTitle = document.getElementById('lightbox-title');
+    const modalDesc = document.getElementById('lightbox-desc');
+    const modalAttr = document.getElementById('lightbox-attr');
+    const closeBtn = document.getElementById('lightbox-close-btn');
+
+    galleryItems.forEach(item => {
+        const openLightbox = () => {
+            const img = item.querySelector('img');
+            const title = item.querySelector('h4');
+            const desc = item.querySelector('p');
+            const attr = item.querySelector('.attribution-tag');
+
+            if (img && modal && modalImg) {
+                modalImg.src = img.src;
+                modalImg.alt = img.alt || '';
+                modalTitle.textContent = title ? title.textContent : 'Scindia Ghat Visual';
+                modalDesc.textContent = desc ? desc.textContent : '';
+                modalAttr.textContent = attr ? attr.textContent : '';
+                modal.hidden = false;
+                if (closeBtn) closeBtn.focus();
+            }
+        };
+
+        item.addEventListener('click', openLightbox);
+        item.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                openLightbox();
+            }
+        });
+    });
+
+    const closeModal = () => {
+        if (modal) modal.hidden = true;
+    };
+
+    if (closeBtn) {
+        closeBtn.addEventListener('click', closeModal);
+    }
+
+    if (modal) {
+        modal.addEventListener('click', (e) => {
+            if (e.target === modal) closeModal();
+        });
+    }
+
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && modal && !modal.hidden) {
+            closeModal();
+        }
+    });
+});

--- a/frontend/scindia-ghat/style.css
+++ b/frontend/scindia-ghat/style.css
@@ -1,0 +1,203 @@
+/* ==========================================================================
+   Scindia Ghat Profile Stylesheet
+   ========================================================================== */
+
+:root {
+    --scindia-teal: #0e7490;
+    --scindia-gold: #eab308;
+    --scindia-copper: #b45309;
+    --scindia-card-bg: rgba(18, 26, 28, 0.85);
+    --scindia-border: rgba(14, 116, 144, 0.32);
+}
+
+body.scindia-page {
+    background-color: #0a1214;
+    color: #eef4f2;
+    font-family: var(--font-body, 'Outfit', -apple-system, BlinkMacSystemFont, sans-serif);
+    line-height: 1.65;
+    margin: 0;
+    padding: 0;
+}
+
+body.scindia-page.light-theme {
+    background-color: #f7fbfb;
+    color: #10201f;
+    --scindia-card-bg: rgba(255, 255, 255, 0.95);
+    --scindia-border: rgba(14, 116, 144, 0.25);
+}
+
+.page-container {
+    max-width: 1150px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem 4rem;
+}
+
+/* --- Hero --- */
+.hero-section.scindia-hero {
+    background: linear-gradient(135deg, rgba(14, 116, 144, 0.3), rgba(234, 179, 8, 0.14)), #0f1c1e;
+    border: 1px solid var(--scindia-border);
+    border-radius: 1.25rem;
+    padding: 3.5rem 2rem 2.5rem;
+    margin-bottom: 3rem;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+}
+
+body.light-theme .hero-section.scindia-hero {
+    background: linear-gradient(135deg, rgba(207, 250, 254, 0.9), rgba(254, 240, 199, 0.7)), #ffffff;
+    box-shadow: 0 10px 30px rgba(14, 116, 144, 0.1);
+}
+
+.badge-container { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-bottom: 1.25rem; }
+.hero-badge { display: inline-flex; align-items: center; padding: 0.35rem 0.85rem; border-radius: 2rem; font-size: 0.85rem; font-weight: 600; }
+.badge-teal { background: rgba(14, 116, 144, 0.24); color: #67e8f9; border: 1px solid rgba(14, 116, 144, 0.45); }
+.badge-gold { background: rgba(234, 179, 8, 0.2); color: #fde68a; border: 1px solid rgba(234, 179, 8, 0.4); }
+.badge-sand { background: rgba(180, 83, 9, 0.2); color: #fdba74; border: 1px solid rgba(180, 83, 9, 0.4); }
+
+.hero-content h1 { font-size: clamp(1.9rem, 4vw, 2.9rem); font-weight: 800; line-height: 1.25; margin-bottom: 0.6rem; color: #ffffff; }
+body.light-theme .hero-content h1 { color: #10201f; }
+.hero-content .accent { color: var(--scindia-gold); }
+
+.subtitle { font-size: 1.1rem; font-weight: 600; font-style: italic; color: #a5f3fc; margin-bottom: 1.1rem; }
+body.light-theme .subtitle { color: #0e7490; }
+
+.hero-desc { font-size: 1.02rem; max-width: 900px; color: #cffafe; }
+body.light-theme .hero-desc { color: #164e63; }
+
+.hero-stats-ribbon {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.25rem;
+    margin-top: 2.25rem;
+    padding-top: 1.75rem;
+    border-top: 1px solid var(--scindia-border);
+}
+.stat-item { background: rgba(255, 255, 255, 0.04); padding: 1rem 1.25rem; border-radius: 0.75rem; border: 1px solid rgba(255, 255, 255, 0.06); }
+body.light-theme .stat-item { background: #ffffff; border-color: rgba(14, 116, 144, 0.18); }
+.stat-label { display: block; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.05em; color: #a5f3fc; margin-bottom: 0.35rem; }
+body.light-theme .stat-label { color: #0e7490; }
+.stat-val { font-size: 1rem; font-weight: 700; color: var(--scindia-gold); }
+
+/* --- Content --- */
+.content-grid { display: flex; flex-direction: column; gap: 2.25rem; margin-bottom: 3rem; }
+
+.info-card {
+    background: var(--scindia-card-bg);
+    border: 1px solid var(--scindia-border);
+    border-radius: 1.25rem;
+    padding: 2.1rem;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
+}
+.info-card h2 { font-size: 1.6rem; margin-bottom: 1.1rem; color: #ecfeff; border-bottom: 2px solid rgba(14, 116, 144, 0.35); padding-bottom: 0.5rem; }
+body.light-theme .info-card h2 { color: #10201f; }
+
+.grid-2col { display: grid; grid-template-columns: 1.3fr 1fr; gap: 1.75rem; align-items: start; }
+@media (max-width: 768px) { .grid-2col { grid-template-columns: 1fr; } }
+
+.callout-box { background: rgba(234, 179, 8, 0.1); border-left: 4px solid var(--scindia-gold); padding: 1.35rem; border-radius: 0.5rem; }
+.callout-box h3 { margin-top: 0; margin-bottom: 0.75rem; color: var(--scindia-gold); }
+body.light-theme .callout-box h3 { color: #a16207; }
+
+.feature-list { list-style: none; padding-left: 0; margin: 1rem 0 0; }
+.feature-list li { margin-bottom: 0.7rem; position: relative; padding-left: 1.6rem; }
+.feature-list li::before { content: "🛕"; position: absolute; left: 0; font-size: 0.85rem; }
+
+/* --- Interactive Hub (Nearby Heritage tabs) --- */
+.hub-section {
+    background: var(--scindia-card-bg);
+    border: 1px solid var(--scindia-border);
+    border-radius: 1.5rem;
+    padding: 2.5rem 2rem;
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
+}
+.hub-section h2 { font-size: 1.6rem; margin-bottom: 1.5rem; color: #ecfeff; }
+body.light-theme .hub-section h2 { color: #10201f; }
+
+.hub-tabs { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-bottom: 1.75rem; border-bottom: 1px solid rgba(255, 255, 255, 0.1); padding-bottom: 1rem; }
+.hub-tab-btn {
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    color: #e2e8f0;
+    padding: 0.65rem 1.25rem;
+    border-radius: 0.5rem;
+    font-size: 0.95rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+body.light-theme .hub-tab-btn { background: #ffffff; border-color: #cbd5e1; color: #10201f; }
+.hub-tab-btn:hover { background: rgba(14, 116, 144, 0.2); border-color: var(--scindia-teal); }
+.hub-tab-btn.active { background: var(--scindia-teal); border-color: var(--scindia-teal); color: #ffffff; font-weight: 600; }
+
+.hub-panel { animation: fade-in 0.3s ease; }
+.hub-panel[hidden] { display: none; }
+
+/* --- Gallery --- */
+.gallery-section { padding: 2rem 0 1rem; }
+.gallery-section h2 { font-size: 1.6rem; margin-bottom: 0.5rem; color: #ecfeff; }
+body.light-theme .gallery-section h2 { color: #10201f; }
+
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+    margin-top: 1.5rem;
+}
+.gallery-card-item {
+    position: relative;
+    border-radius: 1rem;
+    overflow: hidden;
+    cursor: pointer;
+    border: 1px solid var(--scindia-border);
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+.gallery-card-item:hover { transform: translateY(-4px); box-shadow: 0 10px 25px rgba(14, 116, 144, 0.3); }
+.gallery-card-item img { width: 100%; height: 230px; object-fit: cover; display: block; }
+.gallery-caption-overlay {
+    position: absolute;
+    bottom: 0; left: 0; right: 0;
+    background: linear-gradient(to top, rgba(0, 0, 0, 0.9), transparent);
+    padding: 1.25rem 1rem 0.75rem;
+    color: #ffffff;
+}
+.gallery-caption-overlay h4 { margin: 0 0 0.25rem; font-size: 1.05rem; }
+.gallery-caption-overlay p { font-size: 0.82rem; margin: 0 0 0.5rem; color: #cbd5e1; }
+.attribution-tag { font-size: 0.72rem; color: var(--scindia-gold); display: block; }
+
+/* Lightbox */
+.lightbox-modal {
+    position: fixed; top: 0; left: 0; width: 100%; height: 100%;
+    background: rgba(0, 0, 0, 0.85);
+    backdrop-filter: blur(6px);
+    display: flex; align-items: center; justify-content: center;
+    z-index: 1000; padding: 1.5rem;
+}
+.lightbox-modal[hidden] { display: none; }
+.lightbox-content {
+    background: #0f1c1e;
+    border: 1px solid var(--scindia-border);
+    border-radius: 1rem;
+    max-width: 700px; width: 100%;
+    overflow: hidden;
+    position: relative;
+    animation: modal-pop 0.3s ease;
+}
+body.light-theme .lightbox-content { background: #ffffff; }
+.lightbox-close {
+    position: absolute; top: 1rem; right: 1rem;
+    background: rgba(0, 0, 0, 0.6); border: none; color: #ffffff;
+    font-size: 1.5rem; width: 2.5rem; height: 2.5rem; border-radius: 50%;
+    cursor: pointer; z-index: 10;
+}
+#lightbox-img { width: 100%; max-height: 380px; object-fit: cover; display: block; }
+.lightbox-details { padding: 1.5rem; }
+.lightbox-details h3 { margin: 0 0 0.5rem; color: var(--scindia-gold); }
+.lightbox-attribution { font-size: 0.8rem; color: #94a3b8; margin-top: 0.75rem; }
+
+@keyframes fade-in {
+    from { opacity: 0; transform: translateY(6px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+@keyframes modal-pop {
+    from { opacity: 0; transform: scale(0.95); }
+    to { opacity: 1; transform: scale(1); }
+}

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -42,6 +42,13 @@ window.indiaSearchIndex = [
             'Explore Brahmagiri Peak Trek (1,608m) in Coorg & Wayanad, Western Ghats. UNESCO World Heritage Shola forests, Iruppu Falls, Pakshipathalam Cave, Asian Elephant sanctuary habitat, gear checklist, and trek estimator.',
         url: 'frontend/brahmagiri-trek/index.html'
     },
+    {
+    title: "Scindia Ghat: The Partially Submerged Shiva Temple",
+    category: "Varanasi Ghats",
+    description:
+        "Explore Scindia Ghat — its Maratha royal heritage and the famously leaning Ratneshwar Mahadev Temple, partially submerged in the Ganges for over 150 years.",
+    url: "frontend/scindia-ghat/index.html"
+    },
     // --- Harishchandragad Trek ---
     {
         title: 'Harishchandragad Trek (Maharashtra) Profile',


### PR DESCRIPTION
Closes #3283

## Summary
A dedicated page for Scindia Ghat, Varanasi — covering its Maratha royal patronage, architecture, and the famous partially submerged Ratneshwar Mahadev Temple.

## What's included
- **Hero** — location, river, build era, temple tilt stat
- **History** — Vadeshwar Ghat origins (Ahilyabai Holkar, c.1780) → rebuilt by Rani Baija Bai Scindia (1830s) → repaired by Daulatrao Scindia (1937)
- **Scindia Heritage** — the Maratha royal family's role in Varanasi ghat-building
- **Submerged Temple** — structural explanation (foundation unable to bear ghat's weight, ~9° tilt) plus the local "Matru Rin" legend
- **Religious Significance** — Agni birthplace legend, Siddha Kshetra
- **Architecture** — three-tier marhi turret structure
- **Nearby Heritage** — interactive tabs for Manikarnika Ghat relationship, Siddha Kshetra shrines, and a Leaflet map
- **Facts** — 6-point historical list
- **Gallery** — 4 cards with lightbox and photo attribution

## Sources
Facts cross-checked across multiple independent travel/heritage sources (kashi.gov.in, TravelTriangle, TourMyIndia, Wikipedia, Roobaroo Walks, Grokipedia) for consistency on dates, builders, and the temple's tilt measurement.

## Testing
Manually verified in browser — tabs, map, gallery lightbox, and theme toggle all function correctly.
<img width="1440" height="852" alt="Screenshot 2026-08-24 101739" src="https://github.com/user-attachments/assets/46e7667d-6945-4463-a0f0-027aed683791" />
<img width="1440" height="852" alt="Screenshot 2026-08-24 102141" src="https://github.com/user-attachments/assets/987d2385-6302-479e-aeae-e7a198d368ae" />
<img width="1440" height="852" alt="Screenshot 2026-08-24 101751" src="https://github.com/user-attachments/assets/32fa8fa1-2467-490d-9c59-eb7f74f0649d" />
