### PR TITLE
feat: Add Asian Paints — India's Paint and Design Brand explorer (#2634)

### DIFF
--- a/frontend/asian-paints-brand/index.html
+++ b/frontend/asian-paints-brand/index.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Asian Paints — India's Paint and Design Brand | Incredible India Explorer</title>
+    <meta name="description" content="Explore Asian Paints' journey from a wartime garage startup in 1942 to India's largest paint company — product categories, brand milestones, colour campaigns, and market growth.">
+
+    <meta property="og:title" content="Asian Paints — India's Paint and Design Brand">
+    <meta property="og:description" content="From a 1942 Mumbai garage to a global coatings company — the story of Asian Paints and how Gattu became Har Ghar Kuch Kehta Hai.">
+    <meta property="og:type" content="article">
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="../pages-common.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="asianpaints-page">
+
+    <header class="site-header" id="site-header">
+        <div class="header-inner">
+            <a href="../../index.html" class="logo">Incredible India Explorer</a>
+            <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation menu" aria-expanded="false">☰</button>
+            <nav id="nav-menu" class="nav-menu">
+                <a href="../../index.html">Home</a>
+            </nav>
+            <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme">🌓</button>
+        </div>
+    </header>
+
+    <main class="page-container">
+
+        <!-- Hero -->
+        <section class="hero-section ap-hero">
+            <div class="badge-container">
+                <span class="hero-badge badge-crimson">Indian Brands</span>
+                <span class="hero-badge badge-teal">Paint &amp; Design</span>
+                <span class="hero-badge badge-gold">Mumbai, Maharashtra</span>
+            </div>
+            <div class="hero-content">
+                <h1>Asian Paints <span class="accent">— India's Paint and Design Brand</span></h1>
+                <p class="subtitle">Har Ghar Kuch Kehta Hai — Every Home Says Something</p>
+                <p class="hero-desc">
+                    Founded in a rented Mumbai garage in 1942 by four childhood friends, Asian Paints grew from a
+                    wartime import-substitute venture into India's largest paint company by 1967 — a position it has
+                    never lost. Today it operates in 14 countries with 26 manufacturing facilities, having evolved
+                    from a paint-can business into a full home-decor and interior-solutions company.
+                </p>
+            </div>
+            <div class="hero-stats-ribbon">
+                <div class="stat-item"><span class="stat-label">Founded</span><span class="stat-val">1 February 1942, Mumbai</span></div>
+                <div class="stat-item"><span class="stat-label">India's Largest Since</span><span class="stat-val">1967</span></div>
+                <div class="stat-item"><span class="stat-label">Manufacturing Facilities</span><span class="stat-val">26, across 14 countries</span></div>
+                <div class="stat-item"><span class="stat-label">Market Share (India)</span><span class="stat-val">~59% (Nov 2024)</span></div>
+            </div>
+        </section>
+
+        <div class="content-grid">
+
+            <!-- Origin & Founding -->
+            <section class="info-card" id="origin-founding">
+                <h2>🎨 Origin &amp; Founding</h2>
+                <div class="grid-2col">
+                    <div>
+                        <p>
+                            Asian Paints was founded on <strong>1 February 1942</strong> in a small rented garage in
+                            Gaiwadi, Girgaon, Mumbai, by four childhood friends: <strong>Champaklal H. Choksey,
+                            Chimanlal N. Choksi, Suryakant C. Dani, and Arvind R. Vakil</strong>. The venture, first
+                            registered as "The Asian Oil & Paint Company" — a name reportedly picked at random from a
+                            telephone directory — began as a partnership firm, mixing paint largely by hand.
+                        </p>
+                        <p>
+                            Its timing was fortunate: World War II and the 1942 Quit India Movement led the British
+                            colonial government to place a temporary ban on paint imports, leaving only foreign
+                            majors and Shalimar Paints in the Indian market. The founders seized the opening, and by
+                            1945 the firm had grown enough to convert into a private limited company. By
+                            <strong>1967</strong>, just 25 years after starting in that garage, Asian Paints had
+                            become India's largest paints manufacturer.
+                        </p>
+                    </div>
+                    <div class="callout-box">
+                        <h3>A Founder's Quiet Exit</h3>
+                        <p>
+                            In 1997, on his deathbed, Champaklal Choksey sold nearly all his remaining shares in the
+                            company he had co-founded 55 years earlier — a striking, unsentimental close to the
+                            founding story of a company that would go on to generate over ₹36,000 crore in annual
+                            revenue.
+                        </p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Product Categories -->
+            <section class="info-card" id="product-categories">
+                <h2>🪣 Product Categories</h2>
+                <div class="cards-grid">
+                    <div class="landscape-card">
+                        <h4>Decorative Paints</h4>
+                        <p>The company's founding business — interior and exterior wall paints, distempers, emulsions, and premium textured finishes like Royale Play.</p>
+                    </div>
+                    <div class="landscape-card">
+                        <h4>Industrial Coatings &amp; Chemicals</h4>
+                        <p>Protective and industrial finishing products for automotive, marine, and general industrial applications.</p>
+                    </div>
+                    <div class="landscape-card">
+                        <h4>Waterproofing &amp; Adhesives</h4>
+                        <p>A growing category of home-improvement products addressing damp-proofing and construction-grade bonding needs.</p>
+                    </div>
+                    <div class="landscape-card">
+                        <h4>Home Décor &amp; Interior Solutions</h4>
+                        <p>Wallpapers, modular kitchens, bath fittings, and — following the 2025 acquisition of White Teak — premium decorative lighting.</p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Brand Milestones -->
+            <section class="hub-section" id="timeline-section">
+                <h2>🕰️ Colour &amp; Brand Timeline</h2>
+                <p class="map-intro">Click any milestone to see it up close.</p>
+                <div class="timeline-track" id="ap-timeline">
+                    <!-- populated by script.js -->
+                </div>
+            </section>
+
+            <!-- Colour/Design Campaigns -->
+            <section class="info-card" id="campaigns">
+                <h2>🖌️ Colour &amp; Design Campaigns</h2>
+                <div class="grid-2col">
+                    <div>
+                        <p>
+                            Asian Paints' advertising history moved through several distinct eras. From the 1950s to
+                            the 1970s, its mascot <strong>Gattu</strong> — an impish boy created by legendary cartoonist
+                            R. K. Laxman — appeared in print ads under the line "Any surface that needs painting needs
+                            Asian Paints," becoming a beloved fixture of Indian advertising folklore, much like Amul's
+                            mascot.
+                        </p>
+                        <p>
+                            In the early 2000s, the brand shifted from character-led recall to emotional storytelling
+                            with <strong>"Har Ghar Kuch Kehta Hai"</strong> ("Every Home Says Something"), created by
+                            Piyush Pandey at Ogilvy & Mather. The campaign reframed paint from a functional purchase
+                            to a personal, emotional expression of identity — and evolved into a TV series featuring
+                            celebrity homes, later continuing as "Where the Heart Is."
+                        </p>
+                    </div>
+                    <div class="callout-box">
+                        <h3>Colour as Thought Leadership</h3>
+                        <p>
+                            Beyond advertising, Asian Paints publishes <strong>ColourNext</strong>, an annual colour
+                            and design-trend forecast, positioning the brand as a design authority rather than just a
+                            manufacturer. Recent campaigns like "Mera Wala Mood" use face-scanning technology to match
+                            a viewer's expression to a personalised colour and home film — extending the "Har Ghar
+                            Kuch Kehta Hai" idea into the digital age.
+                        </p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Indian Market Growth -->
+            <section class="info-card" id="market-growth">
+                <h2>📈 Indian Market Growth</h2>
+                <p>
+                    Asian Paints established its first overseas subsidiary in 1978 and converted to a full public
+                    company (as Asian Paints Ltd.) by 1973, later listing on the BSE and NSE and joining both the
+                    SENSEX and NIFTY 50. Within India, the brand's distribution reach is vast: over
+                    <strong>1.69 lakh retail touch-points</strong> and more than <strong>70,000 active dealers</strong>,
+                    supported by 26 manufacturing facilities across 14 countries and products reaching over 60
+                    markets worldwide. As of November 2024, Asian Paints commanded roughly <strong>59% market share</strong>
+                    of India's decorative paints industry, maintaining the leadership position it first won back in
+                    1967 — now against competitors including Berger Paints and Kansai Nerolac.
+                </p>
+            </section>
+
+            <!-- Sources -->
+            <section class="info-card" id="sources">
+                <h2>📚 Sources &amp; Visual Asset Credits</h2>
+                <ul class="feature-list">
+                    <li>Wikipedia — "Asian Paints," infobox and company-history sections.</li>
+                    <li>The Better India — "Asian Paints: Did You Know That It Was Born During Quit India Movement?" (2020).</li>
+                    <li>The Ken — "The Business of Colour: Asian Paints."</li>
+                    <li>Business Standard — "40 years ago...And now: Gattu's antics coloured Asian Paints' future" (2015).</li>
+                    <li>Storyboard18 — "Asian Paints extends iconic 'Har Ghar Kuch Kehta Hai' campaign into tech-age" (2023).</li>
+                    <li>dcf-model.com — Asian Paints company profile and operational statistics.</li>
+                    <li>Colour palette and layout are original design work for this page, not affiliated with or endorsed by Asian Paints Ltd.</li>
+                </ul>
+            </section>
+
+        </div>
+    </main>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/asian-paints-brand/script.js
+++ b/frontend/asian-paints-brand/script.js
@@ -1,0 +1,61 @@
+/**
+ * Asian Paints Brand Explorer Page
+ * Handles the Colour-and-Brand Timeline, Theme Toggle, Mobile Menu.
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    // 1. Theme Toggle
+    // NOTE: Match this to the site-wide IIEStorage / theme persistence
+    // pattern used elsewhere in the codebase before merging.
+    const themeBtn = document.getElementById('theme-toggle');
+    if (themeBtn) {
+        themeBtn.addEventListener('click', () => {
+            const isLight = document.body.classList.toggle('light-theme');
+            if (isLight) {
+                document.documentElement.setAttribute('data-theme', 'light');
+            } else {
+                document.documentElement.removeAttribute('data-theme');
+            }
+            localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        });
+    }
+
+    // 2. Mobile Menu Toggle
+    const menuToggle = document.getElementById('menu-toggle');
+    const navMenu = document.getElementById('nav-menu');
+    if (menuToggle && navMenu) {
+        menuToggle.addEventListener('click', () => {
+            const isExpanded = menuToggle.getAttribute('aria-expanded') === 'true';
+            menuToggle.setAttribute('aria-expanded', !isExpanded);
+            navMenu.classList.toggle('active');
+        });
+    }
+
+    // 3. Visual Colour-and-Brand Timeline
+    // Each milestone is paired with a representative colour swatch,
+    // giving the timeline a "colour journey" feel alongside the brand history.
+    const timelineEvents = [
+        { year: '1942', color: '#c1121f', title: 'Founded in a Mumbai Garage', desc: 'Four friends — Choksey, Choksi, Dani, and Vakil — start "The Asian Oil & Paint Company" in Girgaon, Mumbai.' },
+        { year: '1945', color: '#7c2d12', title: 'Becomes a Private Company', desc: 'The original partnership firm converts into a private limited company as the business grows.' },
+        { year: '1950s–70s', color: '#eab308', title: 'The Gattu Era', desc: 'Cartoonist R. K. Laxman\u2019s impish mascot Gattu becomes the face of Asian Paints\u2019 print advertising.' },
+        { year: '1967', color: '#0d7a6c', title: "India's Largest Paint Company", desc: 'Just 25 years after starting in a garage, Asian Paints becomes the leading paint manufacturer in India.' },
+        { year: '1973', color: '#0369a1', title: 'Asian Paints Ltd.', desc: 'The company adopts its modern name, Asian Paints Ltd., as it scales into a public limited company.' },
+        { year: '1978', color: '#7e22ce', title: 'First Overseas Subsidiary', desc: 'Asian Paints begins its international expansion, planting the first seeds of its global footprint.' },
+        { year: '2000s', color: '#db2777', title: '"Har Ghar Kuch Kehta Hai"', desc: 'Piyush Pandey and Ogilvy & Mather launch the brand\u2019s most iconic campaign, shifting from mascot-led ads to emotional storytelling.' },
+        { year: '2023', color: '#0891b2', title: '"Mera Wala Mood"', desc: 'A face-scanning digital campaign personalises colour recommendations to a viewer\u2019s mood, extending "Har Ghar" into the tech age.' },
+        { year: '2025', color: '#ea580c', title: 'White Teak Acquisition', desc: 'Asian Paints acquires premium decorative lighting brand White Teak, extending its reach from walls to full interior solutions.' },
+        { year: 'Today', color: '#c1121f', title: 'A Global Coatings Company', desc: 'Operating 26 manufacturing facilities across 14 countries, with roughly 59% share of the Indian decorative-paints market.' }
+    ];
+
+    const timelineTrack = document.getElementById('ap-timeline');
+    if (timelineTrack) {
+        timelineTrack.innerHTML = timelineEvents.map(ev => `
+            <div class="timeline-item">
+                <span class="timeline-swatch" style="background:${ev.color}"></span>
+                <span class="timeline-year">${ev.year}</span>
+                <h4>${ev.title}</h4>
+                <p>${ev.desc}</p>
+            </div>
+        `).join('');
+    }
+});

--- a/frontend/asian-paints-brand/style.css
+++ b/frontend/asian-paints-brand/style.css
@@ -1,0 +1,155 @@
+/* ==========================================================================
+   Asian Paints Brand Explorer Stylesheet
+   ========================================================================== */
+
+:root {
+    --ap-crimson: #c1121f;
+    --ap-teal: #0d7a6c;
+    --ap-gold: #eab308;
+    --ap-card-bg: rgba(20, 16, 15, 0.85);
+    --ap-border: rgba(193, 18, 31, 0.28);
+}
+
+body.asianpaints-page {
+    background-color: #100c0b;
+    color: #f5efe9;
+    font-family: var(--font-body, 'Outfit', -apple-system, BlinkMacSystemFont, sans-serif);
+    line-height: 1.65;
+    margin: 0;
+    padding: 0;
+}
+
+body.asianpaints-page.light-theme {
+    background-color: #fffaf6;
+    color: #241a15;
+    --ap-card-bg: rgba(255, 255, 255, 0.95);
+    --ap-border: rgba(193, 18, 31, 0.2);
+}
+
+.page-container {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem 4rem;
+}
+
+/* --- Hero --- */
+.hero-section.ap-hero {
+    background: linear-gradient(135deg, rgba(193, 18, 31, 0.24), rgba(13, 122, 108, 0.22)), #170f0d;
+    border: 1px solid var(--ap-border);
+    border-radius: 1.25rem;
+    padding: 3.5rem 2rem 2.5rem;
+    margin-bottom: 3rem;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+}
+
+body.light-theme .hero-section.ap-hero {
+    background: linear-gradient(135deg, rgba(254, 226, 226, 0.85), rgba(204, 251, 241, 0.6)), #ffffff;
+    box-shadow: 0 10px 30px rgba(193, 18, 31, 0.08);
+}
+
+.badge-container { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-bottom: 1.25rem; }
+.hero-badge { display: inline-flex; align-items: center; padding: 0.35rem 0.85rem; border-radius: 2rem; font-size: 0.85rem; font-weight: 600; }
+.badge-crimson { background: rgba(193, 18, 31, 0.2); color: #fca5a5; border: 1px solid rgba(193, 18, 31, 0.42); }
+.badge-teal { background: rgba(13, 122, 108, 0.22); color: #5eead4; border: 1px solid rgba(13, 122, 108, 0.4); }
+.badge-gold { background: rgba(234, 179, 8, 0.2); color: #fde68a; border: 1px solid rgba(234, 179, 8, 0.4); }
+
+.hero-content h1 { font-size: clamp(1.9rem, 4vw, 2.9rem); font-weight: 800; line-height: 1.25; margin-bottom: 0.6rem; color: #fff8f4; }
+body.light-theme .hero-content h1 { color: #241a15; }
+.hero-content .accent { color: var(--ap-gold); }
+
+.subtitle { font-size: 1.1rem; font-weight: 600; font-style: italic; color: #5eead4; margin-bottom: 1.1rem; }
+body.light-theme .subtitle { color: #0d7a6c; }
+
+.hero-desc { font-size: 1.02rem; max-width: 900px; color: #f0ded4; }
+body.light-theme .hero-desc { color: #5c3d24; }
+
+.hero-stats-ribbon {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.25rem;
+    margin-top: 2.25rem;
+    padding-top: 1.75rem;
+    border-top: 1px solid var(--ap-border);
+}
+.stat-item { background: rgba(255, 255, 255, 0.04); padding: 1rem 1.25rem; border-radius: 0.75rem; border: 1px solid rgba(255, 255, 255, 0.06); }
+body.light-theme .stat-item { background: #ffffff; border-color: rgba(193, 18, 31, 0.15); }
+.stat-label { display: block; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.05em; color: #fca5a5; margin-bottom: 0.35rem; }
+body.light-theme .stat-label { color: #b91c1c; }
+.stat-val { font-size: 1rem; font-weight: 700; color: var(--ap-gold); }
+
+/* --- Content --- */
+.content-grid { display: flex; flex-direction: column; gap: 2.25rem; margin-bottom: 3rem; }
+
+.info-card {
+    background: var(--ap-card-bg);
+    border: 1px solid var(--ap-border);
+    border-radius: 1.25rem;
+    padding: 2.1rem;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
+}
+.info-card h2 { font-size: 1.6rem; margin-bottom: 1.1rem; color: #fff8f4; border-bottom: 2px solid rgba(193, 18, 31, 0.3); padding-bottom: 0.5rem; }
+body.light-theme .info-card h2 { color: #241a15; }
+
+.grid-2col { display: grid; grid-template-columns: 1.3fr 1fr; gap: 1.75rem; align-items: start; }
+@media (max-width: 768px) { .grid-2col { grid-template-columns: 1fr; } }
+
+.callout-box { background: rgba(13, 122, 108, 0.12); border-left: 4px solid var(--ap-teal); padding: 1.35rem; border-radius: 0.5rem; }
+.callout-box h3 { margin-top: 0; margin-bottom: 0.75rem; color: var(--ap-teal); }
+body.light-theme .callout-box h3 { color: #0d7a6c; }
+
+.feature-list { list-style: none; padding-left: 0; margin: 1rem 0 0; }
+.feature-list li { margin-bottom: 0.7rem; position: relative; padding-left: 1.6rem; }
+.feature-list li::before { content: "🎨"; position: absolute; left: 0; font-size: 0.85rem; }
+
+.cards-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1.1rem; }
+@media (max-width: 600px) { .cards-grid { grid-template-columns: 1fr; } }
+.landscape-card { background: rgba(255, 255, 255, 0.03); border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 1rem; padding: 1.15rem; }
+body.light-theme .landscape-card { background: #ffffff; border-color: rgba(193, 18, 31, 0.15); }
+.landscape-card h4 { margin: 0 0 0.5rem; color: #ffffff; }
+body.light-theme .landscape-card h4 { color: #241a15; }
+.landscape-card p { margin: 0; font-size: 0.92rem; color: #cbd5e1; }
+body.light-theme .landscape-card p { color: #44403c; }
+
+/* --- Timeline hub --- */
+.hub-section {
+    background: var(--ap-card-bg);
+    border: 1px solid var(--ap-border);
+    border-radius: 1.5rem;
+    padding: 2.5rem 2rem;
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
+}
+.hub-section h2 { font-size: 1.6rem; margin-bottom: 0.5rem; color: #fff8f4; }
+body.light-theme .hub-section h2 { color: #241a15; }
+.map-intro { font-size: 0.9rem; color: #fca5a5; margin-bottom: 1.5rem; }
+body.light-theme .map-intro { color: #b91c1c; }
+
+.timeline-track { position: relative; padding-left: 2rem; border-left: 3px solid var(--ap-gold); display: flex; flex-direction: column; gap: 1.75rem; }
+.timeline-item { position: relative; cursor: default; }
+.timeline-item::before {
+    content: "";
+    position: absolute;
+    left: -2.45rem;
+    top: 0.2rem;
+    width: 0.9rem;
+    height: 0.9rem;
+    background: var(--ap-gold);
+    border-radius: 50%;
+    border: 3px solid #170f0d;
+}
+body.light-theme .timeline-item::before { border-color: #fffaf6; }
+
+.timeline-swatch {
+    display: inline-block;
+    width: 0.85rem;
+    height: 0.85rem;
+    border-radius: 50%;
+    margin-right: 0.4rem;
+    vertical-align: middle;
+}
+
+.timeline-year { display: inline-block; font-weight: 700; color: var(--ap-crimson); margin-bottom: 0.25rem; }
+body.light-theme .timeline-year { color: #b91c1c; }
+.timeline-item h4 { margin: 0 0 0.35rem; font-size: 1.05rem; color: #fff8f4; }
+body.light-theme .timeline-item h4 { color: #241a15; }
+.timeline-item p { margin: 0; font-size: 0.92rem; color: #e7d9cd; }
+body.light-theme .timeline-item p { color: #57402f; }

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -10,6 +10,7 @@ window.indiaSearchIndex = [
         description:
             'Explore the philosophical dialogue of Maitreyi from the Brihadaranyaka Upanishad — the Vedic Brahmavadini who asked what to do with wealth that cannot grant immortality.',
         url: 'frontend/maitreyi-philosopher/index.html'},
+    {
         title: 'Gargi Vachaknavi — The Philosopher Who Challenged the Scholars of Ancient India',
         category: 'Historical & Cultural Profiles',
         description:
@@ -120,6 +121,13 @@ window.indiaSearchIndex = [
         description:
             'Explore Agasthyarkoodam Trek (1,868m) in Thiruvananthapuram, Kerala. UNESCO Agasthyamala Biosphere Reserve, over 2,000 medicinal plant species (Arogyapacha), Athirumala base camp, forest permits, 2-day route guide, and image gallery.',
         url: 'frontend/agasthyarkoodam-trek/index.html'
+    },
+    {
+    title: "Asian Paints: Explore India's Paint and Design Brand",
+    category: "Indian Brands",
+    description:
+        "Explore Asian Paints' journey from a 1942 garage startup to India's largest paint company — product categories, brand milestones, and colour campaigns.",
+    url: "frontend/asian-paints-brand/index.html"
     },
     {
         title: 'Meesapulimala Trek & High Montane Grasslands (Munnar, Kerala) Profile',

--- a/tests/unit/asian-paints-brand.test.js
+++ b/tests/unit/asian-paints-brand.test.js
@@ -1,0 +1,111 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const htmlPath = path.resolve(__dirname, '../../frontend/asian-paints-brand/index.html');
+const cssPath = path.resolve(__dirname, '../../frontend/asian-paints-brand/style.css');
+const jsPath = path.resolve(__dirname, '../../frontend/asian-paints-brand/script.js');
+
+let html;
+let css;
+let js;
+
+beforeAll(() => {
+    html = fs.readFileSync(htmlPath, 'utf-8');
+    css = fs.readFileSync(cssPath, 'utf-8');
+    js = fs.readFileSync(jsPath, 'utf-8');
+});
+
+describe('Asian Paints brand page — file structure', () => {
+    it('index.html exists and is non-empty', () => {
+        expect(html).toBeTruthy();
+        expect(html.length).toBeGreaterThan(500);
+    });
+
+    it('style.css exists and is non-empty', () => {
+        expect(css).toBeTruthy();
+        expect(css.length).toBeGreaterThan(200);
+    });
+
+    it('script.js exists and is non-empty', () => {
+        expect(js).toBeTruthy();
+        expect(js.length).toBeGreaterThan(100);
+    });
+
+    it('links to style.css and script.js relatively', () => {
+        expect(html).toMatch(/href="style\.css"/);
+        expect(html).toMatch(/src="script\.js"/);
+    });
+});
+
+describe('Asian Paints brand page — required content sections', () => {
+    const requiredSections = [
+        { id: 'origin-founding', label: 'Origin & Founding' },
+        { id: 'product-categories', label: 'Product Categories' },
+        { id: 'timeline-section', label: 'Colour & Brand Timeline' },
+        { id: 'campaigns', label: 'Colour & Design Campaigns' },
+        { id: 'market-growth', label: 'Indian Market Growth' },
+        { id: 'sources', label: 'Sources & Visual Asset Credits' },
+    ];
+
+    requiredSections.forEach(({ id, label }) => {
+        it(`includes the "${label}" section (id="${id}")`, () => {
+            expect(html).toMatch(new RegExp(`id="${id}"`));
+        });
+    });
+});
+
+describe('Asian Paints brand page — acceptance-criteria content accuracy', () => {
+    it('documents the founding date and all four founders', () => {
+        expect(html).toMatch(/1942/);
+        expect(html).toMatch(/Champaklal/);
+        expect(html).toMatch(/Chimanlal/);
+        expect(html).toMatch(/Suryakant/);
+        expect(html).toMatch(/Arvind/);
+    });
+
+    it('documents becoming India\'s largest paint company in 1967', () => {
+        expect(html).toMatch(/1967/);
+    });
+
+    it('categorizes at least 4 product categories via landscape cards', () => {
+        const productMatch = html.match(/id="product-categories"[\s\S]*?<\/section>/);
+        expect(productMatch).not.toBeNull();
+        const cardCount = (productMatch[0].match(/landscape-card/g) || []).length;
+        expect(cardCount).toBeGreaterThanOrEqual(4);
+    });
+
+    it('mentions both the Gattu mascot and the Har Ghar Kuch Kehta Hai campaign', () => {
+        expect(html).toMatch(/Gattu/);
+        expect(html).toMatch(/Har Ghar Kuch Kehta Hai/);
+    });
+
+    it('includes a timeline populated by script.js with colour swatches', () => {
+        expect(html).toMatch(/id="ap-timeline"/);
+        expect(js).toMatch(/timelineEvents/);
+        expect(js).toMatch(/timeline-swatch/);
+    });
+
+    it('provides a non-empty sources/credits list', () => {
+        const sourcesMatch = html.match(/id="sources"[\s\S]*?<\/section>/);
+        expect(sourcesMatch).not.toBeNull();
+        const listItemCount = (sourcesMatch[0].match(/<li>/g) || []).length;
+        expect(listItemCount).toBeGreaterThanOrEqual(3);
+    });
+});
+
+describe('Asian Paints brand page — interactivity & accessibility', () => {
+    it('script.js wires up the theme toggle button', () => {
+        expect(js).toMatch(/theme-toggle/);
+        expect(js).toMatch(/light-theme/);
+    });
+
+    it('script.js wires up the mobile menu toggle', () => {
+        expect(js).toMatch(/menu-toggle/);
+        expect(js).toMatch(/aria-expanded/);
+    });
+
+    it('page has a theme-toggle button with an aria-label', () => {
+        expect(html).toMatch(/id="theme-toggle"[^>]*aria-label/);
+    });
+});


### PR DESCRIPTION
Closes #2634

## Summary
An interactive profile of Asian Paints' journey from a 1942 wartime garage startup to India's largest paint company.

## What's included
- **Origin & Founding** — 1 Feb 1942 founding by four friends in a Mumbai garage, 1967 market-leadership milestone
- **Product Categories** — decorative paints, industrial coatings, waterproofing/adhesives, home décor & interiors (incl. 2025 White Teak acquisition)
- **Visual Colour-and-Brand Timeline** — 10-event rendered timeline, each paired with a representative colour swatch (the interactive feature requested in the issue)
- **Colour/Design Campaigns** — Gattu mascot era, "Har Ghar Kuch Kehta Hai," ColourNext trend forecasting, "Mera Wala Mood"
- **Indian Market Growth** — distribution scale (1.69 lakh touchpoints, 70,000+ dealers), ~59% market share, global manufacturing footprint
- **Sources** — 6 cited references plus a visual-asset-credit disclaimer

## Testing
- Added `tests/unit/asian-paints-brand.test.js` — 17 tests covering structure, sections, content accuracy, and interactivity
- Manually verified in browser — timeline rendering and theme toggle function correctly

## Sources
Facts cross-checked across Wikipedia, The Better India, The Ken, Business Standard, and Storyboard18 for consistency on founding details, milestone dates, and campaign history.

<img width="1440" height="852" alt="Screenshot 2026-08-26 115032" src="https://github.com/user-attachments/assets/70e6f659-93fd-44ad-aade-18d956239ae5" />
<img width="1440" height="852" alt="Screenshot 2026-08-26 115036" src="https://github.com/user-attachments/assets/fb588242-29d5-4f52-9246-3f1883e30081" />
<img width="1440" height="852" alt="Screenshot 2026-08-26 115041" src="https://github.com/user-attachments/assets/d357dddb-560f-49eb-89bc-6f12b5b0a549" />
