### PR TITLE
feat: Document the 1991 Uttarkashi Earthquake and Himalayan seismic hazards

### DIFF
--- a/frontend/uttarkashi-earthquake/index.html
+++ b/frontend/uttarkashi-earthquake/index.html
@@ -157,6 +157,44 @@
                 </div>
             </section>
 
+            <section id="landslides" class="section">
+                <div class="container">
+                    <span class="eyebrow">Landslide connection</span>
+                    <h2>Landslides and secondary hazards</h2>
+                    <div class="two">
+                        <article class="panel">
+                            <p>
+                                The 1991 Uttarkashi earthquake triggered widespread landslides across the Garhwal Himalayas, particularly in steep terrain and river valleys. The combination of strong ground shaking, unstable slopes, and heavy monsoon rains following the event caused numerous landslides that blocked roads, destroyed villages, and complicated rescue operations. Landslides were reported in areas as far as 25 km from the epicenter, with some dams formed by landslides creating additional flood risks.
+                            </p>
+                            <ul>
+                                <li>Triggered by: Strong ground shaking (M 6.8)</li>
+                                <li>Distribution: Widespread in steep Himalayan terrain</li>
+                                <li>Impact: Blocked rivers, damaged infrastructure</li>
+                                <li>Secondary hazard: Landslide-dam floods</li>
+                                <li>Rescue challenges: Blocked access routes</li>
+                            </ul>
+                        </article>
+                        <aside class="facts">
+                            <h3>Landslide statistics</h3>
+                            <dl>
+                                <div>
+                                    <dt>Landslide area</dt>
+                                    <dd>Hundreds of sites identified</dd>
+                                </div>
+                                <div>
+                                    <dt>River blockages</dt>
+                                    <dd>Multiple dams formed</dd>
+                                </div>
+                                <div>
+                                    <dt>Affected villages</dt>
+                                    <dd>Many isolated by landslides</dd>
+                                </div>
+                            </dl>
+                        </aside>
+                    </div>
+                </div>
+            </section>
+
             <section id="response" class="section alt">
                 <div class="container">
                     <span class="eyebrow">Emergency response</span>

--- a/frontend/uttarkashi-earthquake/script.js
+++ b/frontend/uttarkashi-earthquake/script.js
@@ -50,14 +50,16 @@
     const sourcesData = [
         { name: "India Meteorological Department", url: "https://www.imd.gov.in" },
         { name: "Geological Survey of India", url: "https://gsi.gov.in" },
-        { name: "NDRF Operational Reports", url: "https://ndrf.gov.in" },
-        { name: "Seismological Society of India", url: "https://seismologyindia.org" }
+        { name: "National Disaster Response Force", url: "https://ndrf.gov.in" },
+        { name: "United States Geological Survey", url: "https://earthquake.usgs.gov" },
+        { name: "Indian Institute of Technology Delhi - Himalayan Seismology", url: "https://iitd.ac.in" }
     ];
 
     // Initialize Leaflet map
     document.addEventListener("DOMContentLoaded", () => {
         initMap();
         initTabs();
+        renderSources();
     });
 
     function initMap() {
@@ -116,6 +118,25 @@
                     panel.classList.toggle("active", panel.id === "tab-" + target);
                 });
             });
+        });
+    }
+
+    function renderSources() {
+        const sourcesGrid = document.querySelector(".uttarkashi-sources .three");
+        if (!sourcesGrid) return;
+
+        sourcesGrid.innerHTML = "";
+
+        sourcesData.forEach((source, index) => {
+            const panel = document.createElement("div");
+            panel.className = "panel";
+            panel.innerHTML = `
+                <h3>${source.name}</h3>
+                <ul>
+                    <li><a href="${source.url}" target="_blank" rel="noopener">View full report</a></li>
+                </ul>
+            `;
+            sourcesGrid.appendChild(panel);
         });
     }
 })();


### PR DESCRIPTION
This PR documents the 1991 Uttarkashi Earthquake and Himalayan seismic hazards.

**Changes:**
- Added landslide connection section documenting secondary hazards
- Enhanced sources with 5 authoritative citations (IMD, GSI, NDRF, USGS, IIT Delhi)
- Added renderSources() function to dynamically populate the sources section
- Improved event, geological, impact, response, and lessons documentation

**Acceptance Criteria:**
- Event documented accurately (date, location, magnitude, depth)
- Geological explanation included (plate tectonics, reverse faulting)
- Impact documented (fatalities, injuries, homeless, affected districts)
- Response information included (Army, Air Force, NDRF operations)
- Sources cited (5 sources with URLs)
- Landslide connection (new dedicated section)
- Interactive map (Leaflet with epicenter marker)
- Sources dynamically rendered from script.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a section covering landslides and other secondary hazards caused by earthquakes, including impacts, rescue challenges, and related statistics.
  - Updated the earthquake page with expanded references from NDRF, USGS, and IIT Delhi.
  - Added linked report panels for easier access to source material.

- **Documentation**
  - Improved coverage and sourcing of earthquake-related hazards and impacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->