### PR TITLE
Add Kadambini Ganguly historical profile

### DIFF
--- a/frontend/kadambini-ganguly-explorer/index.html
+++ b/frontend/kadambini-ganguly-explorer/index.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            if (theme === 'light') {
+                document.documentElement.setAttribute('data-theme', 'light');
+            }
+        })();
+    </script>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description"
+        content="Explore the historical profile of Kadambini Ganguly — among the first women graduates of the British Empire and India's first practising woman physician of Western medicine.">
+    <title>Kadambini Ganguly | Incredible India Explorer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+        href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,400;0,600;0,700;1,400&display=swap"
+        rel="stylesheet">
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="../pages-common.css">
+    <link rel="stylesheet" href="kadambini.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+        integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+</head>
+
+<body>
+    <header class="navbar" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+            <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+                <a href="../personalities/personalities.html" class="nav-link">Personalities</a>
+                <a href="#early-life" class="nav-link">Early Life</a>
+                <a href="#medical-career" class="nav-link">Medical Career</a>
+                <a href="#timeline" class="nav-link">Timeline</a>
+                <a href="#map" class="nav-link">Kolkata Map</a>
+                <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">&#9728;&#65039;</button>
+            </nav>
+        </div>
+    </header>
+
+    <main class="kg-main" id="main-content">
+        <a class="back-link" href="../personalities/personalities.html">&larr; Back to Personalities</a>
+
+        <section class="kg-hero" id="hero">
+            <div class="kg-hero-content">
+                <div>
+                    <span class="kg-hero-badge">&#127891; First Woman Graduate &bull; Pioneer Physician &bull; Social Reformer</span>
+                    <h1>Kadambini Ganguly</h1>
+                    <div class="kg-hero-tagline">The Woman Who Broke Barriers in Indian Medicine (1861&ndash;1923)</div>
+                    <p class="kg-hero-desc">
+                        Kadambini Ganguly was one of the first two women to graduate from the University of Calcutta
+                        &mdash; and from the entire British Empire &mdash; before becoming India's first practising woman
+                        physician of Western medicine. Defying social hostility at every step, she balanced a family of
+                        eight children with a pioneering medical career, spoke at the Indian National Congress, and
+                        forced institutions that had closed their doors to women to open them forever.
+                    </p>
+                    <a href="#early-life" class="kg-nav-btn kg-hero-cta" style="text-decoration:none;">Explore Her Story &rarr;</a>
+                </div>
+                <aside class="kg-fact-card" aria-label="Quick facts about Kadambini Ganguly">
+                    <h3>&#128218; Quick Facts</h3>
+                    <ul id="quick-facts-list"></ul>
+                </aside>
+            </div>
+        </section>
+
+        <nav class="kg-subnav" aria-label="Explorer sections">
+            <div class="kg-subnav-inner">
+                <button class="kg-nav-btn" data-target="early-life">Early Life</button>
+                <button class="kg-nav-btn" data-target="bethune-college">Bethune College</button>
+                <button class="kg-nav-btn" data-target="medical-education">Medical Education</button>
+                <button class="kg-nav-btn" data-target="medical-career">Medical Career</button>
+                <button class="kg-nav-btn" data-target="public-life">Public Life</button>
+                <button class="kg-nav-btn" data-target="timeline">Timeline</button>
+                <button class="kg-nav-btn" data-target="quiz">Quiz</button>
+                <button class="kg-nav-btn" data-target="map">Kolkata Map</button>
+                <button class="kg-nav-btn" data-target="legacy">Legacy</button>
+                <button class="kg-nav-btn" data-target="sources">Sources</button>
+            </div>
+        </nav>
+
+        <section class="kg-section" id="early-life">
+            <div class="kg-section-header">
+                <h2>Early Life</h2>
+                <p>A childhood shaped by the Brahmo Samaj's faith in women's education, in an age when girls were
+                    rarely taught to read.</p>
+            </div>
+            <div class="content-card">
+                <p>Kadambini Basu was born on <strong>18 July 1861</strong> in Bhagalpur, in the Bengal Presidency of
+                    British India (present-day Bihar). Her father, <strong>Brajakishore Basu</strong>, was a
+                    headmaster and a leading light of the <strong>Brahmo Samaj</strong>, the progressive reform
+                    movement founded under Rammohan Roy that championed education and equality for women. The family
+                    hailed from Chandsi village in Barisal district (now in Bangladesh).</p>
+                <p>Education for girls was almost unheard of, but her father insisted his daughter study. Kadambini
+                    began at the Brahmo Eden Female School in Dacca and moved to Calcutta, joining the
+                    <strong>Hindu Mahila Vidyalaya</strong>, a pioneering "higher English school" for girls established
+                    in 1873 by the English educator Annette Ackroyd with the help of Brahmo reformers &mdash; among
+                    them Dwarakanath Ganguly, her future husband, who served as its headmaster. The school was renamed
+                    <strong>Banga Mahila Vidyalaya</strong> in 1876 and merged into <strong>Bethune School</strong> in
+                    1878.</p>
+                <p>In 1879 she passed the University of Calcutta's Entrance examination &mdash; by most accounts the
+                    first girl ever to do so &mdash; opening a door through which generations of Indian women would
+                    follow.</p>
+            </div>
+        </section>
+
+        <section class="kg-section" id="bethune-college">
+            <div class="kg-section-header">
+                <h2>Bethune College</h2>
+                <p>The classroom where two young women became the first female graduates of the British Empire.</p>
+            </div>
+            <div class="content-card">
+                <p>Admitted to the college classes of Bethune School &mdash; which grew into <strong>Bethune
+                        College</strong> &mdash; Kadambini studied alongside <strong>Chandramukhi Basu</strong>. In 1882
+                    both passed the Bachelor of Arts examination of the University of Calcutta, and on <strong>15 March
+                        1883</strong> they received their B.A. degrees at a convocation where the audience cheered the
+                    two young women loudly.</p>
+                <p>They were the <strong>first female graduates not only of India but of the entire British
+                        Empire</strong>. Their success persuaded Bethune College to formally open its First Arts and
+                    degree courses to women, heralding a new era for women's higher education in India.</p>
+                <p>On <strong>12 June 1883</strong>, Kadambini married <strong>Dwarakanath Ganguly</strong>, a
+                    widower some twenty years her senior, editor of the women's journal <em>Abala Bandhab</em> ("Friend
+                    of the Weak"), and one of Bengal's foremost campaigners for women's emancipation. Their marriage,
+                    scandalous to polite society, became a true partnership: he encouraged her every step toward
+                    medicine.</p>
+            </div>
+        </section>
+
+        <section class="kg-section" id="medical-education">
+            <div class="kg-section-header">
+                <h2>Medical Education</h2>
+                <p>The first woman to walk the corridors of Calcutta Medical College &mdash; and the resistance she
+                    faced there.</p>
+            </div>
+            <div class="content-card">
+                <p>Barely days after her wedding, Kadambini sought admission to the <strong>Calcutta Medical
+                        College</strong>, the oldest medical college in South Asia. The institution had never registered
+                    a woman student; professors objected, and the college had to change its age-old practice of
+                    admitting only men. Records variously date her registration to 1883 or 1884, but the fact is not
+                    disputed: <strong>she was its first woman student</strong>.</p>
+                <p>In 1885 the government granted her a scholarship of twenty rupees a month. Even her final
+                    examination became a battleground: an examiner known for opposing women's medical education failed
+                    her by a single mark. The college nonetheless awarded her the special degree of <strong>GBMC
+                        (Graduate of Bengal Medical College)</strong> in <strong>1886</strong>, qualifying her to
+                    practise medicine.</p>
+                <p>That same year Anandibai Joshi, who had trained abroad at the Woman's Medical College of
+                    Pennsylvania, also completed her degree &mdash; but died within months. It was Kadambini who
+                    actually practised, making her <strong>India's first practising woman physician of Western
+                        medicine</strong>.</p>
+            </div>
+        </section>
+
+        <section class="kg-section" id="medical-career">
+            <div class="kg-section-header">
+                <h2>Medical Career</h2>
+                <p>From Lady Dufferin Hospital to a flourishing private practice &mdash; while raising eight children.</p>
+            </div>
+            <div class="content-card">
+                <p>In 1888 Kadambini took up an appointment at the <strong>Lady Dufferin Hospital</strong> on a salary
+                    of three hundred rupees a month, before building a successful private practice in Calcutta as a
+                    specialist in women's and children's health. She was simultaneously mother to eight children;
+                    contemporaries marvelled at how she balanced the wards and the nursery.</p>
+                <p>Determined to deepen her skills against persistent whispers that her qualifications were inferior,
+                    she sailed for Britain in 1893. Within months she earned the celebrated <strong>"triple
+                        qualification"</strong> &mdash; licences from the medical corporations of Edinburgh, Glasgow and
+                    Dublin &mdash; becoming the first Indian woman to hold such credentials, at a time when Scottish
+                    colleges had only just begun admitting women at all.</p>
+                <div class="kg-quote-box">
+                    <p>&ldquo;The hostility she met was open and organised. A Bengali periodical, <em>Bangabashi</em>,
+                        vilified her as unworthy of her profession; her husband sued its editor for libel and won,
+                        sending him to jail. Mahatma Gandhi himself once criticised her attire in <em>Indian
+                            Opinion</em> &mdash; and later withdrew the remark with an apology.&rdquo;</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="kg-section" id="public-life">
+            <div class="kg-section-header">
+                <h2>Public Life</h2>
+                <p>A voice for women inside the Indian National Congress and beyond.</p>
+            </div>
+            <div class="content-card">
+                <p>At the <strong>1889 Annual Session of the Indian National Congress in Bombay</strong>, Kadambini
+                    Ganguly stood among the handful of women delegates in the hall &mdash; and moved the vote of thanks,
+                    becoming one of the first women ever to address the Congress from its platform. Annie Besant hailed
+                    her as <em>"a symbol that India's freedom will uplift India's womanhood."</em></p>
+                <p>She campaigned for women's education and for the training of women teachers, joined protests during
+                    the Swadeshi movement after the 1905 partition of Bengal, and continued to press for women's entry
+                    into the professions. In <strong>1915</strong>, addressing a medical conference at Calcutta Medical
+                    College &mdash; the college that had once shut its doors against her &mdash; she argued so
+                    compellingly that the institution revised its policies and opened its classes to female students.</p>
+            </div>
+        </section>
+
+        <section class="kg-section" id="women-education">
+            <div class="kg-section-header">
+                <h2>Women's Professional Education</h2>
+                <p>Why her career matters far beyond medicine.</p>
+            </div>
+            <div class="kg-milestones-grid" id="milestones-container"></div>
+        </section>
+
+        <section class="kg-section" id="timeline">
+            <div class="kg-section-header">
+                <h2>Timeline</h2>
+                <p>Six decades of firsts, from Bhagalpur to Edinburgh.</p>
+            </div>
+            <div class="timeline" id="timeline-container"></div>
+        </section>
+
+        <section class="kg-section" id="quiz">
+            <div class="kg-section-header">
+                <h2>Knowledge Quiz</h2>
+                <p>Test what you learned about Kadambini Ganguly's pioneering life.</p>
+            </div>
+            <div class="kg-quiz-container">
+                <div id="quiz-body"></div>
+            </div>
+        </section>
+
+        <section class="kg-section" id="map">
+            <div class="kg-section-header">
+                <h2>Kolkata Map</h2>
+                <p>The Kolkata institutions that shaped her life &mdash; click a marker to learn more.</p>
+            </div>
+            <div id="kg-map" class="kg-map" role="region"
+                aria-label="Interactive map of Kolkata landmarks associated with Kadambini Ganguly"></div>
+            <div class="map-note">Map data &copy; <a href="https://www.openstreetmap.org/copyright"
+                    target="_blank" rel="noopener">OpenStreetMap</a> contributors, rendered with <a
+                    href="https://leafletjs.com/" target="_blank" rel="noopener">Leaflet</a>.</div>
+        </section>
+
+        <section class="kg-section" id="legacy">
+            <div class="kg-section-header">
+                <h2>Legacy</h2>
+            </div>
+            <div class="content-card" id="legacy-content"></div>
+        </section>
+
+        <section class="kg-section" id="sources">
+            <div class="kg-section-header">
+                <h2>Sources</h2>
+            </div>
+            <ul class="references-list" id="references-container"></ul>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="footer-credits">
+            <p>&copy; 2026 Incredible India Explorer.</p>
+        </div>
+    </footer>
+
+    <script src="../pages-common.js" defer></script>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+        integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
+    <script src="kadambini-data.js"></script>
+    <script src="kadambini.js" defer></script>
+</body>
+
+</html>

