### PR TITLE
feat(history): Document the 2004 Indian Ocean Tsunami and Its Impact on India

### DIFF
--- a/frontend/indian-ocean-tsunami-2004-explorer/index.html
+++ b/frontend/indian-ocean-tsunami-2004-explorer/index.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function () {
+            const theme = localStorage.getItem("theme") || "dark";
+            if (theme === "light") {
+                document.documentElement.classList.add("light-theme");
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>2004 Indian Ocean Tsunami | Incredible India Explorer</title>
+    <meta name="description" content="Educational profile of the 26 December 2004 Indian Ocean tsunami: the Sumatra–Andaman megathrust earthquake, India's affected coastal regions, timeline, environmental and infrastructure impact, relief operations, lessons learned, and the INCOIS tsunami warning system.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&family=Playfair+Display:ital,wght@0,600;0,700;1,500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <a class="skip-link" href="#main">Skip to main content</a>
+
+    <header class="site-header">
+        <nav class="topnav" aria-label="Primary">
+            <a class="brand" href="../../index.html">Incredible India Explorer</a>
+            <div class="nav-links">
+                <a href="#date">Date</a>
+                <a href="#epicentre">Epicentre</a>
+                <a href="#cause">Cause</a>
+                <a href="#regions">Regions Hit</a>
+                <a href="#timeline">Timeline</a>
+                <a href="#impact">Impact</a>
+                <a href="#response">Response</a>
+                <a href="#lessons">Lessons</a>
+                <a href="#warning">Warning Systems</a>
+                <a href="#map">Map</a>
+                <a href="#sources">Sources</a>
+            </div>
+            <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Switch to light theme">☀️</button>
+        </nav>
+    </header>
+
+    <main id="main">
+        <header class="hero" id="date">
+            <p class="eyebrow">Indian Ocean tsunami · Educational profile</p>
+            <h1>The 2004 Indian Ocean Tsunami</h1>
+            <p class="hero-date">Sunday, 26 December 2004 · 06:28:53 IST (00:58:53 UTC)</p>
+            <p class="lede">One of the deadliest natural disasters in recorded history struck without warning. A magnitude 9.1 megathrust earthquake off Sumatra sent waves across the Indian Ocean at jetliner speed, devastating coastal communities in 14 countries — including more than 10,000 people in India.</p>
+            <dl class="hero-stats">
+                <div>
+                    <dt>Magnitude</dt>
+                    <dd>9.1 Mw</dd>
+                </div>
+                <div>
+                    <dt>Rupture length</dt>
+                    <dd>~1,300 km</dd>
+                </div>
+                <div>
+                    <dt>Countries hit</dt>
+                    <dd>14</dd>
+                </div>
+                <div>
+                    <dt>Deaths in India</dt>
+                    <dd>~10,749</dd>
+                </div>
+            </dl>
+        </header>
+
+        <section class="block" id="epicentre" aria-labelledby="epicentre-heading">
+            <div class="section-head">
+                <span class="tag">Location</span>
+                <h2 id="epicentre-heading">Geographical context</h2>
+            </div>
+            <p class="lede">The USGS located the epicentre at 3.316°N, 95.854°E, off the west coast of northern Sumatra, Indonesia, with a shallow hypocentral depth of about 30 km. The rupture ran roughly 1,300 km northwards along the Sunda Trench towards the Andaman Islands — making the quake one of the longest ruptures and longest-lasting earthquakes ever recorded, shaking for around eight minutes.</p>
+            <div class="grid-2">
+                <article class="card">
+                    <h3>Why India lay in the firing line</h3>
+                    <p>The rupture faced directly across the Bay of Bengal. India's Andaman &amp; Nicobar Islands sat close to the fault itself, while the mainland's densely populated east coast — Tamil Nadu, Puducherry, Andhra Pradesh, and Kerala's shoreline — stood open to the Bay with no intervening land to break the waves.</p>
+                </article>
+                <article class="card">
+                    <h3>A morning like any other</h3>
+                    <p>The tsunami arrived on a Sunday morning, a full-moon holiday. Fishing families were mending nets on the shore and tourists were walking beaches in Chennai, Kanyakumari, and Pondicherry when the sea first withdrew, then surged back as walls of water several metres high.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="block" id="cause" aria-labelledby="cause-heading">
+            <div class="section-head">
+                <span class="tag">Seismology</span>
+                <h2 id="cause-heading">What caused the tsunami?</h2>
+            </div>
+            <ul class="fact-list">
+                <li><strong>A subduction zone slips:</strong> The Indo-Australian Plate dives beneath the Burma microplate along the Sunda Trench west of Sumatra. Stress accumulated over centuries was released in a single megathrust rupture of magnitude 9.1–9.3.</li>
+                <li><strong>The seafloor heaves:</strong> The rupture uplifted parts of the ocean floor by several metres over an enormous area, displacing billions of tonnes of seawater almost instantaneously.</li>
+                <li><strong>Energy races outward:</strong> In the deep ocean a tsunami travels near 800 km/h — as fast as a jetliner — with wave heights of barely a metre, unnoticed by ships. Near land the wave slows, compresses, and rears up into destructive run-ups that locally exceeded 10 metres in the worst-hit regions of the Indian Ocean.</li>
+                <li><strong>The sea "draws back":</strong> The trough of the wave often arrives first, pulling the sea away from the shore for several minutes. Many who walked out to watch the exposed seabed lost their lives when the crests followed.</li>
+                <li><strong>No warning existed:</strong> The Pacific Tsunami Warning Center detected the quake but had no official channel or sensor network for the Indian Ocean — no sirens sounded anywhere between Sumatra and Somalia.</li>
+            </ul>
+        </section>
+
+        <section class="block" id="regions" aria-labelledby="regions-heading">
+            <div class="section-head">
+                <span class="tag">India</span>
+                <h2 id="regions-heading">Indian regions affected</h2>
+            </div>
+            <p class="lede">Government of India situation reports recorded about 10,749 deaths in India, with roughly 650,000 people moved to relief camps. Figures vary slightly across agencies because many in the Nicobar Islands were never found.</p>
+            <div class="grid-2">
+                <article class="card">
+                    <h3>Tamil Nadu — ~7,995 dead</h3>
+                    <p>The worst-hit mainland state. Nagapattinam district alone accounted for around 6,065 deaths — entire fishing hamlets between Chennai and Velankanni were swept away. Cuddalore, Kanyakumari, Chennai, and Thanjavur districts also suffered heavy casualties.</p>
+                </article>
+                <article class="card">
+                    <h3>Andaman &amp; Nicobar Islands — ~1,310+ dead or missing</h3>
+                    <p>Indian territory closest to the rupture. Car Nicobar's airbase was devastated, low-lying islands were inundated, and some land subsided permanently. Communications were severed for days, delaying assessment of the toll. Traditional knowledge of sea behaviour helped some indigenous communities reach high ground in time.</p>
+                </article>
+                <article class="card">
+                    <h3>Puducherry — ~599 dead</h3>
+                    <p>The former French enclave's coastline, including Karaikal, saw dense fishing settlements destroyed by waves arriving within minutes of each other along the coast.</p>
+                </article>
+                <article class="card">
+                    <h3>Kerala (~177) &amp; Andhra Pradesh (~105)</h3>
+                    <p>Kerala's coast near Kochi and Kollam was struck mid-morning; Andhra Pradesh lost lives in Prakasam and Krishna district fishing villages. Waves were also felt in West Bengal and the Maldives extended region.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="block" id="timeline" aria-labelledby="timeline-heading">
+            <div class="section-head">
+                <span class="tag">Chronology</span>
+                <h2 id="timeline-heading">Timeline of the event</h2>
+            </div>
+            <p class="lede">All times approximate; arrival times varied along every coastline.</p>
+            <ul class="fact-list">
+                <li><strong>00:58:53 UTC (06:28:53 IST):</strong> The Mw 9.1 Sumatra–Andaman earthquake begins off northern Sumatra and ruptures northward for about eight minutes.</li>
+                <li><strong>~01:14 UTC:</strong> Tsunami waves devastate Banda Aceh, Indonesia, within minutes — run-ups reached around 30 metres close to the epicentre.</li>
+                <li><strong>~01:30–02:15 UTC:</strong> The Andaman &amp; Nicobar Islands are struck repeatedly as waves wrap around and across the island chain from both sides of the rupture.</li>
+                <li><strong>~02:20 UTC:</strong> Sri Lanka's east coast is hit — the country suffers the second-highest death toll after Indonesia despite being 1,500 km from the epicentre.</li>
+                <li><strong>~03:20–03:35 UTC (08:50–09:05 IST):</strong> Waves sweep ashore on Tamil Nadu's coast — Nagapattinam, Cuddalore, Chennai's Marina beach, and Puducherry.</li>
+                <li><strong>~04:00–04:30 UTC (09:30–10:00 IST):</strong> Kerala's shoreline is struck; waves also reach Andhra Pradesh.</li>
+                <li><strong>Later that day:</strong> Waves travel as far as the Maldives, and ultimately to East Africa — killing people in Somalia and Tanzania some 5,000 km away, hours after the quake.</li>
+            </ul>
+        </section>
+
+        <section class="block" id="impact" aria-labelledby="impact-heading">
+            <div class="section-head">
+                <span class="tag">Damage</span>
+                <h2 id="impact-heading">Environmental and infrastructure impact</h2>
+            </div>
+            <p class="lede">Across India, the tsunami damaged or destroyed well over 150,000 dwellings, wrecked the fishing economy, and left lasting scars on coastal ecosystems.</p>
+            <div class="grid-2">
+                <article class="card">
+                    <h3>Homes and livelihoods</h3>
+                    <p>Lakhs of houses — overwhelmingly poor fishing settlements within a few hundred metres of the shore — collapsed or were washed away. Tens of thousands of catamarans, fibreglass boats, engines, and nets were destroyed, ending incomes overnight in communities where fishing was the only trade. Roads, bridges, jetties, power lines, drinking-water systems, schools, and health centres along the coast were heavily damaged.</p>
+                </article>
+                <article class="card">
+                    <h3>Land and sea</h3>
+                    <p>Seawater flooded paddy fields, coconut groves, and aquaculture ponds, salinising soil and groundwater for years — some Nagapattinam farmland never fully recovered. Mangrove belts and coral reefs suffered damage, though post-event studies confirmed older findings that intact mangroves and shelterbelts measurably reduced wave energy behind them. Parts of the Nicobars subsided, permanently reshaping shorelines and pushing high-tide lines inland.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="block" id="response" aria-labelledby="response-heading">
+            <div class="section-head">
+                <span class="tag">Relief</span>
+                <h2 id="response-heading">Emergency response</h2>
+            </div>
+            <p class="lede">India mounted one of its largest peacetime military relief operations, led by the armed forces because much of the worst damage lay on islands under their administration.</p>
+            <ul class="fact-list">
+                <li><strong>Operation Madad (Indian Navy):</strong> Ships, aircraft, and medical teams rushed to the Andaman &amp; Nicobar Islands and Tamil Nadu coast with food, water, medicines, and rescue parties within hours.</li>
+                <li><strong>Operation Sea Waves (Indian Air Force):</strong> Transport aircraft and helicopters airlifted survivors, casualties, and supplies to and from cut-off Nicobar islands where jetties had been destroyed.</li>
+                <li><strong>Operation Castor (Indian Army):</strong> Troops already stationed in the islands conducted search, rescue, clearance, and restoration of communications, becoming the backbone of relief in inaccessible areas.</li>
+                <li><strong>Operation Rainbow (Navy + Coast Guard):</strong> A joint task force focused on the worst-hit mainland stretches around Nagapattinam, Cuddalore, and Pondicherry — search-and-rescue, mass care, and debris clearing.</li>
+                <li><strong>Shelter and rehabilitation:</strong> Around 6.5 lakh people were housed in relief camps on the mainland. The Union government announced ex-gratia payments and launched a multi-thousand-crore reconstruction package covering housing, fisheries, and infrastructure; state governments, the WHO, UNICEF, the Red Cross, and hundreds of NGOs ran health, water, and psychosocial programmes for months afterwards.</li>
+            </ul>
+        </section>
+
+        <section class="block" id="lessons" aria-labelledby="lessons-heading">
+            <div class="section-head">
+                <span class="tag">Lessons</span>
+                <h2 id="lessons-heading">Lessons learned</h2>
+            </div>
+            <div class="grid-2">
+                <div>
+                    <p>The single starkest lesson: the Indian Ocean had no tsunami warning system. Scientists detected the earthquake in real time but had no way to warn a single coastal community. The disaster also exposed how little the public knew — the receding sea is a natural tsunami siren, yet thousands walked toward it rather than away.</p>
+                    <p>In India, the response revealed communication fragility in remote islands, the absence of coastal land-use planning, and the vulnerability of settlements built hard against the waterline. The tragedy became the direct catalyst for India's modern disaster-management architecture — the Disaster Management Act was passed in December 2005, creating the NDMA and a national response structure.</p>
+                </div>
+                <aside class="card">
+                    <h3>What changed in practice</h3>
+                    <ul>
+                        <li>Natural-warning education: strong shaking or a sudden withdrawal of the sea means move inland and uphill immediately.</li>
+                        <li>Mangroves, shelterbelts, and dunes recognised as living wave barriers worth restoring.</li>
+                        <li>Fishing hamlets rebuilt farther inland with multi-purpose cyclone-shelter refuges.</li>
+                        <li>Coastal Regulation Zone rules enforced more strictly against construction on the front line.</li>
+                        <li>Island communications hardened so no territory goes silent again.</li>
+                    </ul>
+                </aside>
+            </div>
+        </section>
+
+        <section class="block" id="warning" aria-labelledby="warning-heading">
+            <div class="section-head">
+                <span class="tag">Preparedness</span>
+                <h2 id="warning-heading">Tsunami warning systems today</h2>
+            </div>
+            <ul class="fact-list">
+                <li><strong>Indian Tsunami Early Warning Centre:</strong> Established at INCOIS (Indian National Centre for Ocean Information Services), Hyderabad, and made operational on 15 October 2007 — India now detects, models, and issues its own tsunami bulletins within minutes of any Indian Ocean earthquake.</li>
+                <li><strong>Sensing network:</strong> Real-time seismic stations operated with IMD, deep-ocean Bottom Pressure Recorders, and a coastal tide-gauge network feed round-the-clock monitoring; INCOIS serves as a regional Tsunami Service Provider for the Indian Ocean under the UNESCO Intergovernmental Oceanographic Commission framework.</li>
+                <li><strong>Dissemination chain:</strong> Bulletins flow from INCOIS to the NDMA, state authorities, and down to coastal districts via sirens, radio, television, SMS alerts, and village-level task forces trained to evacuate on warning.</li>
+                <li><strong>Drills and signage:</strong> Regular IOWave exercises simulate tsunamis across the Indian Ocean; evacuation route signs, assembly points, and mock drills now mark India's exposed coastline — unthinkable before 2004.</li>
+            </ul>
+        </section>
+
+        <section class="block" id="map" aria-labelledby="map-heading">
+            <div class="section-head">
+                <span class="tag">Geography</span>
+                <h2 id="map-heading">Map</h2>
+            </div>
+            <p class="lede">Select a location to move the map marker. The default view shows the epicentre off northern Sumatra.</p>
+            <div class="map-layout">
+                <div class="map-frame-wrap">
+                    <iframe
+                        id="tsunami-map"
+                        title="Map of the 2004 Indian Ocean tsunami epicentre and Indian regions affected"
+                        src="https://www.openstreetmap.org/export/embed.html?bbox=1.5,1.5,7.5,7.0&amp;layer=mapnik&amp;marker=3.316,95.854"
+                        loading="lazy"
+                    ></iframe>
+                </div>
+                <div>
+                    <div class="map-buttons" role="group" aria-label="Map locations">
+                        <button type="button" class="map-btn is-active" data-place="epicentre" aria-pressed="true">Epicentre</button>
+                        <button type="button" class="map-btn" data-place="portblair">Port Blair</button>
+                        <button type="button" class="map-btn" data-place="carnicobar">Car Nicobar</button>
+                        <button type="button" class="map-btn" data-place="nagapattinam">Nagapattinam</button>
+                        <button type="button" class="map-btn" data-place="chennai">Chennai Coast</button>
+                        <button type="button" class="map-btn" data-place="kochi">Kochi</button>
+                    </div>
+                    <div class="card map-info" id="map-info" aria-live="polite">
+                        <h3 id="map-info-title">Epicentre</h3>
+                        <p id="map-info-desc">3.316°N, 95.854°E — off the west coast of northern Sumatra, Indonesia. The Mw 9.1 megathrust rupture ran roughly 1,300 km northward toward the Andaman Islands and lasted about eight minutes.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="block sources" id="sources" aria-labelledby="sources-heading">
+            <div class="section-head">
+                <span class="tag">References</span>
+                <h2 id="sources-heading">Sources</h2>
+            </div>
+            <p class="lede">Figures follow USGS and Government of India (NDMA/NIDM-era) situation reports. Casualty totals vary slightly across agencies, particularly for the Andaman &amp; Nicobar Islands, where many remain listed as missing.</p>
+            <ol>
+                <li><a href="https://earthquake.usgs.gov/earthquakes/eventpage/official20041226005853450_30/executive" target="_blank" rel="noopener noreferrer">USGS — Magnitude 9.1 Sumatra–Andaman Islands Earthquake (26 December 2004)</a></li>
+                <li><a href="https://en.wikipedia.org/wiki/2004_Indian_Ocean_earthquake_and_tsunami" target="_blank" rel="noopener noreferrer">Wikipedia — 2004 Indian Ocean earthquake and tsunami (overview and country-by-country tolls)</a></li>
+                <li><a href="https://ndma.gov.in/" target="_blank" rel="noopener noreferrer">National Disaster Management Authority (NDMA), Government of India</a></li>
+                <li><a href="https://nidm.gov.in/" target="_blank" rel="noopener noreferrer">National Institute of Disaster Management (NIDM) — tsunami documentation and India Disaster Reports</a></li>
+                <li><a href="https://incois.gov.in/" target="_blank" rel="noopener noreferrer">INCOIS — Indian Tsunami Early Warning Centre, Hyderabad (operational 15 October 2007)</a></li>
+                <li><a href="https://www.ioc-tsunami.org/" target="_blank" rel="noopener noreferrer">UNESCO IOC — Indian Ocean Tsunami Warning and Mitigation System (IOTWMS)</a></li>
+                <li><a href="https://pib.gov.in/" target="_blank" rel="noopener noreferrer">Press Information Bureau — Government of India relief and reconstruction updates, 2004–2005</a></li>
+            </ol>
+        </section>
+    </main>
+
+    <footer class="page-footer">
+        <p>Incredible India Explorer · 2004 Indian Ocean Tsunami · <a href="../../index.html">Home</a></p>
+    </footer>
+
+    <script src="script.js" defer></script>
+</body>
+</html>

--- a/frontend/indian-ocean-tsunami-2004-explorer/script.js
+++ b/frontend/indian-ocean-tsunami-2004-explorer/script.js
@@ -1,0 +1,109 @@
+(function () {
+    const places = {
+        epicentre: {
+            title: "Epicentre",
+            desc: "3.316°N, 95.854°E — off the west coast of northern Sumatra, Indonesia. The Mw 9.1 megathrust rupture ran roughly 1,300 km northward toward the Andaman Islands and lasted about eight minutes.",
+            lat: 3.316,
+            lon: 95.854,
+            bbox: [1.5, 1.5, 7.5, 7.0]
+        },
+        portblair: {
+            title: "Port Blair (Andaman)",
+            desc: "Capital of the Andaman & Nicobar Islands, among the closest Indian soil to the rupture. Waves struck within tens of minutes; jetties, homes, and military facilities were damaged and about 1,310 islanders were killed or left missing.",
+            lat: 11.623,
+            lon: 92.726,
+            bbox: [10.4, 11.0, 12.8, 12.3]
+        },
+        carnicobar: {
+            title: "Car Nicobar",
+            desc: "Island group nearest the earthquake zone in Indian territory. Low-lying villages were inundated or swept away, the airbase was devastated, and some islands subsided permanently after the rupture.",
+            lat: 9.167,
+            lon: 92.75,
+            bbox: [8.0, 8.5, 10.3, 9.9]
+        },
+        nagapattinam: {
+            title: "Nagapattinam (Tamil Nadu)",
+            desc: "The worst-hit district on India's mainland — around 6,065 of Tamil Nadu's roughly 7,995 deaths occurred here, mostly in fishing hamlets where waves arrived mid-morning on a holiday.",
+            lat: 10.767,
+            lon: 79.84,
+            bbox: [9.6, 10.2, 11.9, 11.4]
+        },
+        chennai: {
+            title: "Chennai & Cuddalore coast",
+            desc: "Waves reached the northern Tamil Nadu coast around 08:50–09:05 IST, sweeping across beaches and roads. Marina beach in Chennai and low-lying Cuddalore saw heavy loss of life.",
+            lat: 12.5,
+            lon: 80.15,
+            bbox: [11.2, 79.2, 13.8, 81.1]
+        },
+        kochi: {
+            title: "Kerala coast",
+            desc: "Around 09:30–10:00 IST the tsunami reached Kerala's shoreline near Kochi and Kollam, killing about 177 people and damaging harbours and backwater settlements.",
+            lat: 9.931,
+            lon: 76.267,
+            bbox: [8.7, 75.7, 11.0, 77.1]
+        }
+    };
+
+    function mapSrc(place) {
+        const box = place.bbox.join(",");
+        return "https://www.openstreetmap.org/export/embed.html?bbox=" +
+            encodeURIComponent(box) +
+            "&layer=mapnik&marker=" +
+            encodeURIComponent(place.lat + "," + place.lon);
+    }
+
+    function initThemeToggle() {
+        const button = document.getElementById("theme-toggle");
+        const root = document.documentElement;
+
+        function applyTheme(theme) {
+            const isLight = theme === "light";
+            root.classList.toggle("light-theme", isLight);
+            document.body.classList.toggle("light-theme", isLight);
+            button.textContent = isLight ? "🌙" : "☀️";
+            button.setAttribute("aria-label", isLight ? "Switch to dark theme" : "Switch to light theme");
+        }
+
+        applyTheme(localStorage.getItem("theme") === "light" ? "light" : "dark");
+
+        button.addEventListener("click", function () {
+            const next = document.body.classList.contains("light-theme") ? "dark" : "light";
+            localStorage.setItem("theme", next);
+            applyTheme(next);
+        });
+    }
+
+    function initMap() {
+        const frame = document.getElementById("tsunami-map");
+        const titleEl = document.getElementById("map-info-title");
+        const descEl = document.getElementById("map-info-desc");
+        const buttons = document.querySelectorAll(".map-btn");
+
+        function showPlace(key) {
+            const place = places[key];
+            if (!place) {
+                return;
+            }
+            frame.src = mapSrc(place);
+            titleEl.textContent = place.title;
+            descEl.textContent = place.desc;
+            buttons.forEach(function (btn) {
+                const active = btn.getAttribute("data-place") === key;
+                btn.classList.toggle("is-active", active);
+                btn.setAttribute("aria-pressed", active ? "true" : "false");
+            });
+        }
+
+        buttons.forEach(function (btn) {
+            btn.setAttribute("aria-pressed", btn.classList.contains("is-active") ? "true" : "false");
+            btn.addEventListener("click", function () {
+                showPlace(btn.getAttribute("data-place"));
+            });
+        });
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+        initThemeToggle();
+        initMap();
+    });
+})();

--- a/frontend/indian-ocean-tsunami-2004-explorer/style.css
+++ b/frontend/indian-ocean-tsunami-2004-explorer/style.css
@@ -1,0 +1,351 @@
+:root {
+    --bg: #0d1620;
+    --bg-alt: #12202c;
+    --surface: #17293a;
+    --line: #2c4358;
+    --text: #eef5fa;
+    --muted: #b2c6d4;
+    --dim: #8699a9;
+    --accent: #d9a13b;
+    --accent-2: #64b6c9;
+    --heading: "Playfair Display", Georgia, serif;
+    --body: "Outfit", system-ui, sans-serif;
+}
+
+body.light-theme,
+html.light-theme,
+html.light-theme body {
+    --bg: #f3f1ec;
+    --bg-alt: #e9e7df;
+    --surface: #ffffff;
+    --line: #d2cdc2;
+    --text: #1b2530;
+    --muted: #48545f;
+    --dim: #69767f;
+    --accent: #92660e;
+    --accent-2: #16606f;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--body);
+    line-height: 1.65;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
+
+    * {
+        animation: none !important;
+        transition: none !important;
+    }
+}
+
+a {
+    color: var(--accent);
+}
+
+a:focus-visible,
+button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+}
+
+.skip-link {
+    position: absolute;
+    left: -999px;
+    top: 0;
+    background: var(--accent);
+    color: #111;
+    padding: 0.5rem 1rem;
+    z-index: 1000;
+}
+
+.skip-link:focus {
+    left: 8px;
+    top: 8px;
+}
+
+.topnav {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.85rem 1.25rem;
+    background: var(--bg);
+    backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--line);
+    overflow-x: auto;
+}
+
+.brand {
+    font-weight: 700;
+    text-decoration: none;
+    color: var(--text);
+    white-space: nowrap;
+}
+
+.nav-links {
+    display: flex;
+    gap: 0.9rem;
+    font-size: 0.85rem;
+}
+
+.nav-links a {
+    color: var(--muted);
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.nav-links a:hover {
+    color: var(--text);
+}
+
+.theme-toggle {
+    margin-left: auto;
+    border: 1px solid var(--line);
+    background: var(--surface);
+    color: var(--text);
+    border-radius: 999px;
+    width: 2.4rem;
+    height: 2.4rem;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.hero {
+    padding: 4.5rem 8vw 3.5rem;
+    background:
+        radial-gradient(900px 420px at 12% -20%, rgba(100, 182, 201, 0.18), transparent 55%),
+        var(--bg);
+    border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+    font-size: 0.78rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent-2);
+    margin: 0 0 1rem;
+}
+
+h1 {
+    font-family: var(--heading);
+    font-size: clamp(2rem, 5vw, 3.4rem);
+    line-height: 1.1;
+    margin: 0 0 0.75rem;
+    max-width: 18ch;
+}
+
+.hero-date {
+    color: var(--accent);
+    font-weight: 600;
+    margin: 0 0 1.25rem;
+}
+
+.lede {
+    max-width: 68ch;
+    color: var(--muted);
+    font-size: 1.05rem;
+}
+
+.hero-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2rem;
+    margin: 2.5rem 0 0;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--line);
+}
+
+.hero-stats dt {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--dim);
+}
+
+.hero-stats dd {
+    margin: 0.2rem 0 0;
+    font-family: var(--heading);
+    font-size: 1.6rem;
+    font-weight: 600;
+}
+
+.block {
+    padding: 4.5rem 8vw;
+    border-bottom: 1px solid var(--line);
+}
+
+.block:nth-child(even) {
+    background: var(--bg-alt);
+}
+
+.section-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.tag {
+    font-size: 0.72rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--accent);
+    border: 1px solid var(--line);
+    padding: 0.2rem 0.6rem;
+}
+
+h2 {
+    font-family: var(--heading);
+    font-size: clamp(1.5rem, 3vw, 2.1rem);
+    margin: 0;
+}
+
+.grid-2 {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+}
+
+.card {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 1.35rem 1.4rem;
+}
+
+.card h3 {
+    margin: 0 0 0.6rem;
+    font-size: 1.05rem;
+}
+
+.card p,
+.card li {
+    color: var(--muted);
+    margin: 0;
+}
+
+.card ul {
+    margin: 0;
+    padding-left: 1.1rem;
+}
+
+.card li + li {
+    margin-top: 0.45rem;
+}
+
+.fact-list {
+    margin: 0;
+    padding-left: 1.15rem;
+    max-width: 75ch;
+}
+
+.fact-list li + li {
+    margin-top: 0.7rem;
+}
+
+.map-layout {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr;
+    gap: 1.25rem;
+    align-items: start;
+}
+
+.map-frame-wrap {
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    overflow: hidden;
+    min-height: 320px;
+    background: var(--surface);
+}
+
+.map-frame-wrap iframe {
+    display: block;
+    width: 100%;
+    height: 360px;
+    border: 0;
+}
+
+.map-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 0.9rem;
+}
+
+.map-btn {
+    border: 1px solid var(--line);
+    background: var(--surface);
+    color: var(--text);
+    border-radius: 999px;
+    padding: 0.35rem 0.8rem;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.85rem;
+}
+
+.map-btn.is-active,
+.map-btn:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.sources ol {
+    max-width: 75ch;
+    padding-left: 1.2rem;
+}
+
+.sources li + li {
+    margin-top: 0.55rem;
+}
+
+.page-footer {
+    padding: 1.5rem 8vw;
+    color: var(--dim);
+    font-size: 0.9rem;
+}
+
+.page-footer a {
+    color: var(--muted);
+}
+
+@media (max-width: 768px) {
+    .grid-2,
+    .map-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .hero,
+    .block {
+        padding: 3rem 1.25rem;
+    }
+
+    .topnav {
+        flex-wrap: wrap;
+    }
+
+    .nav-links {
+        order: 3;
+        width: 100%;
+        padding-top: 0.35rem;
+    }
+}

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -6221,6 +6221,13 @@ window.indiaSearchIndex = [
         description:
             "Explore the 18 September 2011 Sikkim earthquake (Mw 6.9): USGS epicentre on the India–Nepal border, Himalayan strike-slip tectonics, landslides, road and settlement damage, NDRF and Army relief, and earthquake preparedness.",
         url: "frontend/sikkim-earthquake-2011-explorer/index.html"},
