### PR TITLE
feat: Add Lava and Kusha — The Young Princes of Ayodhya

### DIFF
--- a/frontend/lava-kusha-story/index.html
+++ b/frontend/lava-kusha-story/index.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <script>
+            (function () {
+                const theme = localStorage.getItem('theme') || 'dark';
+                if (theme === 'light') {
+                    document.body.classList.add('light-theme');
+                }
+            })();
+        </script>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="Explore the story of Lava and Kusha — the young twin princes of Ayodhya, their upbringing in Valmiki's ashram, singing the Ramayana, and Ashwamedha valor."
+        />
+        <title>Lava and Kusha Story Explorer | Incredible India</title>
+
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,600;0,700;0,800;1,600&display=swap"
+            rel="stylesheet"
+        />
+
+        <link rel="stylesheet" href="../../styles.css" />
+        <link rel="stylesheet" href="lava-kusha.css" />
+    </head>
+    <body class="lava-kusha-main">
+        <header class="navbar scrolled" id="navbar">
+            <div class="nav-container">
+                <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                    <span class="saffron">Incredible</span>
+                    <span class="gold">India</span>
+                    <span class="green">Explorer</span>
+                </a>
+                <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu" aria-expanded="false">
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                    <span class="bar"></span>
+                </button>
+                <nav class="nav-menu" id="nav-menu">
+                    <a href="../../index.html#home" class="nav-link">Home</a>
+                    <a href="../folk-tales/folk-tales.html" class="nav-link">Folk Tales & Epics</a>
+                    <a href="index.html" class="nav-link active" style="color: var(--saffron)">Lava & Kusha</a>
+                    <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode" title="Toggle Light Mode">
+                        ☀️
+                    </button>
+                </nav>
+            </div>
+        </header>
+
+        <main>
+            <section class="story-hero">
+                <div class="section-container">
+                    <div class="hero-badges-row">
+                        <span class="hero-pill pill-lineage">☀️ Suryavansha Princes</span>
+                        <span class="hero-pill pill-guru">📜 Sage Valmiki Disciples</span>
+                        <span class="hero-pill pill-epic">🎶 Bards of Ramayana</span>
+                    </div>
+                    <h1>Lava and Kusha <span>(The Young Princes of Ayodhya)</span></h1>
+                    <p class="hero-subtitle">
+                        Explore the heroic and moving narrative of twin princes Lava and Kusha — from their sacred hermitage upbringing and mastery of the Ramayana to capturing the Ashwamedha royal steed.
+                    </p>
+                    <div id="stats-grid" class="stats-grid"></div>
+                </div>
+            </section>
+
+            <section class="story-content-section">
+                <div class="section-container">
+                    <h2>Chronological Story Narrative</h2>
+                    <div class="chapters-grid" id="chapters-grid"></div>
+
+                    <h2 class="sec-title">Cultural, Literary & Historical Significance</h2>
+                    <div class="significance-grid" id="significance-grid"></div>
+                </div>
+            </section>
+
+            <section class="references-section">
+                <div class="section-container">
+                    <h2>Classical References & Critical Editions</h2>
+                    <ul class="references-list" id="references-list"></ul>
+                </div>
+            </section>
+        </main>
+
+        <script src="lava-kusha-data.js"></script>
+        <script src="lava-kusha.js"></script>
+    </body>
+</html>