--- a/frontend/kadambini-ganguly-explorer/kadambini-data.js
+++ b/frontend/kadambini-ganguly-explorer/kadambini-data.js
@@ -1,0 +1,177 @@
+const KADAMBINI_DATA = {
+    quickFacts: {
+        fullName: "Kadambini Basu Ganguly",
+        lifespan: "18 July 1861 \u2013 3 October 1923",
+        birthplace: "Bhagalpur, Bengal Presidency (now Bihar)",
+        primaryFields: ["Medicine", "Women's Education", "Social Reform"],
+        firsts: [
+            "First woman to pass the University of Calcutta Entrance examination (1879)",
+            "One of the first two female graduates of the British Empire (1883)",
+            "First woman admitted to Calcutta Medical College (1883\u201384)",
+            "India's first practising woman physician of Western medicine",
+        ],
+        spouse: "Dwarakanath Ganguly (m. 1883)",
+    },
+
+    milestones: [
+        {
+            title: "Degrees for the Empire's Daughters",
+            desc: "Her 1883 B.A. proved women could complete university education, prompting Bethune College to formally open its F.A. and degree courses to women.",
+        },
+        {
+            title: "Medicine Becomes a Woman's Profession",
+            desc: "Calcutta Medical College rewrote its admissions rules for her; after her 1915 conference address, it opened its classes to female students altogether.",
+        },
+        {
+            title: "A Model of Professional Womanhood",
+            desc: "Running a medical practice while raising eight children, she demonstrated that marriage, motherhood and a profession could coexist for Indian women.",
+        },
+        {
+            title: "Credentials Without Compromise",
+            desc: "By winning Britain's triple qualification in 1893 she answered every doubter, setting a standard for Indian women doctors trained entirely on merit.",
+        },
+    ],
+
+    timelineEvents: [
+        {
+            year: "1861",
+            title: "Birth at Bhagalpur",
+            description: "Born Kadambini Basu on 18 July to Brahmo reformer Brajakishore Basu and his family from Barisal district.",
+        },
+        {
+            year: "1873",
+            title: "Hindu Mahila Vidyalaya",
+            description: "Joined Annette Ackroyd's pioneering girls' school in Calcutta, later renamed Banga Mahila Vidyalaya and merged into Bethune School in 1878.",
+        },
+        {
+            year: "1879",
+            title: "First Through the University Gate",
+            description: "Passed the University of Calcutta Entrance examination, widely recorded as the first girl ever to do so.",
+        },
+        {
+            year: "1883",
+            title: "Graduation & Marriage",
+            description: "Received her B.A. alongside Chandramukhi Basu as the first two female graduates of the British Empire; married Dwarakanath Ganguly on 12 June.",
+        },
+        {
+            year: "1883\u201384",
+            title: "Calcutta Medical College Admits a Woman",
+            description: "Became the first woman student of Calcutta Medical College, forcing the institution to change its male-only admission practice.",
+        },
+        {
+            year: "1886",
+            title: "GBMC Degree",
+            description: "Awarded the Graduate of Bengal Medical College degree, qualifying her to practise Western medicine despite an examiner failing her by one mark.",
+        },
+        {
+            year: "1888",
+            title: "Lady Dufferin Hospital Appointment",
+            description: "Appointed to Lady Dufferin Hospital on a salary of Rs. 300 per month before building a flourishing private practice in Calcutta.",
+        },
+        {
+            year: "1889",
+            title: "Voice of Women at the Congress",
+            description: "Among the six women delegates at the Bombay session of the Indian National Congress; moved the vote of thanks and was hailed by Annie Besant.",
+        },
+        {
+            year: "1893",
+            title: "Triple Qualification from Britain",
+            description: "Earned licences from the medical corporations of Edinburgh, Glasgow and Dublin within months, a first for an Indian woman.",
+        },
+        {
+            year: "1915",
+            title: "Opening the College Doors",
+            description: "Addressed a medical conference at Calcutta Medical College, leading it to admit female students.",
+        },
+        {
+            year: "1923",
+            title: "Death in Service",
+            description: "Collapsed and died in Calcutta on 3 October, hours after returning home from performing an operation, aged 62.",
+        },
+    ],
+
+    quizQuestions: [
+        {
+            id: 1,
+            question: "Where was Kadambini Ganguly born?",
+            options: ["Calcutta", "Bhagalpur", "Barisal", "Dacca"],
+            answerIndex: 1,
+            explanation: "She was born on 18 July 1861 in Bhagalpur, in the Bengal Presidency of British India (present-day Bihar).",
+        },
+        {
+            id: 2,
+            question: "Alongside which classmate did she become one of the first two female graduates of the British Empire?",
+            options: ["Pandita Ramabai", "Anandibai Joshi", "Chandramukhi Basu", "Savitribai Phule"],
+            answerIndex: 2,
+            explanation: "Kadambini Basu and Chandramukhi Basu received their B.A. degrees together from the University of Calcutta at the convocation of 15 March 1883.",
+        },
+        {
+            id: 3,
+            question: "Which qualification, awarded in 1886, entitled her to practise medicine?",
+            options: [
+                "MBBS from Madras University",
+                "GBMC from Calcutta Medical College",
+                "LRCP from Edinburgh",
+                "MD from Pennsylvania",
+            ],
+            answerIndex: 1,
+            explanation: "The Graduate of Bengal Medical College (GBMC) degree made her India's first practising woman physician of Western medicine.",
+        },
+        {
+            id: 4,
+            question: "What did she achieve in Britain in 1893?",
+            options: [
+                "A professorship at Oxford",
+                "Membership of Parliament",
+                "The 'triple qualification' from Edinburgh, Glasgow and Dublin",
+                "A fellowship of the Royal Society",
+            ],
+            answerIndex: 2,
+            explanation: "Within months she earned licences from the medical corporations of Edinburgh, Glasgow and Dublin, becoming the first Indian woman with that distinction.",
+        },
+        {
+            id: 5,
+            question: "How did Annie Besant describe her after the 1889 Congress session?",
+            options: [
+                "'The Nightingale of India'",
+                "'A symbol that India's freedom will uplift India's womanhood'",
+                "'The mother of the nation'",
+                "'India's Joan of Arc'",
+            ],
+            answerIndex: 1,
+            explanation: "Besant hailed Kadambini Ganguly as 'a symbol that India's freedom will uplift India's womanhood' after she addressed the Congress platform.",
+        },
+    ],
+
+    mapCenter: [22.5865, 88.367],
+    mapZoom: 14,
+    mapLocations: [
+        {
+            name: "Bethune School & College",
+            coords: [22.5982, 88.3693],
+            blurb: "Where she studied and became one of the first two female graduates of the British Empire in 1883.",
+        },
+        {
+            name: "University of Calcutta",
+            coords: [22.581, 88.3668],
+            blurb: "Conferred her B.A. degree at its historic convocation of 15 March 1883.",
+        },
+        {
+            name: "Calcutta Medical College & Hospital",
+            coords: [22.5765, 88.365],
+            blurb: "Admitted its first woman student here; GBMC degree 1886, and opened to female students after her 1915 address.",
+        },
+    ],
+
+    legacyText:
+        "Kadambini Ganguly died on 3 October 1923, reportedly hours after returning home from performing an operation \u2014 a doctor to her last breath. She left behind a changed country: universities, medical colleges and professions that had been closed to women now counted them among their students and practitioners. As one of the first two female graduates of the entire British Empire and India's first practising woman physician, her life stands as proof that no barrier of custom is stronger than a determined woman \u2014 and her story continues to inspire generations of Indian women in medicine.",
+
+    sources: [
+        { text: "Wikipedia \u2014 Kadambini Ganguly", link: "https://en.wikipedia.org/wiki/Kadambini_Ganguly" },
+        { text: "Royal College of Physicians of Edinburgh \u2014 Kadambini Ganguli", link: "https://www.rcpe.ac.uk/heritage/kadambini-ganguli" },
+        { text: "Bethune College, Kolkata \u2014 Illustrious Alumnae", link: "https://www.bethunecollege.ac.in/alumni/bethuneCollege-Alumnae.htm" },
+        { text: "Cureus / PMC (NIH) \u2014 Dr. Kadambini Ganguly (1861\u20131923): A Pioneer in Indian Medicine", link: "https://pmc.ncbi.nlm.nih.gov/articles/PMC11289354/" },
+        { text: "University of Edinburgh, 300 Faces \u2014 Kadambini Ganguly", link: "https://medicine-vet-medicine.ed.ac.uk/300-years-of-medicine/300-faces-of-edinburgh-medical-school/300-faces-f-g/kadambini-ganguly" },
+        { text: "Banglapedia \u2014 Ganguly, Kadambini", link: "https://en.banglapedia.org/index.php?title=Ganguly%2C_Kadambini" },
+    ],
+};

