### PR TITLE
feat: add 2023 Himachal Pradesh floods and landslides educational profile (#3566)

### DIFF
--- a/frontend/himachal-floods-2023-explorer/index.html
+++ b/frontend/himachal-floods-2023-explorer/index.html
@@ -1,0 +1,295 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function () {
+            const theme = localStorage.getItem("theme") || "dark";
+            if (theme === "light") {
+                document.documentElement.classList.add("light-theme");
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>2023 Himachal Pradesh Floods &amp; Landslides | Incredible India Explorer</title>
+    <meta name="description" content="Educational profile of the 2023 Himachal Pradesh floods and landslides: extreme monsoon rainfall, Himalayan river geography, affected areas, landslide hazards, infrastructure damage, rescue response, and mountain disaster preparedness.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&family=Playfair+Display:ital,wght@0,600;0,700;1,500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <a class="skip-link" href="#main">Skip to main content</a>
+
+    <header class="site-header">
+        <nav class="topnav" aria-label="Primary">
+            <a class="brand" href="../../index.html">Incredible India Explorer</a>
+            <div class="nav-links">
+                <a href="#overview">Overview</a>
+                <a href="#timeline">Timeline</a>
+                <a href="#rainfall">Rainfall</a>
+                <a href="#geography">Geography</a>
+                <a href="#affected">Affected areas</a>
+                <a href="#landslides">Landslides</a>
+                <a href="#infrastructure">Infrastructure</a>
+                <a href="#response">Response</a>
+                <a href="#preparedness">Preparedness</a>
+                <a href="#map">Map</a>
+                <a href="#sources">Sources</a>
+            </div>
+            <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Switch to light theme">☀️</button>
+        </nav>
+    </header>
+
+    <main id="main">
+        <header class="hero" id="overview">
+            <p class="eyebrow">Monsoon disaster · Educational profile</p>
+            <h1>The 2023 Himachal Pradesh Floods &amp; Landslides</h1>
+            <p class="hero-date">Late June – September 2023 · Southwest monsoon season</p>
+            <p class="lede">An exceptionally wet monsoon lashed Himachal Pradesh, swelling the Beas, Satluj, Ravi, and Yamuna headwaters and triggering thousands of landslides that severed highways, buried temples and buses, destroyed homes, orchards, and power projects, and turned hill roads into the deadliest hazard of the summer.</p>
+            <dl class="hero-stats">
+                <div>
+                    <dt>Deaths (season)</dt>
+                    <dd>300+</dd>
+                </div>
+                <div>
+                    <dt>Peak road closures</dt>
+                    <dd>~900+</dd>
+                </div>
+                <div>
+                    <dt>Estimated losses</dt>
+                    <dd>₹10,000 cr+</dd>
+                </div>
+                <div>
+                    <dt>July rainfall anomaly</dt>
+                    <dd>~60% above normal</dd>
+                </div>
+            </dl>
+        </header>
+
+        <section class="block" id="timeline" aria-labelledby="timeline-heading">
+            <div class="section-head">
+                <span class="tag">Chronology</span>
+                <h2 id="timeline-heading">Event timeline</h2>
+            </div>
+            <p class="lede">The disaster unfolded as a series of intense spells rather than a single event. Each pulse of extreme rain re-saturated slopes and re-filled rivers already destabilised by the previous wave.</p>
+            <ol class="timeline">
+                <li class="timeline-item">
+                    <span class="timeline-date">24 June 2023</span>
+                    <p>The destructive phase begins before the official monsoon onset covers the state. Cloudbursts and flash floods kill the first victims, wash away vehicles, and cut roads across Mandi, Kullu, Chamba, and Shimla districts.</p>
+                </li>
+                <li class="timeline-item">
+                    <span class="timeline-date">8–11 July</span>
+                    <p>The first catastrophic spell. The Beas floods riverside markets and camps in Manali, Kullu, and Mandi; the Chandigarh–Manali highway and Manali–Leh road are breached. Landslides close several hundred roads at once and strand thousands of tourists.</p>
+                </li>
+                <li class="timeline-item">
+                    <span class="timeline-date">9 July</span>
+                    <p>A landslide strikes Shimla's Summer Hill area, burying part of the UNESCO-listed Kalka–Shimla narrow-gauge railway and damaging houses below the cut slope.</p>
+                </li>
+                <li class="timeline-item">
+                    <span class="timeline-date">13 July</span>
+                    <p>In Solan district, a rain-soaked hillside collapses onto Jadoon village during a temple gathering, sweeping away devotees and vehicles. More than 25 people die in one of the season's deadliest single slides.</p>
+                </li>
+                <li class="timeline-item">
+                    <span class="timeline-date">Mid-July</span>
+                    <p>Repeated spells keep nearly every district affected. At the peak, the state's daily situation report lists roughly 900 road closures, including national arteries such as NH-3, NH-5, and NH-205, alongside widespread damage to water schemes and power networks.</p>
+                </li>
+                <li class="timeline-item">
+                    <span class="timeline-date">14 August</span>
+                    <p>Two landslides tear through Shimla within hours — one buries the Shiva temple at Summer Hill, killing about a dozen worshippers, another hits Fagli. The Satluj rises again in Rampur, and fresh slides sever the Hindustan–Tibet road (NH-5).</p>
+                </li>
+                <li class="timeline-item">
+                    <span class="timeline-date">September</span>
+                    <p>Late-season rain continues to hamper restoration. By the end of the season the state government tallies more than 300 deaths (including weather-related road accidents), thousands of damaged houses, and cumulative losses estimated above ₹10,000 crore.</p>
+                </li>
+            </ol>
+        </section>
+
+        <section class="block" id="rainfall" aria-labelledby="rainfall-heading">
+            <div class="section-head">
+                <span class="tag">Climate context</span>
+                <h2 id="rainfall-heading">Extreme rainfall behind the disaster</h2>
+            </div>
+            <div class="grid-2">
+                <article class="card">
+                    <h3>A hyper-active monsoon</h3>
+                    <p>India Meteorological Department data showed the season running far above normal almost continuously. June ended with a large surplus after the pre-onset storms, and July 2023 finished roughly 60% wetter than the long-term average for the state — among the wettest Julys in more than a decade. Several single days produced extremely heavy falls of over 100 mm in 24 hours at valley stations.</p>
+                </article>
+                <article class="card">
+                    <h3>Why intensity mattered</h3>
+                    <p>Mountain damage correlates less with monthly totals than with short bursts of intensity. Cloudburst-scale rain over small catchments sends flash floods down ravines within minutes, while multi-hour deluges saturate soil mantles on 30–70° slopes until they fail as landslides. In 2023 both modes repeated spell after spell, giving slopes no time to drain between events.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="block" id="geography" aria-labelledby="geography-heading">
+            <div class="section-head">
+                <span class="tag">Terrain</span>
+                <h2 id="geography-heading">Rivers and mountains</h2>
+            </div>
+            <p class="lede">Himachal Pradesh climbs from the Shiwalik foothills (about 350 m) to trans-Himalayan peaks above 6,000 m in barely 150 km of map distance, so every drainage is steep and flashy.</p>
+            <ul class="fact-list">
+                <li><strong>Beas:</strong> rises near Rohtang, drains the Kullu valley past Manali and Mandi — the epicentre of the July flooding that swept riverside dhabas, homestays, and the highway.</li>
+                <li><strong>Satluj:</strong> enters from Tibet at Shipki La and powers the Jhakri–Rampur hydropower cascade; its spates repeatedly cut the Hindustan–Tibet road (NH-5) in Kinnaur and Shimla district.</li>
+                <li><strong>Ravi and Chenab:</strong> drain Chamba and the Pangi/Lahaul valleys; flash floods and channel shifts damaged bridges and low-level crossings there.</li>
+                <li><strong>Yamuna tributaries (Giri and Tons):</strong> drain Sirmour and Solan, where the Jadoon landslide occurred on slopes above the Giri headwaters.</li>
+                <li><strong>Geological setting:</strong> young, thrust-stacked, seismically active rock of the Lesser and Higher Himalaya weathers into weak shale–slate slopes; road-cut blasting and construction further undercut them, which is why the Geological Survey of India maps much of the state as high landslide susceptibility.</li>
+            </ul>
+        </section>
+
+        <section class="block" id="affected" aria-labelledby="affected-heading">
+            <div class="section-head">
+                <span class="tag">Impact zones</span>
+                <h2 id="affected-heading">Major affected areas</h2>
+            </div>
+            <div class="grid-2">
+                <article class="card">
+                    <h3>Kullu–Manali and Mandi</h3>
+                    <p>The Beas corridor saw the worst riverine flooding. Manali's mall road and riverside businesses were inundated, apple orchards and hotels along the valley floor were silted, and both national highways serving the valley were cut for weeks, stranding tourists who had to be evacuated by escorted convoys and air effort.</p>
+                </article>
+                <article class="card">
+                    <h3>Shimla and Solan</h3>
+                    <p>The capital region's built-up slopes produced deadly urban landslides — Summer Hill (twice: July rail-line burial, August temple collapse) and Fagli. In Solan district, the Jadoon slide killed a temple congregation. Cut-slope housing below old landslide scars proved especially vulnerable.</p>
+                </article>
+                <article class="card">
+                    <h3>Kinnaur and Rampur belt</h3>
+                    <p>Along the Satluj, slides and bank erosion repeatedly closed NH-5, isolating villages dependent on the single highway. Hydroproject townships at Jhakri and Rampur faced flood damage and long power-generation interruptions.</p>
+                </article>
+                <article class="card">
+                    <h3>Mandi, Chamba, Sirmaur, Kangra</h3>
+                    <p>Mandi recorded some of the highest death counts and road-closure numbers. Chamba's Ravi valley lost bridges and link roads, Paonta Sahib and the Giri valley in Sirmaur saw riverbank collapse, and Kangra's Dhauladhar streams triggered flash floods into Dharamshala and Palampur outskirts.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="block" id="landslides" aria-labelledby="landslides-heading">
+            <div class="section-head">
+                <span class="tag">Hazards</span>
+                <h2 id="landslides-heading">Landslide hazards</h2>
+            </div>
+            <p class="lede">Landslides — not drowning — became the signature killer of the 2023 monsoon, because the same storms acted on slopes weakened over decades.</p>
+            <div class="grid-2">
+                <article class="card">
+                    <h3>How the slopes failed</h3>
+                    <p>Prolonged rain raised pore-water pressure inside colluvium and fractured rock. Slopes failed as debris slides and rockfalls on road cuts, ancient scarps reactivated, and saturated terraces flowed onto settlements below. ISRO/NRSC satellite mapping later catalogued thousands of new or reactivated slides statewide, concentrated along highways and river corridors.</p>
+                </article>
+                <article class="card">
+                    <h3>Why exposure was high</h3>
+                    <p>Hill roads are blasted into the same weak slopes they traverse, so every slide closes an artery. Villages, temples, and schools occupy mid-slope benches and nala mouths; buses and vehicles travel directly beneath active faces. The Jadoon and Summer Hill tragedies both involved people gathered under or beside steep cut slopes during ongoing rain.</p>
+                </article>
+            </div>
+            <aside class="card warning-card">
+                <h3>Standing rule in the hills</h3>
+                <p>During heavy rain, avoid sheltering under cut slopes, below old slide scars, or beside swollen nalas; move to open ground away from the toe of the slope and wait out the spell.</p>
+            </aside>
+        </section>
+
+        <section class="block" id="infrastructure" aria-labelledby="infra-heading">
+            <div class="section-head">
+                <span class="tag">Damage</span>
+                <h2 id="infra-heading">Infrastructure and road damage</h2>
+            </div>
+            <ul class="fact-list">
+                <li><strong>Road network:</strong> at the mid-July peak the Public Works Department listed close to 900 blocked roads, including National Highways 3 (Atari–Leh), 5 (Hindustan–Tibet road), and 205; many stayed shut for weeks while BRO and PWP crews fought recurring fresh slides.</li>
+                <li><strong>Railways:</strong> the Kalka–Shimla UNESCO heritage line suffered breaches and debris burying near Summer Hill and Jutogh; services resumed only after track restoration.</li>
+                <li><strong>Bridges:</strong> spans and approach roads were washed out on the Beas, Ravi, Giri, and smaller khads, cutting village access even where trunk routes reopened.</li>
+                <li><strong>Water and power:</strong> hundreds of drinking-water schemes and thousands of transformers and kilometres of distribution lines were reported damaged; several hydropower stations on the Satluj and Beas halted generation after intake damage and heavy silt loads.</li>
+                <li><strong>Buildings and livelihoods:</strong> well over ten thousand houses and shops were damaged or destroyed, alongside schools, health facilities, horticulture orchards, and tourist properties — the base of the state government's ₹10,000-crore-plus loss estimate.</li>
+            </ul>
+        </section>
+
+        <section class="block" id="response" aria-labelledby="response-heading">
+            <div class="section-head">
+                <span class="tag">Relief</span>
+                <h2 id="response-heading">Rescue and relief response</h2>
+            </div>
+            <p class="lede">With roads cut, the first-week playbook leaned on helicopters, foot columns, and local administration working from district control rooms.</p>
+            <ul class="fact-list">
+                <li><strong>NDRF and SDRF:</strong> multiple teams deployed across districts for search, swift-water rescue, and debris clearance, prioritising slide sites with trapped persons such as Jadoon and Summer Hill.</li>
+                <li><strong>Armed forces:</strong> the Indian Army opened relief columns and shelters, and the Indian Air Force flew helicopters to evacuate stranded tourists from Kasol, Manali, and remote pockets of Lahaul when highways vanished.</li>
+                <li><strong>BRO and PWD:</strong> Border Roads Organisation and state engineers restored single-lane access on NH-3, NH-5, and the Manali axis within days of each closure, often re-opening the same stretches repeatedly.</li>
+                <li><strong>Relief and compensation:</strong> thousands moved to relief camps; the Prime Minister announced ₹2 lakh ex-gratia for each deceased family and ₹50,000 for the injured, supplemented by state relief, while a central inter-ministerial team assessed the damage record that backed the state's demand for a special assistance package.</li>
+            </ul>
+        </section>
+
+        <section class="block" id="preparedness" aria-labelledby="prep-heading">
+            <div class="section-head">
+                <span class="tag">Lessons</span>
+                <h2 id="prep-heading">Mountain disaster preparedness</h2>
+            </div>
+            <div class="grid-2">
+                <div>
+                    <p>The 2023 season showed that Himalayan disasters compound: extreme rain plus fragile slopes plus development choices made decades earlier. Recovery therefore has to treat slope stability, river space, and land-use zoning as core infrastructure — not as obstacles to it.</p>
+                    <p>Cloudburst-scale events still give little warning lead time, so preparedness rests on what is decided before clouds gather: where building is allowed, how roads are engineered, and whether communities know what to do in the first thirty minutes.</p>
+                </div>
+                <aside class="card">
+                    <h3>Practical measures</h3>
+                    <ul>
+                        <li>Zoning: keep construction off active slide scars, nala mouths, and river terraces using GSI landslide-susceptibility mapping.</li>
+                        <li>Slope-first road design: bio-engineering and proper drainage on cuts instead of unregulated vertical blasting.</li>
+                        <li>Restrict riverbed mining and uncontrolled muck dumping that steepen channels and toes of slopes.</li>
+                        <li>Community early-warning drills for flash floods, with rain gauges and siren chains in gully-head villages.</li>
+                        <li>Tourist advisories tied to IMD red alerts, and route contingency plans for single-highway valleys.</li>
+                        <li>Coordinate reservoir and run-of-river project releases downstream during flood spells.</li>
+                    </ul>
+                </aside>
+            </div>
+        </section>
+
+        <section class="block" id="map" aria-labelledby="map-heading">
+            <div class="section-head">
+                <span class="tag">Geography</span>
+                <h2 id="map-heading">Map</h2>
+            </div>
+            <p class="lede">Select a location to move the map marker. The default view is Shimla, where the season's most fatal urban landslides occurred.</p>
+            <div class="map-layout">
+                <div class="map-frame-wrap">
+                    <iframe
+                        id="flood-map"
+                        title="Map of key locations affected by the 2023 Himachal Pradesh floods and landslides"
+                        src="https://www.openstreetmap.org/export/embed.html?bbox=77.02,31.03,77.33,31.19&amp;layer=mapnik&amp;marker=31.1048,77.1734"
+                        loading="lazy"
+                    ></iframe>
+                </div>
+                <div>
+                    <div class="map-buttons" role="group" aria-label="Map locations">
+                        <button type="button" class="map-btn is-active" data-place="shimla" aria-pressed="true">Shimla</button>
+                        <button type="button" class="map-btn" data-place="manali">Manali</button>
+                        <button type="button" class="map-btn" data-place="mandi">Mandi</button>
+                        <button type="button" class="map-btn" data-place="jadoon">Jadoon (Solan)</button>
+                        <button type="button" class="map-btn" data-place="rampur">Rampur</button>
+                        <button type="button" class="map-btn" data-place="dharamshala">Dharamshala</button>
+                    </div>
+                    <div class="card map-info" id="map-info" aria-live="polite">
+                        <h3 id="map-info-title">Shimla</h3>
+                        <p id="map-info-desc">State capital. Landslides at Summer Hill (9 July and 14 August) and Fagli buried the heritage railway, a temple congregation, and homes on built-up cut slopes.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="block sources" id="sources" aria-labelledby="sources-heading">
+            <div class="section-head">
+                <span class="tag">References</span>
+                <h2 id="sources-heading">Sources</h2>
+            </div>
+            <p class="lede">Figures follow Himachal Pradesh SDMA/PWD situation reports, IMD statements, NDRF and PIB updates, and national press coverage. Casualty totals vary slightly across reports because weather-linked road accidents are included; this page uses the state's season tally of more than 300 deaths.</p>
+            <ol>
+                <li><a href="https://hpsdma.nic.in/" target="_blank" rel="noopener noreferrer">Himachal Pradesh State Disaster Management Authority — monsoon situation reports, 2023</a></li>
+                <li><a href="https://mausam.imd.gov.in/" target="_blank" rel="noopener noreferrer">India Meteorological Department — rainfall statistics and severe weather warnings, June–September 2023</a></li>
+                <li><a href="https://www.ndrf.gov.in/" target="_blank" rel="noopener noreferrer">NDRF — deployment updates for the Himachal Pradesh monsoon operations, 2023</a></li>
+                <li><a href="https://pib.gov.in/" target="_blank" rel="noopener noreferrer">Press Information Bureau — central team assessment and ex-gratia announcements, July–August 2023</a></li>
+                <li><a href="https://bhuvan.nrsc.gov.in/" target="_blank" rel="noopener noreferrer">ISRO/NRSC Bhuvan — landslide inventory mapping of the 2023 monsoon in Himachal Pradesh</a></li>
+                <li><a href="https://www.gsi.gov.in/" target="_blank" rel="noopener noreferrer">Geological Survey of India — landslide susceptibility and atlas of the Indian Himalaya</a></li>
+                <li><a href="https://en.wikipedia.org/wiki/2023_Himachal_Pradesh_floods_and_landslides" target="_blank" rel="noopener noreferrer">Wikipedia — 2023 Himachal Pradesh floods and landslides (compiled timeline and casualty table)</a></li>
+            </ol>
+        </section>
+    </main>
+
+    <footer class="page-footer">
+        <p>Incredible India Explorer · 2023 Himachal Pradesh Floods &amp; Landslides · <a href="../../index.html">Home</a></p>
+    </footer>
+
+    <script src="script.js" defer></script>
+</body>
+</html>

--- a/frontend/himachal-floods-2023-explorer/script.js
+++ b/frontend/himachal-floods-2023-explorer/script.js
@@ -1,0 +1,109 @@
+(function () {
+    const places = {
+        shimla: {
+            title: "Shimla",
+            desc: "State capital. Landslides at Summer Hill (9 July and 14 August) and Fagli buried the heritage railway, a temple congregation, and homes on built-up cut slopes.",
+            lat: 31.1048,
+            lon: 77.1734,
+            bbox: [77.02, 31.03, 77.33, 31.19]
+        },
+        manali: {
+            title: "Manali",
+            desc: "Tourist town on the Beas. The river flooded riverside markets and camps on 8–11 July; the Chandigarh–Manali highway and Manali–Leh road were breached, stranding visitors.",
+            lat: 32.2396,
+            lon: 77.1887,
+            bbox: [77.05, 32.13, 77.33, 32.35]
+        },
+        mandi: {
+            title: "Mandi",
+            desc: "Junction town where the Beas leaves the Kullu valley. Among the districts with the highest death tolls and the longest cumulative road closures of the season.",
+            lat: 31.7082,
+            lon: 76.9315,
+            bbox: [76.78, 31.6, 77.08, 31.82]
+        },
+        jadoon: {
+            title: "Jadoon (Solan)",
+            desc: "Village near Kumarhatti in Solan district. On 13 July a rain-soaked slope collapsed onto a temple gathering, killing more than 25 people in one slide.",
+            lat: 30.87,
+            lon: 77.1,
+            bbox: [76.95, 30.75, 77.25, 30.98]
+        },
+        rampur: {
+            title: "Rampur",
+            desc: "Satluj valley township on the Hindustan–Tibet road (NH-5). Repeated slides and bank erosion cut the artery through Kinnaur; nearby Jhakri's hydropower cascade halted on silt.",
+            lat: 31.4526,
+            lon: 77.634,
+            bbox: [77.48, 31.34, 77.79, 31.57]
+        },
+        dharamshala: {
+            title: "Dharamshala",
+            desc: "Kangra town below the Dhauladhar range. Steep tributaries carried flash floods into outskirts and cut link roads during the mid-July spells.",
+            lat: 32.219,
+            lon: 76.3234,
+            bbox: [76.18, 32.1, 76.47, 32.33]
+        }
+    };
+
+    function mapSrc(place) {
+        const box = place.bbox.join(",");
+        return "https://www.openstreetmap.org/export/embed.html?bbox=" +
+            encodeURIComponent(box) +
+            "&layer=mapnik&marker=" +
+            encodeURIComponent(place.lat + "," + place.lon);
+    }
+
+    function initThemeToggle() {
+        const button = document.getElementById("theme-toggle");
+        const root = document.documentElement;
+
+        function applyTheme(theme) {
+            const isLight = theme === "light";
+            root.classList.toggle("light-theme", isLight);
+            document.body.classList.toggle("light-theme", isLight);
+            button.textContent = isLight ? "🌙" : "☀️";
+            button.setAttribute("aria-label", isLight ? "Switch to dark theme" : "Switch to light theme");
+        }
+
+        applyTheme(localStorage.getItem("theme") === "light" ? "light" : "dark");
+
+        button.addEventListener("click", function () {
+            const next = document.body.classList.contains("light-theme") ? "dark" : "light";
+            localStorage.setItem("theme", next);
+            applyTheme(next);
+        });
+    }
+
+    function initMap() {
+        const frame = document.getElementById("flood-map");
+        const titleEl = document.getElementById("map-info-title");
+        const descEl = document.getElementById("map-info-desc");
+        const buttons = document.querySelectorAll(".map-btn");
+
+        function showPlace(key) {
+            const place = places[key];
+            if (!place) {
+                return;
+            }
+            frame.src = mapSrc(place);
+            titleEl.textContent = place.title;
+            descEl.textContent = place.desc;
+            buttons.forEach(function (btn) {
+                const active = btn.getAttribute("data-place") === key;
+                btn.classList.toggle("is-active", active);
+                btn.setAttribute("aria-pressed", active ? "true" : "false");
+            });
+        }
+
+        buttons.forEach(function (btn) {
+            btn.setAttribute("aria-pressed", btn.classList.contains("is-active") ? "true" : "false");
+            btn.addEventListener("click", function () {
+                showPlace(btn.getAttribute("data-place"));
+            });
+        });
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+        initThemeToggle();
+        initMap();
+    });
+})();

--- a/frontend/himachal-floods-2023-explorer/style.css
+++ b/frontend/himachal-floods-2023-explorer/style.css
@@ -1,0 +1,403 @@
+:root {
+    --bg: #101820;
+    --bg-alt: #16202b;
+    --surface: #1c2836;
+    --line: #314155;
+    --text: #eef3f8;
+    --muted: #b4c2d1;
+    --dim: #8a9aab;
+    --accent: #c9a227;
+    --accent-2: #7eb8c9;
+    --heading: "Playfair Display", Georgia, serif;
+    --body: "Outfit", system-ui, sans-serif;
+}
+
+body.light-theme,
+html.light-theme,
+html.light-theme body {
+    --bg: #f4f1ea;
+    --bg-alt: #ebe6dc;
+    --surface: #ffffff;
+    --line: #d4cdc0;
+    --text: #1c2430;
+    --muted: #4a5563;
+    --dim: #6b7280;
+    --accent: #8a6a12;
+    --accent-2: #1f5c6a;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--body);
+    line-height: 1.65;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
+
+    * {
+        animation: none !important;
+        transition: none !important;
+    }
+}
+
+a {
+    color: var(--accent);
+}
+
+a:focus-visible,
+button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+}
+
+.skip-link {
+    position: absolute;
+    left: -999px;
+    top: 0;
+    background: var(--accent);
+    color: #111;
+    padding: 0.5rem 1rem;
+    z-index: 1000;
+}
+
+.skip-link:focus {
+    left: 8px;
+    top: 8px;
+}
+
+.topnav {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.85rem 1.25rem;
+    background: var(--bg);
+    backdrop-filter: blur(8px);
+    border-bottom: 1px solid var(--line);
+    overflow-x: auto;
+}
+
+.brand {
+    font-weight: 700;
+    text-decoration: none;
+    color: var(--text);
+    white-space: nowrap;
+}
+
+.nav-links {
+    display: flex;
+    gap: 0.9rem;
+    font-size: 0.85rem;
+}
+
+.nav-links a {
+    color: var(--muted);
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.nav-links a:hover {
+    color: var(--text);
+}
+
+.theme-toggle {
+    margin-left: auto;
+    border: 1px solid var(--line);
+    background: var(--surface);
+    color: var(--text);
+    border-radius: 999px;
+    width: 2.4rem;
+    height: 2.4rem;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.hero {
+    padding: 4.5rem 8vw 3.5rem;
+    background:
+        radial-gradient(900px 420px at 12% -20%, rgba(126, 184, 201, 0.16), transparent 55%),
+        var(--bg);
+    border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+    font-size: 0.78rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent-2);
+    margin: 0 0 1rem;
+}
+
+h1 {
+    font-family: var(--heading);
+    font-size: clamp(2rem, 5vw, 3.4rem);
+    line-height: 1.1;
+    margin: 0 0 0.75rem;
+    max-width: 16ch;
+}
+
+.hero-date {
+    color: var(--accent);
+    font-weight: 600;
+    margin: 0 0 1.25rem;
+}
+
+.lede {
+    max-width: 68ch;
+    color: var(--muted);
+    font-size: 1.05rem;
+}
+
+.hero-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2rem;
+    margin: 2.5rem 0 0;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--line);
+}
+
+.hero-stats dt {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--dim);
+}
+
+.hero-stats dd {
+    margin: 0.2rem 0 0;
+    font-family: var(--heading);
+    font-size: 1.6rem;
+    font-weight: 600;
+}
+
+.block {
+    padding: 4.5rem 8vw;
+    border-bottom: 1px solid var(--line);
+}
+
+.block:nth-child(even) {
+    background: var(--bg-alt);
+}
+
+.section-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.tag {
+    font-size: 0.72rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--accent);
+    border: 1px solid var(--line);
+    padding: 0.2rem 0.6rem;
+}
+
+h2 {
+    font-family: var(--heading);
+    font-size: clamp(1.5rem, 3vw, 2.1rem);
+    margin: 0;
+}
+
+.grid-2 {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+}
+
+.card {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 1.35rem 1.4rem;
+}
+
+.card h3 {
+    margin: 0 0 0.6rem;
+    font-size: 1.05rem;
+}
+
+.card p,
+.card li {
+    color: var(--muted);
+    margin: 0;
+}
+
+.card ul {
+    margin: 0;
+    padding-left: 1.1rem;
+}
+
+.card li + li {
+    margin-top: 0.45rem;
+}
+
+.fact-list {
+    margin: 0;
+    padding-left: 1.15rem;
+    max-width: 75ch;
+}
+
+.fact-list li + li {
+    margin-top: 0.7rem;
+}
+
+.map-layout {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr;
+    gap: 1.25rem;
+    align-items: start;
+}
+
+.map-frame-wrap {
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    overflow: hidden;
+    min-height: 320px;
+    background: var(--surface);
+}
+
+.map-frame-wrap iframe {
+    display: block;
+    width: 100%;
+    height: 360px;
+    border: 0;
+}
+
+.map-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 0.9rem;
+}
+
+.map-btn {
+    border: 1px solid var(--line);
+    background: var(--surface);
+    color: var(--text);
+    border-radius: 999px;
+    padding: 0.35rem 0.8rem;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.85rem;
+}
+
+.map-btn.is-active,
+.map-btn:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.sources ol {
+    max-width: 75ch;
+    padding-left: 1.2rem;
+}
+
+.sources li + li {
+    margin-top: 0.55rem;
+}
+
+.page-footer {
+    padding: 1.5rem 8vw;
+    color: var(--dim);
+    font-size: 0.9rem;
+}
+
+.page-footer a {
+    color: var(--muted);
+}
+
+@media (max-width: 768px) {
+    .grid-2,
+    .map-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .hero,
+    .block {
+        padding: 3rem 1.25rem;
+    }
+
+    .topnav {
+        flex-wrap: wrap;
+    }
+
+    .nav-links {
+        order: 3;
+        width: 100%;
+        padding-top: 0.35rem;
+    }
+}
+
+.timeline {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    max-width: 78ch;
+}
+
+.timeline-item {
+    position: relative;
+    padding: 0 0 1.6rem 1.6rem;
+    border-left: 2px solid var(--line);
+}
+
+.timeline-item:last-child {
+    padding-bottom: 0;
+    border-left-color: transparent;
+}
+
+.timeline-item::before {
+    content: "";
+    position: absolute;
+    left: -7px;
+    top: 0.35rem;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: var(--accent);
+    box-shadow: 0 0 0 3px var(--bg-alt);
+}
+
+.timeline-item p {
+    margin: 0.35rem 0 0;
+    color: var(--muted);
+}
+
+.timeline-date {
+    font-weight: 700;
+    font-family: var(--heading);
+    font-size: 1.05rem;
+    color: var(--accent);
+}
+
+.warning-card {
+    margin-top: 1.5rem;
+    border-color: #b3641f;
+}
+
+body.light-theme .warning-card,
+html.light-theme .warning-card {
+    border-color: #a3541a;
+}

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -6272,5 +6272,13 @@ window.indiaSearchIndex = [
         description:
             "Explore Kadambini Ganguly's historical profile: one of the first two female graduates of the British Empire, the first woman admitted to Calcutta Medical College, and India's first practising woman physician of Western medicine.",
         url: "frontend/kadambini-ganguly-explorer/index.html"
+    },
+    // --- 2023 Himachal Pradesh Floods & Landslides Explorer (#3566) ---
+    {
+        title: "2023 Himachal Pradesh Floods & Landslides — Monsoon Disaster Profile",
+        category: "Geology & Disasters",
+        description:
+            "Explore the 2023 Himachal Pradesh monsoon disaster: extreme July rainfall, Beas and Satluj flooding, deadly landslides at Summer Hill and Jadoon, highway and heritage-railway damage, NDRF–Army–IAF relief, and mountain disaster preparedness lessons.",
+        url: "frontend/himachal-floods-2023-explorer/index.html"
     }
 ];