--- a/frontend/lava-kusha-story/lava-kusha-data.js
+++ b/frontend/lava-kusha-story/lava-kusha-data.js
@@ -1,0 +1,87 @@
+/**
+ * Lava and Kusha Story Explorer — Data Module
+ * Comprehensive dataset covering Lava and Kusha (The Young Princes of Ayodhya),
+ * Valmiki's hermitage upbringing, singing of the Ramayana, the Ashwamedha challenge,
+ * and the foundational history of Lavapuri and Kushavati.
+ */
+
+const LAVA_KUSHA_INFO = {
+    id: "lava-kusha-story",
+    title: "Lava and Kusha (The Young Princes of Ayodhya)",
+    category: "Culture & Literature",
+    characters: "Lava, Kusha, Sita (Janaki), Rama, Maharishi Valmiki, Lakshmana",
+    birthplace: "Valmiki Ashram (Banks of Tamsa River / Bithoor)",
+    lineage: "Suryavansha (Solar Dynasty) of Ayodhya",
+    mentor: "Maharishi Valmiki (The Adi Kavi / First Poet)",
+    coreThemes: "Filial Devotion, Musical Epic Storytelling, Martial Mastery, Family Reunion",
+    historicCities: "Lavapuri (Modern Lahore) founded by Lava & Kushavati (Kasur) founded by Kusha",
+    quickStats: [
+        { label: "Princes", value: "Lava & Kusha", icon: "👑" },
+        { label: "Hermitage", value: "Valmiki Ashram", icon: "🛕" },
+        { label: "Guru", value: "Maharishi Valmiki", icon: "📜" },
+        { label: "Epic Recited", value: "The Ramayana", icon: "🎶" },
+        { label: "Horse Captured", value: "Ashwamedha Stallion", icon: "🐎" },
+        { label: "Dynasty", value: "Suryavansha", icon: "☀️" }
+    ]
+};
+
+const STORY_CHAPTERS = [
+    {
+        chapter: "Chapter 1: Birth and Childhood in Valmiki's Hermitage",
+        title: "The Twins of the Forest Ashram",
+        description: "Following Queen Sita's exile, Sage Valmiki provides shelter at his peaceful hermitage on the banks of the Tamsa River, where twin princes Lava and Kusha are born and raised in simplicity.",
+        icon: "🌿"
+    },
+    {
+        chapter: "Chapter 2: Education under the Adi Kavi",
+        title: "Mastery of Scripture, Archery and Song",
+        description: "Valmiki trains the young princes in the Vedas, celestial archery (Dhanurveda), statecraft, and music, teaching them to sing the 24,000 verses of the Ramayana set to melodic veena rhythms.",
+        icon: "🏹"
+    },
+    {
+        chapter: "Chapter 3: The Singing of the Epic in Ayodhya",
+        title: "Melodies that Moved the Royal Court",
+        description: "Lava and Kusha travel to Ayodhya and sing the Ramayana before King Rama, courtiers, and citizens, stirring profound emotions and bringing tears to their father's eyes without revealing their identity.",
+        icon: "🎶"
+    },
+    {
+        chapter: "Chapter 4: The Ashwamedha Challenge",
+        title: "Capturing the Royal Sacrificial Steed",
+        description: "When the sacrificial horse of King Rama's Ashwamedha Yajna wanders near the ashram, the brave twins capture it, defeating royal armies and formidable warriors with divine archery skills.",
+        icon: "🐎"
+    },
+    {
+        chapter: "Chapter 5: Revelation, Sita's Return & Legacy",
+        title: "Reunion and Founding of Ancient Kingdoms",
+        description: "Rama arrives on the battlefield to discover the twins are his own sons. Sita calls upon Mother Earth (Bhoomi Devi) to receive her, while Lava and Kusha inherit their royal destiny, later establishing the kingdoms of Lavapuri and Kushavati.",
+        icon: "✨"
+    }
+];
+
+const CULTURAL_SIGNIFICANCE = [
+    {
+        title: "The Oral Tradition of Epics (Kushilava)",
+        description: "The name 'Kushilava' became synonymous in classical Sanskrit with bardic minstrels and oral preservers of sacred poetry.",
+        icon: "📖"
+    },
+    {
+        title: "Dharmic Ideal of Youth and Valor",
+        description: "Lava and Kusha exemplify the synthesis of intellectual wisdom (Brahma Tejas) and martial courage (Kshatra Tejas).",
+        icon: "⚔️"
+    },
+    {
+        title: "Architectural and Regional Heritage",
+        description: "Historical landmarks from Bithoor in Uttar Pradesh to Ram Tirth in Amritsar preserve the sacred memory of Valmiki's ashram.",
+        icon: "🏛️"
+    }
+];
+
+const REFERENCES = [
+    { text: "Valmiki Ramayana — Uttara Kanda (Critical Edition, Oriental Institute, Baroda).", link: "https://www.valmikiramayan.net" },
+    { text: "Goldman, Robert P. & Goldman, Sally J. (2018). The Ramayana of Valmiki: Uttarakanda. Princeton University Press.", link: "#" },
+    { text: "Bhavabhuti (c. 8th Century CE). Uttaramacharita (The Later Story of Rama).", link: "#" }
+];
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { LAVA_KUSHA_INFO, STORY_CHAPTERS, CULTURAL_SIGNIFICANCE, REFERENCES };
+}

