### PR TITLE
feat: add Dasharatha's Promise Explorer page for issue  (#3691)

### DIFF
--- a/frontend/dasharatha-promise-explorer/index.html
+++ b/frontend/dasharatha-promise-explorer/index.html
@@ -1,0 +1,549 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Explore Dasharatha's fateful promises to Kaikeyi — the decisions that led to Rama's exile and reshaped the destiny of Ayodhya. Discover the story, characters, timeline, and themes of duty, sacrifice, and honour.">
+  <title>Dasharatha's Promise — The Decision That Changed Ayodhya | Incredible India</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700;800&family=Playfair+Display:ital,wght@0,500;0,600;0,700;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="stylesheet" href="style.css">
+  <link rel="stylesheet" href="../js-modules/page-progress/page-progress.css">
+
+  <meta property="og:title" content="Dasharatha's Promise — The Decision That Changed Ayodhya | Incredible India Explorer">
+  <meta property="og:description" content="The fateful promises King Dasharatha made to Kaikeyi that led to Rama's exile — a story of duty, honour, and sacrifice from the Ramayana.">
+  <meta property="og:image" content="https://incredibleindiaexplorer.gov.in/frontend/assets/travel_deserts.png">
+  <meta property="og:url" content="https://incredibleindiaexplorer.gov.in/frontend/dasharatha-promise-explorer/index.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Incredible India Explorer">
+  <meta property="og:locale" content="en_IN">
+  <link rel="canonical" href="https://incredibleindiaexplorer.gov.in/frontend/dasharatha-promise-explorer/index.html">
+</head>
+<body>
+  <script>
+    (function() {
+      const theme = localStorage.getItem('theme') || 'dark';
+      if (theme === 'light') {
+        document.body.classList.add('light-theme');
+      }
+    })();
+  </script>
+
+  <header class="navbar" id="navbar">
+    <div class="nav-container">
+      <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+        <span class="saffron">Incredible</span>
+        <span class="gold">India</span>
+        <span class="green">Explorer</span>
+      </a>
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+        <span class="bar"></span><span class="bar"></span><span class="bar"></span>
+      </button>
+      <nav class="nav-menu" id="nav-menu">
+        <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+        <div class="nav-dropdown">
+          <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
+          <div class="dropdown-menu">
+            <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
+            <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+            <a href="../../frontend/islands/islands.html" class="dropdown-item">Islands of India</a>
+            <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+            <a href="../../frontend/route-planner/route-planner.html" class="dropdown-item">Route Planner</a>
+          </div>
+        </div>
+        <div class="nav-dropdown">
+          <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
+          <div class="dropdown-menu">
+            <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+            <a href="../../frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
+            <a href="../../frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
+            <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
+            <a href="../../frontend/freedom-movement-explorer/index.html" class="dropdown-item">Freedom Movement Explorer</a>
+            <a href="index.html" class="dropdown-item" style="color: var(--saffron)">Dasharatha's Promise</a>
+          </div>
+        </div>
+        <div class="nav-dropdown">
+          <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Nature ▾</button>
+          <div class="dropdown-menu">
+            <a href="../../frontend/national-parks-explorer/index.html" class="dropdown-item">National Parks</a>
+            <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+            <a href="../../frontend/endemic-flora-fauna-explorer/index.html" class="dropdown-item">Endemic Flora & Fauna</a>
+          </div>
+        </div>
+        <div class="nav-dropdown">
+          <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Games ▾</button>
+          <div class="dropdown-menu">
+            <a href="../../frontend/passport-quest/passport-quest.html" class="dropdown-item">Passport Quest</a>
+            <a href="../../frontend/culinary-game/culinary-game.html" class="dropdown-item">Culinary Challenge</a>
+            <a href="../../frontend/geo-guesser-india/index.html" class="dropdown-item">GeoGuesser</a>
+          </div>
+        </div>
+        <div class="nav-dropdown">
+          <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Community ▾</button>
+          <div class="dropdown-menu">
+            <a href="../../frontend/contributors/contributors.html" class="dropdown-item">Contributors</a>
+            <a href="../../frontend/world-records-india/index.html" class="dropdown-item">World Records</a>
+          </div>
+        </div>
+        <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+      </nav>
+    </div>
+  </header>
+
+  <main id="app-root" class="dpe-main">
+
+    <!-- Hero Section -->
+    <section class="dpe-hero">
+      <div class="dpe-hero-content">
+        <span class="dpe-kicker">👑 Ramayana · Ayodhya Kanda</span>
+        <h1>Dasharatha's Promise <span>— The Decision That Changed Ayodhya</span></h1>
+        <p>King Dasharatha of Ayodhya, burdened by two ancient promises he had made to his queen Kaikeyi, was forced to send his beloved son Rama into fourteen years of exile. This single act of a father honouring his word altered the destiny of an entire kingdom and set in motion the events of the Ramayana — one of humanity's greatest epics.</p>
+        <div class="dpe-hero-badges" aria-label="Key facts about Dasharatha's Promise">
+          <li>👑 Dasharatha — King of Ayodhya</li>
+          <li>👸 Kaikeyi — The Queen Who Made Demands</li>
+          <li>🏹 Rama — The Exiled Prince</li>
+          <li>📜 Ramayana · Ayodhya Kanda</li>
+        </div>
+        <div class="dpe-bookmark-container">
+          <button class="dpe-bookmark-btn journey-bookmark-btn" type="button" data-bookmark-id="dasharatha-promise-main" aria-pressed="false" aria-label="Bookmark the Dasharatha's Promise Explorer">
+            ♡ Save to Journey
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Introducing Dasharatha -->
+    <section class="dpe-section" id="introduction">
+      <div class="dpe-container dpe-grid-2col">
+        <div class="dpe-text-block">
+          <span class="dpe-eyebrow">The King of Ayodhya</span>
+          <h2>Who Was Dasharatha?</h2>
+          <p>Dasharatha was the noble and virtuous king of Ayodhya, a prosperous kingdom said to be as prosperous as the gods' own city. He was a fearsome warrior, a just ruler, and a devoted husband — but above all, he was a man of his word. His name means "one whose chariot roars through ten directions," reflecting his prowess in battle.</p>
+          <p>Dasharatha had three queens — Kausalya, Kaikeyi, and Sumitra — and four sons: Rama, Bharata, Lakshmana, and Shatrughna. Of these, Rama, born to Kausalya, was the eldest and most beloved, widely regarded as the ideal prince who would one day inherit the throne.</p>
+        </div>
+        <div class="dpe-highlight-box">
+          <h3>🏛️ At a Glance</h3>
+          <ul>
+            <li><strong>Kingdom:</strong> Ayodhya — the radiant capital of the Kosala kingdom</li>
+            <li><strong>Title:</strong> Maharan (Great King), wielder of the bow of Indra</li>
+            <li><strong>Queens:</strong> Kausalya, Kaikeyi, Sumitra</li>
+            <li><strong>Sons:</strong> Rama, Bharata, Lakshmana, Shatrughna</li>
+            <li><strong>Sacred Text:</strong> Ramayana — Ayodhya Kanda (Book 2)</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Introducing Kaikeyi -->
+    <section class="dpe-section" id="kaikeyi">
+      <div class="dpe-container dpe-grid-2col">
+        <div class="dpe-highlight-box">
+          <h3>👸 Who Was Kaikeyi?</h3>
+          <ul>
+            <li><strong>Origin:</strong> Princess of the Kekeya kingdom, daughter of King Ashwapati</li>
+            <li><strong>Role:</strong> Second queen of Dasharatha, mother of Bharata</li>
+            <li><strong>Strength:</strong> A fierce warrior queen who once saved Dasharatha's life in battle</li>
+            <li><strong>Companion:</strong> Her maid Manthara, who stoked her fears and ambitions</li>
+            <li><strong>Legacy:</strong> Remembered both as the antagonist of the exile and as a woman bound by the politics of her time</li>
+          </ul>
+        </div>
+        <div class="dpe-text-block">
+          <span class="dpe-eyebrow">The Second Queen</span>
+          <h2>Kaikeyi — The Woman Behind the Demand</h2>
+          <p>Kaikeyi was no ordinary consort. She was a princess of the Kekeya kingdom and a warrior in her own right — legend holds that she fought alongside Dasharatha in a battle against demons, even saving his life when his chariot wheel was struck. For this valour, Dasharatha had granted her two boons (varas) — promises of any favour she might one day ask.</p>
+          <p>Kaikeyi was deeply fond of Rama and had once even hoped he would be crowned heir. But her jealous maid, <strong>Manthara</strong>, twisted her mind, painting a future in which Rama's coronation would reduce Kaikeyi to a servant. Fear and ambition combined to drive Kaikeyi to demand the two boons Dasharatha had promised her years ago.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: The Two Boons -->
+    <section class="dpe-section" id="boons">
+      <div class="dpe-container">
+        <div class="dpe-section-header">
+          <span class="dpe-eyebrow">The Fateful Boons</span>
+          <h2>The Two Promises That Broke a Kingdom</h2>
+          <p>When Dasharatha offered Kaikeyi any wish to honour her valour in battle, she had kept the boons secret — waiting for the moment they would matter most. That moment came on the eve of Rama's coronation.</p>
+        </div>
+
+        <div class="dpe-encounter-grid">
+          <article class="dpe-encounter-card">
+            <span class="dpe-encounter-icon">👑</span>
+            <h3>First Boon — Bharata's Crown</h3>
+            <p>Kaikeyi demanded that her son <strong>Bharata</strong> be crowned king of Ayodhya instead of Rama. This was the political half of her demand — securing the throne for her own bloodline and ensuring her status as the queen mother of the most powerful kingdom in the land.</p>
+          </article>
+          <article class="dpe-encounter-card">
+            <span class="dpe-encounter-icon">🌲</span>
+            <h3>Second Boon — Rama's Exile</h3>
+            <p>Kaikeyi demanded that Rama be sent into <strong>fourteen years of exile</strong> in the dense forests of Dandaka and Chitrakuta, living as a hermit in simple clothes. Only after Rama's exile could Bharata's coronation be performed — ensuring no rival remained in the kingdom.</p>
+          </article>
+          <article class="dpe-encounter-card">
+            <span class="dpe-encounter-icon">💔</span>
+            <h3>Dasharatha's Agony</h3>
+            <p>The king was devastated. He begged, pleaded, and offered his own life in place of his son's exile. But a promise was a promise — Dasharatha's honour as a king and as a man of dharma bound him to fulfil Kaikeyi's boons, no matter how much they tore his heart apart. He collapsed in grief, and some say his life force began to fade from that moment.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Rama's Exile -->
+    <section class="dpe-section" id="exile">
+      <div class="dpe-container dpe-grid-2col">
+        <div class="dpe-text-block">
+          <span class="dpe-eyebrow">The Departure</span>
+          <h2>Rama Leaves Ayodhya</h2>
+          <p>Rama, upon hearing his father's boons, accepted them without protest. He declared that a son's duty was to uphold his father's honour, and that he would gladly live in the forest for fourteen years to keep Dasharatha's word. <strong>Sita</strong>, his devoted wife, insisted on accompanying him, as did his loyal brother <strong>Lakshmana</strong>.</p>
+          <p>The departure was a scene of unimaginable grief. The entire city of Ayodhya wept as Rama, Sita, and Lakshmana walked out through the gates, dressed in bark and carrying only simple belongings. Dasharatha, broken-hearted, watched from the palace walls and is said to have died of grief shortly after — his soul unable to bear the separation from his beloved son.</p>
+        </div>
+        <div class="dpe-highlight-box">
+          <h3>🌿 The Exile Party</h3>
+          <ul>
+            <li><strong>Rama:</strong> The eldest prince, accepting exile with calm dignity</li>
+            <li><strong>Sita:</strong> His wife, who refused to be left behind — "The forest where you live is my Ayodhya"</li>
+            <li><strong>Lakshmana:</strong> His devoted younger brother, who served as protector and companion</li>
+            <li><strong>Duration:</strong> 14 years in the forests of Dandaka, Panchavati, and Chitrakuta</li>
+            <li><strong>What they left behind:</strong> Comfort, royalty, family — everything for the sake of a promise</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Characters -->
+    <section class="dpe-section" id="characters">
+      <div class="dpe-container">
+        <div class="dpe-section-header">
+          <span class="dpe-eyebrow">Main Characters</span>
+          <h2>Who Played What Role</h2>
+          <p>Select a character to learn their place in the story of Dasharatha's promise.</p>
+        </div>
+
+        <div class="dpe-character-wrap">
+          <div class="dpe-character-board">
+            <button class="dpe-character-node" type="button" data-character="dasharatha" aria-pressed="false">
+              <span class="dpe-character-dot">👑</span>
+              <span class="dpe-character-label">Dasharatha</span>
+              <span class="dpe-character-role">King of Ayodhya · The Father</span>
+            </button>
+            <button class="dpe-character-node" type="button" data-character="kaikeyi" aria-pressed="false">
+              <span class="dpe-character-dot">👸</span>
+              <span class="dpe-character-label">Kaikeyi</span>
+              <span class="dpe-character-role">Second Queen · The Demand Maker</span>
+            </button>
+            <button class="dpe-character-node" type="button" data-character="rama" aria-pressed="false">
+              <span class="dpe-character-dot">🏹</span>
+              <span class="dpe-character-label">Rama</span>
+              <span class="dpe-character-role">Eldest Prince · The Exiled One</span>
+            </button>
+            <button class="dpe-character-node" type="button" data-character="bharata" aria-pressed="false">
+              <span class="dpe-character-dot">🛡️</span>
+              <span class="dpe-character-label">Bharata</span>
+              <span class="dpe-character-role">Second Prince · The Reluctant King</span>
+            </button>
+            <button class="dpe-character-node" type="button" data-character="manthara" aria-pressed="false">
+              <span class="dpe-character-dot">🐍</span>
+              <span class="dpe-character-label">Manthara</span>
+              <span class="dpe-character-role">Kaikeyi's Maid · The Instigator</span>
+            </button>
+            <button class="dpe-character-node" type="button" data-character="sita" aria-pressed="false">
+              <span class="dpe-character-dot">🪷</span>
+              <span class="dpe-character-label">Sita</span>
+              <span class="dpe-character-role">Rama's Wife · The Devoted Companion</span>
+            </button>
+            <button class="dpe-character-node" type="button" data-character="lakshmana" aria-pressed="false">
+              <span class="dpe-character-dot">⚔️</span>
+              <span class="dpe-character-label">Lakshmana</span>
+              <span class="dpe-character-role">Rama's Brother · The Protector</span>
+            </button>
+            <button class="dpe-character-node" type="button" data-character="kausalya" aria-pressed="false">
+              <span class="dpe-character-dot">🌙</span>
+              <span class="dpe-character-label">Kausalya</span>
+              <span class="dpe-character-role">Chief Queen · Rama's Mother</span>
+            </button>
+          </div>
+
+          <div class="dpe-detail-panel" id="dpe-detail-panel" aria-live="polite">
+            <span class="dpe-detail-eyebrow" id="dpe-detail-eyebrow">Select a Character</span>
+            <h3 id="dpe-detail-title">The Characters of Dasharatha's Promise</h3>
+            <p id="dpe-detail-desc">Click any character above to learn who they were and what role they played in this pivotal episode of the Ramayana.</p>
+            <span class="dpe-detail-verdict" id="dpe-detail-verdict"></span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Story Timeline -->
+    <section class="dpe-section" id="timeline">
+      <div class="dpe-container">
+        <div class="dpe-section-header">
+          <span class="dpe-eyebrow">The Story Unfolds</span>
+          <h2>Story Timeline</h2>
+          <p>Filter by phase, or read straight through from the battle boon to Rama's departure.</p>
+        </div>
+
+        <div class="dpe-filter-bar" role="group" aria-label="Filter timeline by phase">
+          <button class="dpe-filter-btn active" type="button" data-phase="all" aria-pressed="true">All Phases</button>
+          <button class="dpe-filter-btn" type="button" data-phase="origin" aria-pressed="false">Origin</button>
+          <button class="dpe-filter-btn" type="button" data-phase="promise" aria-pressed="false">The Promise</button>
+          <button class="dpe-filter-btn" type="button" data-phase="demand" aria-pressed="false">The Demand</button>
+          <button class="dpe-filter-btn" type="button" data-phase="exile" aria-pressed="false">The Exile</button>
+          <button class="dpe-filter-btn" type="button" data-phase="aftermath" aria-pressed="false">Aftermath</button>
+        </div>
+
+        <div class="dpe-timeline">
+          <div class="dpe-timeline-step" data-phase="origin">
+            <div class="dpe-timeline-marker"></div>
+            <div class="dpe-timeline-card">
+              <span class="dpe-timeline-date">The Battle</span>
+              <span class="dpe-timeline-phase">Origin</span>
+              <h3>Kaikeyi Saves Dasharatha</h3>
+              <p>In a great battle against the demon king Shambara, Dasharatha's chariot wheel was shattered. Kaikeyi, riding beside him, fought valiantly and repaired the wheel mid-battle, saving the king's life. Overcome with gratitude, Dasharatha granted her two boons — any two wishes she might ask at any time in the future.</p>
+            </div>
+          </div>
+          <div class="dpe-timeline-step" data-phase="origin">
+            <div class="dpe-timeline-marker"></div>
+            <div class="dpe-timeline-card">
+              <span class="dpe-timeline-date">Years Later</span>
+              <span class="dpe-timeline-phase">Origin</span>
+              <h3>Rama's Coronation Announced</h3>
+              <p>As Rama grew into a noble and capable prince, Dasharatha decided the time had come to crown him Yuvaraja (heir apparent). The entire kingdom rejoiced at the announcement — all except Kaikeyi, who had been told by her maid Manthara that Rama's coronation would end her influence and reduce her to a servant in the palace.</p>
+            </div>
+          </div>
+          <div class="dpe-timeline-step" data-phase="promise">
+            <div class="dpe-timeline-marker"></div>
+            <div class="dpe-timeline-card">
+              <span class="dpe-timeline-date">The Old Promise</span>
+              <span class="dpe-timeline-phase">The Promise</span>
+              <h3>The Boons Remembered</h3>
+              <p>Kaikeyi reminded Dasharatha of the two boons he had sworn to grant her after the battle with Shambara. She had kept them in reserve for exactly this moment. Manthara had coached her: demand the throne for Bharata, and exile for Rama. Dasharatha, bound by his sacred word, could not refuse.</p>
+            </div>
+          </div>
+          <div class="dpe-timeline-step" data-phase="demand">
+            <div class="dpe-timeline-marker"></div>
+            <div class="dpe-timeline-card">
+              <span class="dpe-timeline-date">The Demand</span>
+              <span class="dpe-timeline-phase">The Demand</span>
+              <h3>First Boon — Bharata as King</h3>
+              <p>Kaikeyi demanded that Bharata be crowned king of Ayodhya in Rama's place. This was not merely a mother's ambition — it was a political manoeuvre that would reshape the succession and place her own bloodline on the most powerful throne in the land.</p>
+            </div>
+          </div>
+          <div class="dpe-timeline-step" data-phase="demand">
+            <div class="dpe-timeline-marker"></div>
+            <div class="dpe-timeline-card">
+              <span class="dpe-timeline-date">The Demand</span>
+              <span class="dpe-timeline-phase">The Demand</span>
+              <h3>Second Boon — Rama's Exile</h3>
+              <p>Kaikeyi demanded that Rama be exiled for fourteen years to the forests of Dandaka, dressed as a hermit. This ensured that Bharata's path to the throne would be clear — no rival, no threat, no possibility of Rama's return during the reign.</p>
+            </div>
+          </div>
+          <div class="dpe-timeline-step" data-phase="demand">
+            <div class="dpe-timeline-marker"></div>
+            <div class="dpe-timeline-card">
+              <span class="dpe-timeline-date">The King's Anguish</span>
+              <span class="dpe-timeline-phase">The Demand</span>
+              <h3>Dasharatha's Agony</h3>
+              <p>The king collapsed. He begged Kaikeyi to ask for anything else — wealth, kingdoms, his own life. But Kaikeyi was immovable. Bound by his oath and his dharma as a king, Dasharatha was forced to accept. His grief was so profound that it is said his life force began to drain away from that moment.</p>
+            </div>
+          </div>
+          <div class="dpe-timeline-step" data-phase="exile">
+            <div class="dpe-timeline-marker"></div>
+            <div class="dpe-timeline-card">
+              <span class="dpe-timeline-date">Rama's Response</span>
+              <span class="dpe-timeline-phase">The Exile</span>
+              <h3>Rama Accepts Without Protest</h3>
+              <p>When Rama learned of his father's boons, he accepted them calmly. He declared that a son's duty was to uphold his father's honour, and that he would gladly live in the forest to keep Dasharatha's word. Sita and Lakshmana insisted on accompanying him.</p>
+            </div>
+          </div>
+          <div class="dpe-timeline-step" data-phase="exile">
+            <div class="dpe-timeline-marker"></div>
+            <div class="dpe-timeline-card">
+              <span class="dpe-timeline-date">The Departure</span>
+              <span class="dpe-timeline-phase">The Exile</span>
+              <h3>Rama, Sita, and Lakshmana Leave Ayodhya</h3>
+              <p>The three walked out through the gates of Ayodhya dressed in bark, carrying only simple belongings. The entire city wept. Citizens lay down in the streets to block their path. Dasharatha watched from the palace walls, his heart breaking. He would never see his son again.</p>
+            </div>
+          </div>
+          <div class="dpe-timeline-step" data-phase="aftermath">
+            <div class="dpe-timeline-marker"></div>
+            <div class="dpe-timeline-card">
+              <span class="dpe-timeline-date">The Death of Dasharatha</span>
+              <span class="dpe-timeline-phase">Aftermath</span>
+              <h3>A Father's Grief Consumes Him</h3>
+              <p>Unable to bear the separation from Rama, Dasharatha died of a broken heart within days of the exile. His last words were a lament for Rama and a confession that he had failed as a father — bound by honour but destroyed by love.</p>
+            </div>
+          </div>
+          <div class="dpe-timeline-step" data-phase="aftermath">
+            <div class="dpe-timeline-marker"></div>
+            <div class="dpe-timeline-card">
+              <span class="dpe-timeline-date">Bharata's Refusal</span>
+              <span class="dpe-timeline-phase">Aftermath</span>
+              <h3>Bharata Rejects the Throne</h3>
+              <p>When Bharata learned what had happened, he was furious with his mother. He refused to accept the crown, declaring that Rama was the rightful king. He marched to the forest to beg Rama to return, but Rama refused — bound by his father's word. Bharata accepted the throne only as regent, ruling in Rama's name from the outskirts of Ayodhya, placing Rama's sandals on the throne.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Themes -->
+    <section class="dpe-section" id="themes">
+      <div class="dpe-container">
+        <div class="dpe-section-header">
+          <span class="dpe-eyebrow">Deeper Meanings</span>
+          <h2>Themes & Significance</h2>
+          <p>Every element of this story carries layers of moral and philosophical meaning.</p>
+        </div>
+
+        <div class="dpe-symbol-grid">
+          <article class="dpe-symbol-card">
+            <span class="dpe-symbol-icon">⚖️</span>
+            <h3>Dharma — Duty Over Desire</h3>
+            <p>Dasharatha's promise represents the weight of <strong>dharma</strong> — the moral law that binds a person to their word, regardless of personal cost. A king's oath was sacred; to break it would have undermined the very foundation of righteous rule. Dasharatha chose honour over happiness.</p>
+          </article>
+          <article class="dpe-symbol-card">
+            <span class="dpe-symbol-icon">🤝</span>
+            <h3>The Sanctity of Promises</h3>
+            <p>The story asks a difficult question: what happens when two duties collide? Dasharatha's duty as a father to protect his son clashed with his duty as a king to keep his word. He chose his oath — teaching that in the dharmic tradition, a promise is a bond that transcends personal suffering.</p>
+          </article>
+          <article class="dpe-symbol-card">
+            <span class="dpe-symbol-icon">😔</span>
+            <h3>Sacrifice & Renunciation</h3>
+            <p>Rama's acceptance of exile is the ultimate act of <strong>tyaga</strong> (renunciation). He gave up comfort, power, and family — not because he was forced, but because he believed it was right. Sita and Lakshmana's choice to accompany him shows that sacrifice is not solitary; it is shared by those who love.</p>
+          </article>
+          <article class="dpe-symbol-card">
+            <span class="dpe-symbol-icon">🦋</span>
+            <h3>Consequences of Fear</h3>
+            <p>Kaikeyi's demand was driven by fear — fear of losing status, fear of being overshadowed. Manthara's whispered anxieties turned a loyal queen into the catalyst for a kingdom's tragedy. The story warns that fear, when left unchecked, can distort love into cruelty and trust into betrayal.</p>
+          </article>
+          <article class="dpe-symbol-card">
+            <span class="dpe-symbol-icon">👨‍👦</span>
+            <h3>The Parent-Child Bond</h3>
+            <p>Dasharatha's agony and Rama's obedience illustrate the sacred bond between parent and child. The father is willing to die for his son; the son is willing to suffer for his father's honour. It is a relationship defined by mutual sacrifice, not by power.</p>
+          </article>
+          <article class="dpe-symbol-card">
+            <span class="dpe-symbol-icon">🏛️</span>
+            <h3>Justice vs. Mercy</h3>
+            <p>The story reveals the tension between strict justice (Dasharatha keeping his promise) and mercy (the suffering it caused). In the dharmic worldview, justice sometimes demands harshness — and mercy is not the avoidance of duty, but the compassion that accompanies it.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Bharata's Response -->
+    <section class="dpe-section" id="bharata">
+      <div class="dpe-container dpe-grid-2col">
+        <div class="dpe-text-block">
+          <span class="dpe-eyebrow">The Reluctant King</span>
+          <h2>Bharata's Noble Refusal</h2>
+          <p>Of all the characters in this episode, Bharata's response is perhaps the most unexpected. He had not asked for the throne. He had not schemed with his mother. When he returned to Ayodhya and learned what Kaikeyi had done, he was <strong>furious</strong>.</p>
+          <p>Bharata rejected the crown, confronted his mother, and marched to the forest to beg Rama to return. When Rama refused — saying he could not go back on his father's word — Bharata accepted a compromise: he would rule as <strong>regent</strong>, not as king, and place Rama's sandals on the throne as a symbol of the true ruler's authority. He ruled from <strong>Nandigrama</strong>, outside the city, waiting fourteen years for his brother's return.</p>
+        </div>
+        <div class="dpe-highlight-box">
+          <h3>🛡️ Bharata's Legacy</h3>
+          <ul>
+            <li><strong>Moral Stance:</strong> Refused to benefit from injustice, even when it was offered to him</li>
+            <li><strong>Rama Paduka:</strong> Placed Rama's sandals on the throne as a symbol of true kingship</li>
+            <li><strong>Ruled from Nandigrama:</strong> Did not enter the palace, choosing to live outside the city in devotion to his brother</li>
+            <li><strong>Fourteen Years:</strong> Waited patiently for Rama's return, never claiming the throne for himself</li>
+            <li><strong>Lesson:</strong> Legitimacy comes not from power, but from righteousness</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Cultural Significance -->
+    <section class="dpe-section" id="cultural">
+      <div class="dpe-container dpe-grid-2col">
+        <div class="dpe-text-block">
+          <span class="dpe-eyebrow">Cultural & Literary Significance</span>
+          <h2>A Story That Shaped India</h2>
+          <p>Dasharatha's Promise is one of the most emotionally charged episodes in the <strong>Ramayana</strong>, the ancient Sanskrit epic composed by the sage <strong>Valmiki</strong>. It appears primarily in the <strong>Ayodhya Kanda</strong> (Book 2) and has been retold across every major Indian language and art form for over two millennia.</p>
+          <p>The story has inspired <strong>Ramlila</strong> performances across North India, where the exile scene is invariably the most emotionally devastating moment. In the <strong>Kathakali</strong> tradition of Kerala, the exchange between Dasharatha and Kaikeyi is performed with extraordinary emotional depth. <strong>Tulsidas's Ramcharitmanas</strong>, the most widely read version of the Ramayana in Hindi, gives the episode a devotional intensity that has shaped popular understanding for centuries.</p>
+        </div>
+        <div class="dpe-highlight-box">
+          <h3>🏛️ Where You'll Find It</h3>
+          <ul>
+            <li><strong>Valmiki Ramayana</strong> — Ayodhya Kanda, Sargas 9–19 (primary source)</li>
+            <li><strong>Ramcharitmanas</strong> — Tulsidas's Hindi retelling (Bal Kanda & Ayodhya Kanda)</li>
+            <li><strong>Kamban Ramayanam</strong> — Tamil retelling by poet Kamban</li>
+            <li><strong>Ramlila</strong> — Annual dramatic performances across North India</li>
+            <li><strong>Kathakali & Bharatanatyam</strong> — Classical dance-drama renditions</li>
+            <li><strong>Rajput & Pahari Miniature Paintings</strong> — Visual depictions of the exile scene</li>
+            <li><strong>Hampi & Khajuraho Temples</strong> — Stone carvings of the Ramayana narrative</li>
+            <li><strong>Thai Ramakien</strong> — Thailand's national epic, derived from the Ramayana</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: Legacy -->
+    <section class="dpe-section" id="legacy">
+      <div class="dpe-container">
+        <div class="dpe-section-header">
+          <span class="dpe-eyebrow">Why It Still Matters</span>
+          <h2>The Enduring Legacy</h2>
+          <p>Dasharatha's Promise continues to resonate because its moral questions are timeless.</p>
+        </div>
+
+        <div class="dpe-legacy-grid">
+          <article class="dpe-legacy-card">
+            <span class="dpe-legacy-icon">⚖️</span>
+            <h3>The Weight of a Promise</h3>
+            <p>In a world of broken contracts and convenient exceptions, Dasharatha's story asks: what is a promise worth? The answer the Ramayana gives is devastating — a promise is worth everything, even your own happiness and your own life.</p>
+          </article>
+          <article class="dpe-legacy-card">
+            <span class="dpe-legacy-icon">👑</span>
+            <h3>Leadership as Sacrifice</h3>
+            <p>Dasharatha's story teaches that true leadership is not about power — it is about bearing the weight of your decisions, even when they destroy you. A king who breaks his word is no king at all.</p>
+          </article>
+          <article class="dpe-legacy-card">
+            <span class="dpe-legacy-icon">🌿</span>
+            <h3>Exile as Transformation</h3>
+            <p>Rama's exile, though devastating, was the beginning of his greatest trials — and his greatest triumphs. The forest became the crucible in which the ideal king was forged. Exile was not the end; it was the beginning.</p>
+          </article>
+          <article class="dpe-legacy-card">
+            <span class="dpe-legacy-icon">❤️</span>
+            <h3>The Cost of Unchecked Fear</h3>
+            <p>Kaikeyi's story is a warning: fear, when fed by malicious counsel, can turn love into jealousy and loyalty into betrayal. The greatest tragedies often begin not with evil, but with ordinary fear left unchallenged.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section: References -->
+    <section class="dpe-section" id="references">
+      <div class="dpe-container">
+        <div class="dpe-references">
+          <h3>📚 References & Further Reading</h3>
+          <ul>
+            <li><strong>Valmiki Ramayana</strong> — Ayodhya Kanda, Sargas 9–19. <a href="https://www.wisdomlib.org/hinduism/book/ramayana" target="_blank" rel="noopener noreferrer">Wisdom Library translation</a>.</li>
+            <li><strong>Ramcharitmanas</strong> — Tulsidas. <a href="https://www.wisdomlib.org/hinduism/book/ramcharitmanas" target="_blank" rel="noopener noreferrer">Wisdom Library</a>.</li>
+            <li><strong>Kamban Ramayanam</strong> — Tamil retelling by poet Kamban.</li>
+            <li><strong>Wikipedia</strong>. <a href="https://en.wikipedia.org/wiki/Dasharatha" target="_blank" rel="noopener noreferrer"><em>Dasharatha — King of Ayodhya</em></a>.</li>
+            <li><strong>Wikipedia</strong>. <a href="https://en.wikipedia.org/wiki/Kaikeyi" target="_blank" rel="noopener noreferrer"><em>Kaikeyi — Queen of Ayodhya</em></a>.</li>
+            <li><strong>Buck, William (trans.)</strong> (1973). <em>Ramayana</em>. University of California Press.</li>
+            <li><strong>Narayan, R.K.</strong> (1972). <em>The Ramayana: A Shortened Modern Prose Version</em>. University of Oklahoma Press.</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <footer class="dpe-footer">
+    <div class="dpe-container">
+      <p>Part of <a href="../../index.html">Incredible India Explorer</a> · Dasharatha's Promise — duty, honour, and the price of a king's word.</p>
+    </div>
+  </footer>
+
+  <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Scroll to top">↑</button>
+
+  <script src="../app.js" defer></script>
+  <script src="../../frontend/journey/journey.js" defer></script>
+  <script src="script.js" defer></script>
+  <script type="module" src="../firebase-config.js"></script>
+  <script type="module" src="../auth.js"></script>
+  <script src="../router.js" defer></script>
+  <script src="../js-modules/page-progress/page-progress.js"></script>
+</body>
+</html>