--- a/tests/unit/himachal-floods-2023.test.js
+++ b/tests/unit/himachal-floods-2023.test.js
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function readFile(file) {
+    return readFileSync(
+        resolve(__dirname, '../../frontend/himachal-floods-2023-explorer', file),
+        'utf-8'
+    );
+}
+
+describe('Himachal Floods 2023 — Page Structure & Content (#3566)', () => {
+    let html;
+
+    beforeAll(() => {
+        html = readFile('index.html');
+    });
+
+    it('contains hero section with title and key statistics', () => {
+        expect(html).toContain('class="hero"');
+        expect(html).toContain('2023 Himachal Pradesh Floods');
+        expect(html).toContain('300+');
+        expect(html).toContain('₹10,000 cr+');
+    });
+
+    it('contains all required requirement sections', () => {
+        expect(html).toContain('id="overview"');
+        expect(html).toContain('id="timeline"');
+        expect(html).toContain('id="rainfall"');
+        expect(html).toContain('id="geography"');
+        expect(html).toContain('id="affected"');
+        expect(html).toContain('id="landslides"');
+        expect(html).toContain('id="infrastructure"');
+        expect(html).toContain('id="response"');
+        expect(html).toContain('id="preparedness"');
+        expect(html).toContain('id="map"');
+        expect(html).toContain('id="sources"');
+    });
+
+    it('documents the event timeline of the 2023 monsoon', () => {
+        expect(html).toContain('24 June 2023');
+        expect(html).toContain('8–11 July');
+        expect(html).toContain('9 July');
+        expect(html).toContain('13 July');
+        expect(html).toContain('14 August');
+    });
+
+    it('provides extreme rainfall context', () => {
+        expect(html).toContain('60% wetter');
+        expect(html.toLowerCase()).toContain('cloudburst');
+        expect(html).toContain('India Meteorological Department');
+    });
+
+    it('explains river and mountain geography', () => {
+        expect(html).toContain('Beas');
+        expect(html).toContain('Satluj');
+        expect(html).toContain('Ravi');
+        expect(html).toContain('Giri');
+        expect(html).toContain('Dhauladhar');
+    });
+
+    it('identifies major affected areas', () => {
+        expect(html).toContain('Manali');
+        expect(html).toContain('Mandi');
+        expect(html).toContain('Kullu');
+        expect(html).toContain('Solan');
+        expect(html).toContain('Kinnaur');
+        expect(html).toContain('Shimla');
+    });
+
+    it('documents landslide hazards', () => {
+        expect(html).toContain('Summer Hill');
+        expect(html).toContain('Jadoon');
+        expect(html).toContain('Fagli');
+        expect(html).toContain('landslide-susceptibility');
+    });
+
+    it('documents infrastructure and road damage', () => {
+        expect(html).toContain('NH-5');
+        expect(html).toContain('NH-3');
+        expect(html).toContain('Kalka–Shimla');
+        expect(html).toContain('₹10,000-crore-plus');
+    });
+
+    it('documents rescue and relief response', () => {
+        expect(html).toContain('NDRF');
+        expect(html).toContain('Indian Air Force');
+        expect(html).toContain('Border Roads Organisation');
+        expect(html).toContain('₹2 lakh');
+    });
+
+    it('covers mountain disaster preparedness lessons', () => {
+        expect(html).toContain('Mountain disaster preparedness');
+        expect(html).toContain('Zoning');
+        expect(html).toContain('early-warning drills');
+    });
+
+    it('provides sources from official agencies', () => {
+        expect(html).toContain('hpsdma.nic.in');
+        expect(html).toContain('mausam.imd.gov.in');
+        expect(html).toContain('ndrf.gov.in');
+        expect(html).toContain('pib.gov.in');
+        expect(html).toContain('bhuvan.nrsc.gov.in');
+    });
+});
+
+describe('Himachal Floods 2023 — Scripts & Styles', () => {
+    it('style.css defines timeline, map layout, and theme variables', () => {
+        const css = readFile('style.css');
+        expect(css).toContain('.timeline-item');
+        expect(css).toContain('.map-layout');
+        expect(css).toContain('.light-theme');
+    });
+
+    it('script.js wires theme toggle and interactive OpenStreetMap view switching', () => {
+        const js = readFile('script.js');
+        expect(js).toContain('initMap');
+        expect(js).toContain('theme-toggle');
+        expect(js).toContain('openstreetmap.org/export/embed.html');
+        expect(js).toContain('data-place');
+    });
+
+    it('is registered in the global search index', () => {
+        const index = readFileSync(
+            resolve(__dirname, '../../frontend/search-index.js'),
+            'utf-8'
+        );
+        expect(index).toContain('frontend/himachal-floods-2023-explorer/index.html');
+    });
+});