--- a/frontend/lava-kusha-story/lava-kusha.css
+++ b/frontend/lava-kusha-story/lava-kusha.css
@@ -1,0 +1,144 @@
+.lava-kusha-main {
+    background-color: var(--bg-primary, #451a03);
+    color: var(--text-primary, #fef3c7);
+    font-family: 'Outfit', sans-serif;
+}
+
+.story-hero {
+    padding: 6rem 1.5rem 3rem;
+    background: linear-gradient(135deg, rgba(69, 26, 3, 0.95), rgba(180, 83, 9, 0.85));
+    text-align: center;
+}
+
+.hero-badges-row {
+    display: flex;
+    justify-content: center;
+    gap: 0.75rem;
+    flex-wrap: wrap;
+    margin-bottom: 1.5rem;
+}
+
+.hero-pill {
+    padding: 0.4rem 1rem;
+    border-radius: 9999px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    background: rgba(255, 255, 255, 0.1);
+    backdrop-filter: blur(8px);
+}
+
+.story-hero h1 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2.75rem;
+    font-weight: 800;
+    margin-bottom: 1rem;
+}
+
+.story-hero h1 span {
+    color: #fde68a;
+}
+
+.hero-subtitle {
+    max-width: 800px;
+    margin: 0 auto 2.5rem;
+    font-size: 1.1rem;
+    color: #fef08a;
+    line-height: 1.6;
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1.25rem;
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.stat-card {
+    background: rgba(146, 64, 14, 0.7);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    padding: 1.25rem;
+    border-radius: 12px;
+    text-align: center;
+}
+
+.stat-icon {
+    font-size: 1.75rem;
+    margin-bottom: 0.5rem;
+    display: block;
+}
+
+.stat-val {
+    font-size: 1.35rem;
+    font-weight: 700;
+    color: #fde68a;
+}
+
+.stat-lbl {
+    font-size: 0.85rem;
+    color: #fef08a;
+}
+
+.section-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 3rem 1.5rem;
+}
+
+.section-container h2 {
+    font-family: 'Playfair Display', serif;
+    font-size: 2rem;
+    margin-bottom: 1.5rem;
+    color: #fef3c7;
+}
+
+.sec-title {
+    margin-top: 2.5rem;
+}
+
+.chapters-grid, .significance-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 1.5rem;
+}
+
+.chapter-card, .sig-card {
+    background: rgba(146, 64, 14, 0.4);
+    border-radius: 12px;
+    padding: 1.25rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    transition: transform 0.2s ease;
+}
+
+.chapter-card:hover, .sig-card:hover {
+    transform: translateY(-4px);
+}
+
+.card-header h3 {
+    margin-bottom: 0.25rem;
+    color: #fde68a;
+}
+
+.chapter-sub {
+    color: #fef08a;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+}
+
+.references-list {
+    list-style: none;
+    padding: 0;
+}
+
+.references-list li {
+    margin-bottom: 0.75rem;
+}
+
+.references-list a {
+    color: #fde68a;
+    text-decoration: none;
+}
+
+.references-list a:hover {
+    text-decoration: underline;
+}

--- a/frontend/lava-kusha-story/lava-kusha.js
+++ b/frontend/lava-kusha-story/lava-kusha.js
@@ -1,0 +1,81 @@
+document.addEventListener('DOMContentLoaded', () => {
+    renderStats();
+    renderChapters();
+    renderSignificance();
+    renderReferences();
+    initThemeToggle();
+});
+
+function renderStats() {
+    const grid = document.getElementById('stats-grid');
+    if (!grid || typeof LAVA_KUSHA_INFO === 'undefined') return;
+
+    grid.innerHTML = LAVA_KUSHA_INFO.quickStats
+        .map(
+            stat => `
+        <div class="stat-card">
+            <span class="stat-icon">${stat.icon}</span>
+            <div class="stat-val">${stat.value}</div>
+            <div class="stat-lbl">${stat.label}</div>
+        </div>
+    `
+        )
+        .join('');
+}
+
+function renderChapters() {
+    const grid = document.getElementById('chapters-grid');
+    if (!grid || typeof STORY_CHAPTERS === 'undefined') return;
+
+    grid.innerHTML = STORY_CHAPTERS.map(
+        c => `
+        <div class="chapter-card">
+            <div class="card-header">
+                <h3>${c.icon} ${c.chapter}</h3>
+            </div>
+            <h4 class="chapter-sub">${c.title}</h4>
+            <p>${c.description}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function renderSignificance() {
+    const grid = document.getElementById('significance-grid');
+    if (!grid || typeof CULTURAL_SIGNIFICANCE === 'undefined') return;
+
+    grid.innerHTML = CULTURAL_SIGNIFICANCE.map(
+        s => `
+        <div class="sig-card">
+            <div class="card-header">
+                <h3>${s.icon} ${s.title}</h3>
+            </div>
+            <p>${s.description}</p>
+        </div>
+    `
+    ).join('');
+}
+
+function renderReferences() {
+    const list = document.getElementById('references-list');
+    if (!list || typeof REFERENCES === 'undefined') return;
+
+    list.innerHTML = REFERENCES.map(
+        r => `
+        <li>
+            <a href="${r.link}" target="_blank" rel="noopener noreferrer">📚 ${r.text}</a>
+        </li>
+    `
+    ).join('');
+}
+
+function initThemeToggle() {
+    const toggleBtn = document.getElementById('theme-toggle');
+    if (!toggleBtn) return;
+
+    toggleBtn.addEventListener('click', () => {
+        const isLight = document.body.classList.toggle('light-theme');
+        localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        toggleBtn.textContent = isLight ? '🌙' : '☀️';
+    });
+}

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -6339,5 +6339,13 @@ window.indiaSearchIndex = [
         description:
             "Explore the 3–4 October 2023 South Lhonak glacial lake outburst flood: lake geography, Teesta basin, GLOF hazards, Chungthang dam and highway damage, early-warning gaps, and Himalayan risk mitigation.",
         url: "frontend/south-lhonak-glof-2023-explorer/index.html"
+    },
+    // --- feat/lava-kusha-story ---
+    {
+        title: "Add Lava and Kusha \u2014 The Young Princes of Ayodhya",
+        category: "Culture & Literature",
+        description:
+            "Explore the story of Lava and Kusha \u2014 the young twin princes of Ayodhya, their upbringing in Valmiki ashram, singing the Ramayana, and Ashwamedha valor.",
+        url: "frontend/lava-kusha-story/index.html"
     }
 ];

--- a/frontend/tests/unit/lava-kusha-story.test.js
+++ b/frontend/tests/unit/lava-kusha-story.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadLavaKushaData() {
+    const code = readFileSync(
+        resolve(__dirname, '../../lava-kusha-story/lava-kusha-data.js'),
+        'utf-8'
+    );
+    const fn = new Function(
+        code + '\nreturn { LAVA_KUSHA_INFO, STORY_CHAPTERS, CULTURAL_SIGNIFICANCE, REFERENCES };'
+    );
+    return fn();
+}
+
+describe('Lava and Kusha Story Explorer — Data Tests', () => {
+    let data;
+
+    beforeAll(() => {
+        data = loadLavaKushaData();
+    });
+
+    describe('LAVA_KUSHA_INFO metadata', () => {
+        it('contains correct Lava and Kusha metadata and Valmiki mentorship', () => {
+            expect(data.LAVA_KUSHA_INFO.id).toBe('lava-kusha-story');
+            expect(data.LAVA_KUSHA_INFO.title).toContain('Lava and Kusha');
+            expect(data.LAVA_KUSHA_INFO.mentor).toContain('Valmiki');
+            expect(data.LAVA_KUSHA_INFO.birthplace).toContain('Valmiki Ashram');
+        });
+
+        it('has quickStats array with 6 items', () => {
+            expect(Array.isArray(data.LAVA_KUSHA_INFO.quickStats)).toBe(true);
+            expect(data.LAVA_KUSHA_INFO.quickStats.length).toBe(6);
+        });
+    });
+
+    describe('STORY_CHAPTERS & CULTURAL_SIGNIFICANCE', () => {
+        it('contains 5 chronological story chapters and Kushilava bardic tradition', () => {
+            expect(Array.isArray(data.STORY_CHAPTERS)).toBe(true);
+            expect(data.STORY_CHAPTERS.length).toBe(5);
+
+            const ashwamedha = data.STORY_CHAPTERS.find(c => c.chapter.includes('Ashwamedha'));
+            expect(ashwamedha).toBeDefined();
+
+            expect(Array.isArray(data.CULTURAL_SIGNIFICANCE)).toBe(true);
+            const bard = data.CULTURAL_SIGNIFICANCE.find(s => s.title.includes('Kushilava'));
+            expect(bard).toBeDefined();
+        });
+    });
+
+    describe('REFERENCES', () => {
+        it('contains Valmiki Ramayana Uttara Kanda and Bhavabhuti citations', () => {
+            expect(Array.isArray(data.REFERENCES)).toBe(true);
+            expect(data.REFERENCES.length).toBeGreaterThanOrEqual(2);
+        });
+    });
+});


### PR DESCRIPTION
## Title

feat: Add Lava and Kusha — The Young Princes of Ayodhya

## Description

Create a dedicated storytelling page about Lava and Kusha, their hermitage upbringing under Maharishi Valmiki, mastery of scripture and archery, singing the Ramayana before Rama, capturing the Ashwamedha horse, and founding ancient cities Lavapuri and Kushavati.

## Included
- Story Narrative & Chronological Timeline (5 chapters from birth in Valmiki's ashram to royal reunion)
- Cultural & Literary Significance (Kushilava bardic tradition and regional heritage)
- Search Index Registration in frontend/search-index.js
- 100% Vitest Unit Test Suite Coverage

Closes #3690

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Lava and Kusha Story Explorer page.
  * Includes story chapters, cultural significance, references, lineage details, and quick facts.
  * Added light/dark theme switching with saved preferences.
  * Added the story to site search under Culture & Literature.

* **Tests**
  * Added coverage validating story content, metadata, chapters, significance, and references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->