### PR TITLE
feat: Add Stone Age Tool Discoveries of Didwana profile page (#3790)

### DIFF
--- a/frontend/didwana-stone-age-tools/index.html
+++ b/frontend/didwana-stone-age-tools/index.html
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            document.documentElement.setAttribute('data-theme', theme);
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Stone Age Tool Discoveries of Didwana | Prehistoric Rajasthan</title>
+    <link rel="stylesheet" href="../pages-common.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="didwana-page">
+    <header class="header">
+        <header class="navbar" id="navbar">
+    <div class="nav-container">
+        <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+            <span class="saffron">Incredible</span>
+            <span class="gold">India</span>
+            <span class="green">Explorer</span>
+        </a>
+        <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+            <span class="bar"></span>
+            <span class="bar"></span>
+            <span class="bar"></span>
+        </button>
+        <nav class="nav-menu" id="nav-menu">
+            <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+                    Safety ▾
+                </button>
+                <div class="dropdown-menu">
+                    <a
+                        href="../../frontend/emergency-assistance/emergency.html"
+                        class="dropdown-item"
+                    >
+                        🚨 Emergency Assistance
+                    </a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
+                    <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                    <a href="../../frontend/ancient-ports-explorer/index.html" class="dropdown-item">Ancient Ports of India</a>
+                    <a href="../../frontend/islands/islands.html" class="dropdown-item">Islands of India</a>
+                    <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    <a href="../../frontend/route-planner/route-planner.html" class="dropdown-item">Route Planner</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+                    <a href="../../frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
+                    <a href="../../frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
+                    <a href="../../frontend/event-discovery/index.html" class="dropdown-item">Festival & Event Discovery</a>
+                    <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
+                    <a href="../../frontend/national-symbols-gallery/national-symbols-gallery.html" class="dropdown-item">National Symbols</a>
+                    <a href="../../frontend/cuisine-discovery-hub/index.html" class="dropdown-item">UP Cuisine</a>
+                    <a href="../../frontend/handicrafts-showcase/index.html" class="dropdown-item">UP Handicrafts</a>
+                    <a href="../../frontend/national-days-calendar/index.html" class="dropdown-item">National Days</a>
+                    <a href="../../frontend/ganga-ghats-experience/index.html" class="dropdown-item">Ganga Ghats</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Nature ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/national-parks-explorer/index.html" class="dropdown-item">National Parks</a>
+                    <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                    <a href="../../frontend/wildlife-rescue/wildlife-rescue.html" class="dropdown-item">Wildlife Rescue</a>
+                    <a href="../../frontend/endemic-flora-fauna-explorer/index.html" class="dropdown-item">Endemic Flora & Fauna</a>
+                    <a href="../../frontend/harike-wetland/harike-wetland.html" class="dropdown-item">Harike Wetland</a>
+                    <a href="../../frontend/wular-lake/wular-lake.html" class="dropdown-item">Wular Lake</a>
+                    <a href="../../frontend/crowd-density/index.html" class="dropdown-item">Crowd Density Predictor</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Games ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/passport-quest/passport-quest.html" class="dropdown-item">Passport Quest</a>
+                    <a href="../../frontend/culinary-game/culinary-game.html" class="dropdown-item">Culinary Challenge</a>
+                    <a href="../../frontend/monsoon-game/monsoon-game.html" class="dropdown-item">Monsoon Game</a>
+                    <a href="../../frontend/river-game/river-game.html" class="dropdown-item">River Explorer</a>
+                    <a href="../../frontend/geo-guesser-india/index.html" class="dropdown-item">GeoGuesser</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Community ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/contributors/contributors.html" class="dropdown-item">Contributors</a>
+                    <a href="../../frontend/world-records-india/index.html" class="dropdown-item">World Records</a>
+                </div>
+            </div>
+
+            <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+        </nav>
+    </div>
+</header>
+    </header>
+
+    <main class="page-container" id="main-view">
+
+        <!-- Hero Section -->
+        <section class="hero-section" aria-labelledby="hero-heading">
+            <div class="hero-content">
+                <div class="unesco-badge">🪨 Prehistoric Archaeological Site</div>
+                <h1 id="hero-heading">Stone Age Tool Discoveries of Didwana</h1>
+                <p class="subtitle">Prehistoric Stone Tools from the Thar Desert Margin</p>
+                <p class="location">📍 Didwana, Nagaur District, Rajasthan, India</p>
+                <p class="hero-desc">Didwana, on the eastern margin of the Thar Desert near an ancient salt lake, is one of India's most important open-air Stone Age sites. Sand-dune sections here preserve stratified layers of Lower, Middle and Upper Palaeolithic tools, offering rare evidence of early human presence and adaptation in a desert environment.</p>
+            </div>
+        </section>
+
+        <!-- Content Grid -->
+        <div class="content-grid">
+
+            <!-- Archaeological Period -->
+            <section class="info-section">
+                <h2>Archaeological Period</h2>
+                <div class="info-card">
+                    <p>The Didwana dune sections contain a long, layered sequence spanning the <strong>Lower Palaeolithic</strong>, <strong>Middle Palaeolithic</strong>, and <strong>Upper Palaeolithic</strong> phases of the Stone Age.</p>
+                    <p>Because each period's tools lie in a distinct sand layer, Didwana is regarded as a rare "type site" for studying how stone tool technology changed over tens of thousands of years in a single desert-margin location.</p>
+                </div>
+            </section>
+
+            <!-- Discovery Context -->
+            <section class="info-section">
+                <h2>Discovery Context</h2>
+                <div class="info-card">
+                    <p>Tools were discovered eroding out of wind-blown sand-dune sections near the Didwana salt lake, first brought to wider attention through explorations and excavations from the 1970s onward.</p>
+                    <p>Researchers exposed vertical dune sections to record the tools layer by layer, allowing each tool type to be linked to a specific stratigraphic horizon rather than being found loose on the surface.</p>
+                </div>
+            </section>
+
+        </div>
+
+        <!-- Tool Types -->
+        <section class="discoveries-section" aria-labelledby="discoveries-heading">
+            <h2 id="discoveries-heading" class="section-title">Tool Types Discovered</h2>
+            <div class="discoveries-grid">
+                <div class="discovery-card">
+                    <h3>🪓 Hand Axes & Cleavers</h3>
+                    <p>Large bifacial hand axes and cleavers characteristic of the Lower Palaeolithic (Acheulian) tradition.</p>
+                </div>
+                <div class="discovery-card">
+                    <h3>🔪 Scrapers</h3>
+                    <p>Flake-based scrapers associated with the Middle Palaeolithic layers, used for processing hides and wood.</p>
+                </div>
+                <div class="discovery-card">
+                    <h3>🗡️ Points & Borers</h3>
+                    <p>Pointed flake tools and borers from the Middle Palaeolithic, likely used for piercing and hafting.</p>
+                </div>
+                <div class="discovery-card">
+                    <h3>🔻 Blades & Burins</h3>
+                    <p>Narrow blades and burins from the Upper Palaeolithic layers, marking a shift toward more refined flaking techniques.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Materials -->
+        <section class="facts-section" aria-labelledby="materials-heading">
+            <h2 id="materials-heading" class="section-title">Materials Used</h2>
+            <div class="facts-grid">
+                <div class="fact-card">
+                    <span class="fact-icon">🪨</span>
+                    <strong>Quartzite</strong>
+                    <p>The dominant raw material, chosen for its availability and toughness when knapped into tools.</p>
+                </div>
+                <div class="fact-card">
+                    <span class="fact-icon">🧱</span>
+                    <strong>Sandstone</strong>
+                    <p>Used alongside quartzite for larger, heavier tool forms such as hand axes.</p>
+                </div>
+                <div class="fact-card">
+                    <span class="fact-icon">⛏️</span>
+                    <strong>Chert & Chalcedony</strong>
+                    <p>Finer-grained stones favoured for smaller, more precise Upper Palaeolithic blade tools.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Scientific Significance -->
+        <section class="timeline-section" aria-labelledby="significance-heading">
+            <h2 id="significance-heading" class="section-title">Scientific Significance</h2>
+            <div class="content-grid" style="margin-bottom: 0;">
+                <section class="info-section">
+                    <div class="info-card">
+                        <p>Didwana's stacked dune layers let researchers apply <strong>thermoluminescence (TL) dating</strong> to the sand itself, giving age estimates for the tool layers rather than relying on the tools alone.</p>
+                    </div>
+                </section>
+                <section class="info-section">
+                    <div class="info-card">
+                        <p>The unbroken sequence from Lower to Upper Palaeolithic in one location makes Didwana valuable for tracing the gradual evolution of stone tool technology in South Asia.</p>
+                    </div>
+                </section>
+                <section class="info-section">
+                    <div class="info-card">
+                        <p>As a desert-margin site, Didwana also provides evidence of how prehistoric groups adapted to an arid, resource-scarce environment near an ancient saline lake.</p>
+                    </div>
+                </section>
+            </div>
+        </section>
+
+        <!-- Gallery Section -->
+        <section class="gallery-section" aria-labelledby="gallery-heading">
+            <h2 id="gallery-heading" class="section-title">Visual Gallery</h2>
+            <div class="gallery-grid" tabindex="0" aria-label="Image gallery of Didwana Stone Age tool discoveries">
+                <div class="gallery-item item-large">
+                    <div class="img-placeholder" style="background-color: #d6b98c;" role="img" aria-label="Wide view of the layered sand-dune section at Didwana where tools were found">Dune Section View</div>
+                </div>
+                <div class="gallery-item">
+                    <div class="img-placeholder" style="background-color: #a3785a;" role="img" aria-label="A Lower Palaeolithic quartzite hand axe from Didwana">Hand Axe</div>
+                </div>
+                <div class="gallery-item">
+                    <div class="img-placeholder" style="background-color: #c9a66b;" role="img" aria-label="Middle Palaeolithic flake scrapers and points">Scrapers & Points</div>
+                </div>
+                <div class="gallery-item">
+                    <div class="img-placeholder" style="background-color: #8d6e4a;" role="img" aria-label="Upper Palaeolithic blade and burin tools">Blades & Burins</div>
+                </div>
+                <div class="gallery-item item-wide">
+                    <div class="img-placeholder" style="background-color: #e0c9a6;" role="img" aria-label="The Didwana salt lake landscape near the archaeological site">Didwana Salt Lake</div>
+                </div>
+            </div>
+        </section>
+
+    </main>
+
+    <footer class="footer">
+        <div class="footer-content">
+            <p>&copy; 2026 Incredible India Explorer. Open Source Project.</p>
+        </div>
+    </footer>
+
+    <!-- Scripts -->
+    <script src="../app.js"></script>
+</body>
+</html>

--- a/frontend/didwana-stone-age-tools/style.css
+++ b/frontend/didwana-stone-age-tools/style.css
@@ -1,0 +1,293 @@
+/* Variables for Didwana Stone Age Page */
+:root {
+    --primary-color: #92400e; /* Earthy desert brown */
+    --accent-color: #d97706;
+    --hero-bg: #fefce8;
+    --card-bg: #ffffff;
+    --text-color: #334155;
+    --heading-color: #1e293b;
+    --border-color: #e2e8f0;
+    --timeline-line: #cbd5e1;
+}
+
+body:not(.light-theme) {
+    --primary-color: #fbbf24;
+    --accent-color: #f59e0b;
+    --hero-bg: #292524;
+    --card-bg: #1e293b;
+    --text-color: #cbd5e1;
+    --heading-color: #f8fafc;
+    --border-color: #334155;
+    --timeline-line: #475569;
+}
+
+.page-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+}
+
+.section-title {
+    color: var(--primary-color);
+    text-align: center;
+    margin-bottom: 2rem;
+    font-size: 2.2rem;
+    border-bottom: 2px solid var(--accent-color);
+    display: inline-block;
+    padding-bottom: 0.5rem;
+}
+
+/* Hero Section */
+.hero-section {
+    background-color: var(--hero-bg);
+    border: 2px solid var(--accent-color);
+    border-radius: 16px;
+    padding: 4rem 2rem;
+    text-align: center;
+    margin-bottom: 4rem;
+    position: relative;
+    overflow: hidden;
+}
+
+.unesco-badge {
+    display: inline-block;
+    background: var(--accent-color);
+    color: #fff;
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+body:not(.light-theme) .unesco-badge { color: #111; }
+
+.hero-content h1 {
+    font-size: 3.5rem;
+    color: var(--primary-color);
+    margin: 0 0 1rem;
+}
+
+.subtitle {
+    font-size: 1.4rem;
+    color: var(--heading-color);
+    margin-bottom: 1rem;
+    font-weight: 500;
+}
+
+.location {
+    font-size: 1.1rem;
+    color: var(--text-color);
+    font-style: italic;
+    margin-bottom: 1.5rem;
+}
+
+.hero-desc {
+    max-width: 800px;
+    margin: 0 auto;
+    font-size: 1.1rem;
+    color: var(--text-color);
+    line-height: 1.6;
+}
+
+/* Content Grid */
+.content-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    gap: 2.5rem;
+    margin-bottom: 4rem;
+}
+
+.info-section h2 {
+    color: var(--primary-color);
+    border-bottom: 2px solid var(--accent-color);
+    padding-bottom: 0.5rem;
+    margin-bottom: 1.5rem;
+    font-size: 1.6rem;
+}
+
+.info-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1.8rem;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+    height: 100%;
+    color: var(--text-color);
+    line-height: 1.7;
+    font-size: 1.05rem;
+}
+.info-card p {
+    margin-bottom: 1rem;
+}
+.info-card p:last-child {
+    margin-bottom: 0;
+}
+
+/* Discoveries Grid */
+.discoveries-section {
+    margin-bottom: 4rem;
+}
+
+.discoveries-section h2 {
+    text-align: center;
+}
+
+.discoveries-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+}
+
+.discovery-card {
+    background: var(--card-bg);
+    border-left: 4px solid var(--accent-color);
+    border-radius: 8px;
+    padding: 1.5rem;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+}
+
+.discovery-card h3 {
+    color: var(--heading-color);
+    margin-bottom: 0.5rem;
+    font-size: 1.2rem;
+}
+
+/* Scientific Significance (reuses timeline-section wrapper for spacing) */
+.timeline-section {
+    margin-bottom: 4rem;
+}
+
+.timeline-section h2 {
+    text-align: center;
+    color: var(--primary-color);
+    margin-bottom: 2rem;
+}
+
+/* Facts Grid */
+.facts-section {
+    margin-bottom: 4rem;
+}
+
+.facts-section h2 {
+    text-align: center;
+}
+
+.facts-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.5rem;
+}
+
+.fact-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1.5rem;
+    text-align: center;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+    transition: transform 0.3s;
+}
+
+.fact-card:hover {
+    transform: translateY(-5px);
+    border-color: var(--accent-color);
+}
+
+.fact-icon {
+    font-size: 2.5rem;
+    display: block;
+    margin-bottom: 1rem;
+}
+
+.fact-card strong {
+    display: block;
+    margin-bottom: 0.5rem;
+    color: var(--heading-color);
+}
+
+.fact-card p {
+    color: var(--text-color);
+    margin: 0;
+    line-height: 1.5;
+    font-size: 0.95rem;
+}
+
+/* Gallery - Masonry-like Grid */
+.gallery-section h2 {
+    text-align: center;
+}
+
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-auto-rows: 250px;
+    gap: 1.5rem;
+}
+
+.gallery-grid:focus {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 4px;
+}
+
+.gallery-item {
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+    transition: transform 0.3s ease;
+}
+
+.gallery-item:hover, .gallery-item:focus-within {
+    transform: translateY(-5px);
+}
+
+.img-placeholder {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: #1f2937;
+    font-weight: 600;
+    font-size: 1.2rem;
+    text-align: center;
+    padding: 1rem;
+}
+
+@media (min-width: 768px) {
+    .item-large {
+        grid-column: span 2;
+        grid-row: span 2;
+    }
+    .item-wide {
+        grid-column: span 2;
+    }
+}
+
+/* Accessibility Focus States */
+a:focus, button:focus {
+    outline: 2px dashed var(--accent-color);
+    outline-offset: 4px;
+}
+
+/* Responsive */
+@media (max-width: 1024px) {
+    .content-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    .hero-content h1 {
+        font-size: 2.5rem;
+    }
+
+    .gallery-grid {
+        grid-auto-rows: 200px;
+    }
+    .item-large, .item-wide {
+        grid-column: span 1;
+        grid-row: span 1;
+    }
+}

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -6498,5 +6498,13 @@ window.indiaSearchIndex = [
         description:
             "Explore the 2013 Uttarakhand flood disaster: extreme monsoon rainfall, Chorabari Tal glacial lake breach, Kedarnath devastation, Mandakini and Alaknanda valley impacts, Operation Surya Hope rescue, and disaster preparedness lessons.",
         url: "frontend/uttarakhand-floods-2013/index.html"
+    },
+    // --- Stone Age Tool Discoveries of Didwana (#3790) ---
+    {
+        title: "Stone Age Tool Discoveries of Didwana \u2014 Prehistoric Rajasthan",
+        category: "Archaeological Excavations",
+        description:
+            "Explore the Stone Age tool discoveries of Didwana, Rajasthan: Lower, Middle and Upper Palaeolithic tool types, quartzite and sandstone raw materials, dune-section discovery context, and their scientific significance for dating early human occupation in the Thar Desert.",
+        url: "frontend/didwana-stone-age-tools/index.html"
     }
 ];