### PR DESCRIPTION
## Summary

Adds an educational profile for the **2023 Himachal Pradesh floods and landslides** (monsoon disaster, late June–September 2023), following the pattern of the recently merged 2011 Sikkim earthquake profile.

Closes #3566

## What's included

- `frontend/himachal-floods-2023-explorer/index.html` — full profile covering all issue requirements:
  - **Event timeline** — 24 June onset storms → 8–11 July Beas flooding → 9 July Summer Hill rail-line slide → 13 July Jadoon (Solan) slide → mid-July ~900 road closures → 14 August Shimla temple landslides → September season tally
  - **Extreme rainfall context** — IMD surplus (~60% above normal in July), cloudburst intensity vs monthly totals
  - **River and mountain geography** — Beas, Satluj, Ravi, Chenab, Yamuna tributaries; Shiwalik-to-trans-Himalaya gradient and fragile geology
  - **Major affected areas** — Kullu–Manali, Mandi, Shimla–Solan, Kinnaur/Rampur belt, Chamba, Sirmaur, Kangra
  - **Landslide hazards** — failure mechanics, exposure factors, safety guidance
  - **Infrastructure and road damage** — NH-3/NH-5/NH-205 closures, Kalka–Shimla heritage railway, bridges, water/power schemes, ₹10,000 cr+ losses
  - **Rescue and relief** — NDRF/SDRF, Army/IAF helicopter evacuation of stranded tourists, BRO road restoration, ex-gratia announcements
  - **Mountain disaster preparedness** — slope-first zoning, road design, mining restrictions, community early-warning drills, tourist advisories
- **Interactive map** — OpenStreetMap embed with six selectable locations (Shimla, Manali, Mandi, Jadoon, Rampur, Dharamshala), matching the Sikkim profile's implementation
- **Sources cited** — HP SDMA, IMD, NDRF, PIB, ISRO/NRSC Bhuvan, GSI, Wikipedia overview
- `frontend/search-index.js` — site search entry under "Geology & Disasters"
- `tests/unit/himachal-floods-2023.test.js` — 14 structural/content tests in the repo's existing vitest pattern

## Testing

- [x] `npx vitest run tests/unit/himachal-floods-2023.test.js` — 14/14 pass
- [x] Existing disaster-profile suite (`chennai-floods-2015.test.js`) still passes alongside (30/30)
- [x] `node --check frontend/search-index.js` — syntax valid

## Screenshots

Dark/light themed page with sticky nav, hero stats, styled timeline, section cards, interactive map panel, and sources list — consistent with existing explorer profiles.
