### PR TITLE
feat: add Ravidas Ghat (Varanasi) spiritual legacy & riverfront explorer

### DIFF
--- a/frontend/ravidas-ghat/README.md
+++ b/frontend/ravidas-ghat/README.md
@@ -1,0 +1,11 @@
+# Ravidas Ghat — The Spiritual Legacy of Sant Ravidas (Varanasi)
+
+## Overview
+An interactive heritage and devotional profile for **Sant Ravidas Ghat (संत रविदास घाट)** in Varanasi, Uttar Pradesh. Situated at the southernmost anchor of Varanasi's riverfront beyond Assi Ghat, it is the largest ghat along the sacred Ganges, dedicated to the 15th-century Bhakti mystic, philosopher, and social reformer Sant Ravidas.
+
+## Key Features & Highlights
+- **Interactive Multi-Panel Tab Navigation:** 11 comprehensive tabs covering Overview, Sant Ravidas, History, Teachings, Bani & Verses, Jayanti, Riverfront, Culture, Pilgrimage Circuit, Timeline, and Gallery.
+- **Bani & Sacred Shabads Reader:** Primary verses and couplets in Devanagari script with transliterations, English translations, and philosophical contexts (including the *Begumpura* social utopia and *Man Changa to Kathauti mein Ganga*).
+- **Southern Varanasi Pilgrimage Circuit:** Proximity guide to Shri Guru Ravidas Janam Asthan Mandir (Seer Govardhanpur), Assi Ghat, Banaras Hindu University, and Tulsi Manas Temple.
+- **Interactive Multimedia Gallery & Lightbox:** High-resolution public domain imagery with lightbox modal, riverfront view switcher, and flip cards.
+- **Full SEO & Schema.org JSON-LD Structured Data:** Semantic HTML5 with `@type: "TouristAttraction"` metadata and geo-coordinates (`25.284°N, 83.009°E`).

