### PR TITLE
feat: document the 2011 Sikkim Earthquake

### DIFF
--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -6118,5 +6118,14 @@ window.indiaSearchIndex = [
         description:
             "Explore Usha Mehta's heroic historical profile — the 22-year-old freedom fighter who operated the secret underground Congress Radio during the Quit India Movement in 1942, featuring an interactive 42.34m radio tuner simulator, biography, Yerwada trial, and Padma Vibhushan legacy.",
         url: "frontend/usha-mehta-explorer/index.html"
+    },
+
+    // --- 2011 Sikkim Earthquake Explorer (#3552) ---
+    {
+        title: "2011 Sikkim Earthquake — Himalayan Seismic Event Profile",
+        category: "Geology & Disasters",
+        description:
+            "Explore the 18 September 2011 Sikkim earthquake (Mw 6.9): USGS epicentre on the India–Nepal border, Himalayan strike-slip tectonics, landslides, road and settlement damage, NDRF and Army relief, and earthquake preparedness.",
+        url: "frontend/sikkim-earthquake-2011-explorer/index.html"
     }
 ];

--- a/frontend/sikkim-earthquake-2011-explorer/index.html
+++ b/frontend/sikkim-earthquake-2011-explorer/index.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function () {
+            const theme = localStorage.getItem("theme") || "dark";
+            if (theme === "light") {
+                document.documentElement.classList.add("light-theme");
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>2011 Sikkim Earthquake | Incredible India Explorer</title>
+    <meta name="description" content="Educational profile of the 18 September 2011 Sikkim earthquake: epicentre, Himalayan tectonics, landslides, infrastructure damage, rescue response, and preparedness.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&family=Playfair+Display:ital,wght@0,600;0,700;1,500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <a class="skip-link" href="#main">Skip to main content</a>
+
+    <header class="site-header">
+        <nav class="topnav" aria-label="Primary">
+            <a class="brand" href="../../index.html">Incredible India Explorer</a>
+            <div class="nav-links">
+                <a href="#date">Date</a>
+                <a href="#epicentre">Epicentre</a>
+                <a href="#characteristics">Characteristics</a>
+                <a href="#tectonics">Tectonics</a>
+                <a href="#landslides">Landslides</a>
+                <a href="#roads">Roads</a>
+                <a href="#response">Response</a>
+                <a href="#preparedness">Preparedness</a>
+                <a href="#map">Map</a>
+                <a href="#sources">Sources</a>
+            </div>
+            <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Switch to light theme">☀️</button>
+        </nav>
+    </header>
+
+    <main id="main">
+        <header class="hero" id="date">
+            <p class="eyebrow">Himalayan seismic event · Educational profile</p>
+            <h1>The 2011 Sikkim Earthquake</h1>
+            <p class="hero-date">18 September 2011 · 18:10 IST (12:40 UTC)</p>
+            <p class="lede">A magnitude 6.9 earthquake struck the India–Nepal border near the Kanchenjunga Conservation Area, shaking the eastern Himalaya and triggering widespread landslides across Sikkim and neighbouring regions.</p>
+            <dl class="hero-stats">
+                <div>
+                    <dt>Magnitude</dt>
+                    <dd>6.9 Mw</dd>
+                </div>
+                <div>
+                    <dt>Depth (USGS)</dt>
+                    <dd>19.7 km</dd>
+                </div>
+                <div>
+                    <dt>Peak shaking</dt>
+                    <dd>MMI VII</dd>
+                </div>
+                <div>
+                    <dt>Deaths</dt>
+                    <dd>At least 111</dd>
+                </div>
+            </dl>
+        </header>
+
+        <section class="block" id="epicentre" aria-labelledby="epicentre-heading">
+            <div class="section-head">
+                <span class="tag">Location</span>
+                <h2 id="epicentre-heading">Epicentre and affected regions</h2>
+            </div>
+            <p class="lede">The USGS located the epicentre at 27.723°N, 88.064°E, about 68 km northwest of Gangtok, in the India–Nepal border region of the Kanchenjunga Conservation Area (Taplejung side).</p>
+            <div class="grid-2">
+                <article class="card">
+                    <h3>Worst-hit areas</h3>
+                    <p>North Sikkim — especially Mangan and Chungthang — and settlements along the Teesta valley suffered the heaviest shaking and slope failure. Gangtok saw collapsed and unusable buildings, including government offices and hospitals. Several villages, including Lingzya, Sakyong, Pentong, Bay, and Tholong, were destroyed. Fatalities were also reported near Singtam in East Sikkim.</p>
+                </article>
+                <article class="card">
+                    <h3>Wider region</h3>
+                    <p>Strong shaking reached Siliguri, Darjeeling, and Kalimpong in West Bengal. Deaths were recorded in Sikkim, Bihar, and West Bengal, and also in Nepal, southern Tibet, and Bhutan. Tremors were felt across northeastern India, Bangladesh, and as far as Delhi.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="block" id="characteristics" aria-labelledby="char-heading">
+            <div class="section-head">
+                <span class="tag">Seismology</span>
+                <h2 id="char-heading">Earthquake characteristics</h2>
+            </div>
+            <ul class="fact-list">
+                <li><strong>Date and time:</strong> Sunday, 18 September 2011, 18:10 IST (12:40:48 UTC).</li>
+                <li><strong>Magnitude:</strong> 6.9 moment magnitude (Mw). IMD initially reported about 6.8 on the Richter scale.</li>
+                <li><strong>Duration:</strong> Strong shaking lasted about 30–40 seconds.</li>
+                <li><strong>Focal depth:</strong> USGS reported 19.7 km (shallow). Some later Indian waveform studies place the source deeper, around 47 km.</li>
+                <li><strong>Mechanism:</strong> Strike-slip faulting, likely a complex rupture of two closely spaced events, rather than a typical Himalayan thrust earthquake.</li>
+                <li><strong>Intensity:</strong> Maximum Modified Mercalli intensity VII (Very strong) near the epicentral region; around VI in Gangtok and Siliguri.</li>
+                <li><strong>Aftershocks:</strong> Magnitudes 5.7, 5.1, and 4.6 within about 30 minutes; more than 20 aftershocks overnight in Sikkim.</li>
+            </ul>
+        </section>
+
+        <section class="block" id="tectonics" aria-labelledby="tectonics-heading">
+            <div class="section-head">
+                <span class="tag">Geology</span>
+                <h2 id="tectonics-heading">Himalayan tectonic context</h2>
+            </div>
+            <div class="grid-2">
+                <div>
+                    <p>The Himalaya form where the Indian plate converges with Eurasia at roughly 40–46 mm per year. Most large Himalayan earthquakes are thrust events on the Main Himalayan Thrust and related structures such as the Main Central Thrust and Main Boundary Thrust, which cross Sikkim.</p>
+                    <p>The 2011 event was different. USGS and later studies interpret it as strike-slip rupture on a transverse structure — commonly linked to the Tista (Teesta) lineament — cutting across the Himalayan arc. That wrench-style motion, rather than simple underthrusting, helps explain the deep, strike-slip source and the linear belts of landslides along existing faults.</p>
+                </div>
+                <aside class="card">
+                    <h3>Why this matters</h3>
+                    <p>Sikkim was mapped in Seismic Zone IV of the Indian code (IS 1893) at the time — high hazard, though not the highest (Zone V). A strike-slip Himalayan earthquake still produced MMI VII shaking, hundreds of landslides, and severe damage to unengineered buildings and mountain roads.</p>
+                </aside>
+            </div>
+        </section>
+
+        <section class="block" id="landslides" aria-labelledby="landslides-heading">
+            <div class="section-head">
+                <span class="tag">Secondary hazards</span>
+                <h2 id="landslides-heading">Landslides and infrastructure damage</h2>
+            </div>
+            <p class="lede">The earthquake struck during the monsoon. Saturated slopes failed across north Sikkim, compounding the shaking damage to buildings, hydropower works, and communications.</p>
+            <div class="grid-2">
+                <article class="card">
+                    <h3>Landslides</h3>
+                    <p>NRSC/ISRO satellite mapping identified 1,196 new or reactivated landslides. Mangan and Chungthang were among the worst-hit. Be village, west of Mangan, was destroyed by a large rock slide. NIDM recorded more than 300 landslides that cut road access to Mangan, Chungthang, and Lachung, with falling boulders, lake bursts, and flash floods in the days that followed.</p>
+                </article>
+                <article class="card">
+                    <h3>Buildings and projects</h3>
+                    <p>Two Indo-Tibetan Border Police buildings collapsed at Pegong in North Sikkim. Many Gangtok offices and hospitals were left unusable. NIDM recorded 16 deaths at the Teesta Stage III hydroelectric project. Power and water supplies failed in parts of Sikkim and the Darjeeling hills, including an affected substation in Siliguri.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="block" id="roads" aria-labelledby="roads-heading">
+            <div class="section-head">
+                <span class="tag">Access</span>
+                <h2 id="roads-heading">Impact on roads and settlements</h2>
+            </div>
+            <div class="grid-2">
+                <article class="card">
+                    <h3>Highways</h3>
+                    <p>National Highway 31A (now NH-10), the main road from Siliguri to Gangtok, was blocked by landslides and only gradually reopened. The North Sikkim Highway toward Mangan and Chungthang was cut by multiple slides (16 reported toward Chungthang). The Gangtok–Nathula road had about 12 landslide blocks. South and West Sikkim also remained hard to reach while rain continued.</p>
+                </article>
+                <article class="card">
+                    <h3>Settlements</h3>
+                    <p>North Sikkim hamlets along the Teesta and its tributaries lost houses, road links, and communications. Tens of thousands of people left damaged buildings. About 2,000 civilians were later sheltered in Army camps at Gangtok, Chungthang, Pegong, and Darjeeling; hundreds more used ITBP camps. A Chungthang gurdwara fed several hundred labourers in the first days.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="block" id="response" aria-labelledby="response-heading">
+            <div class="section-head">
+                <span class="tag">Relief</span>
+                <h2 id="response-heading">Rescue and relief response</h2>
+            </div>
+            <p class="lede">Rain and blocked roads delayed ground access. Airlifts, road-opening parties, and camps in north Sikkim formed the core of the first-week response.</p>
+            <ul class="fact-list">
+                <li><strong>NDRF:</strong> Ten teams (403 personnel) from 08 Bn Greater Noida and 02 Bn Kolkata, with 14 search dogs, were airlifted via Bagdogra. They carried out search, medical aid, tentage, and relief distribution. NDRF issued 200 arctic tents and medical aid in the worst-hit areas.</li>
+                <li><strong>Indian Army:</strong> Eastern Command’s 33 Corps ran Operation Trishakti Madad — 72 columns including infantry and combat engineers, with Dhruv and Cheetah helicopters. Special Forces inserted into villages by slithering from helicopters when roads were closed. Twenty-one engineering columns restored partial road connectivity to parts of north Sikkim.</li>
+                <li><strong>ITBP and medical teams:</strong> ITBP units operated in Pegong and ran additional camps. A 20-doctor specialist team from Delhi was held at Bagdogra on 19 September because NH-31A was blocked.</li>
+                <li><strong>Compensation:</strong> Prime Minister Manmohan Singh announced ex-gratia of ₹2 lakh for families of the deceased and ₹1 lakh for the seriously injured. Sikkim Chief Minister Pawan Chamling announced additional state relief for the dead and injured.</li>
+            </ul>
+        </section>
+
+        <section class="block" id="preparedness" aria-labelledby="prep-heading">
+            <div class="section-head">
+                <span class="tag">Lessons</span>
+                <h2 id="prep-heading">Earthquake preparedness</h2>
+            </div>
+            <div class="grid-2">
+                <div>
+                    <p>Post-event surveys (including NICEE/IIT Kanpur) found that much of the housing stock was unengineered masonry in Seismic Zone IV, with little enforcement of IS 1893 detailing. Hospitals and offices lost use from non-structural damage as well as structural cracks. Roads failed because slopes along the Teesta corridor had not been assessed or stabilised for earthquake-triggered landslides.</p>
+                    <p>Preparedness in this setting means enforcing seismic building codes, protecting critical facilities (hospitals, power, communications), keeping monsoon-season road-opening capacity, and treating landslide hazard as part of earthquake planning — not as a separate problem.</p>
+                </div>
+                <aside class="card">
+                    <h3>Practical measures</h3>
+                    <ul>
+                        <li>Build and retrofit to IS 1893 / IS 13920 in Zone IV–V Himalayan districts.</li>
+                        <li>Keep drop, cover, and hold-on drills in schools and offices.</li>
+                        <li>Store water, food, and first aid for several days when roads may close.</li>
+                        <li>Avoid steep cut-slopes and river-edge construction in monsoon.</li>
+                        <li>Know local NDRF / SDRF / Army camp points after a major shock.</li>
+                    </ul>
+                </aside>
+            </div>
+        </section>
+
+        <section class="block" id="map" aria-labelledby="map-heading">
+            <div class="section-head">
+                <span class="tag">Geography</span>
+                <h2 id="map-heading">Map</h2>
+            </div>
+            <p class="lede">Select a location to move the map marker. The default view is the USGS epicentre on the India–Nepal border.</p>
+            <div class="map-layout">
+                <div class="map-frame-wrap">
+                    <iframe
+                        id="eq-map"
+                        title="Map of the 2011 Sikkim earthquake epicentre and affected towns"
+                        src="https://www.openstreetmap.org/export/embed.html?bbox=87.4,27.05,89.05,28.15&amp;layer=mapnik&amp;marker=27.723,88.064"
+                        loading="lazy"
+                    ></iframe>
+                </div>
+                <div>
+                    <div class="map-buttons" role="group" aria-label="Map locations">
+                        <button type="button" class="map-btn is-active" data-place="epicentre" aria-pressed="true">Epicentre</button>
+                        <button type="button" class="map-btn" data-place="gangtok">Gangtok</button>
+                        <button type="button" class="map-btn" data-place="mangan">Mangan</button>
+                        <button type="button" class="map-btn" data-place="chungthang">Chungthang</button>
+                        <button type="button" class="map-btn" data-place="siliguri">Siliguri</button>
+                        <button type="button" class="map-btn" data-place="taplejung">Taplejung</button>
+                    </div>
+                    <div class="card map-info" id="map-info" aria-live="polite">
+                        <h3 id="map-info-title">Epicentre</h3>
+                        <p id="map-info-desc">27.723°N, 88.064°E — about 68 km northwest of Gangtok, in the Kanchenjunga Conservation Area on the India–Nepal border. USGS depth 19.7 km.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="block sources" id="sources" aria-labelledby="sources-heading">
+            <div class="section-head">
+                <span class="tag">References</span>
+                <h2 id="sources-heading">Sources</h2>
+            </div>
+            <p class="lede">Figures below follow USGS, NRSC/ISRO, NDRF, PIB, and NIDM. Casualty totals vary slightly across early situation reports; this page uses the commonly cited minimum of 111 deaths.</p>
+            <ol>
+                <li><a href="https://web.archive.org/web/20110921163147/http://earthquake.usgs.gov/earthquakes/recenteqsww/Quakes/usc0005wg6.php" target="_blank" rel="noopener noreferrer">USGS — Magnitude 6.9, India–Nepal border region (18 September 2011)</a></li>
+                <li><a href="https://bhuvan-app1.nrsc.gov.in/disaster/usrtasks/quake/doc/sikkim_eq.pdf" target="_blank" rel="noopener noreferrer">NRSC/ISRO — Assessment of the 6.9 Mw Sikkim earthquake (landslide mapping)</a></li>
+                <li><a href="https://ndrf.gov.in/en/operations/sikkim-earthquake-sep-2011" target="_blank" rel="noopener noreferrer">NDRF — Sikkim Earthquake, September 2011</a></li>
+                <li><a href="https://pib.gov.in/newsite/erelcontent.aspx?relid=76088" target="_blank" rel="noopener noreferrer">Press Information Bureau — Earthquake update, 19 September 2011</a></li>
+                <li><a href="https://nidm.gov.in/PDF/pubs/India%20Disaster%20Report%202011.pdf" target="_blank" rel="noopener noreferrer">NIDM — India Disaster Report 2011 (Sikkim earthquake chapter)</a></li>
+                <li><a href="https://www.iitk.ac.in/nicee/wcee/article/WCEE2012_0625.pdf" target="_blank" rel="noopener noreferrer">Rai et al., NICEE/IIT Kanpur — Observations from damages in the 2011 Sikkim earthquake (WCEE 2012)</a></li>
+                <li><a href="https://en.wikipedia.org/wiki/2011_Sikkim_earthquake" target="_blank" rel="noopener noreferrer">Wikipedia — 2011 Sikkim earthquake (overview and casualty table)</a></li>
+            </ol>
+        </section>
+    </main>
+
+    <footer class="page-footer">
+        <p>Incredible India Explorer · 2011 Sikkim Earthquake · <a href="../../index.html">Home</a></p>
+    </footer>
+
+    <script src="script.js" defer></script>
+</body>
+</html>

--- a/frontend/sikkim-earthquake-2011-explorer/script.js
+++ b/frontend/sikkim-earthquake-2011-explorer/script.js
@@ -1,0 +1,109 @@
+(function () {
+    const places = {
+        epicentre: {
+            title: "Epicentre",
+            desc: "27.723°N, 88.064°E — about 68 km northwest of Gangtok, in the Kanchenjunga Conservation Area on the India–Nepal border. USGS depth 19.7 km.",
+            lat: 27.723,
+            lon: 88.064,
+            bbox: [87.4, 27.05, 89.05, 28.15]
+        },
+        gangtok: {
+            title: "Gangtok",
+            desc: "Capital of Sikkim, about 68 km southeast of the epicentre. Offices and hospitals were left unusable; several buildings collapsed. MMI around VI.",
+            lat: 27.3389,
+            lon: 88.6065,
+            bbox: [88.35, 27.2, 88.85, 27.48]
+        },
+        mangan: {
+            title: "Mangan",
+            desc: "North Sikkim headquarters among the areas worst affected by shaking and landslides. NRSC mapping showed dense new slides around Mangan.",
+            lat: 27.509,
+            lon: 88.527,
+            bbox: [88.3, 27.38, 88.75, 27.65]
+        },
+        chungthang: {
+            title: "Chungthang",
+            desc: "North Sikkim town on the Teesta. The highway from Gangtok was blocked by many landslides. Relief camps and a gurdwara langar sheltered labourers here.",
+            lat: 27.604,
+            lon: 88.645,
+            bbox: [88.4, 27.48, 88.9, 27.75]
+        },
+        siliguri: {
+            title: "Siliguri",
+            desc: "West Bengal gateway to Sikkim. NH-31A from Siliguri to Gangtok was the critical access route; a local substation outage cut power in adjoining hill districts.",
+            lat: 26.727,
+            lon: 88.395,
+            bbox: [88.15, 26.55, 88.65, 26.9]
+        },
+        taplejung: {
+            title: "Taplejung (Nepal)",
+            desc: "Nepalese district on the far side of the border epicentral region. Eastern Nepal saw damaged homes and monsoon mudslides; Kathmandu had limited damage but some fatalities.",
+            lat: 27.35,
+            lon: 87.67,
+            bbox: [87.35, 27.15, 88.05, 27.6]
+        }
+    };
+
+    function mapSrc(place) {
+        const box = place.bbox.join(",");
+        return "https://www.openstreetmap.org/export/embed.html?bbox=" +
+            encodeURIComponent(box) +
+            "&layer=mapnik&marker=" +
+            encodeURIComponent(place.lat + "," + place.lon);
+    }
+
+    function initThemeToggle() {
+        const button = document.getElementById("theme-toggle");
+        const root = document.documentElement;
+
+        function applyTheme(theme) {
+            const isLight = theme === "light";
+            root.classList.toggle("light-theme", isLight);
+            document.body.classList.toggle("light-theme", isLight);
+            button.textContent = isLight ? "🌙" : "☀️";
+            button.setAttribute("aria-label", isLight ? "Switch to dark theme" : "Switch to light theme");
+        }
+
+        applyTheme(localStorage.getItem("theme") === "light" ? "light" : "dark");
+
+        button.addEventListener("click", function () {
+            const next = document.body.classList.contains("light-theme") ? "dark" : "light";
+            localStorage.setItem("theme", next);
+            applyTheme(next);
+        });
+    }
+
+    function initMap() {
+        const frame = document.getElementById("eq-map");
+        const titleEl = document.getElementById("map-info-title");
+        const descEl = document.getElementById("map-info-desc");
+        const buttons = document.querySelectorAll(".map-btn");
+
+        function showPlace(key) {
+            const place = places[key];
+            if (!place) {
+                return;
+            }
+            frame.src = mapSrc(place);
+            titleEl.textContent = place.title;
+            descEl.textContent = place.desc;
+            buttons.forEach(function (btn) {
+                const active = btn.getAttribute("data-place") === key;
+                btn.classList.toggle("is-active", active);
+                btn.setAttribute("aria-pressed", active ? "true" : "false");
+            });
+        }
+
+        buttons.forEach(function (btn) {
+            btn.setAttribute("aria-pressed", btn.classList.contains("is-active") ? "true" : "false");
+            btn.addEventListener("click", function () {
+                showPlace(btn.getAttribute("data-place"));
+            });
+        });
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+        initThemeToggle();
+        initMap();
+    });
+})();

--- a/frontend/sikkim-earthquake-2011-explorer/style.css
+++ b/frontend/sikkim-earthquake-2011-explorer/style.css
@@ -1,0 +1,351 @@
+:root {
+    --bg: #101820;
+    --bg-alt: #16202b;
+    --surface: #1c2836;
+    --line: #314155;
+    --text: #eef3f8;
+    --muted: #b4c2d1;
+    --dim: #8a9aab;
+    --accent: #c9a227;
+    --accent-2: #7eb8c9;
+    --heading: "Playfair Display", Georgia, serif;
+    --body: "Outfit", system-ui, sans-serif;
+}
+
+body.light-theme,
+html.light-theme,
+html.light-theme body {
+    --bg: #f4f1ea;
+    --bg-alt: #ebe6dc;
+    --surface: #ffffff;
+    --line: #d4cdc0;
+    --text: #1c2430;
+    --muted: #4a5563;
+    --dim: #6b7280;
+    --accent: #8a6a12;
+    --accent-2: #1f5c6a;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--body);
+    line-height: 1.65;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
+
+    * {
+        animation: none !important;
+        transition: none !important;
+    }
+}
+
+a {
+    color: var(--accent);
+}
+
+a:focus-visible,
+button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+}
+
+.skip-link {
+    position: absolute;
+    left: -999px;
+    top: 0;
+    background: var(--accent);
+    color: #111;
+    padding: 0.5rem 1rem;
+    z-index: 1000;
+}
+
+.skip-link:focus {
+    left: 8px;
+    top: 8px;
+}
+
+.topnav {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.85rem 1.25rem;
+    background: var(--bg);
+    backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--line);
+    overflow-x: auto;
+}
+
+.brand {
+    font-weight: 700;
+    text-decoration: none;
+    color: var(--text);
+    white-space: nowrap;
+}
+
+.nav-links {
+    display: flex;
+    gap: 0.9rem;
+    font-size: 0.85rem;
+}
+
+.nav-links a {
+    color: var(--muted);
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.nav-links a:hover {
+    color: var(--text);
+}
+
+.theme-toggle {
+    margin-left: auto;
+    border: 1px solid var(--line);
+    background: var(--surface);
+    color: var(--text);
+    border-radius: 999px;
+    width: 2.4rem;
+    height: 2.4rem;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.hero {
+    padding: 4.5rem 8vw 3.5rem;
+    background:
+        radial-gradient(900px 420px at 12% -20%, rgba(126, 184, 201, 0.16), transparent 55%),
+        var(--bg);
+    border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+    font-size: 0.78rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent-2);
+    margin: 0 0 1rem;
+}
+
+h1 {
+    font-family: var(--heading);
+    font-size: clamp(2rem, 5vw, 3.4rem);
+    line-height: 1.1;
+    margin: 0 0 0.75rem;
+    max-width: 16ch;
+}
+
+.hero-date {
+    color: var(--accent);
+    font-weight: 600;
+    margin: 0 0 1.25rem;
+}
+
+.lede {
+    max-width: 68ch;
+    color: var(--muted);
+    font-size: 1.05rem;
+}
+
+.hero-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2rem;
+    margin: 2.5rem 0 0;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--line);
+}
+
+.hero-stats dt {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--dim);
+}
+
+.hero-stats dd {
+    margin: 0.2rem 0 0;
+    font-family: var(--heading);
+    font-size: 1.6rem;
+    font-weight: 600;
+}
+
+.block {
+    padding: 4.5rem 8vw;
+    border-bottom: 1px solid var(--line);
+}
+
+.block:nth-child(even) {
+    background: var(--bg-alt);
+}
+
+.section-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.tag {
+    font-size: 0.72rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--accent);
+    border: 1px solid var(--line);
+    padding: 0.2rem 0.6rem;
+}
+
+h2 {
+    font-family: var(--heading);
+    font-size: clamp(1.5rem, 3vw, 2.1rem);
+    margin: 0;
+}
+
+.grid-2 {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+}
+
+.card {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 1.35rem 1.4rem;
+}
+
+.card h3 {
+    margin: 0 0 0.6rem;
+    font-size: 1.05rem;
+}
+
+.card p,
+.card li {
+    color: var(--muted);
+    margin: 0;
+}
+
+.card ul {
+    margin: 0;
+    padding-left: 1.1rem;
+}
+
+.card li + li {
+    margin-top: 0.45rem;
+}
+
+.fact-list {
+    margin: 0;
+    padding-left: 1.15rem;
+    max-width: 75ch;
+}
+
+.fact-list li + li {
+    margin-top: 0.7rem;
+}
+
+.map-layout {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr;
+    gap: 1.25rem;
+    align-items: start;
+}
+
+.map-frame-wrap {
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    overflow: hidden;
+    min-height: 320px;
+    background: var(--surface);
+}
+
+.map-frame-wrap iframe {
+    display: block;
+    width: 100%;
+    height: 360px;
+    border: 0;
+}
+
+.map-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 0.9rem;
+}
+
+.map-btn {
+    border: 1px solid var(--line);
+    background: var(--surface);
+    color: var(--text);
+    border-radius: 999px;
+    padding: 0.35rem 0.8rem;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.85rem;
+}
+
+.map-btn.is-active,
+.map-btn:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.sources ol {
+    max-width: 75ch;
+    padding-left: 1.2rem;
+}
+
+.sources li + li {
+    margin-top: 0.55rem;
+}
+
+.page-footer {
+    padding: 1.5rem 8vw;
+    color: var(--dim);
+    font-size: 0.9rem;
+}
+
+.page-footer a {
+    color: var(--muted);
+}
+
+@media (max-width: 768px) {
+    .grid-2,
+    .map-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .hero,
+    .block {
+        padding: 3rem 1.25rem;
+    }
+
+    .topnav {
+        flex-wrap: wrap;
+    }
+
+    .nav-links {
+        order: 3;
+        width: 100%;
+        padding-top: 0.35rem;
+    }
+}


### PR DESCRIPTION
## Description

Adds an educational profile for the 18 September 2011 Sikkim earthquake (Mw 6.9), covering the USGS epicentre, Himalayan tectonic setting, landslides and infrastructure damage, road and settlement impact, NDRF/Army relief, and preparedness.

Fixes #3552

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Tested locally in browser
- [x] Tested in both dark and light themes
- [x] Tested at mobile viewport widths
- [x] Verified no console errors

## Checklist

- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an educational explorer covering the 2011 Sikkim earthquake, including its history, tectonic setting, impacts, relief response, and preparedness guidance.
  * Added an interactive map with selectable locations and synchronized details.
  * Added the explorer to global search under “Geology & Disasters.”
  * Added responsive layouts, accessible navigation, and light/dark theme support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->