--- a/frontend/kadambini-ganguly-explorer/kadambini.css
+++ b/frontend/kadambini-ganguly-explorer/kadambini.css
@@ -1,0 +1,486 @@
+.kg-main {
+    padding-top: 80px;
+    background: var(--bg-dark);
+}
+
+.back-link {
+    display: inline-block;
+    padding: 20px;
+    color: var(--primary-gold);
+    text-decoration: none;
+    font-weight: 500;
+    transition: color 0.3s ease;
+}
+
+.back-link:hover {
+    color: white;
+}
+
+.kg-hero {
+    background:
+        radial-gradient(circle at 20% 30%, rgba(255, 153, 51, 0.25), transparent 45%),
+        radial-gradient(circle at 80% 70%, rgba(19, 136, 8, 0.22), transparent 50%),
+        linear-gradient(rgba(10, 10, 18, 0.82), rgba(10, 10, 18, 0.94));
+    min-height: 62vh;
+    display: flex;
+    align-items: center;
+    padding: 60px 24px;
+}
+
+.kg-hero-content {
+    max-width: 1100px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: 1.6fr 1fr;
+    gap: 40px;
+    align-items: start;
+    animation: fadeIn 1s ease-out;
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translateY(16px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.kg-hero-badge {
+    display: inline-block;
+    font-size: 0.9rem;
+    letter-spacing: 0.06em;
+    color: var(--primary-gold);
+    border: 1px solid var(--primary-gold);
+    border-radius: 999px;
+    padding: 6px 14px;
+    margin-bottom: 18px;
+}
+
+.kg-hero h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: 3.6rem;
+    line-height: 1.1;
+    color: var(--primary-saffron);
+    margin-bottom: 12px;
+}
+
+.kg-hero-tagline {
+    font-size: 1.4rem;
+    color: #ffffff;
+    margin-bottom: 16px;
+    font-weight: 500;
+}
+
+.kg-hero-desc {
+    color: var(--text-color, #e0e0e0);
+    font-size: 1.08rem;
+    line-height: 1.7;
+    max-width: 640px;
+    margin-bottom: 24px;
+}
+
+.kg-hero-cta {
+    background: var(--primary-saffron);
+    color: #14140f;
+    border-radius: 8px;
+    padding: 12px 26px;
+    border: none;
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.kg-fact-card {
+    background: var(--bg-dark-card, #1e1e1e);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-top: 4px solid var(--primary-gold);
+    border-radius: 14px;
+    padding: 24px;
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+}
+
+.kg-fact-card h3 {
+    color: var(--primary-saffron);
+    margin-bottom: 14px;
+}
+
+.kg-fact-list,
+#quick-facts-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.kg-fact-item {
+    display: flex;
+    flex-direction: column;
+    padding-bottom: 10px;
+    border-bottom: 1px dashed rgba(255, 255, 255, 0.15);
+}
+
+.kg-fact-item:last-child {
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+.kg-fact-item strong {
+    color: var(--primary-gold);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 2px;
+}
+
+.kg-fact-item span {
+    color: var(--text-color, #e0e0e0);
+    font-size: 0.95rem;
+    line-height: 1.5;
+}
+
+.kg-subnav {
+    position: sticky;
+    top: 64px;
+    z-index: 20;
+    background: rgba(16, 16, 22, 0.96);
+    backdrop-filter: blur(6px);
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    overflow-x: auto;
+}
+
+.kg-subnav-inner {
+    display: flex;
+    gap: 10px;
+    padding: 12px 20px;
+    min-width: max-content;
+    margin: 0 auto;
+}
+
+[data-theme="light"] .kg-subnav {
+    background: rgba(250, 246, 238, 0.96);
+}
+
+.kg-nav-btn {
+    background: transparent;
+    color: var(--text-color, #e0e0e0);
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    border-radius: 999px;
+    padding: 8px 18px;
+    font-size: 0.92rem;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: all 0.25s ease;
+}
+
+[data-theme="light"] .kg-nav-btn {
+    border-color: rgba(0, 0, 0, 0.3);
+    color: #33302a;
+}
+
+.kg-nav-btn:hover,
+.kg-nav-btn:focus-visible {
+    background: var(--primary-saffron);
+    color: #14140f;
+    border-color: var(--primary-saffron);
+    outline: none;
+}
+
+.kg-section {
+    max-width: 980px;
+    margin: 64px auto;
+    padding: 0 20px;
+}
+
+.kg-section-header h2 {
+    color: var(--primary-saffron);
+    font-size: 2.4rem;
+    margin-bottom: 12px;
+    border-bottom: 2px solid var(--primary-gold);
+    padding-bottom: 10px;
+}
+
+.kg-section-header p {
+    color: var(--text-color, #e0e0e0);
+    margin-bottom: 24px;
+    font-size: 1.08rem;
+}
+
+.content-card {
+    background: var(--bg-dark-card, #1e1e1e);
+    padding: 30px;
+    border-radius: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.content-card p {
+    font-size: 1.05rem;
+    line-height: 1.85;
+    color: var(--text-color, #e0e0e0);
+    margin-bottom: 18px;
+}
+
+.content-card p:last-child {
+    margin-bottom: 0;
+}
+
+.kg-quote-box {
+    border-left: 4px solid var(--primary-gold);
+    background: rgba(255, 255, 255, 0.04);
+    padding: 18px 22px;
+    border-radius: 0 10px 10px 0;
+    margin-top: 22px;
+}
+
+.kg-quote-box p {
+    font-style: italic;
+    margin-bottom: 0;
+}
+
+.kg-milestones-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 20px;
+}
+
+.kg-milestone-card {
+    background: var(--bg-dark-card, #1e1e1e);
+    padding: 25px;
+    border-radius: 12px;
+    border-top: 4px solid var(--primary-gold);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.kg-milestone-card:hover,
+.kg-milestone-card:focus-visible {
+    transform: translateY(-5px);
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.5);
+}
+
+.kg-milestone-card h3 {
+    color: var(--primary-saffron);
+    margin-bottom: 12px;
+}
+
+.kg-milestone-card p {
+    color: var(--text-color, #e0e0e0);
+    line-height: 1.7;
+}
+
+.timeline {
+    position: relative;
+    padding: 20px 0;
+}
+
+.timeline::after {
+    content: '';
+    position: absolute;
+    width: 2px;
+    background: var(--primary-gold);
+    top: 0;
+    bottom: 0;
+    left: 20px;
+}
+
+.timeline-item {
+    padding: 10px 0 30px 50px;
+    position: relative;
+    opacity: 0;
+    transform: translateY(20px);
+    transition: all 0.5s ease;
+}
+
+.timeline-item.visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.timeline-item::after {
+    content: '';
+    position: absolute;
+    width: 16px;
+    height: 16px;
+    left: 13px;
+    top: 15px;
+    background: var(--bg-dark);
+    border: 3px solid var(--primary-saffron);
+    border-radius: 50%;
+    z-index: 1;
+    transition: background 0.3s ease;
+}
+
+.timeline-item:hover::after,
+.timeline-item:focus-within::after {
+    background: var(--primary-gold);
+}
+
+.timeline-year {
+    font-weight: bold;
+    color: var(--primary-gold);
+    font-size: 1.2rem;
+    margin-bottom: 5px;
+}
+
+.timeline-content {
+    background: var(--bg-dark-card, #1e1e1e);
+    padding: 20px;
+    border-radius: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.timeline-content h3 {
+    color: #ffffff;
+    margin-bottom: 8px;
+}
+
+.timeline-content p {
+    color: var(--text-color, #e0e0e0);
+    line-height: 1.65;
+}
+
+.kg-quiz-container {
+    background: var(--bg-dark-card, #1e1e1e);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 14px;
+    padding: 28px;
+    max-width: 720px;
+}
+
+.kg-quiz-progress {
+    color: var(--primary-gold);
+    font-size: 0.9rem;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    margin-bottom: 12px;
+}
+
+.kg-quiz-card h3 {
+    color: #ffffff;
+    font-size: 1.3rem;
+    margin-bottom: 18px;
+}
+
+.kg-quiz-options {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.kg-quiz-option {
+    text-align: left;
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--text-color, #e0e0e0);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    border-radius: 10px;
+    padding: 13px 18px;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.kg-quiz-option:hover:not(:disabled),
+.kg-quiz-option:focus-visible {
+    border-color: var(--primary-saffron);
+    outline: none;
+}
+
+.kg-quiz-option.correct {
+    background: rgba(19, 136, 8, 0.28);
+    border-color: #138808;
+}
+
+.kg-quiz-option.wrong {
+    background: rgba(180, 30, 30, 0.25);
+    border-color: #b41e1e;
+}
+
+.kg-quiz-explanation {
+    margin-top: 16px;
+    color: var(--text-color, #e0e0e0);
+    line-height: 1.6;
+}
+
+.kg-quiz-next {
+    margin-top: 18px;
+    background: var(--primary-saffron);
+    color: #14140f;
+    border: none;
+    border-radius: 8px;
+    padding: 11px 22px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.kg-map {
+    height: 400px;
+    border-radius: 14px;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    overflow: hidden;
+    box-shadow: 0 12px 32px rgba(0, 0, 0, 0.35);
+}
+
+.map-note {
+    margin-top: 12px;
+    font-size: 0.85rem;
+    color: var(--text-color, #bfbfbf);
+}
+
+.map-note a {
+    color: var(--primary-gold);
+}
+
+.references-list {
+    list-style: none;
+    padding: 0;
+}
+
+.references-list li {
+    margin-bottom: 15px;
+    padding-left: 25px;
+    position: relative;
+}
+
+.references-list li::before {
+    content: "\25A0";
+    color: var(--primary-saffron);
+    position: absolute;
+    left: 0;
+    font-size: 0.8rem;
+    top: 5px;
+}
+
+.references-list a {
+    color: var(--primary-gold);
+    text-decoration: none;
+}
+
+.references-list a:hover {
+    text-decoration: underline;
+}
+
+@media screen and (max-width: 900px) {
+    .kg-hero-content {
+        grid-template-columns: 1fr;
+    }
+
+    .kg-hero h1 {
+        font-size: 2.6rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+
+    .timeline-item,
+    .kg-milestone-card,
+    .kg-hero-content {
+        animation: none;
+        transition: none;
+        opacity: 1;
+        transform: none !important;
+    }
+}

--- a/frontend/kadambini-ganguly-explorer/kadambini.js
+++ b/frontend/kadambini-ganguly-explorer/kadambini.js
@@ -1,0 +1,231 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const data = window.KADAMBINI_DATA || (typeof KADAMBINI_DATA !== 'undefined' ? KADAMBINI_DATA : null);
+
+    function renderQuickFacts() {
+        const list = document.getElementById('quick-facts-list');
+        if (!list || !data) return;
+        const facts = data.quickFacts;
+        const rows = [
+            ['Lifespan', facts.lifespan],
+            ['Birthplace', facts.birthplace],
+            ['Fields', facts.primaryFields.join(', ')],
+            ...facts.firsts.map((f, i) => [i === 0 ? 'Firsts' : '', f]),
+            ['Spouse', facts.spouse],
+        ];
+        rows.forEach(([label, value]) => {
+            const li = document.createElement('li');
+            li.className = 'kg-fact-item';
+            if (label) {
+                const strong = document.createElement('strong');
+                strong.textContent = label;
+                li.appendChild(strong);
+            }
+            const span = document.createElement('span');
+            span.textContent = value;
+            li.appendChild(span);
+            list.appendChild(li);
+        });
+    }
+
+    function renderMilestones() {
+        const grid = document.getElementById('milestones-container');
+        if (!grid || !data) return;
+        data.milestones.forEach(item => {
+            const el = document.createElement('div');
+            el.className = 'kg-milestone-card';
+            el.tabIndex = 0;
+            const h3 = document.createElement('h3');
+            h3.textContent = item.title;
+            const p = document.createElement('p');
+            p.textContent = item.desc;
+            el.append(h3, p);
+            grid.appendChild(el);
+        });
+    }
+
+    function renderTimeline() {
+        const container = document.getElementById('timeline-container');
+        if (!container || !data) return;
+        data.timelineEvents.forEach(item => {
+            const el = document.createElement('div');
+            el.className = 'timeline-item';
+            el.tabIndex = 0;
+            el.innerHTML = `
+                <div class="timeline-year"></div>
+                <div class="timeline-content">
+                    <h3></h3>
+                    <p></p>
+                </div>
+            `;
+            el.querySelector('.timeline-year').textContent = item.year;
+            el.querySelector('h3').textContent = item.title;
+            el.querySelector('p').textContent = item.description;
+            container.appendChild(el);
+        });
+
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('visible');
+                }
+            });
+        }, { threshold: 0.1 });
+
+        document.querySelectorAll('.timeline-item').forEach(el => observer.observe(el));
+    }
+
+    function renderLegacy() {
+        const box = document.getElementById('legacy-content');
+        if (!box || !data) return;
+        const p = document.createElement('p');
+        p.textContent = data.legacyText;
+        box.appendChild(p);
+    }
+
+    function renderSources() {
+        const list = document.getElementById('references-container');
+        if (!list || !data) return;
+        data.sources.forEach(src => {
+            const li = document.createElement('li');
+            const a = document.createElement('a');
+            a.href = src.link;
+            a.target = '_blank';
+            a.rel = 'noopener noreferrer';
+            a.textContent = src.text;
+            li.appendChild(a);
+            list.appendChild(li);
+        });
+    }
+
+    function initSubnav() {
+        const buttons = document.querySelectorAll('.kg-nav-btn[data-target]');
+        buttons.forEach(btn => {
+            btn.addEventListener('click', () => {
+                const target = document.getElementById(btn.dataset.target);
+                if (target) {
+                    target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                }
+            });
+        });
+    }
+
+    function initQuiz() {
+        const section = document.getElementById('quiz-body');
+        if (!section || !data) return;
+        let score = 0;
+        let answered = 0;
+
+        function renderQuestion(q, index) {
+            section.innerHTML = '';
+            const card = document.createElement('div');
+            card.className = 'kg-quiz-card';
+
+            const progress = document.createElement('div');
+            progress.className = 'kg-quiz-progress';
+            progress.textContent = `Question ${index + 1} of ${data.quizQuestions.length}`;
+            card.appendChild(progress);
+
+            const h3 = document.createElement('h3');
+            h3.textContent = q.question;
+            card.appendChild(h3);
+
+            const optionsBox = document.createElement('div');
+            optionsBox.className = 'kg-quiz-options';
+
+            q.options.forEach((opt, i) => {
+                const btn = document.createElement('button');
+                btn.type = 'button';
+                btn.className = 'kg-quiz-option';
+                btn.textContent = opt;
+                btn.addEventListener('click', () => {
+                    answered += 1;
+                    const correct = i === q.answerIndex;
+                    if (correct) score += 1;
+                    optionsBox.querySelectorAll('.kg-quiz-option').forEach((b, bi) => {
+                        b.disabled = true;
+                        if (bi === q.answerIndex) b.classList.add('correct');
+                        else if (bi === i && !correct) b.classList.add('wrong');
+                    });
+                    const explain = document.createElement('p');
+                    explain.className = 'kg-quiz-explanation';
+                    explain.textContent = (correct ? '\u2705 Correct. ' : '\u274C Not quite. ') + q.explanation;
+                    card.appendChild(explain);
+
+                    const next = document.createElement('button');
+                    next.type = 'button';
+                    next.className = 'kg-quiz-next';
+                    next.textContent = index + 1 < data.quizQuestions.length ? 'Next Question \u2192' : 'See My Score \u2192';
+                    next.addEventListener('click', () => {
+                        if (index + 1 < data.quizQuestions.length) {
+                            renderQuestion(data.quizQuestions[index + 1], index + 1);
+                        } else {
+                            renderResult();
+                        }
+                    });
+                    card.appendChild(next);
+                });
+                optionsBox.appendChild(btn);
+            });
+
+            card.appendChild(optionsBox);
+            section.appendChild(card);
+        }
+
+        function renderResult() {
+            section.innerHTML = '';
+            const card = document.createElement('div');
+            card.className = 'kg-quiz-card kg-quiz-result';
+            const h3 = document.createElement('h3');
+            h3.textContent = `You scored ${score} out of ${data.quizQuestions.length}!`;
+            const p = document.createElement('p');
+            p.textContent = score === data.quizQuestions.length
+                ? 'Perfect! You know the story of Kadambini Ganguly inside out.'
+                : 'Every pioneer\u2019s story has more to discover \u2014 scroll back through her life above.';
+            const restart = document.createElement('button');
+            restart.type = 'button';
+            restart.className = 'kg-quiz-next';
+            restart.textContent = '\u21bb Try Again';
+            restart.addEventListener('click', () => {
+                score = 0;
+                answered = 0;
+                renderQuestion(data.quizQuestions[0], 0);
+            });
+            card.append(h3, p, restart);
+            section.appendChild(card);
+        }
+
+        if (data.quizQuestions.length) {
+            renderQuestion(data.quizQuestions[0], 0);
+        }
+    }
+
+    function initMap() {
+        const mapEl = document.getElementById('kg-map');
+        if (!mapEl || !data || typeof L === 'undefined') return;
+
+        const map = L.map(mapEl, { scrollWheelZoom: false }).setView(data.mapCenter, data.mapZoom);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 19,
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">OpenStreetMap</a> contributors',
+        }).addTo(map);
+
+        data.mapLocations.forEach(loc => {
+            L.circleMarker(loc.coords, {
+                radius: 9,
+                color: '#ff9933',
+                weight: 3,
+                fillColor: '#138808',
+                fillOpacity: 0.85,
+            }).addTo(map).bindPopup(`<strong>${loc.name}</strong><br>${loc.blurb}`);
+        });
+    }
+
+    renderQuickFacts();
+    renderMilestones();
+    renderTimeline();
+    renderLegacy();
+    renderSources();
+    initSubnav();
+    initQuiz();
+    initMap();
+});

--- a/frontend/personalities/personalities.html
+++ b/frontend/personalities/personalities.html
@@ -542,6 +542,27 @@
                                 service, mentoring a generation that shaped India's freedom.</p>
                         </div>
                     </div>
+                    <div class="person-card" data-category="freedom-fighter"
+                        data-id="personalities-kadambini-ganguly" style="cursor:pointer;"
+                        onclick="window.location.href='../kadambini-ganguly-explorer/index.html'">
+                        <div class="person-img-wrapper">
+                            <picture>
+                                <source srcset="../assets/Bhagat.webp" type="image/webp">
+                                <img alt="Kadambini Ganguly" class="person-img" src="../assets/Bhagat.png"
+                                    loading="lazy" />
+                            </picture>
+                            <button aria-label="Save Kadambini Ganguly to My Journey" aria-pressed="false"
+                                class="person-card-bookmark-btn journey-bookmark-btn"
+                                data-bookmark-id="personalities-kadambini-ganguly" type="button"
+                                onclick="event.stopPropagation();">♡</button>
+                        </div>
+                        <div class="person-info">
+                            <h3 class="person-name">Kadambini Ganguly</h3>
+                            <div class="person-title">India's First Practising Woman Doctor</div>
+                            <p class="person-desc">One of the British Empire's first female graduates who broke every
+                                barrier to become a pioneering physician of Western medicine in India.</p>
+                        </div>
+                    </div>
                     <div class="person-card" data-category="freedom-fighter" data-id="personalities-bhagat-singh">
                         <div class="person-img-wrapper">
                             <picture>

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -6222,5 +6222,13 @@ window.indiaSearchIndex = [
         description:
             "Explore Anis Kidwai's historical profile: writer, social worker, and Rajya Sabha Member of Parliament who documented Partition in 'Azadi Ki Chhaon Mein' and led refugee rehabilitation.",
         url: "frontend/anis-kidwai-explorer/index.html"
+    },
+    // --- Add Kadambini Ganguly historical profile ---
+    {
+        title: "Kadambini Ganguly — The Woman Who Broke Barriers in Indian Medicine",
+        category: "History & Royalty",
+        description:
+            "Explore Kadambini Ganguly's historical profile: one of the first two female graduates of the British Empire, the first woman admitted to Calcutta Medical College, and India's first practising woman physician of Western medicine.",
+        url: "frontend/kadambini-ganguly-explorer/index.html"
     }
 ];

--- a/tests/unit/kadambini-ganguly-explorer.test.js
+++ b/tests/unit/kadambini-ganguly-explorer.test.js
@@ -1,0 +1,201 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function readProfileFile(file) {
+    return readFileSync(
+        resolve(__dirname, '../../frontend/kadambini-ganguly-explorer', file),
+        'utf-8'
+    );
+}
+
+function loadProfileData() {
+    const code = readProfileFile('kadambini-data.js');
+    const fn = new Function(
+        code + '\nreturn { KADAMBINI_DATA };'
+    );
+    return fn();
+}
+
+function readPersonalitiesPage() {
+    return readFileSync(
+        resolve(__dirname, '../../frontend/personalities/personalities.html'),
+        'utf-8'
+    );
+}
+
+function readSearchIndex() {
+    return readFileSync(
+        resolve(__dirname, '../../frontend/search-index.js'),
+        'utf-8'
+    );
+}
+
+describe('Kadambini Ganguly Profile — Page Structure & Assets', () => {
+    let html;
+    let js;
+    let css;
+
+    beforeAll(() => {
+        html = readProfileFile('index.html');
+        js = readProfileFile('kadambini.js');
+        css = readProfileFile('kadambini.css');
+    });
+
+    it('renders header, title and tagline correctly', () => {
+        expect(html).toContain('Kadambini Ganguly');
+        expect(html).toContain('The Woman Who Broke Barriers in Indian Medicine');
+        expect(html).toContain('class="kg-hero"');
+    });
+
+    it('contains all required sections from the issue', () => {
+        const sections = [
+            'hero',
+            'early-life',
+            'bethune-college',
+            'medical-education',
+            'medical-career',
+            'public-life',
+            'women-education',
+            'timeline',
+            'quiz',
+            'map',
+            'legacy',
+            'sources'
+        ];
+        sections.forEach(id => {
+            expect(html).toContain(`id="${id}"`);
+        });
+    });
+
+    it('documents the key biographical details', () => {
+        expect(html).toContain('18 July 1861');
+        expect(html).toContain('Bhagalpur');
+        expect(html).toContain('Bethune');
+        expect(html).toContain('Chandramukhi Basu');
+        expect(html).toContain('Calcutta Medical College');
+        expect(html).toContain('GBMC');
+        expect(html).toContain('Dwarakanath Ganguly');
+        expect(html).toContain('Lady Dufferin Hospital');
+        expect(html).toContain('Indian National Congress');
+        expect(html).toContain('Annie Besant');
+        expect(html).toContain('triple');
+        expect(html).toContain('qualification');
+    });
+
+    it('embeds an interactive Kolkata map with Leaflet', () => {
+        expect(html).toContain('id="kg-map"');
+        expect(html).toContain('leaflet@1.9.4/dist/leaflet.css');
+        expect(html).toContain('leaflet@1.9.4/dist/leaflet.js');
+        expect(js).toContain("L.map");
+        expect(js).toContain('tile.openstreetmap.org');
+    });
+
+    it('links shared stylesheets and local assets', () => {
+        expect(html).toContain('href="../../styles.css"');
+        expect(html).toContain('../pages-common.js');
+        expect(html).toContain('href="kadambini.css"');
+        expect(html).toContain('src="kadambini-data.js"');
+        expect(html).toContain('src="kadambini.js"');
+    });
+
+    it('has a semantic heading hierarchy (single h1, multiple h2s)', () => {
+        const h1Count = (html.match(/<h1[\s>]/g) || []).length;
+        const h2Count = (html.match(/<h2[\s>]/g) || []).length;
+        expect(h1Count).toBe(1);
+        expect(h2Count).toBeGreaterThanOrEqual(8);
+    });
+
+    it('includes a non-empty stylesheet with the expected selectors', () => {
+        expect(css.length).toBeGreaterThan(1000);
+        expect(css).toContain('.kg-hero');
+        expect(css).toContain('.kg-section');
+        expect(css).toContain('.timeline-item');
+        expect(css).toContain('.kg-map');
+        expect(css).toContain('.kg-quiz-option');
+    });
+
+    it('contains interactive renderers and handlers in javascript', () => {
+        expect(js).toContain('renderQuickFacts');
+        expect(js).toContain('renderTimeline');
+        expect(js).toContain('initQuiz');
+        expect(js).toContain('initMap');
+        expect(js).toContain("document.addEventListener('DOMContentLoaded'");
+    });
+});
+
+describe('Kadambini Ganguly Profile — Dataset Verification', () => {
+    let dataObj;
+
+    beforeAll(() => {
+        dataObj = loadProfileData();
+    });
+
+    it('verifies profile metadata fields', () => {
+        expect(dataObj.KADAMBINI_DATA.quickFacts.fullName).toBe('Kadambini Basu Ganguly');
+        expect(dataObj.KADAMBINI_DATA.quickFacts.lifespan).toContain('1861');
+        expect(dataObj.KADAMBINI_DATA.quickFacts.lifespan).toContain('1923');
+        expect(dataObj.KADAMBINI_DATA.quickFacts.primaryFields).toContain('Medicine');
+    });
+
+    it('contains a chronological history timeline', () => {
+        expect(dataObj.KADAMBINI_DATA.timelineEvents.length).toBeGreaterThanOrEqual(8);
+        const graduation = dataObj.KADAMBINI_DATA.timelineEvents.find(t => t.year === '1883');
+        expect(graduation).toBeDefined();
+        expect(graduation.title).toContain('Graduation & Marriage');
+        const death = dataObj.KADAMBINI_DATA.timelineEvents.find(t => t.year === '1923');
+        expect(death).toBeDefined();
+    });
+
+    it('defines Kolkata map locations for her life landmarks', () => {
+        expect(dataObj.KADAMBINI_DATA.mapLocations.length).toBeGreaterThanOrEqual(3);
+        const names = dataObj.KADAMBINI_DATA.mapLocations.map(l => l.name);
+        expect(names.some(n => n.includes('Bethune'))).toBe(true);
+        expect(names.some(n => n.includes('Medical College'))).toBe(true);
+        dataObj.KADAMBINI_DATA.mapLocations.forEach(loc => {
+            expect(Array.isArray(loc.coords)).toBe(true);
+            expect(loc.coords).toHaveLength(2);
+            expect(loc.coords[0]).toBeGreaterThan(22.5);
+            expect(loc.coords[0]).toBeLessThan(22.7);
+            expect(loc.coords[1]).toBeGreaterThan(88.2);
+            expect(loc.coords[1]).toBeLessThan(88.5);
+        });
+    });
+
+    it('contains quiz questions with explanations', () => {
+        expect(dataObj.KADAMBINI_DATA.quizQuestions.length).toBe(5);
+        const firstQ = dataObj.KADAMBINI_DATA.quizQuestions.find(q => q.id === 1);
+        expect(firstQ).toBeDefined();
+        expect(firstQ.question).toContain('born');
+        expect(firstQ.explanation).toContain('Bhagalpur');
+        dataObj.KADAMBINI_DATA.quizQuestions.forEach(q => {
+            expect(q.options).toHaveLength(4);
+            expect(q.answerIndex).toBeGreaterThanOrEqual(0);
+            expect(q.answerIndex).toBeLessThan(4);
+        });
+    });
+
+    it('cites reliable sources', () => {
+        expect(dataObj.KADAMBINI_DATA.sources.length).toBeGreaterThanOrEqual(5);
+        dataObj.KADAMBINI_DATA.sources.forEach(src => {
+            expect(src.link).toMatch(/^https:/);
+        });
+    });
+});
+
+describe('Kadambini Ganguly Profile — Digital Archive Integrations', () => {
+    it('is listed as a card on the personalities hub page', () => {
+        const page = readPersonalitiesPage();
+        expect(page).toContain('Kadambini Ganguly');
+        expect(page).toContain("../kadambini-ganguly-explorer/index.html");
+        expect(page).toContain('personalities-kadambini-ganguly');
+    });
+
+    it('is registered in search-index.js', () => {
+        const searchIdx = readSearchIndex();
+        expect(searchIdx).toContain('frontend/kadambini-ganguly-explorer/index.html');
+    });
+});


### PR DESCRIPTION
## Summary

Adds a dedicated historical profile for **Kadambini Ganguly** - one of the first two female graduates of the British Empire and India's first practising woman physician of Western medicine.

Closes #3428

## Sections Implemented (per issue)

- [x] Hero (with Quick Facts sidebar)
- [x] Early Life
- [x] Bethune College
- [x] Medical Education
- [x] Medical Career
- [x] Women's Professional Education
- [x] Public Life (Indian National Congress, 1889 session)
- [x] Interactive Timeline
- [x] Kolkata Map (interactive Leaflet/OpenStreetMap with landmark markers)
- [x] Legacy
- [x] Sources & References (Wikipedia, RCPE Edinburgh, Bethune College, PMC/NIH, University of Edinburgh, Banglapedia)

## Extras

- Interactive knowledge quiz (5 questions)
- Sticky section sub-navigation
- Card on the Personalities hub page (rontend/personalities/personalities.html)
- Registered in rontend/search-index.js
- Unit tests: 	ests/unit/kadambini-ganguly-explorer.test.js (15 tests, all passing)

## Testing

- 
px vitest run tests/unit/kadambini-ganguly-explorer.test.js ? 15/15 passing
- Verified no regressions in related explorer test suites (remaining failures are pre-existing on upstream/main)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive Kadambini Ganguly historical explorer with biography, milestones, timeline, legacy, references, and responsive navigation.
  * Added an interactive Kolkata map with historical locations.
  * Added a five-question quiz with scoring and restart functionality.
  * Added Kadambini Ganguly to the personalities directory and site search.
  * Added responsive dark-theme styling with reduced-motion accessibility support.

* **Tests**
  * Added coverage for page structure, historical data, quiz content, map locations, references, directory integration, and search registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->