--- a/frontend/dasharatha-promise-explorer/script.js
+++ b/frontend/dasharatha-promise-explorer/script.js
@@ -1,0 +1,183 @@
+(function () {
+  'use strict';
+
+  /* =======================================================================
+     Dasharatha's Promise Explorer — Interactive Logic
+     Handles: timeline filtering, character detail board, bookmark integration,
+     and scroll-to-top behaviour.
+     ======================================================================= */
+
+  /* ---- Character Data ---- */
+  var characters = {
+    dasharatha: {
+      eyebrow: 'The King',
+      title: 'Dasharatha — King of Ayodhya',
+      desc: 'Dasharatha was the noble and virtuous ruler of Ayodhya, a man whose word was his bond. When his queen Kaikeyi saved his life in battle against the demon Shambara, he granted her two boons — any wishes she might ask. Years later, on the eve of Rama\'s coronation, Kaikeyi demanded those boons: the throne for her son Bharata, and fourteen years of exile for Rama. Bound by dharma, Dasharatha fulfilled the boons and died of a broken heart.',
+      verdict: 'A king destroyed by his own honour'
+    },
+    kaikeyi: {
+      eyebrow: 'The Queen',
+      title: 'Kaikeyi — The Demand Maker',
+      desc: 'Kaikeyi was a warrior queen of the Kekeya kingdom who had once saved Dasharatha\'s life in battle. For this, she received two boons. Years later, coached by her jealous maid Manthara, she demanded those boons on the eve of Rama\'s coronation — the throne for her son Bharata, and exile for Rama. Her demand was not born of evil, but of fear: fear of being sidelined, fear of losing influence. She is remembered both as an antagonist and as a woman trapped by the politics of her time.',
+      verdict: 'Fear turned loyalty into betrayal'
+    },
+    rama: {
+      eyebrow: 'The Exiled Prince',
+      title: 'Rama — The Ideal Son',
+      desc: 'Rama, the eldest son of Dasharatha and the rightful heir to Ayodhya, accepted his father\'s boons without protest. He declared that a son\'s duty was to uphold his father\'s honour, and that he would gladly live in the forest for fourteen years to keep Dasharatha\'s word. With his wife Sita and brother Lakshmana, he walked out of Ayodhya dressed in bark, beginning the exile that would lead to the great events of the Ramayana — the battle with Ravana, and the establishment of Ram Rajya.',
+      verdict: 'Dharma incarnate — duty above desire'
+    },
+    bharata: {
+      eyebrow: 'The Reluctant King',
+      title: 'Bharata — The Noble Refuser',
+      desc: 'Bharata, Kaikeyi\'s son, had not asked for the throne and was furious when he learned what his mother had done. He rejected the crown, marched to the forest, and begged Rama to return. When Rama refused, Bharata accepted rule only as regent, placing Rama\'s sandals on the throne as a symbol of the true king\'s authority. He ruled from Nandigrama, outside the city, waiting fourteen years for his brother\'s return.',
+      verdict: 'Legitimacy comes from righteousness, not power'
+    },
+    manthara: {
+      eyebrow: 'The Instigator',
+      title: 'Manthara — The Malicious Advisor',
+      desc: 'Manthara was Kaikeyi\'s hunchbacked maid who poisoned her mind against Rama. She painted a terrifying future in which Rama\'s coronation would reduce Kaikeyi to a servant, stoking fears that had never existed before. Whether Manthara acted out of genuine loyalty to Kaikeyi, or out of her own malice, her whispered counsels were the spark that set the tragedy in motion.',
+      verdict: 'Fear, once planted, grows into destruction'
+    },
+    sita: {
+      eyebrow: 'The Devoted Companion',
+      title: 'Sita — The Wife Who Chose Exile',
+      desc: 'When Rama was sentenced to exile, Sita refused to remain in Ayodhya. She declared that the forest where Rama lived was her Ayodhya, and that she would rather face danger at his side than comfort without him. Her devotion, courage, and unwavering support made her the ideal companion — and her eventual abduction by Ravana would become the catalyst for the Ramayana\'s greatest battle.',
+      verdict: 'Love is not comfort — it is presence'
+    },
+    lakshmana: {
+      eyebrow: 'The Protector',
+      title: 'Lakshmana — The Loyal Brother',
+      desc: 'Lakshmana, Rama\'s younger brother by Sumitra, insisted on accompanying him into exile. He left behind his own wife Urmila, accepting fourteen years of separation to serve as Rama\'s protector and companion. Throughout the exile, Lakshmana built shelters, stood guard, and fought whenever danger threatened. His devotion to Rama is one of the most celebrated examples of brotherly loyalty in Indian literature.',
+      verdict: 'Devilry means standing beside, not behind'
+    },
+    kausalya: {
+      eyebrow: 'The Grieving Mother',
+      title: 'Kausalya — Rama\'s Mother',
+      desc: 'Kausalya, Dasharatha\'s chief queen and Rama\'s mother, was devastated by her son\'s exile. She had waited years for Rama to be crowned, and now that hope was shattered. Her grief at Rama\'s departure was among the most heartbreaking scenes in the Ramayana — a mother watching her beloved son walk into the forest, powerless to stop it. She remained in Ayodhya, mourning, until Dasharatha\'s death.',
+      verdict: 'A mother\'s grief knows no bounds'
+    }
+  };
+
+  /* ---- Timeline Filtering ---- */
+  function initTimelineFilters() {
+    var filterBar = document.querySelector('.dpe-filter-bar');
+    if (!filterBar) return;
+
+    var buttons = filterBar.querySelectorAll('.dpe-filter-btn');
+    var steps = document.querySelectorAll('.dpe-timeline-step');
+
+    buttons.forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var phase = this.getAttribute('data-phase');
+
+        buttons.forEach(function (b) {
+          b.classList.remove('active');
+          b.setAttribute('aria-pressed', 'false');
+        });
+        this.classList.add('active');
+        this.setAttribute('aria-pressed', 'true');
+
+        steps.forEach(function (step) {
+          if (phase === 'all' || step.getAttribute('data-phase') === phase) {
+            step.classList.remove('is-filtered-out');
+          } else {
+            step.classList.add('is-filtered-out');
+          }
+        });
+      });
+    });
+  }
+
+  /* ---- Character Board ---- */
+  function initCharacterBoard() {
+    var nodes = document.querySelectorAll('.dpe-character-node');
+    var eyebrow = document.getElementById('dpe-detail-eyebrow');
+    var title = document.getElementById('dpe-detail-title');
+    var desc = document.getElementById('dpe-detail-desc');
+    var verdict = document.getElementById('dpe-detail-verdict');
+
+    if (!nodes.length || !title) return;
+
+    nodes.forEach(function (node) {
+      node.addEventListener('click', function () {
+        var key = this.getAttribute('data-character');
+        var data = characters[key];
+        if (!data) return;
+
+        nodes.forEach(function (n) {
+          n.classList.remove('active');
+          n.setAttribute('aria-pressed', 'false');
+        });
+        this.classList.add('active');
+        this.setAttribute('aria-pressed', 'true');
+
+        if (eyebrow) eyebrow.textContent = data.eyebrow;
+        title.textContent = data.title;
+        desc.textContent = data.desc;
+        if (verdict) verdict.textContent = data.verdict;
+      });
+    });
+  }
+
+  /* ---- Bookmark Integration ---- */
+  function initBookmark() {
+    var btn = document.querySelector('.dpe-bookmark-btn');
+    if (!btn) return;
+
+    var bookmarkId = btn.getAttribute('data-bookmark-id') || 'dasharatha-promise-main';
+    var bookmarkData = {
+      id: bookmarkId,
+      title: "Dasharatha's Promise Explorer",
+      description: "Explore the story of Dasharatha's fateful promises to Kaikeyi that led to Rama's exile.",
+      category: 'Culture & Mythology',
+      image: '',
+      link: window.location.href
+    };
+
+    function updateButtonState() {
+      var saved = window.Journey && typeof window.Journey.isSaved === 'function'
+        ? window.Journey.isSaved(bookmarkId)
+        : false;
+      btn.classList.toggle('is-saved', saved);
+      btn.setAttribute('aria-pressed', saved ? 'true' : 'false');
+      btn.innerHTML = saved
+        ? '&#10084; Saved to Journey'
+        : '&#9825; Save to Journey';
+    }
+
+    updateButtonState();
+
+    btn.addEventListener('click', function () {
+      if (!window.Journey || typeof window.Journey.toggle !== 'function') {
+        btn.textContent = 'Journey not loaded';
+        setTimeout(updateButtonState, 1500);
+        return;
+      }
+      window.Journey.toggle(bookmarkData);
+      updateButtonState();
+    });
+  }
+
+  /* ---- Scroll-to-Top ---- */
+  function initScrollTop() {
+    var scrollBtn = document.getElementById('btn-scroll-top');
+    if (!scrollBtn) return;
+
+    window.addEventListener('scroll', function () {
+      scrollBtn.classList.toggle('visible', window.scrollY > 400);
+    }, { passive: true });
+
+    scrollBtn.addEventListener('click', function () {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+  }
+
+  /* ---- Init ---- */
+  document.addEventListener('DOMContentLoaded', function () {
+    initTimelineFilters();
+    initCharacterBoard();
+    initBookmark();
+    initScrollTop();
+  });
+})();