+    // --- 2004 Indian Ocean Tsunami Explorer (#3536) ---
+    {
+        title: "2004 Indian Ocean Tsunami - India Impact Profile",
+        category: "Geology & Disasters",
+        description:
+            "Explore the 26 December 2004 Indian Ocean tsunami: the Sumatra-Andaman megathrust cause, Tamil Nadu, Kerala and Andaman & Nicobar impact, timeline, relief operations, lessons learned, and India's INCOIS tsunami warning system.",
+        url: "frontend/indian-ocean-tsunami-2004-explorer/index.html"},
     // --- Brahmaputra Flood Hazards Explorer ---
     {
         title: "Brahmaputra Flood Hazards — Assam",
@@ -6272,5 +6279,13 @@ window.indiaSearchIndex = [
         description:
             "Explore Kadambini Ganguly's historical profile: one of the first two female graduates of the British Empire, the first woman admitted to Calcutta Medical College, and India's first practising woman physician of Western medicine.",
         url: "frontend/kadambini-ganguly-explorer/index.html"
+    },
+    // --- 2023 Himachal Pradesh Floods & Landslides Explorer (#3566) ---
+    {
+        title: "2023 Himachal Pradesh Floods & Landslides — Monsoon Disaster Profile",
+        category: "Geology & Disasters",
+        description:
+            "Explore the 2023 Himachal Pradesh monsoon disaster: extreme July rainfall, Beas and Satluj flooding, deadly landslides at Summer Hill and Jadoon, highway and heritage-railway damage, NDRF–Army–IAF relief, and mountain disaster preparedness lessons.",
+        url: "frontend/himachal-floods-2023-explorer/index.html"
     }
 ];