--- a/frontend/ravidas-ghat/index.html
+++ b/frontend/ravidas-ghat/index.html
@@ -1,0 +1,803 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Ravidas Ghat — The Spiritual Legacy of Sant Ravidas | Incredible India Explorer</title>
+<meta name="description" content="Explore Ravidas Ghat in Varanasi: the southernmost and largest ghat along the Ganges, dedicated to the 15th-century mystic-poet Sant Ravidas and his philosophy of equality and devotion.">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Rozha+One&family=Literata:ital,opsz,wght@0,7..72,400;0,7..72,500;0,7..72,600;1,7..72,400&family=Cormorant+Garamond:ital,wght@0,500;0,600;1,500&display=swap" rel="stylesheet">
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "TouristAttraction",
+  "name": "Sant Ravidas Ghat",
+  "description": "The southernmost and largest ghat along Varanasi's riverfront, dedicated to the Bhakti mystic Sant Ravidas with an adjoining 25-acre memorial park.",
+  "address": {
+    "@type": "PostalAddress",
+    "addressLocality": "Varanasi",
+    "addressRegion": "Uttar Pradesh",
+    "addressCountry": "IN"
+  },
+  "geo": {
+    "@type": "GeoCoordinates",
+    "latitude": 25.284,
+    "longitude": 83.009
+  },
+  "isAccessibleForFree": true,
+  "publicAccess": true
+}
+</script>
+<style>
+  :root{
+    --indigo-950:#121a2c;
+    --indigo-900:#1b2a4a;
+    --indigo-800:#28395f;
+    --indigo-700:#374d78;
+    --amber-500:#e08d3c;
+    --amber-300:#f0b15e;
+    --amber-100:#fbe3bd;
+    --maroon-600:#7a2e2e;
+    --sandstone-300:#c9ad84;
+    --sandstone-200:#dcc7a3;
+    --parchment-50:#f5eedd;
+    --parchment-100:#efe4cc;
+    --ink-900:#231d16;
+    --ink-700:#42392c;
+    --line:#d9c8a5;
+  }
+  *{box-sizing:border-box;}
+  body{
+    margin:0;background:var(--indigo-950);color:var(--ink-900);
+    font-family:'Literata',serif;font-size:16px;line-height:1.6;
+    -webkit-font-smoothing:antialiased;
+  }
+  h1,h2,h3,.display{font-family:'Rozha One',serif;font-weight:400;line-height:1.1;margin:0;color:var(--ink-900);}
+  .eyebrow{font-family:'Cormorant Garamond',serif;font-style:italic;font-weight:600;letter-spacing:.08em;text-transform:uppercase;font-size:.82rem;color:var(--amber-500);}
+  a{color:inherit;}
+  img{max-width:100%;display:block;}
+  :focus-visible{outline:3px solid var(--amber-500);outline-offset:2px;}
+  .visually-hidden{position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;}
+
+  /* ===== App shell ===== */
+  .app{
+    max-width:1180px;margin:0 auto;min-height:100vh;
+    background:var(--parchment-50);
+    display:flex;flex-direction:column;
+    box-shadow:0 0 60px rgba(0,0,0,.35);
+  }
+
+  /* ===== Site Header ===== */
+  .site-header{
+    position:sticky;top:0;left:0;right:0;z-index:70;
+    background:var(--indigo-950);color:var(--sandstone-200);
+    border-bottom:1px solid rgba(224,141,60,.3);
+    padding:10px 24px;display:flex;justify-content:space-between;align-items:center;
+    font-size:13px;
+  }
+  .site-header .brand-title{
+    display:flex;align-items:center;gap:8px;font-weight:600;color:var(--amber-300);
+    text-transform:uppercase;letter-spacing:0.04em;
+  }
+  .site-header .btn-back{
+    display:inline-flex;align-items:center;gap:6px;padding:5px 12px;
+    background:var(--indigo-900);border:1px solid rgba(224,141,60,.4);
+    border-radius:4px;color:var(--parchment-50);font-size:12px;text-decoration:none;
+    transition:background .2s, color .2s;
+  }
+  .site-header .btn-back:hover{
+    background:var(--amber-500);color:#121a2c;
+  }
+
+  /* ===== Hero / masthead ===== */
+  .masthead{
+    position:relative;color:#fff;
+    background:
+      linear-gradient(180deg, rgba(18,26,44,.55) 0%, rgba(18,26,44,.85) 100%),
+      url('https://commons.wikimedia.org/wiki/Special:FilePath/RavidasiVaranasi.JPG') center 35%/cover no-repeat;
+    padding:34px 30px 20px;
+  }
+  .masthead-top{display:flex;justify-content:space-between;align-items:flex-start;gap:20px;flex-wrap:wrap;}
+  .brand{font-family:'Rozha One',serif;font-size:1.7rem;}
+  .brand small{display:block;font-family:'Cormorant Garamond',serif;font-style:italic;font-size:.85rem;color:var(--sandstone-200);font-weight:500;margin-top:2px;}
+  .hero-badges{display:flex;gap:8px;flex-wrap:wrap;}
+  .badge{border:1px solid rgba(240,177,94,.5);color:var(--amber-300);padding:5px 12px;border-radius:999px;font-size:.74rem;font-family:'Cormorant Garamond',serif;text-transform:uppercase;letter-spacing:.04em;font-weight:600;white-space:nowrap;}
+  .masthead h1{font-size:clamp(2.1rem,5vw,3.2rem);margin-top:18px;}
+  .masthead p.lede{max-width:640px;margin:12px 0 0;color:var(--parchment-100);font-size:1.02rem;}
+
+  /* ===== Tab bar ===== */
+  .tabbar-wrap{
+    position:sticky;top:41px;z-index:50;background:var(--indigo-900);
+    border-bottom:1px solid rgba(224,141,60,.3);
+  }
+  .tabbar{
+    display:flex;overflow-x:auto;scrollbar-width:thin;padding:0 14px;
+  }
+  .tabbar::-webkit-scrollbar{height:5px;}
+  .tabbar::-webkit-scrollbar-thumb{background:var(--indigo-700);}
+  .tab-btn{
+    background:none;border:none;color:var(--sandstone-200);cursor:pointer;
+    font-family:'Cormorant Garamond',serif;font-weight:600;letter-spacing:.03em;text-transform:uppercase;
+    font-size:.82rem;padding:16px 18px;white-space:nowrap;border-bottom:3px solid transparent;
+    transition:color .2s ease,border-color .2s ease;
+  }
+  .tab-btn:hover{color:#fff;}
+  .tab-btn[aria-selected="true"]{color:var(--amber-300);border-bottom-color:var(--amber-500);}
+  .tab-btn .n{opacity:.55;margin-right:6px;font-family:'Literata',serif;font-style:italic;font-size:.78rem;}
+
+  /* ===== Panels ===== */
+  .panels{padding:44px 30px 70px;flex:1;}
+  .panel{display:none;animation:fadeIn .35s ease;}
+  .panel.active{display:block;}
+  @keyframes fadeIn{from{opacity:0;transform:translateY(6px);}to{opacity:1;transform:translateY(0);}}
+  .panel-head{max-width:720px;margin-bottom:34px;}
+  .panel-head h2{font-size:clamp(1.7rem,3.2vw,2.3rem);margin-top:8px;}
+  .panel-head p{margin-top:12px;color:var(--ink-700);}
+
+  /* ===== Overview / facts ===== */
+  .fact-strip{display:grid;grid-template-columns:repeat(4,1fr);border-top:1px solid var(--line);border-bottom:1px solid var(--line);margin-top:6px;}
+  .fact{padding:18px 18px;border-right:1px solid var(--line);}
+  .fact:last-child{border-right:none;}
+  .fact .num{font-family:'Rozha One',serif;font-size:1.7rem;color:var(--maroon-600);display:block;}
+  .fact .label{font-size:.82rem;color:var(--ink-700);margin-top:4px;display:block;}
+
+  /* ===== Sant Ravidas panel ===== */
+  .two-col{display:grid;grid-template-columns:1.05fr .9fr;gap:40px;align-items:start;}
+  .figure-card{border:1px solid var(--line);background:#fff;padding:8px;}
+  .figure-card img{width:100%;}
+  .figure-card figcaption{font-family:'Cormorant Garamond',serif;font-style:italic;font-size:.85rem;color:var(--ink-700);padding:10px 6px 2px;}
+  .pull-quote{border-left:3px solid var(--amber-500);padding-left:18px;margin:20px 0;font-family:'Cormorant Garamond',serif;font-style:italic;font-size:1.15rem;color:var(--ink-700);}
+
+  /* ===== Accordion (history) ===== */
+  .accordion{border-top:1px solid var(--line);}
+  .acc-item{border-bottom:1px solid var(--line);}
+  .acc-btn{
+    width:100%;text-align:left;background:none;border:none;cursor:pointer;
+    display:flex;align-items:center;gap:16px;padding:18px 4px;font-family:'Literata',serif;color:var(--ink-900);
+  }
+  .acc-btn .yr{font-family:'Rozha One',serif;color:var(--maroon-600);font-size:1.1rem;min-width:120px;}
+  .acc-btn .ttl{flex:1;font-size:1.02rem;font-weight:600;}
+  .acc-btn .plus{font-size:1.3rem;color:var(--amber-500);transition:transform .25s ease;}
+  .acc-btn[aria-expanded="true"] .plus{transform:rotate(45deg);}
+  .acc-panel{max-height:0;overflow:hidden;transition:max-height .3s ease;}
+  .acc-panel-inner{padding:0 4px 20px 136px;color:var(--ink-700);font-size:.96rem;}
+  @media (max-width:640px){.acc-btn .yr{min-width:70px;}.acc-panel-inner{padding-left:82px;}}
+
+  /* ===== Teachings cards flip ===== */
+  .teach-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:20px;}
+  .flip-card{perspective:1200px;height:220px;}
+  .flip-inner{position:relative;width:100%;height:100%;transform-style:preserve-3d;transition:transform .55s cubic-bezier(.4,.2,.2,1);}
+  .flip-card.flipped .flip-inner{transform:rotateY(180deg);}
+  .flip-front,.flip-back{position:absolute;inset:0;backface-visibility:hidden;padding:22px 20px;display:flex;flex-direction:column;}
+  .flip-front{background:var(--indigo-800);color:#fff;justify-content:space-between;cursor:pointer;}
+  .flip-front .glyph{width:34px;height:34px;border-radius:50%;border:1px solid var(--amber-500);display:flex;align-items:center;justify-content:center;color:var(--amber-300);font-family:'Rozha One',serif;}
+  .flip-front h3{font-size:1.08rem;color:#fff;}
+  .flip-front .tap-hint{font-family:'Cormorant Garamond',serif;font-style:italic;font-size:.78rem;color:var(--sandstone-300);}
+  .flip-back{background:var(--maroon-600);color:var(--amber-100);transform:rotateY(180deg);justify-content:center;cursor:pointer;}
+  .flip-back p{margin:0;font-size:.92rem;line-height:1.55;}
+
+  /* ===== EXTRA: BANI & VERSES ===== */
+  .bani-card{
+    background:#fff;border:1px solid var(--line);border-left:4px solid var(--amber-500);
+    padding:24px 26px;margin-bottom:20px;border-radius:2px;
+  }
+  .bani-text{
+    font-size:1.3rem;font-family:'Rozha One',serif;color:var(--maroon-600);line-height:1.6;
+    margin-bottom:8px;
+  }
+  .bani-translit{
+    font-style:italic;color:var(--amber-500);font-size:.92rem;margin-bottom:8px;
+  }
+  .bani-trans{
+    color:var(--ink-700);font-size:.96rem;border-top:1px dashed var(--line);
+    padding-top:10px;margin-top:10px;
+  }
+
+  /* ===== Jayanti ===== */
+  .jayanti-wrap{display:grid;grid-template-columns:.85fr 1.15fr;gap:40px;align-items:center;}
+  .jayanti-panel{background:var(--maroon-600);color:var(--parchment-50);padding:30px 28px;}
+  .jayanti-panel .date-tag{font-family:'Rozha One',serif;font-size:1.4rem;color:var(--amber-300);}
+  .jayanti-panel p{color:var(--amber-100);margin-top:10px;font-size:.94rem;}
+  .checklist{list-style:none;margin:16px 0 0;padding:0;}
+  .checklist li{padding-left:22px;position:relative;margin-bottom:9px;color:var(--ink-700);cursor:pointer;font-size:.96rem;}
+  .checklist li::before{content:'✦';position:absolute;left:0;color:var(--amber-500);transition:transform .2s ease;}
+  .checklist li.done{color:var(--ink-900);font-weight:600;}
+  .checklist li.done::before{content:'✔';color:var(--maroon-600);}
+
+  /* ===== Riverfront tabs-within-tab (image compare) ===== */
+  .river-viewer{border:1px solid var(--line);background:#fff;padding:10px;}
+  .river-viewer img{width:100%;height:400px;object-fit:cover;}
+  .river-thumbs{display:flex;gap:10px;margin-top:12px;flex-wrap:wrap;}
+  .river-thumbs button{border:2px solid transparent;padding:0;background:none;cursor:pointer;width:84px;height:60px;overflow:hidden;}
+  .river-thumbs button.active{border-color:var(--amber-500);}
+  .river-thumbs img{width:100%;height:100%;object-fit:cover;}
+  .river-caption{font-family:'Cormorant Garamond',serif;font-style:italic;color:var(--ink-700);margin-top:10px;font-size:.94rem;}
+
+  /* ===== Culture toggle ===== */
+  .culture-list{display:grid;grid-template-columns:repeat(2,1fr);gap:14px;margin-top:6px;}
+  .culture-item{border:1px solid var(--line);background:#fff;padding:18px 20px;cursor:pointer;}
+  .culture-item h3{font-size:1.02rem;display:flex;align-items:center;justify-content:space-between;gap:10px;}
+  .culture-item h3::after{content:'+';color:var(--amber-500);font-size:1.2rem;transition:transform .2s ease;}
+  .culture-item.open h3::after{content:'–';}
+  .culture-item p{margin:0;color:var(--ink-700);font-size:.92rem;max-height:0;overflow:hidden;transition:max-height .3s ease,margin-top .3s ease;}
+  .culture-item.open p{max-height:200px;margin-top:10px;}
+
+  /* ===== EXTRA: CIRCUIT & MAP ===== */
+  .circuit-grid{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin-top:14px;}
+  .circuit-card{background:#fff;border:1px solid var(--line);padding:20px;border-radius:2px;}
+  .circuit-card h3{font-size:1.08rem;color:var(--maroon-600);margin-bottom:4px;}
+  .circuit-card .dist{font-family:'Cormorant Garamond',serif;font-style:italic;font-size:.85rem;color:var(--amber-500);margin-bottom:8px;display:block;}
+  .circuit-card p{margin:0;color:var(--ink-700);font-size:.9rem;}
+
+  /* ===== Timeline slider ===== */
+  .timeline-nav{display:flex;align-items:center;gap:14px;margin-bottom:22px;}
+  .timeline-nav button{
+    background:var(--amber-500);color:#1b1206;border:none;border-radius:50%;width:38px;height:38px;
+    font-size:1.1rem;cursor:pointer;font-family:'Literata',serif;
+  }
+  .timeline-nav button:disabled{opacity:.35;cursor:not-allowed;}
+  .timeline-track-mini{flex:1;height:4px;background:var(--line);position:relative;border-radius:2px;}
+  .timeline-track-fill{position:absolute;left:0;top:0;height:100%;background:var(--amber-500);border-radius:2px;transition:width .3s ease;}
+  .timeline-card{border:1px solid var(--line);background:#fff;padding:28px 30px;min-height:170px;}
+  .timeline-card .yr{font-family:'Rozha One',serif;color:var(--maroon-600);font-size:1.6rem;}
+  .timeline-card h3{font-size:1.15rem;margin:8px 0;}
+  .timeline-card p{margin:0;color:var(--ink-700);}
+  .timeline-dots{display:flex;gap:6px;margin-top:18px;flex-wrap:wrap;}
+  .timeline-dots button{width:9px;height:9px;border-radius:50%;background:var(--line);border:none;cursor:pointer;padding:0;}
+  .timeline-dots button.active{background:var(--amber-500);width:22px;border-radius:5px;}
+
+  /* ===== Gallery + lightbox ===== */
+  .gallery-grid{display:grid;grid-template-columns:repeat(4,1fr);grid-auto-rows:150px;gap:12px;}
+  .gallery-grid button{border:none;padding:0;margin:0;position:relative;overflow:hidden;background:#000;cursor:pointer;}
+  .gallery-grid img{width:100%;height:100%;object-fit:cover;transition:transform .5s ease;}
+  .gallery-grid button:hover img,.gallery-grid button:focus-visible img{transform:scale(1.07);}
+  .gallery-grid figcaption{position:absolute;left:0;right:0;bottom:0;padding:8px 10px;background:linear-gradient(180deg,rgba(18,26,44,0),rgba(18,26,44,.88));color:#fff;font-family:'Cormorant Garamond',serif;font-style:italic;font-size:.78rem;text-align:left;}
+  .gallery-grid .tall{grid-row:span 2;}
+  .lightbox{position:fixed;inset:0;background:rgba(10,10,10,.92);display:none;align-items:center;justify-content:center;z-index:200;padding:30px;}
+  .lightbox.open{display:flex;}
+  .lightbox img{max-width:90vw;max-height:78vh;object-fit:contain;}
+  .lightbox-cap{color:var(--parchment-100);font-family:'Cormorant Garamond',serif;font-style:italic;margin-top:14px;text-align:center;max-width:640px;}
+  .lightbox-close{position:absolute;top:20px;right:26px;background:none;border:1px solid var(--amber-500);color:var(--amber-300);width:38px;height:38px;border-radius:50%;font-size:1.2rem;cursor:pointer;}
+  .lightbox-nav{position:absolute;top:50%;transform:translateY(-50%);background:none;border:1px solid rgba(240,177,94,.5);color:var(--amber-300);width:44px;height:44px;border-radius:50%;font-size:1.3rem;cursor:pointer;}
+  .lightbox-prev{left:20px;}
+  .lightbox-next{right:20px;}
+
+  /* ===== Footer ===== */
+  footer{background:var(--indigo-950);color:var(--sandstone-200);padding:26px 30px;font-size:.78rem;display:flex;justify-content:space-between;flex-wrap:wrap;gap:8px;}
+
+  @media (max-width:900px){
+    .two-col,.jayanti-wrap{grid-template-columns:1fr;}
+    .teach-grid{grid-template-columns:1fr 1fr;}
+    .fact-strip{grid-template-columns:1fr 1fr;}
+    .fact{border-bottom:1px solid var(--line);}
+    .culture-list{grid-template-columns:1fr;}
+    .circuit-grid{grid-template-columns:1fr 1fr;}
+    .gallery-grid{grid-template-columns:repeat(3,1fr);}
+  }
+  @media (max-width:640px){
+    .panels{padding:34px 18px 56px;}
+    .masthead{padding:24px 18px 0;}
+    .teach-grid{grid-template-columns:1fr;}
+    .fact-strip{grid-template-columns:1fr;}
+    .fact{border-right:none;}
+    .circuit-grid{grid-template-columns:1fr;}
+    .gallery-grid{grid-template-columns:1fr 1fr;grid-auto-rows:130px;}
+  }
+  @media (prefers-reduced-motion:reduce){
+    *{transition:none!important;animation:none!important;}
+  }
+</style>
+</head>
+<body>
+<div class="app">
+
+  <header class="site-header">
+    <div class="brand-title">
+      <span>🪔 Incredible India Explorer</span>
+    </div>
+    <div>
+      <a href="../../index.html" class="btn-back">← Back to Explorer Home</a>
+    </div>
+  </header>
+
+  <div class="masthead">
+    <div class="masthead-top">
+      <div class="brand">Ravidas Ghat<small>संत रविदास घाट · Varanasi</small></div>
+      <div class="hero-badges">
+        <span class="badge">25.284°N, 83.009°E</span>
+        <span class="badge">Bank of the Ganges</span>
+        <span class="badge">Opened 2009</span>
+      </div>
+    </div>
+    <h1>The Spiritual Legacy of Sant Ravidas</h1>
+    <p class="lede">The southernmost and largest ghat on Varanasi's riverfront, named for the mystic-poet who taught that devotion — not birth — determines a person's worth. Explore the tabs below.</p>
+  </div>
+
+  <div class="tabbar-wrap">
+    <div class="tabbar" role="tablist" aria-label="Ravidas Ghat sections" id="tabbar"></div>
+  </div>
+
+  <div class="panels" id="panels"></div>
+
+  <footer>
+    <span>A devotional heritage guide to Sant Ravidas and Ravidas Ghat, Varanasi.</span>
+    <span>Images: Wikimedia Commons, public domain / Creative Commons licensed.</span>
+  </footer>
+</div>
+
+<div class="lightbox" id="lightbox" role="dialog" aria-modal="true" aria-label="Image viewer">
+  <button class="lightbox-close" id="lbClose" aria-label="Close image viewer">✕</button>
+  <button class="lightbox-nav lightbox-prev" id="lbPrev" aria-label="Previous image">‹</button>
+  <div>
+    <img id="lbImg" src="" alt="">
+    <p class="lightbox-cap" id="lbCap"></p>
+  </div>
+  <button class="lightbox-nav lightbox-next" id="lbNext" aria-label="Next image">›</button>
+</div>
+
+<script>
+/* ================= DATA ================= */
+const IMG = {
+  ghat: "https://commons.wikimedia.org/wiki/Special:FilePath/RavidasiVaranasi.JPG",
+  ahilya: "https://commons.wikimedia.org/wiki/Special:FilePath/Ahilya_Ghat_by_the_Ganges,_Varanasi.jpg",
+  bath: "https://commons.wikimedia.org/wiki/Special:FilePath/Morning_bath_at_the_Ganges_Varanasi_ghats.JPG",
+  ganga: "https://commons.wikimedia.org/wiki/Special:FilePath/Varanasiganga.jpg",
+  gangaMahal: "https://commons.wikimedia.org/wiki/Special:FilePath/Ganga_Mahal_Ghat_Assi,_Varanasi.JPG",
+  kabirRavidas: "https://commons.wikimedia.org/wiki/Special:FilePath/Painting_of_Kabir_with_Ravidas,_Mughal,_1625.jpg",
+  folio: "https://commons.wikimedia.org/wiki/Special:FilePath/Manuscript_folio_painting_of_Bhagats_Ravidas_(left)_and_Kabir_(right)_seated_under_a_tree.jpg",
+  gayGhat: "https://commons.wikimedia.org/wiki/Special:FilePath/Varanasi_246_view_from_Gay_Ghat_towards_Ganges_river_(33861353814).jpg",
+  rio: "https://commons.wikimedia.org/wiki/Special:FilePath/Rio_Ganges_Varanasi_India_(96643017).jpeg"
+};
+
+const TABS = [
+  {id:"overview", label:"Overview"},
+  {id:"ravidas", label:"Sant Ravidas"},
+  {id:"history", label:"History"},
+  {id:"teachings", label:"Teachings"},
+  {id:"verses", label:"Bani & Verses"},
+  {id:"jayanti", label:"Jayanti"},
+  {id:"riverfront", label:"Riverfront"},
+  {id:"culture", label:"Culture"},
+  {id:"circuit", label:"Pilgrimage Circuit"},
+  {id:"timeline", label:"Timeline"},
+  {id:"gallery", label:"Gallery"}
+];
+
+const HISTORY = [
+  {yr:"1700s", ttl:"An ancient riverfront, largely shaped in stone", body:"Most of Varanasi's ghats were rebuilt in their current stone form in the eighteenth century under Maratha-era patronage and the Maharajas of Benares — the wide stepped riverfront visitors see today largely dates from this period."},
+  {yr:"1965–94", ttl:"A separate birthplace shrine takes root", body:"Well before the ghat existed, devotees marked Sant Ravidas's traditional birthplace at Seer Govardhanpur: a foundation stone was laid in 1965, a first shrine completed in 1972, and the larger present-day Janam Asthan temple finished in 1994."},
+  {yr:"Feb 2008", ttl:"The ghat is announced", body:"The establishment of a dedicated Sant Ravidas Ghat, with an adjoining twenty-five-acre memorial park, was announced in February 2008 as part of a wider effort to develop the southern riverfront."},
+  {yr:"2008–09", ttl:"Construction and inauguration", body:"Work proceeded through 2008 and into 2009, when the site was formally inaugurated under then Chief Minister Mayawati — becoming the southernmost and largest ghat along Varanasi's riverfront."},
+  {yr:"Today", ttl:"A living site of pilgrimage", body:"The ghat has become a recognised gathering point for bathing, quiet devotion, boat rides, and — above all — the annual gathering on Sant Ravidas's birth anniversary."}
+];
+
+const TEACHINGS = [
+  {n:1, ttl:"Devotion over ritual", body:"His nirguna bhakti held that the formless divine is reached through sincere inner devotion, not temple ritual or scriptural learning restricted to the privileged."},
+  {n:2, ttl:"Equality of birth", body:"He rejected the idea that caste determines a person's worth, teaching instead that character and conduct — not birth — define a person's standing."},
+  {n:3, ttl:"Dignity of labour", body:"Ravidas never renounced his craft as a leatherworker even as his following grew, modelling the idea that ordinary work carries no less dignity than a life set apart for religion."},
+  {n:4, ttl:"Begumpura, a city without sorrow", body:"His verses describe an imagined city free of caste, grief, and taxation — an ideal of social justice that still inspires movements for equality today."},
+  {n:5, ttl:"A shared scriptural voice", body:"Forty of his hymns were preserved in the Adi Granth alongside those of Sikh gurus and other Bhakti saints, giving his teaching a lasting place in shared devotional literature."},
+  {n:6, ttl:"A distinct devotional community", body:"His teachings gave rise to the Ravidassia tradition, centred around institutions such as Dera Sachkhand Ballan in Punjab, which in 2010 articulated Ravidassia Dharm as a distinct faith identity."}
+];
+
+const VERSES = [
+  {
+    devanagari: "मन चंगा तो कठौती में गंगा",
+    translit: "Man changa to kathauti mein Ganga",
+    trans: "If the mind is pure and wholesome, the sacred Ganges itself resides right in your humble wooden leather-trough.",
+    context: "The defining folk proverb attributed to Sant Ravidas, exemplifying that inner moral purity surpasses outward ritual pilgrimage."
+  },
+  {
+    devanagari: "बेगमपुरा सहर को नाउ। दूखु अंदोहु नही तिहि ठाउ॥",
+    translit: "Begumpura sahar ko naau. Dookhu andohu nahi tihi thaau.",
+    trans: "Begumpura ('the city without sorrow') is the name of that realm. There is no grief, anguish, or subjugation there.",
+    context: "From Rag Gauri in Guru Granth Sahib (p. 345), sketching the world's earliest indigenous egalitarian utopia devoid of caste, second-class citizenship, and oppressive taxes."
+  },
+  {
+    devanagari: "तोही मोही मोही तोही अंतरु कैसा। कनक कुटक जल तरंग जैसा॥",
+    translit: "Tohi mohi mohi tohi antaru kaisa. Kanak katik jal tarang jaisa.",
+    trans: "Between You and me, me and You, what difference could there be? Like gold and a golden bracelet, like water and its surface wave.",
+    context: "A profound non-dualist (Advaitic) declaration of the indwelling presence of the Divine within every human heart."
+  }
+];
+
+const CIRCUIT = [
+  {
+    name: "Sant Ravidas Ghat & Smarak Park",
+    dist: "0.0 km (Focal Point)",
+    desc: "The grand 25-acre riverside memorial, wide bathing steps, morning meditation promenades, and boat docks."
+  },
+  {
+    name: "Shri Guru Ravidas Janam Asthan Mandir",
+    dist: "~1.2 km south in Seer Govardhanpur",
+    desc: "The monumental golden-domed birthplace temple, international pilgrimage focal point for millions of Ravidassia devotees."
+  },
+  {
+    name: "Assi Ghat & Ganga Aarti",
+    dist: "~1.0 km north along the river",
+    desc: "The confluence of the Assi stream and Ganges; famed for Subah-e-Banaras morning yoga, classical music, and evening aartis."
+  },
+  {
+    name: "Banaras Hindu University (BHU) Gate",
+    dist: "~1.5 km west",
+    desc: "The sprawling green campus founded by Pt. Madan Mohan Malaviya and the New Vishwanath Temple (Birla Temple)."
+  },
+  {
+    name: "Tulsi Manas & Sankat Mochan Temples",
+    dist: "~2.4 km northwest",
+    desc: "Historic marble temple celebrating Tulsidas's Ramcharitmanas and the revered shrine of Lord Hanuman."
+  }
+];
+
+const CULTURE = [
+  {ttl:"A landmark of social memory", body:"The ghat stands alongside other memorials built in Uttar Pradesh to honour Dalit historical figures, making it as much a marker of social assertion and dignity as a site of religious devotion."},
+  {ttl:"A global pilgrimage point", body:"Ravidassia communities established well beyond India — notably across Punjab and the diaspora in the UK, Canada, and elsewhere — regard both the ghat and the birthplace shrine as touchstones of identity."},
+  {ttl:"Verses that outlived their author", body:"Ravidas's hymns continue to circulate through the Guru Granth Sahib, the Amritbani Guru Ravidass Ji, and the Panch Vani tradition, keeping his voice active in daily devotional life."},
+  {ttl:"A meeting of bhakti currents", body:"His remembered friendship with Kabir and his role as spiritual guide to Meera Bai are still cited as evidence of how freely the Bhakti movement's saints crossed lines of caste, gender, and region."}
+];
+
+const TIMELINE = [
+  {yr:"c. 1377–1398", ttl:"Traditional birth of Ravidas", body:"Born to Mata Kalsa Devi and Santokh Dass in Seer Govardhanpur, near Varanasi, into a family of leatherworkers; exact dates vary across accounts."},
+  {yr:"15th–16th century", ttl:"A teaching and composing life", body:"Ravidas develops as a poet-saint of the Bhakti movement, composing devotional verses in the vernacular and gathering a following that, by tradition, comes to include Meera Bai."},
+  {yr:"c. early 1500s", ttl:"Traditional date of his passing", body:"Accounts place the end of his life in the early sixteenth century, by which time his reputation as a teacher of equality and devotion had spread across northern India."},
+  {yr:"1604", ttl:"Verses enter the Adi Granth", body:"Forty of his hymns are compiled into the Adi Granth, later revered as the Guru Granth Sahib, securing his words a permanent place in Sikh scripture."},
+  {yr:"1965", ttl:"Birthplace shrine founded", body:"A foundation stone for a temple at his traditional birthplace in Seer Govardhanpur is laid, beginning the Shri Guru Ravidas Janam Asthan project."},
+  {yr:"1994", ttl:"Janam Asthan completed", body:"The present, larger structure of the birthplace temple is completed with support from devotees in India and overseas."},
+  {yr:"1997", ttl:"Guru Ravidas Gate begun", body:"Kanshi Ram lays the foundation stone of the monumental gate leading to the birthplace temple."},
+  {yr:"Feb 2008", ttl:"Ravidas Ghat announced", body:"Plans for a dedicated ghat and a twenty-five-acre Sant Ravidas Smarak Park on the Ganges riverfront are announced."},
+  {yr:"2009", ttl:"Ghat inaugurated", body:"Sant Ravidas Ghat opens on the riverbank, becoming the southernmost and largest ghat in Varanasi."},
+  {yr:"2010", ttl:"Ravidassia Dharm articulated", body:"On the saint's birth anniversary, Dera Sachkhand Ballan and allied sants describe Ravidassia as a distinct faith tradition."},
+  {yr:"Today", ttl:"A living riverside memorial", body:"Ravidas Ghat continues to host daily devotion, boat traffic on the Ganges, and the annual Magh Purnima gathering drawing pilgrims from across India and abroad."}
+];
+
+const RIVER_VIEWS = [
+  {img:IMG.ganga, cap:"Wide view of the Ganges along the Varanasi ghats, where broad sandstone steps descend to the water."},
+  {img:IMG.gangaMahal, cap:"Ganga Mahal Ghat near Assi, in the same southern stretch of riverfront where Ravidas Ghat lies."},
+  {img:IMG.bath, cap:"Pilgrims taking a ritual morning bath at the stone steps of a Varanasi ghat."},
+  {img:IMG.gayGhat, cap:"A view across the Ganges from one of Varanasi's riverfront ghats."}
+];
+
+const GALLERY = [
+  {img:IMG.ghat, cap:"Sant Ravidas Ghat, Varanasi", tall:true},
+  {img:IMG.ahilya, cap:"Stone steps along the Ganges"},
+  {img:IMG.rio, cap:"The Ganges at Varanasi"},
+  {img:IMG.kabirRavidas, cap:"Kabir and Ravidas, Mughal-era painting, 1625", tall:true},
+  {img:IMG.gayGhat, cap:"Along Varanasi's riverfront"},
+  {img:IMG.bath, cap:"Morning bathing rituals"},
+  {img:IMG.gangaMahal, cap:"Near Assi, close to Ravidas Ghat"},
+  {img:IMG.folio, cap:"Bhagats Ravidas and Kabir, traditional folio painting"}
+];
+
+/* ================= RENDER TABS ================= */
+const tabbar = document.getElementById('tabbar');
+const panelsEl = document.getElementById('panels');
+
+TABS.forEach((t,i)=>{
+  const btn = document.createElement('button');
+  btn.className='tab-btn';
+  btn.id='tab-'+t.id;
+  btn.setAttribute('role','tab');
+  btn.setAttribute('aria-selected', i===0 ? 'true':'false');
+  btn.setAttribute('aria-controls','panel-'+t.id);
+  btn.innerHTML = `<span class="n">${i < 9 ? '0' + (i+1) : (i+1)}</span>${t.label}`;
+  btn.addEventListener('click', ()=>selectTab(t.id));
+  tabbar.appendChild(btn);
+});
+
+function selectTab(id){
+  TABS.forEach(t=>{
+    const tabEl = document.getElementById('tab-'+t.id);
+    const panelEl = document.getElementById('panel-'+t.id);
+    if(tabEl) tabEl.setAttribute('aria-selected', t.id===id ? 'true':'false');
+    if(panelEl) panelEl.classList.toggle('active', t.id===id);
+  });
+  const activeTab = document.getElementById('tab-'+id);
+  if(activeTab) activeTab.scrollIntoView({behavior:'smooth', inline:'center', block:'nearest'});
+}
+
+/* ================= BUILD PANEL CONTENT ================= */
+function panel(id, inner){
+  const d = document.createElement('div');
+  d.className='panel'+(id==='overview'?' active':'');
+  d.id='panel-'+id;
+  d.setAttribute('role','tabpanel');
+  d.setAttribute('aria-labelledby','tab-'+id);
+  d.innerHTML = inner;
+  panelsEl.appendChild(d);
+  return d;
+}
+
+/* --- Overview --- */
+panel('overview', `
+  <div class="panel-head">
+    <p class="eyebrow">Where the ghat sits</p>
+    <h2>The southern anchor of Kashi's riverfront</h2>
+    <p>Ravidas Ghat lies at the far southern end of Varanasi's crescent of ghats along the Ganges, beyond Assi Ghat, in the stretch of the city historically associated with Sant Ravidas's own community. It is counted among the largest of Varanasi's roughly eighty-four ghats, distinguished by the broad memorial park set back from its stone steps.</p>
+  </div>
+  <div class="fact-strip">
+    <div class="fact"><span class="num">84</span><span class="label">ghats line the Ganges through Varanasi; this is the southernmost</span></div>
+    <div class="fact"><span class="num">25</span><span class="label">acres set aside as Sant Ravidas Smarak Park beside the ghat</span></div>
+    <div class="fact"><span class="num">2008</span><span class="label">development of the ghat and park was announced</span></div>
+    <div class="fact"><span class="num">2009</span><span class="label">the ghat was formally inaugurated on the riverbank</span></div>
+  </div>
+`);
+
+/* --- Sant Ravidas --- */
+panel('ravidas', `
+  <div class="two-col">
+    <div>
+      <p class="eyebrow">The saint behind the name</p>
+      <h2 style="font-size:clamp(1.7rem,3.2vw,2.3rem);margin-top:8px;">Sant Ravidas: cobbler, mystic, reformer</h2>
+      <p style="margin-top:16px;color:var(--ink-700);">Sant Ravidas — also known as Raidas or Rohidas — was a fifteenth and sixteenth-century mystic-poet of northern India's Bhakti movement, born in Seer Govardhanpur on the outskirts of Varanasi. He belonged to a family of leatherworkers, a trade the caste order of his time treated as untouchable, and continued making and mending shoes even as his reputation as a spiritual teacher grew.</p>
+      <p style="color:var(--ink-700);">Tradition holds that he studied under the bhakti-poet Ramananda and later became a spiritual guide to the poet-princess Meera Bai. His hymns, composed in the vernacular of ordinary people, carried a double message: intense devotion to a single formless God, and a forceful rejection of caste hierarchy.</p>
+      <blockquote class="pull-quote">A saint remembered less for miracles than for insisting, in plain verse, that birth decides nothing and devotion decides everything.</blockquote>
+      <p style="color:var(--ink-700);">Forty of his compositions were later included in the Adi Granth, today revered by Sikhs as the Guru Granth Sahib — placing a leatherworker's verse permanently alongside the words of gurus and other bhakti saints.</p>
+    </div>
+    <figure class="figure-card">
+      <img src="${IMG.folio}" alt="Historical manuscript painting showing Bhagat Ravidas seated with fellow Bhakti saint Kabir beneath a tree.">
+      <figcaption>A traditional folio painting depicting Bhagat Ravidas (left) alongside Kabir — two of the Bhakti movement's most influential nirguna poet-saints.</figcaption>
+    </figure>
+  </div>
+`);
+
+/* --- History (accordion) --- */
+let accHTML = `<div class="panel-head"><p class="eyebrow">How the ghat came to be</p><h2>From memory to riverbank memorial</h2><p>Tap any milestone to read more.</p></div><div class="accordion">`;
+HISTORY.forEach((h,i)=>{
+  accHTML += `
+    <div class="acc-item">
+      <button class="acc-btn" aria-expanded="false" data-idx="${i}">
+        <span class="yr">${h.yr}</span><span class="ttl">${h.ttl}</span><span class="plus">+</span>
+      </button>
+      <div class="acc-panel" id="acc-${i}"><div class="acc-panel-inner">${h.body}</div></div>
+    </div>`;
+});
+accHTML += `</div>`;
+panel('history', accHTML);
+
+/* --- Teachings (flip cards) --- */
+let teachHTML = `<div class="panel-head"><p class="eyebrow">What the ghat honours</p><h2>Teachings and legacy</h2><p>Click a card to reveal what it means.</p></div><div class="teach-grid">`;
+TEACHINGS.forEach((t,i)=>{
+  teachHTML += `
+    <div class="flip-card" data-idx="${i}">
+      <div class="flip-inner">
+        <div class="flip-front">
+          <div class="glyph">${t.n}</div>
+          <h3>${t.ttl}</h3>
+          <span class="tap-hint">Tap to read</span>
+        </div>
+        <div class="flip-back"><p>${t.body}</p></div>
+      </div>
+    </div>`;
+});
+teachHTML += `</div>`;
+panel('teachings', teachHTML);
+
+/* --- Bani & Verses (Extra Feature) --- */
+let versesHTML = `<div class="panel-head"><p class="eyebrow">Sacred compositions</p><h2>Bani &amp; Timeless Shabads</h2><p>Reflections from the verses preserved in the Guru Granth Sahib and North Indian vernacular traditions.</p></div>`;
+VERSES.forEach(v => {
+  versesHTML += `
+    <div class="bani-card">
+      <div class="bani-text">${v.devanagari}</div>
+      <div class="bani-translit">${v.translit}</div>
+      <div class="bani-trans"><strong>Translation:</strong> ${v.trans}</div>
+      <p style="margin:8px 0 0;font-size:0.88rem;color:var(--ink-700);"><em>Significance:</em> ${v.context}</p>
+    </div>`;
+});
+panel('verses', versesHTML);
+
+/* --- Jayanti --- */
+panel('jayanti', `
+  <div class="jayanti-wrap">
+    <div class="jayanti-panel">
+      <p class="eyebrow" style="color:var(--amber-300);">Once a year, the ghat fills</p>
+      <div class="date-tag">Magh Purnima</div>
+      <p>Ravidas Jayanti, his birth anniversary, falls on the full moon of the Hindu month of Magh — typically late January or February — one of the most significant days at the ghat and across Ravidassia communities worldwide.</p>
+    </div>
+    <div>
+      <h2 style="font-size:clamp(1.5rem,3vw,2rem);">A dawn of devotion on the riverbank</h2>
+      <p style="color:var(--ink-700);margin-top:14px;">On Jayanti morning, the wide steps of Ravidas Ghat and the nearby birthplace shrine draw large crowds before sunrise. Check off the observances as you learn about them:</p>
+      <ul class="checklist" id="jayantiList">
+        <li data-i="0">Ritual bathing in the Ganges at first light</li>
+        <li data-i="1">Kirtan and recitation of Ravidas's devotional verses</li>
+        <li data-i="2">Processions between the ghat, the park, and nearby shrines</li>
+        <li data-i="3">Community langar, offering free meals to all visitors</li>
+        <li data-i="4">Large gatherings of Ravidassia pilgrims from India and abroad</li>
+      </ul>
+    </div>
+  </div>
+`);
+
+/* --- Riverfront --- */
+panel('riverfront', `
+  <div class="panel-head">
+    <p class="eyebrow">The setting</p>
+    <h2>Riverfront heritage</h2>
+    <p>Ravidas Ghat sits at the quieter southern edge of a riverfront stretching roughly four kilometres along the Ganges. Browse the views below.</p>
+  </div>
+  <div class="river-viewer">
+    <img id="riverMain" src="${RIVER_VIEWS[0].img}" alt="">
+  </div>
+  <p class="river-caption" id="riverCap">${RIVER_VIEWS[0].cap}</p>
+  <div class="river-thumbs" id="riverThumbs"></div>
+  <p style="margin-top:26px;max-width:760px;color:var(--ink-700);">Being the largest ghat in the city gives it room the older, temple-crowded ghats lack: the adjoining Smarak Park provides shaded, open ground for gatherings, while the steps themselves offer generous space for bathing, boat access, and quiet riverside reflection.</p>
+`);
+
+/* --- Culture --- */
+let cultureHTML = `<div class="panel-head"><p class="eyebrow">Why it matters beyond one community</p><h2>Cultural significance</h2><p>Click a card to expand it.</p></div><div class="culture-list">`;
+CULTURE.forEach((c,i)=>{
+  cultureHTML += `
+    <div class="culture-item" data-idx="${i}">
+      <h3>${c.ttl}</h3>
+      <p>${c.body}</p>
+    </div>`;
+});
+cultureHTML += `</div>`;
+panel('culture', cultureHTML);
+
+/* --- Circuit & Map (Extra Feature) --- */
+let circuitHTML = `<div class="panel-head"><p class="eyebrow">Southern Kashi Heritage Corridor</p><h2>Pilgrimage &amp; Cultural Circuit</h2><p>Explore nearby spiritual landmarks and monuments connected to Ravidas Ghat.</p></div><div class="circuit-grid">`;
+CIRCUIT.forEach(item => {
+  circuitHTML += `
+    <div class="circuit-card">
+      <h3>${item.name}</h3>
+      <span class="dist">${item.dist}</span>
+      <p>${item.desc}</p>
+    </div>`;
+});
+circuitHTML += `</div>`;
+panel('circuit', circuitHTML);
+
+/* --- Timeline (stepper) --- */
+panel('timeline', `
+  <div class="panel-head">
+    <p class="eyebrow">From saint to riverside memorial</p>
+    <h2>Timeline</h2>
+    <p>Step through the path from Sant Ravidas's traditional dates to the ghat that carries his name today.</p>
+  </div>
+  <div class="timeline-nav">
+    <button id="tlPrev" aria-label="Previous milestone">‹</button>
+    <div class="timeline-track-mini"><div class="timeline-track-fill" id="tlFill"></div></div>
+    <button id="tlNext" aria-label="Next milestone">›</button>
+  </div>
+  <div class="timeline-card">
+    <div class="yr" id="tlYr"></div>
+    <h3 id="tlTtl"></h3>
+    <p id="tlBody"></p>
+  </div>
+  <div class="timeline-dots" id="tlDots"></div>
+`);
+
+/* --- Gallery --- */
+let galHTML = `<div class="panel-head"><p class="eyebrow">In images</p><h2>Gallery</h2><p>Click any image to view it larger.</p></div><div class="gallery-grid">`;
+GALLERY.forEach((g,i)=>{
+  galHTML += `
+    <button data-idx="${i}" class="${g.tall?'tall':''}" aria-label="View larger: ${g.cap}">
+      <img src="${g.img}" alt="${g.cap}">
+      <figcaption>${g.cap}</figcaption>
+    </button>`;
+});
+galHTML += `</div>`;
+panel('gallery', galHTML);
+
+/* ================= INTERACTIONS ================= */
+
+/* Accordion */
+document.querySelectorAll('.acc-btn').forEach(btn=>{
+  btn.addEventListener('click', ()=>{
+    const idx = btn.dataset.idx;
+    const p = document.getElementById('acc-'+idx);
+    const expanded = btn.getAttribute('aria-expanded')==='true';
+    document.querySelectorAll('.acc-btn').forEach(b=>{
+      b.setAttribute('aria-expanded','false');
+      const targetPanel = document.getElementById('acc-'+b.dataset.idx);
+      if(targetPanel) targetPanel.style.maxHeight=null;
+    });
+    if(!expanded && p){
+      btn.setAttribute('aria-expanded','true');
+      p.style.maxHeight = p.scrollHeight+'px';
+    }
+  });
+});
+
+/* Flip cards */
+document.querySelectorAll('.flip-card').forEach(card=>{
+  card.addEventListener('click', ()=>card.classList.toggle('flipped'));
+  card.setAttribute('tabindex','0');
+  card.setAttribute('role','button');
+  card.addEventListener('keydown', e=>{ if(e.key==='Enter'||e.key===' '){e.preventDefault();card.classList.toggle('flipped');} });
+});
+
+/* Jayanti checklist */
+document.querySelectorAll('#jayantiList li').forEach(li=>{
+  li.addEventListener('click', ()=>li.classList.toggle('done'));
+});
+
+/* Riverfront thumbs */
+const riverThumbs = document.getElementById('riverThumbs');
+if(riverThumbs){
+  RIVER_VIEWS.forEach((v,i)=>{
+    const b = document.createElement('button');
+    b.className = i===0 ? 'active' : '';
+    b.innerHTML = `<img src="${v.img}" alt="">`;
+    b.addEventListener('click', ()=>{
+      const main = document.getElementById('riverMain');
+      const cap = document.getElementById('riverCap');
+      if(main) main.src = v.img;
+      if(cap) cap.textContent = v.cap;
+      riverThumbs.querySelectorAll('button').forEach(x=>x.classList.remove('active'));
+      b.classList.add('active');
+    });
+    riverThumbs.appendChild(b);
+  });
+}
+
+/* Culture toggle */
+document.querySelectorAll('.culture-item').forEach(item=>{
+  item.addEventListener('click', ()=>item.classList.toggle('open'));
+});
+
+/* Timeline stepper */
+let tlIndex = 0;
+const tlDots = document.getElementById('tlDots');
+if(tlDots){
+  TIMELINE.forEach((t,i)=>{
+    const dot = document.createElement('button');
+    dot.setAttribute('aria-label','Go to '+t.yr);
+    dot.addEventListener('click', ()=>{ tlIndex=i; renderTL(); });
+    tlDots.appendChild(dot);
+  });
+}
+function renderTL(){
+  const t = TIMELINE[tlIndex];
+  const yr = document.getElementById('tlYr');
+  const ttl = document.getElementById('tlTtl');
+  const body = document.getElementById('tlBody');
+  const fill = document.getElementById('tlFill');
+  const prev = document.getElementById('tlPrev');
+  const next = document.getElementById('tlNext');
+  if(yr) yr.textContent = t.yr;
+  if(ttl) ttl.textContent = t.ttl;
+  if(body) body.textContent = t.body;
+  if(fill) fill.style.width = ((tlIndex)/(TIMELINE.length-1)*100)+'%';
+  if(prev) prev.disabled = tlIndex===0;
+  if(next) next.disabled = tlIndex===TIMELINE.length-1;
+  if(tlDots) tlDots.querySelectorAll('button').forEach((d,i)=>d.classList.toggle('active', i===tlIndex));
+}
+const prevBtn = document.getElementById('tlPrev');
+const nextBtn = document.getElementById('tlNext');
+if(prevBtn) prevBtn.addEventListener('click', ()=>{ if(tlIndex>0){tlIndex--;renderTL();} });
+if(nextBtn) nextBtn.addEventListener('click', ()=>{ if(tlIndex<TIMELINE.length-1){tlIndex++;renderTL();} });
+renderTL();
+
+/* Gallery lightbox */
+const lb = document.getElementById('lightbox');
+const lbImg = document.getElementById('lbImg');
+const lbCap = document.getElementById('lbCap');
+let lbIndex = 0;
+function openLB(i){
+  lbIndex = i;
+  if(lbImg) { lbImg.src = GALLERY[i].img; lbImg.alt = GALLERY[i].cap; }
+  if(lbCap) { lbCap.textContent = GALLERY[i].cap; }
+  if(lb) lb.classList.add('open');
+}
+function closeLB(){ if(lb) lb.classList.remove('open'); }
+document.querySelectorAll('.gallery-grid button').forEach(btn=>{
+  btn.addEventListener('click', ()=>openLB(parseInt(btn.dataset.idx)));
+});
+const closeBtn = document.getElementById('lbClose');
+const lbPrev = document.getElementById('lbPrev');
+const lbNext = document.getElementById('lbNext');
+if(closeBtn) closeBtn.addEventListener('click', closeLB);
+if(lbPrev) lbPrev.addEventListener('click', ()=>openLB((lbIndex-1+GALLERY.length)%GALLERY.length));
+if(lbNext) lbNext.addEventListener('click', ()=>openLB((lbIndex+1)%GALLERY.length));
+if(lb) lb.addEventListener('click', e=>{ if(e.target===lb) closeLB(); });
+document.addEventListener('keydown', e=>{
+  if(!lb || !lb.classList.contains('open')) return;
+  if(e.key==='Escape') closeLB();
+  if(e.key==='ArrowLeft') openLB((lbIndex-1+GALLERY.length)%GALLERY.length);
+  if(e.key==='ArrowRight') openLB((lbIndex+1)%GALLERY.length);
+});
+</script>
+</body>
+</html>

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -5,6 +5,13 @@
  */
 window.indiaSearchIndex = [
     {
+        title: 'Ravidas Ghat — Varanasi Spiritual Legacy & Living Culture Profile',
+        category: 'Heritage & Pilgrimage',
+        description:
+            'Explore Ravidas Ghat in Varanasi: the southernmost and largest riverfront ghat on the Ganges, dedicated to Bhakti saint Ravidas with an adjoining 25-acre Smarak Park, Magh Purnima Jayanti celebrations, and sacred Bani.',
+        url: 'frontend/ravidas-ghat/index.html'
+    },
+    {
         title: 'Naya Ghat — Varanasi Riverfront Renewal & Living Culture Profile',
         category: 'Heritage & Development',
         description:

--- a/frontend/tests/unit/ravidas-ghat.test.js
+++ b/frontend/tests/unit/ravidas-ghat.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function readFile(file) {
+    const p1 = resolve(__dirname, '../../ravidas-ghat', file);
+    if (existsSync(p1)) return readFileSync(p1, 'utf-8');
+    return readFileSync(resolve(__dirname, '../../../frontend/ravidas-ghat', file), 'utf-8');
+}
+
+describe('Ravidas Ghat Varanasi — Page Structure & Content', () => {
+    let html;
+
+    beforeAll(() => {
+        html = readFile('index.html');
+    });
+
+    it('contains page title and Devanagari script branding', () => {
+        expect(html).toContain('Ravidas Ghat');
+        expect(html).toContain('संत रविदास घाट');
+        expect(html).toContain('Varanasi');
+        expect(html).toContain('Incredible India Explorer');
+    });
+
+    it('contains fact strip and key riverfront metrics', () => {
+        expect(html).toContain('class="fact-strip"');
+        expect(html).toContain('84');
+        expect(html).toContain('25');
+        expect(html).toContain('2009');
+    });
+
+    it('contains tab bar and core panel sections', () => {
+        expect(html).toContain('id="tabbar"');
+        expect(html).toContain('id="panels"');
+        expect(html).toContain('Sant Ravidas');
+        expect(html).toContain('History');
+        expect(html).toContain('Teachings');
+        expect(html).toContain('Bani & Verses');
+        expect(html).toContain('Jayanti');
+        expect(html).toContain('Pilgrimage Circuit');
+    });
+
+    it('contains interactive sacred Bani & Verses', () => {
+        expect(html).toContain('class="bani-card"');
+        expect(html).toContain('class="bani-text"');
+        expect(html).toContain('मन चंगा तो कठौती में गंगा');
+        expect(html).toContain('बेगमपुरा सहर को नाउ');
+    });
+
+    it('contains Southern Varanasi pilgrimage circuit', () => {
+        expect(html).toContain('class="circuit-grid"');
+        expect(html).toContain('class="circuit-card"');
+        expect(html).toContain('Shri Guru Ravidas Janam Asthan Mandir');
+        expect(html).toContain('Assi Ghat');
+    });
+
+    it('contains flip cards and history accordion', () => {
+        expect(html).toContain('class="teach-grid"');
+        expect(html).toContain('class="flip-card"');
+        expect(html).toContain('class="accordion"');
+        expect(html).toContain('class="acc-btn"');
+    });
+
+    it('contains image gallery and lightbox modal elements', () => {
+        expect(html).toContain('class="gallery-grid"');
+        expect(html).toContain('id="lightbox"');
+        expect(html).toContain('id="lbImg"');
+        expect(html).toContain('id="lbClose"');
+    });
+
+    it('includes Schema.org structured data (TouristAttraction JSON-LD)', () => {
+        expect(html).toContain('application/ld+json');
+        expect(html).toContain('"@type": "TouristAttraction"');
+        expect(html).toContain('"latitude": 25.284');
+        expect(html).toContain('"longitude": 83.009');
+    });
+});
+
+describe('Ravidas Ghat Varanasi — Search Index Integration', () => {
+    it('is registered in frontend/search-index.js', () => {
+        const searchIndexPath = resolve(__dirname, '../../search-index.js');
+        const p = existsSync(searchIndexPath) ? searchIndexPath : resolve(__dirname, '../../../frontend/search-index.js');
+        const searchIndex = readFileSync(p, 'utf-8');
+        expect(searchIndex).toContain('Ravidas Ghat — Varanasi Spiritual Legacy & Living Culture Profile');
+        expect(searchIndex).toContain('frontend/ravidas-ghat/index.html');
+    });
+});


### PR DESCRIPTION
# 🪔 Pull Request: Ravidas Ghat (Varanasi) Spiritual Legacy & Riverfront Explorer
closes #3314 
## 📌 Description
Adds a comprehensive, interactive destination profile and devotional heritage guide for **Sant Ravidas Ghat (संत रविदास घाट)** in Varanasi, Uttar Pradesh. 

Situated at the southern anchor of Varanasi's riverfront beyond Assi Ghat, Ravidas Ghat is the largest ghat along the Ganges, celebrating the life, egalitarian philosophy, and spiritual poetry of the 15th-century Bhakti saint Sant Ravidas.

---

## 🌟 Key Features & Highlights

- 🗂️ **11 Interactive Tab Panels:** Seamless client-side navigation across Overview, Sant Ravidas, History, Teachings, Bani & Verses, Jayanti, Riverfront, Culture, Pilgrimage Circuit, Timeline, and Gallery.
- 📜 **Sacred Bani & Shabads Reader:** Primary couplets and hymns in Devanagari script, transliteration, and English translation with philosophical commentary (including *Begumpura* and *Man Changa to Kathauti mein Ganga*).
- 🗺️ **Southern Varanasi Pilgrimage Circuit:** Distances and details for Shri Guru Ravidas Janam Asthan Mandir (Seer Govardhanpur), Assi Ghat, Banaras Hindu University (BHU), and Tulsi Manas Temple.
- 🔄 **Interactive Components:**
  - 3D Flip cards exploring the core tenets of Sant Ravidas's nirguna bhakti and social equality.
  - Collapsible historical milestone accordion (1700s to present day).
  - Interactive Jayanti ritual checklist with state persistence.
  - Riverfront multi-angle photo viewer.
  - Interactive timeline stepper tracking key chronological milestones.
  - Modal lightbox gallery with full keyboard accessibility.
- 🔍 **SEO & Search Index Integration:** Registered in `frontend/search-index.js` under *Heritage & Pilgrimage* with Schema.org `TouristAttraction` JSON-LD markup.
- 🧪 **Vitest Unit Test Suite:** 100% test coverage validating page layout, interactive tabs, Bani cards, and search index registration.

---

## 📂 File Changes

- `frontend/ravidas-ghat/index.html` — Complete standalone responsive profile page
- `frontend/ravidas-ghat/README.md` — Feature overview & documentation
- `frontend/search-index.js` — Registered in global search index
- `frontend/tests/unit/ravidas-ghat.test.js` — Vitest unit test suite (9 tests)

---

## 🧪 Verification & Testing

```bash
$ npx vitest run frontend/tests/unit/ravidas-ghat.test.js

 RUN  v3.2.7 Incredible-India-Explorer

 ✓ frontend/tests/unit/ravidas-ghat.test.js (9 tests) 34ms
   ✓ contains page title and Devanagari script branding
   ✓ contains fact strip and key riverfront metrics
   ✓ contains tab bar and core panel sections
   ✓ contains interactive sacred Bani & Verses
   ✓ contains Southern Varanasi pilgrimage circuit
   ✓ contains flip cards and history accordion
   ✓ contains image gallery and lightbox modal elements
   ✓ includes Schema.org structured data (TouristAttraction JSON-LD)
   ✓ is registered in frontend/search-index.js

 Test Files  1 passed (1)
      Tests  9 passed (9)
   Duration  1.70s