### PR DESCRIPTION
## Description
Adds a new focused profile page documenting the prehistoric Stone Age tool
discoveries from Didwana, Rajasthan, as requested in issue #3790.

## Changes
- Added new page: frontend/didwana-stone-age-tools/index.html
- Added new stylesheet: frontend/didwana-stone-age-tools/style.css
- Registered the new page in frontend/search-index.js so it appears in
  site search under the "Archaeological Excavations" category

## Content covered
- Tool types (hand axes, cleavers, scrapers, points/borers, blades, burins)
- Archaeological period (Lower, Middle, Upper Palaeolithic)
- Materials (quartzite, sandstone, chert/chalcedony)
- Discovery context (stratified sand-dune sections near Didwana salt lake)
- Scientific significance (thermoluminescence dating, tool-technology
  sequence, desert adaptation evidence)
- Visual gallery placeholders for the above

## Testing
- Opened index.html locally in a browser to confirm layout, dark/light
  theme variables, and navbar render correctly
- Verified new entry appears in search-index.js array without breaking
  existing entries

Fixes #3790

@Eshajha19 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated Didwana Stone Age archaeological information page.
  * Included historical context, discoveries, tool types, materials, scientific significance, image gallery, and key facts.
  * Added shared navigation, footer, theme support, and responsive layouts for mobile and desktop.
  * Added accessibility-focused interactions and visual focus states.
  * Added the Didwana Stone Age discoveries to site search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->