--- a/frontend/dasharatha-promise-explorer/style.css
+++ b/frontend/dasharatha-promise-explorer/style.css
@@ -1,0 +1,818 @@
+/* ==========================================================================
+   Dasharatha's Promise Explorer — Stylesheet
+   Palette: royal crimson, temple gold, aged parchment, deep indigo.
+   ========================================================================== */
+
+:root {
+  --dpe-ink: #0f0d1a;
+  --dpe-ink-light: #1a1628;
+  --dpe-gold: #c9a84c;
+  --dpe-gold-light: #e8d48b;
+  --dpe-gold-dark: #8a6d1b;
+  --dpe-crimson: #a83232;
+  --dpe-crimson-light: #d44444;
+  --dpe-saffron: #c25b16;
+  --dpe-saffron-light: #e07b35;
+  --dpe-indigo: #3b3070;
+  --dpe-glass: rgba(26, 22, 40, 0.6);
+  --dpe-border: rgba(201, 168, 76, 0.22);
+}
+
+.dpe-main {
+  background-color: var(--dpe-ink);
+  color: #f1f5f9;
+  font-family: Outfit, sans-serif;
+  overflow-x: hidden;
+}
+
+/* Hero */
+.dpe-hero {
+  min-height: 58vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+  padding: 120px 0 60px;
+  background: radial-gradient(circle at 50% 20%, rgba(168, 50, 50, 0.1), transparent 60%),
+              linear-gradient(180deg, rgba(15, 13, 26, 0.72), rgba(15, 13, 26, 0.97));
+  text-align: center;
+}
+
+.dpe-hero-content {
+  position: relative;
+  z-index: 2;
+  width: min(920px, 90%);
+}
+
+.dpe-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 20px;
+  padding: 6px 16px;
+  background: rgba(201, 168, 76, 0.12);
+  border: 1px solid rgba(201, 168, 76, 0.35);
+  border-radius: 100px;
+  color: var(--dpe-gold-light);
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  backdrop-filter: blur(8px);
+}
+
+.dpe-hero h1 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(2.1rem, 5vw, 3.6rem);
+  line-height: 1.15;
+  margin: 0 0 20px;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.dpe-hero h1 span {
+  color: var(--dpe-gold-light);
+  background: linear-gradient(135deg, var(--dpe-gold-light), var(--dpe-gold-dark));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.dpe-hero p {
+  font-size: clamp(1rem, 2vw, 1.15rem);
+  line-height: 1.6;
+  color: #d6cfc0;
+  margin: 0 auto;
+  max-width: 780px;
+}
+
+.dpe-hero-badges {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+  margin: 26px 0 0;
+  padding: 0;
+}
+
+.dpe-hero-badges li {
+  background: rgba(201, 168, 76, 0.08);
+  border: 1px solid var(--dpe-border);
+  border-radius: 100px;
+  padding: 6px 16px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--dpe-gold-light);
+}
+
+/* Sections */
+.dpe-section {
+  padding: 80px 0;
+}
+
+.dpe-section:nth-of-type(even) {
+  background-color: rgba(255, 255, 255, 0.01);
+}
+
+.dpe-container {
+  width: min(1200px, 90%);
+  margin: 0 auto;
+}
+
+.dpe-section-header {
+  margin-bottom: 50px;
+  text-align: center;
+}
+
+.dpe-eyebrow {
+  color: var(--dpe-gold-light);
+  font-size: 0.85rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.dpe-section-header h2 {
+  font-family: 'Playfair Display', serif;
+  font-size: clamp(1.9rem, 3.6vw, 2.6rem);
+  margin: 0 0 16px;
+  color: #ffffff;
+}
+
+.dpe-section-header p {
+  color: #b3aa98;
+  max-width: 720px;
+  margin: 0 auto;
+  line-height: 1.6;
+  font-size: 1.05rem;
+}
+
+/* Grid */
+.dpe-grid-2col {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 50px;
+  align-items: center;
+}
+
+@media (max-width: 900px) {
+  .dpe-grid-2col {
+    grid-template-columns: 1fr;
+    gap: 30px;
+  }
+}
+
+.dpe-text-block p {
+  line-height: 1.75;
+  color: #d6cfc0;
+  margin-bottom: 20px;
+  font-size: 1.05rem;
+}
+
+.dpe-text-block p:last-child {
+  margin-bottom: 0;
+}
+
+/* Highlight Box */
+.dpe-highlight-box {
+  background: var(--dpe-glass);
+  border: 1px solid var(--dpe-border);
+  border-radius: 16px;
+  padding: 30px;
+  backdrop-filter: blur(12px);
+}
+
+.dpe-highlight-box h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.4rem;
+  margin: 0 0 16px;
+  color: var(--dpe-gold-light);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.dpe-highlight-box ul {
+  padding-left: 20px;
+  margin: 0;
+}
+
+.dpe-highlight-box li {
+  color: #d6cfc0;
+  margin-bottom: 12px;
+  line-height: 1.6;
+}
+
+.dpe-highlight-box li:last-child {
+  margin-bottom: 0;
+}
+
+/* Encounter Cards */
+.dpe-encounter-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.dpe-encounter-card {
+  background: var(--dpe-glass);
+  border: 1px solid var(--dpe-border);
+  border-radius: 16px;
+  padding: 30px;
+  backdrop-filter: blur(10px);
+  transition: transform 0.3s, border-color 0.3s;
+}
+
+.dpe-encounter-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(201, 168, 76, 0.5);
+}
+
+.dpe-encounter-icon {
+  font-size: 1.8rem;
+  display: block;
+  margin-bottom: 12px;
+}
+
+.dpe-encounter-card h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.25rem;
+  margin: 0 0 12px;
+  color: #ffffff;
+}
+
+.dpe-encounter-card p {
+  color: #d6cfc0;
+  line-height: 1.7;
+  margin: 0;
+  font-size: 0.97rem;
+}
+
+.dpe-encounter-card strong {
+  color: var(--dpe-gold-light);
+}
+
+/* Character Board */
+.dpe-character-wrap {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 30px;
+  align-items: stretch;
+}
+
+@media (max-width: 900px) {
+  .dpe-character-wrap {
+    grid-template-columns: 1fr;
+  }
+}
+
+.dpe-character-board {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  align-content: center;
+  background: linear-gradient(160deg, rgba(201, 168, 76, 0.1), rgba(59, 48, 112, 0.1));
+  border: 1px solid var(--dpe-border);
+  border-radius: 20px;
+  padding: 30px;
+}
+
+.dpe-character-node {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  background: var(--dpe-glass);
+  border: 1px solid var(--dpe-border);
+  border-radius: 14px;
+  padding: 20px 12px;
+  cursor: pointer;
+  font-family: Outfit, sans-serif;
+  transition: transform 0.2s, border-color 0.2s, background 0.2s;
+}
+
+.dpe-character-dot {
+  font-size: 1.7rem;
+}
+
+.dpe-character-label {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: #f1f5f9;
+  text-align: center;
+}
+
+.dpe-character-role {
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: #b3aa98;
+  text-align: center;
+}
+
+.dpe-character-node:hover,
+.dpe-character-node:focus-visible {
+  transform: translateY(-3px);
+  border-color: rgba(201, 168, 76, 0.6);
+  background: rgba(201, 168, 76, 0.14);
+}
+
+.dpe-character-node:focus-visible {
+  outline: 2px solid var(--dpe-gold-light);
+  outline-offset: 3px;
+}
+
+.dpe-character-node.active {
+  border-color: var(--dpe-gold-light);
+  background: rgba(201, 168, 76, 0.18);
+}
+
+.dpe-character-node.active .dpe-character-label {
+  color: var(--dpe-gold-light);
+}
+
+.dpe-detail-panel {
+  background: var(--dpe-glass);
+  border: 1px solid var(--dpe-border);
+  border-radius: 20px;
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.dpe-detail-eyebrow {
+  color: var(--dpe-gold-light);
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  display: block;
+  margin-bottom: 10px;
+}
+
+.dpe-detail-panel h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.5rem;
+  margin: 0 0 14px;
+  color: #ffffff;
+}
+
+.dpe-detail-panel p {
+  color: #d6cfc0;
+  line-height: 1.7;
+  margin: 0 0 16px;
+}
+
+.dpe-detail-verdict {
+  display: inline-block;
+  background: rgba(201, 168, 76, 0.14);
+  border: 1px solid rgba(201, 168, 76, 0.35);
+  color: var(--dpe-gold-light);
+  padding: 6px 16px;
+  border-radius: 100px;
+  font-size: 0.85rem;
+  font-weight: 700;
+  align-self: flex-start;
+}
+
+.dpe-detail-verdict:empty {
+  display: none;
+}
+
+/* Filter Bar */
+.dpe-filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
+  margin-bottom: 36px;
+}
+
+.dpe-filter-btn {
+  font-family: Outfit, sans-serif;
+  background: var(--dpe-glass);
+  border: 1px solid var(--dpe-border);
+  color: #d6cfc0;
+  padding: 8px 18px;
+  border-radius: 100px;
+  font-size: 0.88rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.dpe-filter-btn:hover {
+  border-color: var(--dpe-gold-light);
+  color: var(--dpe-gold-light);
+}
+
+.dpe-filter-btn:focus-visible {
+  outline: 2px solid var(--dpe-gold-light);
+  outline-offset: 2px;
+}
+
+.dpe-filter-btn.active {
+  background: var(--dpe-gold);
+  border-color: var(--dpe-gold);
+  color: var(--dpe-ink);
+}
+
+/* Timeline */
+.dpe-timeline {
+  position: relative;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 20px 0;
+}
+
+.dpe-timeline::before {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: linear-gradient(180deg, transparent, var(--dpe-border) 10%, var(--dpe-border) 90%, transparent);
+  transform: translateX(-50%);
+}
+
+.dpe-timeline-step {
+  display: flex;
+  justify-content: flex-end;
+  padding-right: 50%;
+  position: relative;
+  margin-bottom: 40px;
+  transition: opacity 0.2s;
+}
+
+.dpe-timeline-step:nth-child(even) {
+  justify-content: flex-start;
+  padding-right: 0;
+  padding-left: 50%;
+}
+
+.dpe-timeline-step.is-filtered-out {
+  display: none;
+}
+
+.dpe-timeline-marker {
+  position: absolute;
+  left: 50%;
+  top: 15px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--dpe-ink);
+  border: 3px solid var(--dpe-gold-light);
+  transform: translateX(-50%);
+  z-index: 2;
+  transition: background 0.3s;
+}
+
+.dpe-timeline-step:hover .dpe-timeline-marker {
+  background: var(--dpe-gold);
+  box-shadow: 0 0 10px var(--dpe-gold-light);
+}
+
+.dpe-timeline-card {
+  background: var(--dpe-glass);
+  border: 1px solid var(--dpe-border);
+  border-radius: 12px;
+  padding: 24px;
+  width: 85%;
+  margin-right: 40px;
+  position: relative;
+  transition: transform 0.3s, border-color 0.3s;
+}
+
+.dpe-timeline-step:nth-child(even) .dpe-timeline-card {
+  margin-right: 0;
+  margin-left: 40px;
+}
+
+.dpe-timeline-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--dpe-gold-light);
+}
+
+.dpe-timeline-date {
+  color: var(--dpe-gold-light);
+  font-weight: 800;
+  font-size: 1.05rem;
+  margin-right: 10px;
+}
+
+.dpe-timeline-phase {
+  display: inline-block;
+  background: rgba(168, 50, 50, 0.16);
+  color: var(--dpe-crimson-light);
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 2px 10px;
+  border-radius: 100px;
+}
+
+.dpe-timeline-card h3 {
+  margin: 10px 0 8px;
+  font-size: 1.1rem;
+  color: #ffffff;
+}
+
+.dpe-timeline-card p {
+  margin: 0;
+  color: #b3aa98;
+  line-height: 1.6;
+  font-size: 0.95rem;
+}
+
+@media (max-width: 768px) {
+  .dpe-timeline::before {
+    left: 20px;
+  }
+  .dpe-timeline-step {
+    justify-content: flex-start;
+    padding-left: 45px;
+    padding-right: 0;
+  }
+  .dpe-timeline-step:nth-child(even) {
+    padding-left: 45px;
+  }
+  .dpe-timeline-marker {
+    left: 20px;
+  }
+  .dpe-timeline-card {
+    width: 100%;
+    margin-right: 0;
+  }
+  .dpe-timeline-step:nth-child(even) .dpe-timeline-card {
+    margin-left: 0;
+  }
+}
+
+/* Symbol Grid */
+.dpe-symbol-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.dpe-symbol-card {
+  background: var(--dpe-glass);
+  border: 1px solid var(--dpe-border);
+  border-radius: 16px;
+  padding: 30px;
+  backdrop-filter: blur(10px);
+  transition: transform 0.3s, border-color 0.3s;
+}
+
+.dpe-symbol-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(201, 168, 76, 0.5);
+}
+
+.dpe-symbol-icon {
+  font-size: 1.8rem;
+  display: block;
+  margin-bottom: 12px;
+}
+
+.dpe-symbol-card h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.2rem;
+  margin: 0 0 12px;
+  color: #ffffff;
+}
+
+.dpe-symbol-card p {
+  color: #d6cfc0;
+  line-height: 1.7;
+  margin: 0;
+  font-size: 0.97rem;
+}
+
+.dpe-symbol-card strong {
+  color: var(--dpe-gold-light);
+}
+
+/* Legacy Grid */
+.dpe-legacy-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.dpe-legacy-card {
+  background: var(--dpe-glass);
+  border: 1px solid var(--dpe-border);
+  border-radius: 16px;
+  padding: 30px;
+  backdrop-filter: blur(10px);
+  transition: transform 0.3s, border-color 0.3s;
+}
+
+.dpe-legacy-card:hover {
+  transform: translateY(-4px);
+  border-color: rgba(201, 168, 76, 0.5);
+}
+
+.dpe-legacy-icon {
+  font-size: 1.8rem;
+  display: block;
+  margin-bottom: 12px;
+}
+
+.dpe-legacy-card h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.25rem;
+  margin: 0 0 12px;
+  color: #ffffff;
+}
+
+.dpe-legacy-card p {
+  color: #d6cfc0;
+  line-height: 1.7;
+  margin: 0;
+  font-size: 0.97rem;
+}
+
+/* References */
+.dpe-references {
+  background: var(--dpe-glass);
+  border: 1px solid var(--dpe-border);
+  border-radius: 16px;
+  padding: 40px;
+}
+
+.dpe-references h3 {
+  font-family: 'Playfair Display', serif;
+  font-size: 1.4rem;
+  margin: 0 0 20px;
+  color: #ffffff;
+}
+
+.dpe-references ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.dpe-references li {
+  position: relative;
+  padding-left: 24px;
+  margin-bottom: 16px;
+  line-height: 1.6;
+  color: #d6cfc0;
+  font-size: 0.98rem;
+}
+
+.dpe-references li:last-child {
+  margin-bottom: 0;
+}
+
+.dpe-references li::before {
+  content: '\1F4D6';
+  position: absolute;
+  left: 0;
+  top: 2px;
+  font-size: 0.9rem;
+}
+
+.dpe-references li a {
+  color: var(--dpe-gold-light);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.dpe-references li a:hover,
+.dpe-references li a:focus-visible {
+  color: var(--dpe-gold);
+  border-bottom-color: currentColor;
+}
+
+/* Footer */
+.dpe-footer {
+  padding: 40px 0;
+  text-align: center;
+  color: #b3aa98;
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.dpe-footer a {
+  color: var(--dpe-gold-light);
+  text-decoration: none;
+  font-weight: 600;
+  transition: color 0.2s;
+}
+
+.dpe-footer a:hover {
+  color: var(--dpe-gold);
+}
+
+/* Bookmark */
+.dpe-bookmark-container {
+  display: flex;
+  justify-content: center;
+  margin-top: 30px;
+}
+
+.dpe-bookmark-btn {
+  background: var(--dpe-glass);
+  border: 1px solid var(--dpe-border);
+  color: var(--dpe-gold-light);
+  padding: 10px 24px;
+  border-radius: 30px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  transition: all 0.2s ease;
+}
+
+.dpe-bookmark-btn:hover {
+  border-color: var(--dpe-gold-light);
+  background: rgba(201, 168, 76, 0.12);
+  transform: translateY(-1px);
+}
+
+.dpe-bookmark-btn.is-saved {
+  background: var(--dpe-gold);
+  color: var(--dpe-ink);
+  border-color: var(--dpe-gold);
+}
+
+/* ==========================================================================
+   Light Theme Overrides
+   ========================================================================== */
+
+body.light-theme .dpe-main {
+  --dpe-ink: #f5f1e6;
+  --dpe-ink-light: #ffffff;
+  --dpe-gold: #8a6d1b;
+  --dpe-gold-light: #6b5a2e;
+  --dpe-gold-dark: #57481f;
+  --dpe-crimson: #8a2020;
+  --dpe-crimson-light: #6b1a1a;
+  --dpe-saffron: #a3480e;
+  --dpe-saffron-light: #8a3d0c;
+  --dpe-indigo: #2d2450;
+  --dpe-glass: rgba(255, 255, 255, 0.72);
+  --dpe-border: rgba(107, 90, 50, 0.2);
+
+  background-color: var(--dpe-ink);
+  color: #3a3224;
+}
+
+body.light-theme .dpe-section:nth-of-type(even) {
+  background-color: rgba(107, 90, 50, 0.04);
+}
+
+body.light-theme .dpe-hero {
+  background: radial-gradient(circle at 50% 20%, rgba(168, 50, 50, 0.06), transparent 60%),
+              linear-gradient(180deg, rgba(245, 241, 230, 0.6), rgba(245, 241, 230, 0.97));
+}
+
+body.light-theme .dpe-hero h1,
+body.light-theme .dpe-section-header h2,
+body.light-theme .dpe-detail-panel h3,
+body.light-theme .dpe-encounter-card h3,
+body.light-theme .dpe-symbol-card h3,
+body.light-theme .dpe-timeline-card h3,
+body.light-theme .dpe-legacy-card h3,
+body.light-theme .dpe-references h3,
+body.light-theme .dpe-character-label {
+  color: #33290f;
+}
+
+body.light-theme .dpe-hero p,
+body.light-theme .dpe-text-block p,
+body.light-theme .dpe-highlight-box li,
+body.light-theme .dpe-section-header p,
+body.light-theme .dpe-detail-panel p,
+body.light-theme .dpe-encounter-card p,
+body.light-theme .dpe-symbol-card p,
+body.light-theme .dpe-timeline-card p,
+body.light-theme .dpe-legacy-card p,
+body.light-theme .dpe-references li,
+body.light-theme .dpe-filter-btn,
+body.light-theme .dpe-footer,
+body.light-theme .dpe-character-role {
+  color: #5c4f2e;
+}
+
+body.light-theme .dpe-filter-btn.active,
+body.light-theme .dpe-bookmark-btn.is-saved {
+  color: #ffffff;
+}
+
+body.light-theme .dpe-character-node.active .dpe-character-label {
+  color: var(--dpe-gold);
+}


### PR DESCRIPTION
## Description

Adds a complete Dasharatha's Promise Explorer page covering the pivotal Ramayana episode where King Dasharatha's fateful promises to Kaikeyi lead to Rama's exile.

Includes hero section, story of Dasharatha & Kaikeyi, the two boons, Rama's exile, chronological timeline with phase filters, 8 interactive character profiles, 6 thematic interpretations, Bharata's response, cultural significance, and Journey bookmark integration.

Fixes #3691

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Tested locally in browser
- [x] Tested in both dark and light themes
- [x] Tested at mobile viewport widths
- [x] Verified no console errors

## Checklist

- [x] My code follows the coding standards of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)