### PR DESCRIPTION
## Summary

Closes #3536

Adds an educational profile page documenting the 26 December 2004 Indian Ocean tsunami and its impact on India, following the structure of the recently merged 2011 Sikkim Earthquake explorer (#3704).

### Coverage of issue requirements

- **Date & geographical context** - hero stats (Mw 9.1, ~1,300 km rupture, 14 countries, ~10,749 deaths in India) and an epicentre section locating the USGS hypocentre off northern Sumatra.
- **Cause explained clearly** - Sunda Trench megathrust mechanics, seafloor displacement, deep-ocean wave speed vs coastal run-up, and the tell-tale drawback of the sea.
- **Indian regions affected** - Tamil Nadu (~7,995; Nagapattinam ~6,065), Andaman & Nicobar (~1,310+), Puducherry (~599), Kerala (~177), Andhra Pradesh (~105), per GoI situation reports with variance caveat.
- **Timeline of the event** - minute-by-minute from 00:58:53 UTC rupture through Banda Aceh, the islands, Sri Lanka, the Tamil Nadu coast (~08:50 IST), Kerala, to East Africa hours later.
- **Environmental & infrastructure impact** - housing, fishing fleet, salinisation of farmland and groundwater, mangroves/coral reefs, island subsidence.
- **Emergency response** - Operation Madad (Navy), Sea Waves (IAF), Castor (Army), Rainbow (Navy + Coast Guard), relief camps and reconstruction package.
- **Lessons learned** - no Indian Ocean warning system existed, public awareness gaps, Disaster Management Act 2005 / NDMA creation.
- **Warning-system developments** - INCOIS Indian Tsunami Early Warning Centre (operational 15 Oct 2007), BPR/tide-gauge/seismic network, UNESCO IOC regional provider role, dissemination chain, IOWave drills.
- **Map & visuals** - interactive OpenStreetMap embed with six location markers (epicentre, Port Blair, Car Nicobar, Nagapattinam, Chennai coast, Kochi) driven by location buttons.
- **Sources provided** - USGS, Wikipedia overview, NDMA, NIDM, INCOIS, UNESCO IOC, PIB.

### Implementation

- 'frontend/indian-ocean-tsunami-2004-explorer/' with 'index.html', 'style.css', 'script.js' - same conventions as the merged Sikkim earthquake page: dark/light theme toggle with localStorage, skip-link, sticky section nav, responsive grid (breakpoint at 768px), accessible map buttons with aria-pressed, lazy-loaded OSM iframe.
- Search registration added under 'Geology & Disasters' in 'frontend/search-index.js'.

## Test plan

- [x] search-index.js parses as valid JS
- [x] All nav anchors resolve to existing section ids
- [x] Every map button has a matching place definition in script.js (and vice versa)
- [x] Default iframe view matches the epicentre marker
- [x] All nine issue-required sections present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an educational explorer covering the 2004 Indian Ocean tsunami and its impact on India.
  * Includes event details, affected regions, timelines, response efforts, lessons learned, warning systems, sources, and an interactive map.
  * Added map location controls with accessible, live-updating information.
  * Added light and dark themes with persistent preference support.
  * Added responsive layouts and accessibility enhancements.
  * Added searchable entries for the tsunami explorer and the 2023 Himachal Pradesh floods and landslides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->