### PR TITLE
feat(wildlife-ecotourism): implement Enterprise Indian Wildlife & Ecotourism Explorer Suite (#3639)

### DIFF
--- a/frontend/indian-wildlife-ecotourism/index.html
+++ b/frontend/indian-wildlife-ecotourism/index.html
@@ -1,0 +1,171 @@
+<!DOCTYPE html>
+<html lang="en">
+<!-- ==========================================================================
+     INDIAN WILDLIFE & ECOTOURISM EXPLORER — DASHBOARD
+     Enterprise-grade interactive suite for exploring India's national parks,
+     wildlife sanctuaries, and ecotourism destinations.
+     ========================================================================== -->
+<head>
+    <script>(function(){const t=localStorage.getItem('theme')||'dark';if(t==='light')document.body.classList.add('light-theme');})();</script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Explore India's wildlife sanctuaries, national parks, and ecotourism destinations.">
+    <title>Indian Wildlife &amp; Ecotourism Explorer | Incredible India</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../../styles/design-tokens.css">
+    <link rel="stylesheet" href="style.css">
+    <meta property="og:title" content="Indian Wildlife & Ecotourism Explorer | Incredible India">
+    <meta property="og:description" content="Interactive dashboard for India's wildlife, national parks, and ecotourism.">
+    <meta property="og:site_name" content="Incredible India Explorer">
+    <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/wildlife-ecotourism.html">
+</head>
+<body class="wildlife-page-body">
+
+    <!-- NAVBAR -->
+    <header class="navbar scrolled" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo"><span class="saffron">Incredible</span> <span class="gold">India</span> <span class="green">Explorer</span></a>
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu"><span class="bar"></span><span class="bar"></span><span class="bar"></span></button>
+            <nav class="nav-menu" id="nav-menu" role="navigation" aria-label="Main">
+                <a href="#parks" class="nav-link">Parks</a>
+                <a href="#sanctuaries" class="nav-link">Sanctuaries</a>
+                <a href="#species" class="nav-link">Species</a>
+                <a href="#analytics" class="nav-link">Analytics</a>
+            </nav>
+        </div>
+    </header>
+
+    <!-- HERO -->
+    <section class="wildlife-hero" id="hero" aria-label="Hero">
+        <div class="hero-canopy" aria-hidden="true"></div>
+        <div class="hero-content">
+            <span class="hero-kicker">Biodiversity of India</span>
+            <h1>Indian Wildlife &amp; <span>Eco</span>tourism</h1>
+            <p>From the mangroves of the Sundarbans to the alpine meadows of Ladakh, India shelters 8% of the world's biodiversity across 100+ national parks and 500+ wildlife sanctuaries.</p>
+            <div class="hero-stats">
+                <div class="stat-card"><span class="stat-number" id="stat-parks">0</span><span class="stat-label">National Parks</span></div>
+                <div class="stat-card"><span class="stat-number" id="stat-sanctuaries">0</span><span class="stat-label">Sanctuaries</span></div>
+                <div class="stat-card"><span class="stat-number" id="stat-species">0</span><span class="stat-label">Species</span></div>
+                <div class="stat-card"><span class="stat-number" id="stat-states">0</span><span class="stat-label">States</span></div>
+            </div>
+        </div>
+    </section>
+
+    <!-- SEARCH -->
+    <section class="search-section" id="search" aria-label="Search">
+        <div class="search-container">
+            <div class="search-box">
+                <svg class="search-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle cx="11" cy="11" r="8" stroke="currentColor" stroke-width="2"/><line x1="21" y1="21" x2="16.65" y2="16.65" stroke="currentColor" stroke-width="2"/></svg>
+                <input type="text" id="global-search" class="search-input" placeholder="Search parks, sanctuaries, species…" aria-label="Search">
+            </div>
+            <div class="filter-group">
+                <button class="filter-btn active" data-filter="all" aria-pressed="true">All</button>
+                <button class="filter-btn" data-filter="park" aria-pressed="false">Parks</button>
+                <button class="filter-btn" data-filter="sanctuary" aria-pressed="false">Sanctuaries</button>
+                <button class="filter-btn" data-filter="species" aria-pressed="false">Species</button>
+            </div>
+            <div class="sort-group">
+                <label for="sort-select" class="sr-only">Sort</label>
+                <select id="sort-select" class="sort-select" aria-label="Sort">
+                    <option value="name-asc">Name A→Z</option>
+                    <option value="name-desc">Name Z→A</option>
+                    <option value="origin">By State</option>
+                </select>
+            </div>
+        </div>
+    </section>
+
+    <!-- SECTION 1: NATIONAL PARKS -->
+    <section class="explorer-section" id="parks" aria-label="National Parks">
+        <div class="section-container">
+            <div class="section-header">
+                <h2 class="section-title">🦁 National <span>Parks</span></h2>
+                <p class="section-subtitle">Explore India's premier national parks — each one a unique ecosystem protecting endangered species and fragile habitats.</p>
+            </div>
+            <div class="sub-filter-bar">
+                <button class="sub-filter active" data-biome="all" aria-pressed="true">All Biomes</button>
+                <button class="sub-filter" data-biome="tropical" aria-pressed="false">🌴 Tropical</button>
+                <button class="sub-filter" data-biome="grassland" aria-pressed="false">🌾 Grassland</button>
+                <button class="sub-filter" data-biome="mountain" aria-pressed="false">🏔️ Mountain</button>
+                <button class="sub-filter" data-biome="wetland" aria-pressed="false">🌊 Wetland</button>
+                <button class="sub-filter" data-biome="desert" aria-pressed="false">🏜️ Desert</button>
+            </div>
+            <div class="card-grid" id="park-grid" role="list"></div>
+            <div class="empty-state" id="park-empty" hidden><p>No parks match your filters.</p></div>
+        </div>
+    </section>
+
+    <!-- SECTION 2: WILDLIFE SANCTUARIES -->
+    <section class="explorer-section" id="sanctuaries" aria-label="Wildlife Sanctuaries">
+        <div class="section-container">
+            <div class="section-header">
+                <h2 class="section-title">🦌 Wildlife <span>Sanctuaries</span></h2>
+                <p class="section-subtitle">India's wildlife sanctuaries protect diverse ecosystems from tropical forests to high-altitude deserts.</p>
+            </div>
+            <div class="sub-filter-bar">
+                <button class="sub-filter active" data-habitat="all" aria-pressed="true">All Habitats</button>
+                <button class="sub-filter" data-habitat="forest" aria-pressed="false">🌲 Forest</button>
+                <button class="sub-filter" data-habitat="coastal" aria-pressed="false">🏖️ Coastal</button>
+                <button class="sub-filter" data-habitat="riverine" aria-pressed="false">🏞️ Riverine</button>
+                <button class="sub-filter" data-habitat="grassland" aria-pressed="false">🌾 Grassland</button>
+            </div>
+            <div class="card-grid" id="sanctuary-grid" role="list"></div>
+            <div class="empty-state" id="sanctuary-empty" hidden><p>No sanctuaries match your filters.</p></div>
+        </div>
+    </section>
+
+    <!-- SECTION 3: KEY SPECIES -->
+    <section class="explorer-section" id="species" aria-label="Key Species">
+        <div class="section-container">
+            <div class="section-header">
+                <h2 class="section-title">🐅 Key <span>Species</span></h2>
+                <p class="section-subtitle">India is home to iconic species found nowhere else on Earth — each one a critical part of the ecosystem.</p>
+            </div>
+            <div class="sub-filter-bar">
+                <button class="sub-filter active" data-conservation="all" aria-pressed="true">All Status</button>
+                <button class="sub-filter" data-conservation="endangered" aria-pressed="false">🔴 Endangered</button>
+                <button class="sub-filter" data-conservation="vulnerable" aria-pressed="false">🟡 Vulnerable</button>
+                <button class="sub-filter" data-conservation="least-concern" aria-pressed="false">🟢 Least Concern</button>
+            </div>
+            <div class="species-grid" id="species-grid" role="list"></div>
+            <div class="empty-state" id="species-empty" hidden><p>No species match your filters.</p></div>
+        </div>
+    </section>
+
+    <!-- SECTION 4: ANALYTICS -->
+    <section class="explorer-section analytics-section" id="analytics" aria-label="Analytics">
+        <div class="section-container">
+            <div class="section-header">
+                <h2 class="section-title">📊 Analytics <span>Dashboard</span></h2>
+                <p class="section-subtitle">Geographic and categorical breakdown of India's wildlife heritage.</p>
+            </div>
+            <div class="analytics-grid">
+                <div class="analytics-card"><h3>State-wise Distribution</h3><div class="chart-bar-container" id="state-chart" role="img" aria-label="State distribution"></div></div>
+                <div class="analytics-card"><h3>Biome Distribution</h3><div class="biome-distribution" id="biome-chart" role="img" aria-label="Biome distribution"></div></div>
+                <div class="analytics-card"><h3>Conservation Status</h3><div class="conservation-breakdown" id="conservation-chart" role="img" aria-label="Conservation status"></div></div>
+                <div class="analytics-card"><h3>Wildlife Heritage Timeline</h3><div class="timeline-chart" id="timeline-chart" role="img" aria-label="Timeline"></div></div>
+            </div>
+        </div>
+    </section>
+
+    <!-- FOOTER -->
+    <footer class="wildlife-footer">
+        <div class="footer-container">
+            <div class="footer-content">
+                <p class="footer-brand">🇮🇳 Incredible India Explorer — Wildlife &amp; Ecotourism Suite</p>
+                <p class="footer-credits">Built with ❤️ for India's wildlife heritage. Data sourced from Project Tiger, Project Elephant, and Ministry of Environment.</p>
+                <div class="footer-links">
+                    <a href="../../index.html">Home</a>
+                    <a href="../wildlife/">Wildlife</a>
+                    <a href="../national-parks-explorer/">Parks</a>
+                    <a href="#hero">Back to Top</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script type="module" src="wildlife-engine.js"></script>
+</body>
+</html>

--- a/frontend/indian-wildlife-ecotourism/style.css
+++ b/frontend/indian-wildlife-ecotourism/style.css
@@ -1,0 +1,172 @@
+/* ==========================================================================
+   INDIAN WILDLIFE & ECOTOURISM EXPLORER — STYLESHEET
+   Enterprise glassmorphic dark-mode UI with CSS variables.
+   ========================================================================== */
+
+:root {
+    --we-saffron:#ff9933;--we-green:#138808;--we-gold:#FFB01F;--we-white:#f8fafc;--we-muted:#94a3b8;
+    --we-glass-bg:rgba(15,23,42,0.65);--we-glass-border:rgba(255,255,255,0.10);
+    --we-glass-border-hover:rgba(255,176,31,0.35);--we-card-hover:0 12px 40px rgba(255,153,51,0.15);
+    --we-shadow-md:0 8px 30px rgba(0,0,0,0.35);--we-font-heading:'Playfair Display',Georgia,serif;
+    --we-font-body:'Outfit',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+    --we-section-gap:80px;--we-card-radius:16px;--we-btn-radius:10px;
+    --we-transition:all 0.35s cubic-bezier(0.165,0.84,0.44,1);--we-max-w:1200px;
+}
+
+.wildlife-page-body{margin:0;padding:0;font-family:var(--we-font-body);
+    background:linear-gradient(135deg,#0a0e1a 0%,#0f1729 40%,#0a1a0e 100%);
+    color:var(--we-white);min-height:100vh;overflow-x:hidden;line-height:1.6;}
+.wildlife-page-body*{box-sizing:border-box;}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}
+
+/* NAVBAR */
+.wildlife-page-body .navbar{position:fixed;top:0;left:0;right:0;z-index:1000;
+    background:rgba(10,14,26,0.85);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px);
+    border-bottom:1px solid var(--we-glass-border);transition:var(--we-transition);}
+.wildlife-page-body .nav-container{max-width:var(--we-max-w);margin:0 auto;padding:0 24px;
+    display:flex;align-items:center;justify-content:space-between;height:70px;}
+.wildlife-page-body .nav-logo{text-decoration:none;font-family:var(--we-font-heading);font-size:1.3rem;font-weight:700;}
+.wildlife-page-body .nav-logo .saffron{color:var(--we-saffron);}
+.wildlife-page-body .nav-logo .gold{color:var(--we-gold);}
+.wildlife-page-body .nav-logo .green{color:var(--we-green);}
+.wildlife-page-body .nav-menu{display:flex;gap:8px;}
+.wildlife-page-body .nav-link{color:var(--we-muted);text-decoration:none;font-size:0.88rem;font-weight:500;
+    padding:8px 16px;border-radius:var(--we-btn-radius);transition:var(--we-transition);}
+.wildlife-page-body .nav-link:hover,.wildlife-page-body .nav-link:focus-visible{color:var(--we-saffron);background:rgba(255,153,51,0.10);}
+.wildlife-page-body .menu-toggle{display:none;flex-direction:column;gap:5px;background:none;border:none;cursor:pointer;padding:6px;}
+.wildlife-page-body .menu-toggle .bar{width:24px;height:2px;background:var(--we-white);border-radius:2px;transition:var(--we-transition);}
+
+/* HERO */
+.wildlife-hero{position:relative;min-height:70vh;display:flex;align-items:center;justify-content:center;overflow:hidden;
+    background:linear-gradient(135deg,rgba(10,14,26,0.90),rgba(10,26,14,0.75)),
+    radial-gradient(ellipse at 30% 50%,rgba(19,136,8,0.15) 0%,transparent 60%),
+    radial-gradient(ellipse at 70% 50%,rgba(255,153,51,0.10) 0%,transparent 60%);padding-top:70px;}
+.hero-canopy{position:absolute;inset:0;
+    background:repeating-linear-gradient(0deg,transparent,transparent 14px,rgba(19,136,8,0.03) 14px,rgba(19,136,8,0.03) 15px);
+    animation:canopySway 25s linear infinite;}
+@keyframes canopySway{0%{transform:translateY(0);}100%{transform:translateY(-15px);}}
+.hero-content{position:relative;z-index:1;text-align:center;max-width:820px;padding:60px 24px 40px;}
+.hero-kicker{display:inline-block;padding:8px 20px;border:1px solid rgba(255,255,255,0.20);border-radius:999px;
+    background:rgba(0,0,0,0.30);font-size:0.78rem;font-weight:700;letter-spacing:0.10em;text-transform:uppercase;
+    color:var(--we-gold);margin-bottom:20px;}
+.wildlife-hero h1{font-family:var(--we-font-heading);font-size:clamp(2.2rem,5vw,3.4rem);margin:0 0 18px;line-height:1.15;}
+.wildlife-hero h1 span{color:var(--we-green);}
+.wildlife-hero p{color:rgba(255,255,255,0.78);font-size:1.05rem;max-width:620px;margin:0 auto 40px;}
+.hero-stats{display:grid;grid-template-columns:repeat(4,1fr);gap:16px;max-width:600px;margin:0 auto;}
+.stat-card{background:var(--we-glass-bg);border:1px solid var(--we-glass-border);border-radius:var(--we-card-radius);padding:20px 12px;text-align:center;backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);}
+.stat-number{display:block;font-size:1.8rem;font-weight:800;color:var(--we-green);line-height:1;margin-bottom:6px;}
+.stat-label{font-size:0.72rem;font-weight:600;text-transform:uppercase;letter-spacing:0.06em;color:var(--we-muted);}
+
+/* SEARCH */
+.search-section{padding:0 24px;margin-top:-30px;position:relative;z-index:5;}
+.search-container{max-width:var(--we-max-w);margin:0 auto;display:flex;align-items:center;gap:16px;
+    background:var(--we-glass-bg);border:1px solid var(--we-glass-border);border-radius:var(--we-card-radius);
+    padding:14px 24px;backdrop-filter:blur(14px);-webkit-backdrop-filter:blur(14px);box-shadow:var(--we-shadow-md);}
+.search-box{flex:1;display:flex;align-items:center;gap:10px;}
+.search-icon{color:var(--we-muted);flex-shrink:0;}
+.search-input{width:100%;background:transparent;border:none;outline:none;color:var(--we-white);font-family:var(--we-font-body);font-size:0.95rem;padding:6px 0;}
+.search-input::placeholder{color:rgba(148,163,184,0.6);}
+.filter-group{display:flex;gap:6px;}
+.filter-btn{background:rgba(255,255,255,0.06);border:1px solid var(--we-glass-border);color:var(--we-muted);
+    font-family:var(--we-font-body);font-size:0.80rem;font-weight:500;padding:6px 14px;border-radius:var(--we-btn-radius);
+    cursor:pointer;transition:var(--we-transition);}
+.filter-btn:hover,.filter-btn:focus-visible{border-color:var(--we-saffron);color:var(--we-saffron);}
+.filter-btn.active{background:rgba(255,153,51,0.18);border-color:var(--we-saffron);color:var(--we-saffron);font-weight:600;}
+.sort-select{background:rgba(255,255,255,0.06);border:1px solid var(--we-glass-border);color:var(--we-muted);
+    font-family:var(--we-font-body);font-size:0.80rem;padding:8px 12px;border-radius:var(--we-btn-radius);cursor:pointer;outline:none;}
+.sort-select option{background:#1e293b;color:var(--we-white);}
+
+/* SECTIONS */
+.explorer-section{padding:var(--we-section-gap) 24px;}
+.section-container{max-width:var(--we-max-w);margin:0 auto;}
+.section-header{text-align:center;margin-bottom:40px;}
+.section-title{font-family:var(--we-font-heading);font-size:clamp(1.6rem,3.5vw,2.4rem);margin:0 0 12px;}
+.section-title span{color:var(--we-green);}
+.section-subtitle{color:var(--we-muted);font-size:0.95rem;max-width:600px;margin:0 auto;}
+.sub-filter-bar{display:flex;justify-content:center;flex-wrap:wrap;gap:8px;margin-bottom:32px;}
+.sub-filter{background:rgba(255,255,255,0.05);border:1px solid var(--we-glass-border);color:var(--we-muted);
+    font-family:var(--we-font-body);font-size:0.78rem;font-weight:500;padding:7px 16px;border-radius:999px;
+    cursor:pointer;transition:var(--we-transition);}
+.sub-filter:hover,.sub-filter:focus-visible{border-color:var(--we-gold);color:var(--we-gold);}
+.sub-filter.active{background:rgba(255,176,31,0.15);border-color:var(--we-gold);color:var(--we-gold);font-weight:600;}
+
+/* CARDS */
+.card-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:20px;}
+.wl-card{background:var(--we-glass-bg);border:1px solid var(--we-glass-border);border-radius:var(--we-card-radius);
+    padding:24px;transition:var(--we-transition);position:relative;overflow:hidden;}
+.wl-card::before{content:'';position:absolute;top:0;left:0;right:0;height:4px;
+    background:linear-gradient(90deg,var(--we-green),var(--we-gold),var(--we-saffron));opacity:0;transition:opacity 0.35s ease;}
+.wl-card:hover{transform:translateY(-4px);box-shadow:var(--we-card-hover);border-color:var(--we-glass-border-hover);}
+.wl-card:hover::before{opacity:1;}
+.wl-card:focus-within{outline:2px solid var(--we-green);outline-offset:2px;}
+.card-header{display:flex;align-items:flex-start;justify-content:space-between;margin-bottom:12px;}
+.card-title{font-family:var(--we-font-heading);font-size:1.15rem;margin:0;line-height:1.3;}
+.card-badge{font-size:0.68rem;font-weight:700;text-transform:uppercase;letter-spacing:0.05em;padding:4px 10px;border-radius:999px;white-space:nowrap;flex-shrink:0;}
+.badge-tropical{background:rgba(19,136,8,0.20);color:#4ade80;}
+.badge-grassland{background:rgba(250,204,21,0.20);color:#facc15;}
+.badge-mountain{background:rgba(56,189,248,0.20);color:#38bdf8;}
+.badge-wetland{background:rgba(139,92,246,0.20);color:#a78bfa;}
+.badge-desert{background:rgba(251,146,60,0.20);color:#fb923c;}
+.badge-forest{background:rgba(19,136,8,0.20);color:#4ade80;}
+.badge-coastal{background:rgba(56,189,248,0.20);color:#38bdf8;}
+.badge-riverine{background:rgba(139,92,246,0.20);color:#a78bfa;}
+.badge-endangered{background:rgba(244,63,94,0.20);color:#fb7185;}
+.badge-vulnerable{background:rgba(250,204,21,0.20);color:#facc15;}
+.badge-least-concern{background:rgba(34,197,94,0.20);color:#4ade80;}
+.card-description{color:var(--we-muted);font-size:0.88rem;line-height:1.6;margin-bottom:14px;}
+.card-tags{display:flex;flex-wrap:wrap;gap:6px;}
+.card-tag{font-size:0.70rem;font-weight:500;padding:4px 10px;border-radius:6px;background:rgba(255,255,255,0.06);
+    border:1px solid rgba(255,255,255,0.08);color:var(--we-muted);}
+
+/* SPECIES GRID */
+.species-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(320px,1fr));gap:20px;}
+.sp-card{background:var(--we-glass-bg);border:1px solid var(--we-glass-border);border-radius:var(--we-card-radius);
+    padding:24px;display:flex;gap:18px;transition:var(--we-transition);}
+.sp-card:hover{transform:translateY(-3px);box-shadow:var(--we-card-hover);border-color:var(--we-glass-border-hover);}
+.sp-avatar{width:64px;height:64px;border-radius:50%;background:linear-gradient(135deg,var(--we-green),var(--we-saffron));
+    display:flex;align-items:center;justify-content:center;font-size:1.4rem;flex-shrink:0;}
+.sp-info{flex:1;min-width:0;}
+.sp-name{font-family:var(--we-font-heading);font-size:1.08rem;margin:0 0 4px;}
+.sp-meta{font-size:0.78rem;color:var(--we-muted);margin-bottom:8px;}
+.sp-desc{font-size:0.84rem;color:rgba(148,163,184,0.85);line-height:1.5;}
+
+/* ANALYTICS */
+.analytics-grid{display:grid;grid-template-columns:repeat(2,1fr);gap:20px;}
+.analytics-card{background:var(--we-glass-bg);border:1px solid var(--we-glass-border);border-radius:var(--we-card-radius);padding:24px;}
+.analytics-card h3{font-family:var(--we-font-heading);font-size:1.05rem;margin:0 0 18px;color:var(--we-gold);}
+.chart-bar-container{display:flex;flex-direction:column;gap:10px;}
+.chart-bar-row{display:flex;align-items:center;gap:10px;}
+.chart-bar-label{font-size:0.76rem;color:var(--we-muted);min-width:110px;text-align:right;}
+.chart-bar-track{flex:1;height:20px;background:rgba(255,255,255,0.05);border-radius:6px;overflow:hidden;}
+.chart-bar-fill{height:100%;border-radius:6px;transition:width 1s ease-out;}
+.chart-bar-fill.green{background:linear-gradient(90deg,var(--we-green),#4ade80);}
+.chart-bar-fill.gold{background:linear-gradient(90deg,var(--we-gold),#fbbf24);}
+.chart-bar-fill.saffron{background:linear-gradient(90deg,var(--we-saffron),var(--we-gold));}
+.chart-bar-fill.blue{background:linear-gradient(90deg,#3b82f6,#60a5fa);}
+.chart-bar-value{font-size:0.76rem;font-weight:600;color:var(--we-white);min-width:28px;}
+.biome-distribution,.conservation-breakdown{display:flex;flex-direction:column;gap:10px;}
+.biome-row,.cons-row{display:flex;align-items:center;gap:10px;}
+.biome-dot,.cons-dot{width:12px;height:12px;border-radius:50%;flex-shrink:0;}
+.biome-name,.cons-name{font-size:0.80rem;color:var(--we-muted);min-width:100px;}
+.biome-count,.cons-count{font-size:0.80rem;font-weight:600;color:var(--we-white);margin-left:auto;}
+.timeline-chart{display:flex;flex-direction:column;gap:14px;}
+.timeline-entry{display:flex;align-items:flex-start;gap:14px;}
+.timeline-dot{width:14px;height:14px;border-radius:50%;background:var(--we-green);border:3px solid var(--we-glass-bg);
+    box-shadow:0 0 0 2px var(--we-green);margin-top:3px;flex-shrink:0;}
+.timeline-info{flex:1;}
+.timeline-year{font-size:0.76rem;font-weight:700;color:var(--we-green);}
+.timeline-text{font-size:0.80rem;color:var(--we-muted);line-height:1.4;}
+.empty-state{text-align:center;padding:60px 24px;color:var(--we-muted);font-size:0.95rem;}
+
+/* FOOTER */
+.wildlife-footer{padding:50px 24px;border-top:1px solid var(--we-glass-border);margin-top:var(--we-section-gap);}
+.footer-container{max-width:var(--we-max-w);margin:0 auto;text-align:center;}
+.footer-brand{font-family:var(--we-font-heading);font-size:1.1rem;margin:0 0 10px;}
+.footer-credits{color:var(--we-muted);font-size:0.84rem;line-height:1.7;margin:0 0 20px;}
+.footer-links{display:flex;justify-content:center;gap:24px;}
+.footer-links a{color:var(--we-saffron);text-decoration:none;font-size:0.84rem;font-weight:500;transition:color 0.25s ease;}
+.footer-links a:hover{color:var(--we-gold);}
+
+@media(max-width:768px){.search-container{flex-direction:column;align-items:stretch;}.filter-group{justify-content:center;}.hero-stats{grid-template-columns:repeat(2,1fr);}.analytics-grid{grid-template-columns:1fr;}.sp-card{flex-direction:column;align-items:center;text-align:center;}.wildlife-page-body .nav-menu{display:none;}.wildlife-page-body .menu-toggle{display:flex;}}
+@media(max-width:480px){.card-grid,.species-grid{grid-template-columns:1fr;}.hero-stats{grid-template-columns:repeat(2,1fr);gap:10px;}.sub-filter{font-size:0.72rem;padding:6px 12px;}}
+.wl-card:focus-visible,.sp-card:focus-visible,.filter-btn:focus-visible,.sub-filter:focus-visible{outline:2px solid var(--we-green);outline-offset:2px;}

--- a/frontend/indian-wildlife-ecotourism/wildlife-engine.js
+++ b/frontend/indian-wildlife-ecotourism/wildlife-engine.js
@@ -1,0 +1,253 @@
+/* ==========================================================================
+   WILDLIFE ENGINE — Core Business Logic for Indian Wildlife & Ecotourism
+   ========================================================================== */
+
+class NationalPark {
+    constructor(name, biome, state, area, description, highlights, tags) {
+        this.name = name; this.biome = biome; this.state = state; this.area = area;
+        this.description = description; this.highlights = highlights || []; this.tags = tags || [];
+        this.type = 'park';
+    }
+}
+
+class Sanctuary {
+    constructor(name, habitat, state, description, keySpecies, tags) {
+        this.name = name; this.habitat = habitat; this.state = state;
+        this.description = description; this.keySpecies = keySpecies || []; this.tags = tags || [];
+        this.type = 'sanctuary';
+    }
+}
+
+class WildlifeSpecies {
+    constructor(name, conservation, habitat, description, range, emoji) {
+        this.name = name; this.conservation = conservation; this.habitat = habitat;
+        this.description = description; this.range = range;
+        this.emoji = emoji || '🦁'; this.tags = [conservation, habitat];
+        this.type = 'species';
+    }
+}
+
+const PARKS = [
+    new NationalPark('Jim Corbett', 'tropical', 'Uttarakhand', '1318 sq km', 'India\'s oldest national park, famous for Bengal tigers. Established in 1936 as Hailey National Park.', ['Bengal Tiger', 'Elephant', 'Bird Watching'], ['Project Tiger', 'Oldest']),
+    new NationalPark('Sundarbans', 'wetland', 'West Bengal', '2585 sq km', 'The largest mangrove forest in the world and a UNESCO World Heritage Site. Home to the Royal Bengal Tiger.', ['Royal Bengal Tiger', 'Mangrove', 'UNESCO'], ['UNESCO', 'Mangrove']),
+    new NationalPark('Kaziranga', 'grassland', 'Assam', '1030 sq km', 'Home to two-thirds of the world\'s one-horned rhinoceros. UNESCO World Heritage Site since 1985.', ['One-horned Rhino', 'Elephant', 'Tiger'], ['UNESCO', 'Rhino']),
+    new NationalPark('Ranthambore', 'dry deciduous', 'Rajasthan', '1334 sq km', 'Famous for its royal Bengal tigers and the ancient Ranthambore Fort within the park.', ['Bengal Tiger', 'Fort', 'Leopard'], ['Project Tiger', 'Desert Edge']),
+    new NationalPark('Gir', 'dry deciduous', 'Gujarat', '1412 sq km', 'The only home of the Asiatic lion in the wild. A remarkable conservation success story.', ['Asiatic Lion', 'Leopard', 'Hyena'], ['Only Lions', 'Conservation Success']),
+    new NationalPark('Bandipur', 'tropical', 'Karnataka', '874 sq km', 'Part of the Nilgiri Biosphere Reserve, home to elephants, tigers, and diverse birdlife.', ['Tiger', 'Elephant', 'Gaur'], ['Nilgiri', 'Project Tiger']),
+    new NationalPark('Periyar', 'tropical', 'Kerala', '305 sq km', 'A scenic wildlife sanctuary centered on the Periyar Lake, famous for elephant and tiger sightings.', ['Elephant', 'Tiger', 'Boat Safari'], ['Kerala', 'Lake']),
+    new NationalPark('Kaziranga (Manas)', 'tropical', 'Assam', '500 sq km', 'A UNESCO World Heritage Site known for its rare golden langur and pygmy hog.', ['Golden Langur', 'Pygmy Hog', 'Tiger'], ['UNESCO', 'Rare Species']),
+    new NationalPark('Panna', 'dry deciduous', 'Madhya Pradesh', '543 sq km', 'Known for its diamond mines and successful tiger reintroduction program.', ['Tiger', 'Gharial', 'Vulture'], ['Tiger Reintroduction']),
+    new NationalPark('Hemis', 'mountain', 'Ladakh', '4400 sq km', 'India\'s largest national park, home to the rare snow leopard and the famous Hemis monastery.', ['Snow Leopard', 'Tibetan Wolf', 'Monastery'], ['Largest', 'Snow Leopard']),
+];
+
+const SANCTUARIES = [
+    new Sanctuary('Bhadra', 'forest', 'Karnataka', 'A dense forest sanctuary famous for its tiger population and stunning Western Ghats biodiversity.', ['Tiger', 'Elephant', 'Gaur'], ['Western Ghats', 'Tiger']),
+    new Sanctuary('Bhitarkanika', 'coastal', 'Odisha', 'India\'s second-largest mangrove ecosystem, home to saltwater crocodiles and olive ridley turtles.', ['Saltwater Crocodile', 'Olive Ridley', 'Mangrove'], ['Mangrove', 'Crocodile']),
+    new Sanctuary('Chilika Lake', 'riverine', 'Odisha', 'Asia\'s largest brackish water lagoon, hosting over 160 species of migratory birds in winter.', ['Migratory Birds', 'Irrawaddy Dolphin', 'Flamingos'], ['Bird Sanctuary', 'Lake']),
+    new Sanctuary('Pong Dam', 'wetland', 'Himachal Pradesh', 'A reservoir on the Beas River attracting thousands of migratory birds including bar-headed geese.', ['Bar-headed Goose', 'Migratory Birds', 'Fish'], ['Migratory', 'Himachal']),
+    new Sanctuary('Dachigam', 'forest', 'Jammu & Kashmir', 'The last refuge of the endangered Hangul (Kashmiri stag) in the Dachigam hills.', ['Hangul', 'Musk Deer', 'Leopard'], ['Hangul', 'Kashmir']),
+    new Sanctuary('Namdapha', 'forest', 'Arunachal Pradesh', 'One of the most biodiversity-rich areas in India, home to four big cat species.', ['Tiger', 'Leopard', 'Snow Leopard'], ['Four Big Cats', 'NE India']),
+    new Sanctuary('Rolla', 'grassland', 'Karnataka', 'A grassland and scrub jungle sanctuary famous for Indian gaur and blackbuck populations.', ['Indian Gaur', 'Blackbuck', 'Elephant'], ['Grassland', 'Gaur']),
+    new Sanctuary('Nal Sarovar', 'wetland', 'Gujarat', 'India\'s largest lake bird sanctuary, hosting over 200 species of migratory birds.', ['Flamingos', 'Pelicans', 'Storks'], ['Bird Sanctuary', 'Flamingos']),
+];
+
+const SPECIES = [
+    new WildlifeSpecies('Bengal Tiger', 'endangered', 'Tropical/Grassland', 'India\'s national animal and an apex predator. Project Tiger has helped stabilize populations across reserves.', 'Central India, Sundarbans, Western Ghats', '🐅'),
+    new WildlifeSpecies('Asiatic Lion', 'endangered', 'Dry Deciduous', 'The last surviving population of lions outside Africa, found exclusively in Gujarat\'s Gir Forest.', 'Gir Forest, Gujarat', '🦁'),
+    new WildlifeSpecies('One-horned Rhinoceros', 'endangered', 'Grassland', 'A conservation triumph — from fewer than 200 to over 3,000 individuals in Kaziranga.', 'Kaziranga, Assam', '🦏'),
+    new WildlifeSpecies('Snow Leopard', 'vulnerable', 'Mountain', 'The elusive ghost of the mountains, adapted to extreme cold in the Himalayan highlands.', 'Ladakh, Himachal Pradesh, Uttarakhand', '🐆'),
+    new WildlifeSpecies('Asian Elephant', 'endangered', 'Tropical', 'India holds 60% of the world\'s wild elephant population, a keystone species for forest ecosystems.', 'Karnataka, Kerala, Assam', '🐘'),
+    new WildlifeSpecies('Indian Peafowl', 'least-concern', 'Mixed', 'India\'s national bird, found across the subcontinent in forests, farmlands, and even urban areas.', 'Pan India', '🦚'),
+    new WildlifeSpecies('Gharial', 'endangered', 'Riverine', 'A critically endangered fish-eating crocodile with a distinctive long, thin snout. Found only in Indian rivers.', 'Chambal, Girwa', '🐊'),
+    new WildlifeSpecies('Indian Pangolin', 'endangered', 'Forest', 'The world\'s most trafficked mammal, covered in protective keratin scales. Nocturnal insectivore.', 'Central & South India', '🦔'),
+    new WildlifeSpecies('Red Panda', 'endangered', 'Mountain', 'A arboreal mammal found in the eastern Himalayas, consuming mainly bamboo.', 'Sikkim, Arunachal Pradesh', '🐾'),
+    new WildlifeSpecies('Blackbuck', 'least-concern', 'Grassland', 'India\'s fastest animal, known for its spiraling horns and dramatic leaping displays.', 'Rajasthan, Gujarat', '🦌'),
+];
+
+const TIMELINE = [
+    { year: '1936', text: 'Jim Corbett (then Hailey) becomes India\'s first national park.' },
+    { year: '1972', text: 'Wildlife Protection Act enacted; Project Tiger launched.' },
+    { year: '1973', text: 'Project Tiger establishes 9 tiger reserves across India.' },
+    { year: '1985', text: 'Kaziranga and Sundarbans designated as UNESCO World Heritage Sites.' },
+    { year: '1992', text: 'Indian Wildlife Protection Act amended for stricter enforcement.' },
+    { year: '2006', text: 'Tiger Census reveals 1,411 tigers — a historic low point.' },
+    { year: '2010', text: 'National Tiger Conservation Authority strengthens anti-poaching efforts.' },
+    { year: '2022', text: 'India reports 3,167 tigers — a remarkable conservation recovery.' },
+];
+
+class WildlifeEngine {
+    constructor(config = {}) {
+        this.parks = config.parks || PARKS;
+        this.sanctuaries = config.sanctuaries || SANCTUARIES;
+        this.species = config.species || SPECIES;
+        this.state = { searchQuery: '', categoryFilter: 'all', parkBiomeFilter: 'all',
+            sanctuaryHabitatFilter: 'all', speciesConservationFilter: 'all', sortBy: 'name-asc' };
+    }
+
+    getParks() { return [...this.parks]; }
+    getSanctuaries() { return [...this.sanctuaries]; }
+    getSpecies() { return [...this.species]; }
+    getAllItems() { return [...this.parks, ...this.sanctuaries, ...this.species]; }
+
+    getStats() {
+        const states = new Set();
+        this.parks.forEach(p => states.add(p.state));
+        this.sanctuaries.forEach(s => states.add(s.state));
+        return { parks: this.parks.length, sanctuaries: this.sanctuaries.length,
+            species: this.species.length, states: states.size };
+    }
+
+    matchesSearch(item, query) {
+        if (!query || query.trim() === '') return true;
+        const terms = query.toLowerCase().trim().split(/\s+/);
+        const text = [item.name, item.description, item.state || '', item.habitat || '',
+            item.biome || '', item.range || '', item.conservation || '', item.area || '',
+            ...(item.highlights || []), ...(item.keySpecies || []),
+            ...(item.tags || [])].join(' ').toLowerCase();
+        return terms.every(term => text.includes(term));
+    }
+
+    searchItems(items, query) { return items.filter(item => this.matchesSearch(item, query)); }
+
+    filterParksByBiome(biome) { return biome === 'all' ? this.parks : this.parks.filter(p => p.biome === biome || (biome === 'tropical' && p.biome === 'dry deciduous')); }
+    filterSanctuariesByHabitat(habitat) { return habitat === 'all' ? this.sanctuaries : this.sanctuaries.filter(s => s.habitat === habitat); }
+    filterSpeciesByConservation(c) { return c === 'all' ? this.species : this.species.filter(s => s.conservation === c); }
+
+    sortItems(items, sortBy = this.state.sortBy) {
+        const sorted = [...items];
+        switch (sortBy) {
+            case 'name-asc': return sorted.sort((a, b) => a.name.localeCompare(b.name));
+            case 'name-desc': return sorted.sort((a, b) => b.name.localeCompare(a.name));
+            case 'origin': return sorted.sort((a, b) => (a.state || a.habitat || '').localeCompare(b.state || b.habitat || ''));
+            default: return sorted;
+        }
+    }
+
+    getFilteredParks() { return this.sortItems(this.searchItems(this.filterParksByBiome(this.state.parkBiomeFilter), this.state.searchQuery)); }
+    getFilteredSanctuaries() { return this.sortItems(this.searchItems(this.filterSanctuariesByHabitat(this.state.sanctuaryHabitatFilter), this.state.searchQuery)); }
+    getFilteredSpecies() { return this.sortItems(this.searchItems(this.filterSpeciesByConservation(this.state.speciesConservationFilter), this.state.searchQuery)); }
+
+    getStateDistribution() {
+        const counts = {};
+        this.parks.forEach(p => { counts[p.state] = (counts[p.state] || 0) + 1; });
+        this.sanctuaries.forEach(s => { counts[s.state] = (counts[s.state] || 0) + 1; });
+        return Object.entries(counts).map(([state, count]) => ({ state, count }))
+            .sort((a, b) => b.count - a.count).slice(0, 8);
+    }
+
+    getBiomeDistribution() {
+        const counts = {};
+        this.parks.forEach(p => { counts[p.biome] = (counts[p.biome] || 0) + 1; });
+        return Object.entries(counts).map(([biome, count]) => ({ biome, count })).sort((a, b) => b.count - a.count);
+    }
+
+    getConservationBreakdown() {
+        const counts = {};
+        this.species.forEach(s => { counts[s.conservation] = (counts[s.conservation] || 0) + 1; });
+        return Object.entries(counts).map(([status, count]) => ({ status, count })).sort((a, b) => b.count - a.count);
+    }
+
+    getTimeline() { return TIMELINE; }
+
+    setSearchQuery(q) { this.state.searchQuery = q; }
+    setCategoryFilter(f) { this.state.categoryFilter = f; }
+    setParkBiomeFilter(b) { this.state.parkBiomeFilter = b; }
+    setSanctuaryHabitatFilter(h) { this.state.sanctuaryHabitatFilter = h; }
+    setSpeciesConservationFilter(c) { this.state.speciesConservationFilter = c; }
+    setSortBy(s) { this.state.sortBy = s; }
+    resetFilters() { this.state = { searchQuery: '', categoryFilter: 'all', parkBiomeFilter: 'all',
+        sanctuaryHabitatFilter: 'all', speciesConservationFilter: 'all', sortBy: 'name-asc' }; }
+
+    getBadgeClass(v) {
+        return { tropical:'badge-tropical',grassland:'badge-grassland',mountain:'badge-mountain',
+            wetland:'badge-wetland',desert:'badge-desert','dry deciduous':'badge-tropical',
+            forest:'badge-forest',coastal:'badge-coastal',riverine:'badge-riverine',
+            endangered:'badge-endangered',vulnerable:'badge-vulnerable','least-concern':'badge-least-concern' }[v] || 'badge-tropical';
+    }
+
+    getChartColor(i) { return ['green','gold','saffron','blue'][i % 4]; }
+    getBiomeDotColor(b) { return { tropical:'#4ade80',grassland:'#facc15',mountain:'#38bdf8',wetland:'#a78bfa',desert:'#fb923c','dry deciduous':'#4ade80' }[b] || '#94a3b8'; }
+    getConsDotColor(c) { return { endangered:'#fb7185',vulnerable:'#facc15','least-concern':'#4ade80' }[c] || '#94a3b8'; }
+}
+
+/* Renderers */
+function renderParkCard(p) { const b = engine.getBadgeClass(p.biome); const h = p.highlights.map(x => `<span class="card-tag">✨ ${x}</span>`).join(''); const t = p.tags.map(x => `<span class="card-tag">${x}</span>`).join('');
+    return `<article class="wl-card" role="listitem" tabindex="0" aria-label="${p.name}"><div class="card-header"><h3 class="card-title">🦁 ${p.name}</h3><span class="card-badge ${b}">${p.biome}</span></div><p class="card-description">${p.description}</p><div class="card-tags"><span class="card-tag">📍 ${p.state}</span><span class="card-tag">📐 ${p.area}</span>${h}${t}</div></article>`; }
+
+function renderSanctuaryCard(s) { const b = engine.getBadgeClass(s.habitat); const sp = s.keySpecies.map(x => `<span class="card-tag">🐾 ${x}</span>`).join(''); const t = s.tags.map(x => `<span class="card-tag">${x}</span>`).join('');
+    return `<article class="wl-card" role="listitem" tabindex="0" aria-label="${s.name}"><div class="card-header"><h3 class="card-title">🦌 ${s.name}</h3><span class="card-badge ${b}">${s.habitat}</span></div><p class="card-description">${s.description}</p><div class="card-tags"><span class="card-tag">📍 ${s.state}</span>${sp}${t}</div></article>`; }
+
+function renderSpeciesCard(sp) { const b = engine.getBadgeClass(sp.conservation);
+    return `<article class="sp-card" role="listitem" tabindex="0" aria-label="${sp.name}"><div class="sp-avatar">${sp.emoji}</div><div class="sp-info"><h3 class="sp-name">${sp.name}</h3><p class="sp-meta"><span class="card-badge ${b}">${sp.conservation}</span> &nbsp; 🌍 ${sp.habitat} &nbsp; 📍 ${sp.range}</p><p class="sp-desc">${sp.description}</p></div></article>`; }
+
+function renderStateChart(d) { const mx = Math.max(...d.map(x=>x.count)); return d.map((i,idx) => `<div class="chart-bar-row"><span class="chart-bar-label">${i.state}</span><div class="chart-bar-track"><div class="chart-bar-fill ${engine.getChartColor(idx)}" style="width:${(i.count/mx*100).toFixed(0)}%"></div></div><span class="chart-bar-value">${i.count}</span></div>`).join(''); }
+function renderBiomeChart(d) { return d.map(i => `<div class="biome-row"><span class="biome-dot" style="background:${engine.getBiomeDotColor(i.biome)}"></span><span class="biome-name">${i.biome.charAt(0).toUpperCase()+i.biome.slice(1)}</span><span class="biome-count">${i.count}</span></div>`).join(''); }
+function renderConsChart(d) { return d.map(i => `<div class="cons-row"><span class="cons-dot" style="background:${engine.getConsDotColor(i.status)}"></span><span class="cons-name">${i.status.split('-').map(w=>w.charAt(0).toUpperCase()+w.slice(1)).join(' ')}</span><span class="cons-count">${i.count}</span></div>`).join(''); }
+function renderTimeline(d) { return d.map(i => `<div class="timeline-entry"><span class="timeline-dot"></span><div class="timeline-info"><span class="timeline-year">${i.year}</span><p class="timeline-text">${i.text}</p></div></div>`).join(''); }
+
+function renderAll() {
+    const parks = engine.getFilteredParks(), sanctuaries = engine.getFilteredSanctuaries(), species = engine.getFilteredSpecies();
+    const pg = document.getElementById('park-grid'), pe = document.getElementById('park-empty');
+    const sg = document.getElementById('sanctuary-grid'), se = document.getElementById('sanctuary-empty');
+    const spg = document.getElementById('species-grid'), spe = document.getElementById('species-empty');
+    if (pg) { pg.innerHTML = parks.map(renderParkCard).join(''); if (pe) pe.hidden = parks.length > 0; }
+    if (sg) { sg.innerHTML = sanctuaries.map(renderSanctuaryCard).join(''); if (se) se.hidden = sanctuaries.length > 0; }
+    if (spg) { spg.innerHTML = species.map(renderSpeciesCard).join(''); if (spe) spe.hidden = species.length > 0; }
+    const stats = engine.getStats();
+    const sp = document.getElementById('stat-parks'), ss = document.getElementById('stat-sanctuaries');
+    const spp = document.getElementById('stat-species'), st = document.getElementById('stat-states');
+    if (sp) sp.textContent = stats.parks; if (ss) ss.textContent = stats.sanctuaries;
+    if (spp) spp.textContent = stats.species; if (st) st.textContent = stats.states;
+    const sc = document.getElementById('state-chart'), bc = document.getElementById('biome-chart');
+    const cc = document.getElementById('conservation-chart'), tl = document.getElementById('timeline-chart');
+    if (sc) sc.innerHTML = renderStateChart(engine.getStateDistribution());
+    if (bc) bc.innerHTML = renderBiomeChart(engine.getBiomeDistribution());
+    if (cc) cc.innerHTML = renderConsChart(engine.getConservationBreakdown());
+    if (tl) tl.innerHTML = renderTimeline(engine.getTimeline());
+}
+
+function wireEventHandlers() {
+    const si = document.getElementById('global-search');
+    if (si) si.addEventListener('input', e => { engine.setSearchQuery(e.target.value); renderAll(); });
+    document.querySelectorAll('.filter-btn[data-filter]').forEach(btn => {
+        btn.addEventListener('click', () => {
+            document.querySelectorAll('.filter-btn[data-filter]').forEach(b => { b.classList.remove('active'); b.setAttribute('aria-pressed', 'false'); });
+            btn.classList.add('active'); btn.setAttribute('aria-pressed', 'true'); engine.setCategoryFilter(btn.dataset.filter);
+            const f = btn.dataset.filter;
+            document.getElementById('parks').style.display = (f === 'all' || f === 'park') ? '' : 'none';
+            document.getElementById('sanctuaries').style.display = (f === 'all' || f === 'sanctuary') ? '' : 'none';
+            document.getElementById('species').style.display = (f === 'all' || f === 'species') ? '' : 'none';
+        });
+    });
+    const ss = document.getElementById('sort-select');
+    if (ss) ss.addEventListener('change', e => { engine.setSortBy(e.target.value); renderAll(); });
+    document.querySelectorAll('.sub-filter[data-biome]').forEach(btn => {
+        btn.addEventListener('click', () => {
+            document.querySelectorAll('.sub-filter[data-biome]').forEach(b => { b.classList.remove('active'); b.setAttribute('aria-pressed', 'false'); });
+            btn.classList.add('active'); btn.setAttribute('aria-pressed', 'true'); engine.setParkBiomeFilter(btn.dataset.biome); renderAll();
+        });
+    });
+    document.querySelectorAll('.sub-filter[data-habitat]').forEach(btn => {
+        btn.addEventListener('click', () => {
+            document.querySelectorAll('.sub-filter[data-habitat]').forEach(b => { b.classList.remove('active'); b.setAttribute('aria-pressed', 'false'); });
+            btn.classList.add('active'); btn.setAttribute('aria-pressed', 'true'); engine.setSanctuaryHabitatFilter(btn.dataset.habitat); renderAll();
+        });
+    });
+    document.querySelectorAll('.sub-filter[data-conservation]').forEach(btn => {
+        btn.addEventListener('click', () => {
+            document.querySelectorAll('.sub-filter[data-conservation]').forEach(b => { b.classList.remove('active'); b.setAttribute('aria-pressed', 'false'); });
+            btn.classList.add('active'); btn.setAttribute('aria-pressed', 'true'); engine.setSpeciesConservationFilter(btn.dataset.conservation); renderAll();
+        });
+    });
+    const mt = document.getElementById('menu-toggle'), nm = document.getElementById('nav-menu');
+    if (mt && nm) mt.addEventListener('click', () => nm.classList.toggle('open'));
+    window.addEventListener('scroll', () => { const nb = document.getElementById('navbar'); if (nb) nb.classList.toggle('scrolled', window.scrollY > 50); });
+}
+
+const engine = new WildlifeEngine();
+function initEngine() { wireEventHandlers(); renderAll(); }
+if (typeof document !== 'undefined') { if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', initEngine); else initEngine(); }
+
+export { NationalPark, Sanctuary, WildlifeSpecies, WildlifeEngine, PARKS, SANCTUARIES, SPECIES, TIMELINE,
+    renderParkCard, renderSanctuaryCard, renderSpeciesCard, renderStateChart, renderBiomeChart,
+    renderConsChart, renderTimeline, engine };

--- a/tests/unit/wildlife-engine.test.mjs
+++ b/tests/unit/wildlife-engine.test.mjs
@@ -1,0 +1,101 @@
+/* WILDLIFE ENGINE — Unit Tests (Vitest) */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { NationalPark, Sanctuary, WildlifeSpecies, WildlifeEngine, PARKS, SANCTUARIES, SPECIES,
+    renderParkCard, renderSanctuaryCard, renderSpeciesCard, renderStateChart, renderBiomeChart,
+    renderConsChart, renderTimeline } from '../../frontend/indian-wildlife-ecotourism/wildlife-engine.js';
+
+describe('NationalPark', () => {
+    it('should create with all properties', () => { const p = new NationalPark('Test','tropical','TN','100 km2','D',['H'],['t']); expect(p.name).toBe('Test'); expect(p.type).toBe('park'); });
+    it('should default highlights and tags', () => { const p = new NationalPark('X','grassland','UP','50 km2','D'); expect(p.highlights).toEqual([]); expect(p.tags).toEqual([]); });
+});
+
+describe('Sanctuary', () => {
+    it('should create with all properties', () => { const s = new Sanctuary('Test','forest','TN','D',['Tiger'],['t']); expect(s.name).toBe('Test'); expect(s.type).toBe('sanctuary'); });
+    it('should default', () => { const s = new Sanctuary('X','coastal','GJ','D'); expect(s.keySpecies).toEqual([]); expect(s.tags).toEqual([]); });
+});
+
+describe('WildlifeSpecies', () => {
+    it('should create with all properties', () => { const s = new WildlifeSpecies('Tiger','endangered','Grassland','D','India','🐅'); expect(s.name).toBe('Tiger'); expect(s.type).toBe('species'); expect(s.emoji).toBe('🐅'); });
+    it('should default emoji', () => { const s = new WildlifeSpecies('X','vulnerable','Forest','D','India'); expect(s.emoji).toBe('🦁'); });
+});
+
+describe('WildlifeEngine - Accessors', () => {
+    let engine; beforeEach(() => { engine = new WildlifeEngine(); });
+    it('should return all data', () => { expect(engine.getParks()).toHaveLength(PARKS.length); expect(engine.getSanctuaries()).toHaveLength(SANCTUARIES.length); expect(engine.getSpecies()).toHaveLength(SPECIES.length); });
+    it('should return combined', () => { expect(engine.getAllItems()).toHaveLength(PARKS.length + SANCTUARIES.length + SPECIES.length); });
+    it('should return stats', () => { const s = engine.getStats(); expect(s.parks).toBe(PARKS.length); expect(s.states).toBeGreaterThan(0); });
+    it('should return copies', () => { expect(engine.getParks()).not.toBe(engine.getParks()); });
+});
+
+describe('WildlifeEngine - Search', () => {
+    let engine; beforeEach(() => { engine = new WildlifeEngine(); });
+    it('empty query', () => expect(engine.matchesSearch(engine.getParks()[0], '')).toBe(true));
+    it('match name', () => { const p = engine.getParks()[0]; expect(engine.matchesSearch(p, p.name.toLowerCase())).toBe(true); });
+    it('match state', () => { const p = engine.getParks()[0]; expect(engine.matchesSearch(p, p.state.toLowerCase())).toBe(true); });
+    it('multi-term', () => { const p = engine.getParks().find(x => x.name === 'Jim Corbett'); expect(engine.matchesSearch(p, 'corbett uttarakhand')).toBe(true); });
+    it('no match', () => expect(engine.matchesSearch(engine.getParks()[0], 'zzz')).toBe(false));
+    it('searchItems', () => { expect(engine.searchItems(engine.getParks(), 'tiger').length).toBeGreaterThan(0); });
+});
+
+describe('WildlifeEngine - Filtering', () => {
+    let engine; beforeEach(() => { engine = new WildlifeEngine(); });
+    it('parks by biome', () => { expect(engine.filterParksByBiome('all')).toHaveLength(PARKS.length); const t = engine.filterParksByBiome('tropical'); expect(t.length).toBeGreaterThan(0); });
+    it('sanctuaries by habitat', () => { expect(engine.filterSanctuariesByHabitat('all')).toHaveLength(SANCTUARIES.length); const f = engine.filterSanctuariesByHabitat('forest'); expect(f.length).toBeGreaterThan(0); });
+    it('species by conservation', () => { expect(engine.filterSpeciesByConservation('all')).toHaveLength(SPECIES.length); const e = engine.filterSpeciesByConservation('endangered'); expect(e.length).toBeGreaterThan(0); expect(e.every(s => s.conservation === 'endangered')).toBe(true); });
+});
+
+describe('WildlifeEngine - Sorting', () => {
+    let engine; beforeEach(() => { engine = new WildlifeEngine(); });
+    it('sort asc', () => { const s = engine.sortItems(engine.getParks(), 'name-asc'); expect(s).toHaveLength(PARKS.length); });
+    it('sort desc', () => { const s = engine.sortItems(engine.getParks(), 'name-desc'); expect(s).toHaveLength(PARKS.length); });
+    it('sort origin', () => { const s = engine.sortItems(engine.getParks(), 'origin'); expect(s).toHaveLength(PARKS.length); });
+    it('default', () => { const s = engine.sortItems(engine.getParks(), 'x'); expect(s).toHaveLength(PARKS.length); });
+});
+
+describe('WildlifeEngine - Pipelines', () => {
+    let engine; beforeEach(() => { engine = new WildlifeEngine(); });
+    it('all defaults', () => { expect(engine.getFilteredParks()).toHaveLength(PARKS.length); expect(engine.getFilteredSanctuaries()).toHaveLength(SANCTUARIES.length); expect(engine.getFilteredSpecies()).toHaveLength(SPECIES.length); });
+    it('search narrows', () => { engine.setSearchQuery('tiger'); expect(engine.getFilteredParks().length).toBeLessThan(PARKS.length); });
+    it('filter narrows', () => { engine.setSpeciesConservationFilter('endangered'); expect(engine.getFilteredSpecies().length).toBeLessThan(SPECIES.length); });
+});
+
+describe('WildlifeEngine - Analytics', () => {
+    let engine; beforeEach(() => { engine = new WildlifeEngine(); });
+    it('state dist', () => { const d = engine.getStateDistribution(); expect(d.length).toBeGreaterThan(0); expect(d.length).toBeLessThanOrEqual(8); });
+    it('biome dist', () => { const d = engine.getBiomeDistribution(); expect(d.length).toBeGreaterThan(0); });
+    it('conservation', () => { const d = engine.getConservationBreakdown(); expect(d.length).toBeGreaterThan(0); });
+    it('timeline', () => { expect(engine.getTimeline().length).toBeGreaterThan(0); });
+});
+
+describe('WildlifeEngine - State', () => {
+    let engine; beforeEach(() => { engine = new WildlifeEngine(); });
+    it('set and reset', () => { engine.setSearchQuery('x'); engine.setParkBiomeFilter('tropical'); engine.setSanctuaryHabitatFilter('forest');
+        engine.setSpeciesConservationFilter('endangered'); engine.setSortBy('name-desc'); engine.setCategoryFilter('park');
+        engine.resetFilters(); expect(engine.state.searchQuery).toBe(''); expect(engine.state.parkBiomeFilter).toBe('all'); });
+});
+
+describe('WildlifeEngine - Helpers', () => {
+    let engine; beforeEach(() => { engine = new WildlifeEngine(); });
+    it('badge', () => { expect(engine.getBadgeClass('tropical')).toBe('badge-tropical'); expect(engine.getBadgeClass('x')).toBe('badge-tropical'); });
+    it('chart color', () => { expect(engine.getChartColor(0)).toBe('green'); expect(engine.getChartColor(4)).toBe('green'); });
+    it('biome dot', () => { expect(engine.getBiomeDotColor('tropical')).toBe('#4ade80'); expect(engine.getBiomeDotColor('x')).toBe('#94a3b8'); });
+    it('cons dot', () => { expect(engine.getConsDotColor('endangered')).toBe('#fb7185'); expect(engine.getConsDotColor('x')).toBe('#94a3b8'); });
+});
+
+describe('Render', () => {
+    const p = new NationalPark('Test','tropical','TN','100 km2','D',['H'],['t']);
+    const s = new Sanctuary('Test','forest','TN','D',['Tiger'],['t']);
+    const sp = new WildlifeSpecies('Tiger','endangered','Forest','D','India','🐅');
+    it('park', () => { const h = renderParkCard(p); expect(h).toContain('Test'); expect(h).toContain('tropical'); });
+    it('sanctuary', () => { const h = renderSanctuaryCard(s); expect(h).toContain('Test'); expect(h).toContain('forest'); });
+    it('species', () => { const h = renderSpeciesCard(sp); expect(h).toContain('Tiger'); expect(h).toContain('endangered'); });
+    it('state chart', () => { expect(renderStateChart([{state:'TN',count:3},{state:'UP',count:2}])).toContain('TN'); });
+    it('biome chart', () => { expect(renderBiomeChart([{biome:'tropical',count:5}])).toContain('Tropical'); });
+    it('cons chart', () => { expect(renderConsChart([{status:'endangered',count:3}])).toContain('Endangered'); });
+    it('timeline', () => { expect(renderTimeline([{year:'1972',text:'Test'}])).toContain('1972'); });
+});
+
+describe('Config', () => {
+    it('custom data', () => { const e = new WildlifeEngine({ parks: [new NationalPark('X','tropical','TN','100','D')], sanctuaries: [new Sanctuary('X','forest','TN','D')], species: [new WildlifeSpecies('X','endangered','Forest','D','India')] });
+        expect(e.getParks()).toHaveLength(1); expect(e.getSanctuaries()).toHaveLength(1); expect(e.getSpecies()).toHaveLength(1); });
+});


### PR DESCRIPTION
## Summary
Indian Wildlife & Ecotourism Explorer — 697 lines across 4 files.

## Related Issue
Fixes #3639

## Changes
- `frontend/indian-wildlife-ecotourism/index.html` — Dashboard HTML (171 lines)
- `frontend/indian-wildlife-ecotourism/style.css` — Glassmorphic CSS (172 lines)
- `frontend/indian-wildlife-ecotourism/wildlife-engine.js` — Engine (253 lines)
- `tests/unit/wildlife-engine.test.mjs` — Vitest tests (101 lines)

## Features
🦁 National Parks (10) | 🦌 Sanctuaries (8) | 🐅 Species (10) | 📊 Analytics | 🔍 Search

### Checklist
- [x] Tests passing
- [x] Accessibility reviewed
- [x] Ready for review

Closes #3639