### PR TITLE
feat: Add Acheulean Stone Technology in India educational overview page (#3791)

### DIFF
--- a/frontend/acheulean-stone-technology/index.html
+++ b/frontend/acheulean-stone-technology/index.html
@@ -1,0 +1,270 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            document.documentElement.setAttribute('data-theme', theme);
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Acheulean Stone Technology in India | Prehistoric Overview</title>
+    <link rel="stylesheet" href="../pages-common.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="acheulean-page">
+    <header class="header">
+        <header class="navbar" id="navbar">
+    <div class="nav-container">
+        <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+            <span class="saffron">Incredible</span>
+            <span class="gold">India</span>
+            <span class="green">Explorer</span>
+        </a>
+        <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+            <span class="bar"></span>
+            <span class="bar"></span>
+            <span class="bar"></span>
+        </button>
+        <nav class="nav-menu" id="nav-menu">
+            <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+                    Safety ▾
+                </button>
+                <div class="dropdown-menu">
+                    <a
+                        href="../../frontend/emergency-assistance/emergency.html"
+                        class="dropdown-item"
+                    >
+                        🚨 Emergency Assistance
+                    </a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
+                    <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                    <a href="../../frontend/ancient-ports-explorer/index.html" class="dropdown-item">Ancient Ports of India</a>
+                    <a href="../../frontend/islands/islands.html" class="dropdown-item">Islands of India</a>
+                    <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    <a href="../../frontend/route-planner/route-planner.html" class="dropdown-item">Route Planner</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+                    <a href="../../frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
+                    <a href="../../frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
+                    <a href="../../frontend/event-discovery/index.html" class="dropdown-item">Festival & Event Discovery</a>
+                    <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
+                    <a href="../../frontend/national-symbols-gallery/national-symbols-gallery.html" class="dropdown-item">National Symbols</a>
+                    <a href="../../frontend/cuisine-discovery-hub/index.html" class="dropdown-item">UP Cuisine</a>
+                    <a href="../../frontend/handicrafts-showcase/index.html" class="dropdown-item">UP Handicrafts</a>
+                    <a href="../../frontend/national-days-calendar/index.html" class="dropdown-item">National Days</a>
+                    <a href="../../frontend/ganga-ghats-experience/index.html" class="dropdown-item">Ganga Ghats</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Nature ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/national-parks-explorer/index.html" class="dropdown-item">National Parks</a>
+                    <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                    <a href="../../frontend/wildlife-rescue/wildlife-rescue.html" class="dropdown-item">Wildlife Rescue</a>
+                    <a href="../../frontend/endemic-flora-fauna-explorer/index.html" class="dropdown-item">Endemic Flora & Fauna</a>
+                    <a href="../../frontend/harike-wetland/harike-wetland.html" class="dropdown-item">Harike Wetland</a>
+                    <a href="../../frontend/wular-lake/wular-lake.html" class="dropdown-item">Wular Lake</a>
+                    <a href="../../frontend/crowd-density/index.html" class="dropdown-item">Crowd Density Predictor</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Games ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/passport-quest/passport-quest.html" class="dropdown-item">Passport Quest</a>
+                    <a href="../../frontend/culinary-game/culinary-game.html" class="dropdown-item">Culinary Challenge</a>
+                    <a href="../../frontend/monsoon-game/monsoon-game.html" class="dropdown-item">Monsoon Game</a>
+                    <a href="../../frontend/river-game/river-game.html" class="dropdown-item">River Explorer</a>
+                    <a href="../../frontend/geo-guesser-india/index.html" class="dropdown-item">GeoGuesser</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Community ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/contributors/contributors.html" class="dropdown-item">Contributors</a>
+                    <a href="../../frontend/world-records-india/index.html" class="dropdown-item">World Records</a>
+                </div>
+            </div>
+
+            <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+        </nav>
+    </div>
+</header>
+    </header>
+
+    <main class="page-container" id="main-view">
+
+        <!-- Hero Section -->
+        <section class="hero-section" aria-labelledby="hero-heading">
+            <div class="hero-content">
+                <div class="unesco-badge">🪨 Prehistoric Technology Overview</div>
+                <h1 id="hero-heading">Acheulean Stone Technology in India</h1>
+                <p class="subtitle">Handaxes, Cleavers & the Lower Palaeolithic Toolmakers</p>
+                <p class="location">📍 Sites Across the Indian Subcontinent</p>
+                <p class="hero-desc">The Acheulean is a Lower Palaeolithic stone tool tradition marked by large, deliberately shaped bifacial tools. Across India, from the Deccan plateau to the Gangetic plains, Acheulean sites reveal how early hominins worked stone into standardised handaxes and cleavers over hundreds of thousands of years.</p>
+            </div>
+        </section>
+
+        <!-- Content Grid -->
+        <div class="content-grid">
+
+            <!-- Acheulean Technology -->
+            <section class="info-section">
+                <h2>Acheulean Technology</h2>
+                <div class="info-card">
+                    <p>The <strong>Acheulean</strong> tradition is defined by large bifacial tools flaked on both faces to produce a symmetrical, standardised shape, a marked advance over the simpler pebble-core tools of the earlier Oldowan-like industries.</p>
+                    <p>In India, Acheulean assemblages are found across a wide range of landscapes, including river terraces, lake margins, and rocky uplands, showing that this technology was carried and adapted by hominin groups across very different environments.</p>
+                </div>
+            </section>
+
+            <!-- Handaxes -->
+            <section class="info-section">
+                <h2>Handaxes</h2>
+                <div class="info-card">
+                    <p>Handaxes are teardrop or oval-shaped bifacial tools, worked around most of their edge to create a versatile cutting and chopping implement.</p>
+                    <p>Indian handaxes range from large, roughly flaked early forms to smaller, thinner, more symmetrical examples, reflecting a gradual refinement of technique over the course of the Acheulean.</p>
+                </div>
+            </section>
+
+        </div>
+
+        <!-- Cleavers -->
+        <section class="discoveries-section" aria-labelledby="cleavers-heading">
+            <h2 id="cleavers-heading" class="section-title" style="display:block;">Cleavers</h2>
+            <div class="discoveries-grid">
+                <div class="discovery-card">
+                    <h3>🪓 Flake Cleavers</h3>
+                    <p>Made on large flakes, cleavers carry a broad, straight cutting edge opposite a worked butt end.</p>
+                </div>
+                <div class="discovery-card">
+                    <h3>⚒️ Heavy-Duty Use</h3>
+                    <p>Their wide, robust edge is well suited to chopping wood and processing large animal carcasses.</p>
+                </div>
+                <div class="discovery-card">
+                    <h3>🔷 Regional Variation</h3>
+                    <p>Cleaver forms and frequency vary between Indian sites, offering clues about local raw material and toolmaking traditions.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Major Archaeological Sites -->
+        <section class="facts-section" aria-labelledby="sites-heading">
+            <h2 id="sites-heading" class="section-title">Major Archaeological Sites</h2>
+            <div class="facts-grid">
+                <div class="fact-card">
+                    <span class="fact-icon">🏞️</span>
+                    <strong>Attirampakkam, Tamil Nadu</strong>
+                    <p>A long, well-dated Acheulean sequence on the Kortallayar river, important for tracing changes in tool technology over time.</p>
+                </div>
+                <div class="fact-card">
+                    <span class="fact-icon">⛰️</span>
+                    <strong>Hunsgi–Isampur, Karnataka</strong>
+                    <p>A cluster of Acheulean localities on the Deccan plateau, with Isampur notable as an early stone tool workshop site.</p>
+                </div>
+                <div class="fact-card">
+                    <span class="fact-icon">🗿</span>
+                    <strong>Bhimbetka Area, Madhya Pradesh</strong>
+                    <p>Rock shelters and surrounding terrain preserving evidence of long-term prehistoric occupation, including Acheulean tools.</p>
+                </div>
+                <div class="fact-card">
+                    <span class="fact-icon">🏔️</span>
+                    <strong>Chirki-Nevasa, Maharashtra</strong>
+                    <p>A well-studied Godavari valley locality yielding large Acheulean handaxe and cleaver assemblages.</p>
+                </div>
+                <div class="fact-card">
+                    <span class="fact-icon">🏜️</span>
+                    <strong>Didwana, Rajasthan</strong>
+                    <p>Dune sections on the Thar Desert margin preserving Acheulean tools within a dated stratigraphic sequence.</p>
+                </div>
+                <div class="fact-card">
+                    <span class="fact-icon">🌾</span>
+                    <strong>Paisra, Bihar</strong>
+                    <p>A Kharagpur hills site with an in-situ Acheulean occupation surface and possible hut feature.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Timeline -->
+        <section class="timeline-section" aria-labelledby="timeline-heading">
+            <h2 id="timeline-heading" class="section-title">Timeline</h2>
+            <div class="timeline-container">
+                <div class="timeline-item">
+                    <div class="timeline-year">Early Acheulean</div>
+                    <div class="timeline-content">
+                        <strong>Emergence of Bifacial Technology</strong>
+                        <p>Hominin groups in India begin producing large, roughly worked bifacial handaxes and cleavers.</p>
+                    </div>
+                </div>
+                <div class="timeline-item">
+                    <div class="timeline-year">Middle Acheulean</div>
+                    <div class="timeline-content">
+                        <strong>Wider Spread</strong>
+                        <p>Acheulean toolkits appear across the Deccan plateau, river valleys, and desert margins of India.</p>
+                    </div>
+                </div>
+                <div class="timeline-item">
+                    <div class="timeline-year">Late Acheulean</div>
+                    <div class="timeline-content">
+                        <strong>Refinement of Form</strong>
+                        <p>Tools become thinner, more symmetrical, and more standardised, showing increasing skill in flaking technique.</p>
+                    </div>
+                </div>
+                <div class="timeline-item">
+                    <div class="timeline-year">20th–21st Cent.</div>
+                    <div class="timeline-content">
+                        <strong>Scientific Documentation</strong>
+                        <p>Systematic excavation and dating at sites such as Attirampakkam and Didwana build a detailed chronology of the Indian Acheulean.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Interactive Map -->
+        <section class="map-section" aria-labelledby="map-heading">
+            <h2 id="map-heading" class="section-title">Interactive Map of Major Sites</h2>
+            <p class="map-intro">Click a marker to see a short summary of that Acheulean site.</p>
+            <div class="acheulean-map-wrapper">
+                <div class="india-map" id="acheulean-map">
+                    <svg viewBox="0 0 400 500" class="india-outline">
+                        <path d="M200,20 L260,50 L300,80 L320,120 L340,160 L350,200 L360,240 L370,280 L360,320 L340,360 L310,400 L280,430 L250,460 L220,480 L200,490 L180,480 L150,460 L120,430 L90,400 L70,360 L50,320 L40,280 L45,240 L55,200 L70,160 L90,120 L120,80 L160,50 Z"
+                              fill="none" stroke="currentColor" stroke-width="2" opacity="0.3"/>
+                    </svg>
+                    <!-- Site markers rendered dynamically by script.js -->
+                </div>
+                <div class="map-legend" id="acheulean-legend">
+                    <!-- Legend items rendered dynamically by script.js -->
+                </div>
+            </div>
+        </section>
+
+    </main>
+
+    <footer class="footer">
+        <div class="footer-content">
+            <p>&copy; 2026 Incredible India Explorer. Open Source Project.</p>
+        </div>
+    </footer>
+
+    <!-- Scripts -->
+    <script src="../app.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/acheulean-stone-technology/script.js
+++ b/frontend/acheulean-stone-technology/script.js
@@ -1,0 +1,117 @@
+/**
+ * script.js
+ * Interactive map for the Acheulean Stone Technology in India page.
+ * Renders clickable site markers on a stylised India outline, each
+ * showing a short popup summary of that Acheulean site on click.
+ */
+
+const ACHEULEAN_SITES = [
+    {
+        id: 'attirampakkam',
+        name: 'Attirampakkam',
+        state: 'Tamil Nadu',
+        color: '#dc2626',
+        top: '78%',
+        left: '52%',
+        summary: 'A long, well-dated Acheulean sequence on the Kortallayar river used to trace changes in tool technology over time.'
+    },
+    {
+        id: 'hunsgi-isampur',
+        name: 'Hunsgi–Isampur',
+        state: 'Karnataka',
+        color: '#ea580c',
+        top: '62%',
+        left: '38%',
+        summary: 'A cluster of Deccan plateau localities; Isampur is notable as an early stone tool workshop site.'
+    },
+    {
+        id: 'bhimbetka',
+        name: 'Bhimbetka Area',
+        state: 'Madhya Pradesh',
+        color: '#65a30d',
+        top: '46%',
+        left: '46%',
+        summary: 'Rock shelters and surrounding terrain preserving evidence of long prehistoric occupation, including Acheulean tools.'
+    },
+    {
+        id: 'chirki-nevasa',
+        name: 'Chirki-Nevasa',
+        state: 'Maharashtra',
+        color: '#0891b2',
+        top: '52%',
+        left: '32%',
+        summary: 'A Godavari valley locality yielding large Acheulean handaxe and cleaver assemblages.'
+    },
+    {
+        id: 'didwana',
+        name: 'Didwana',
+        state: 'Rajasthan',
+        color: '#7c3aed',
+        top: '30%',
+        left: '34%',
+        summary: 'Thar Desert dune sections preserving Acheulean tools within a dated stratigraphic sequence.'
+    },
+    {
+        id: 'paisra',
+        name: 'Paisra',
+        state: 'Bihar',
+        color: '#c026d3',
+        top: '34%',
+        left: '62%',
+        summary: 'A Kharagpur hills site with an in-situ Acheulean occupation surface and possible hut feature.'
+    }
+];
+
+function closeOpenPopup() {
+    const existing = document.querySelector('.map-popup');
+    if (existing) existing.remove();
+}
+
+function showPopup(marker, site) {
+    closeOpenPopup();
+    const popup = document.createElement('div');
+    popup.className = 'map-popup';
+    popup.innerHTML = `
+        <h4>${site.name}</h4>
+        <p>${site.state}</p>
+        <p>${site.summary}</p>
+    `;
+    marker.appendChild(popup);
+    setTimeout(() => document.addEventListener('click', closeOpenPopup, { once: true }), 10);
+}
+
+function renderAcheuleanMap() {
+    const mapContainer = document.getElementById('acheulean-map');
+    const legendContainer = document.getElementById('acheulean-legend');
+    if (!mapContainer || !legendContainer) return;
+
+    ACHEULEAN_SITES.forEach(site => {
+        const marker = document.createElement('button');
+        marker.type = 'button';
+        marker.className = 'map-marker';
+        marker.style.top = site.top;
+        marker.style.left = site.left;
+        marker.style.setProperty('--marker-color', site.color);
+        marker.setAttribute('aria-label', `${site.name}, ${site.state}`);
+        marker.innerHTML = `
+            <span class="marker-dot"></span>
+            <span class="marker-label">${site.name}</span>
+        `;
+        marker.addEventListener('click', (e) => {
+            e.stopPropagation();
+            showPopup(marker, site);
+        });
+        mapContainer.appendChild(marker);
+
+        const legendItem = document.createElement('div');
+        legendItem.className = 'legend-item';
+        legendItem.innerHTML = `
+            <span class="legend-color" style="background:${site.color}"></span>
+            <span class="legend-name">${site.name}, ${site.state}</span>
+        `;
+        legendItem.addEventListener('click', () => showPopup(marker, site));
+        legendContainer.appendChild(legendItem);
+    });
+}
+
+document.addEventListener('DOMContentLoaded', renderAcheuleanMap);

--- a/frontend/acheulean-stone-technology/style.css
+++ b/frontend/acheulean-stone-technology/style.css
@@ -1,0 +1,484 @@
+/* Variables for Acheulean Stone Technology Page */
+:root {
+    --primary-color: #57534e; /* Stone grey */
+    --accent-color: #a16207;
+    --hero-bg: #fafaf9;
+    --card-bg: #ffffff;
+    --text-color: #334155;
+    --heading-color: #1e293b;
+    --border-color: #e2e8f0;
+    --timeline-line: #cbd5e1;
+}
+
+body:not(.light-theme) {
+    --primary-color: #d6d3d1;
+    --accent-color: #eab308;
+    --hero-bg: #1c1917;
+    --card-bg: #1e293b;
+    --text-color: #cbd5e1;
+    --heading-color: #f8fafc;
+    --border-color: #334155;
+    --timeline-line: #475569;
+}
+
+.page-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+}
+
+.section-title {
+    color: var(--primary-color);
+    text-align: center;
+    margin-bottom: 2rem;
+    font-size: 2.2rem;
+    border-bottom: 2px solid var(--accent-color);
+    display: inline-block;
+    padding-bottom: 0.5rem;
+}
+
+/* Hero Section */
+.hero-section {
+    background-color: var(--hero-bg);
+    border: 2px solid var(--accent-color);
+    border-radius: 16px;
+    padding: 4rem 2rem;
+    text-align: center;
+    margin-bottom: 4rem;
+    position: relative;
+    overflow: hidden;
+}
+
+.unesco-badge {
+    display: inline-block;
+    background: var(--accent-color);
+    color: #fff;
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+body:not(.light-theme) .unesco-badge { color: #111; }
+
+.hero-content h1 {
+    font-size: 3.5rem;
+    color: var(--primary-color);
+    margin: 0 0 1rem;
+}
+
+.subtitle {
+    font-size: 1.4rem;
+    color: var(--heading-color);
+    margin-bottom: 1rem;
+    font-weight: 500;
+}
+
+.location {
+    font-size: 1.1rem;
+    color: var(--text-color);
+    font-style: italic;
+    margin-bottom: 1.5rem;
+}
+
+.hero-desc {
+    max-width: 800px;
+    margin: 0 auto;
+    font-size: 1.1rem;
+    color: var(--text-color);
+    line-height: 1.6;
+}
+
+/* Content Grid */
+.content-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    gap: 2.5rem;
+    margin-bottom: 4rem;
+}
+
+.info-section h2 {
+    color: var(--primary-color);
+    border-bottom: 2px solid var(--accent-color);
+    padding-bottom: 0.5rem;
+    margin-bottom: 1.5rem;
+    font-size: 1.6rem;
+}
+
+.info-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1.8rem;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+    height: 100%;
+    color: var(--text-color);
+    line-height: 1.7;
+    font-size: 1.05rem;
+}
+.info-card p {
+    margin-bottom: 1rem;
+}
+.info-card p:last-child {
+    margin-bottom: 0;
+}
+
+/* Discoveries Grid (Cleavers) */
+.discoveries-section {
+    margin-bottom: 4rem;
+    text-align: center;
+}
+
+.discoveries-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+    text-align: left;
+}
+
+.discovery-card {
+    background: var(--card-bg);
+    border-left: 4px solid var(--accent-color);
+    border-radius: 8px;
+    padding: 1.5rem;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+}
+
+.discovery-card h3 {
+    color: var(--heading-color);
+    margin-bottom: 0.5rem;
+    font-size: 1.2rem;
+}
+
+/* Facts Grid (Major Sites) */
+.facts-section {
+    margin-bottom: 4rem;
+}
+
+.facts-section h2 {
+    text-align: center;
+}
+
+.facts-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+}
+
+.fact-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1.5rem;
+    text-align: center;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+    transition: transform 0.3s;
+}
+
+.fact-card:hover {
+    transform: translateY(-5px);
+    border-color: var(--accent-color);
+}
+
+.fact-icon {
+    font-size: 2.5rem;
+    display: block;
+    margin-bottom: 1rem;
+}
+
+.fact-card strong {
+    display: block;
+    margin-bottom: 0.5rem;
+    color: var(--heading-color);
+}
+
+.fact-card p {
+    color: var(--text-color);
+    margin: 0;
+    line-height: 1.5;
+    font-size: 0.95rem;
+}
+
+/* Timeline Section */
+.timeline-section {
+    margin-bottom: 4rem;
+}
+
+.timeline-section h2 {
+    text-align: center;
+    color: var(--primary-color);
+    margin-bottom: 2rem;
+}
+
+.timeline-container {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    padding: 2rem 0;
+}
+
+.timeline-container::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 4px;
+    background-color: var(--timeline-line);
+    border-radius: 2px;
+}
+
+.timeline-item {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    width: 50%;
+    padding-right: 2rem;
+    margin-bottom: 2rem;
+    position: relative;
+}
+
+.timeline-item:nth-child(even) {
+    align-self: flex-end;
+    justify-content: flex-start;
+    padding-right: 0;
+    padding-left: 2rem;
+}
+
+.timeline-item::after {
+    content: "";
+    position: absolute;
+    right: -8px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 16px;
+    height: 16px;
+    background-color: var(--accent-color);
+    border: 4px solid var(--card-bg);
+    border-radius: 50%;
+    z-index: 1;
+}
+
+.timeline-item:nth-child(even)::after {
+    right: auto;
+    left: -8px;
+}
+
+.timeline-year {
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--primary-color);
+    margin-bottom: 0.5rem;
+}
+
+.timeline-content {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    padding: 1.5rem;
+    border-radius: 12px;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+    width: 100%;
+}
+
+.timeline-content strong {
+    display: block;
+    font-size: 1.2rem;
+    color: var(--heading-color);
+    margin-bottom: 0.5rem;
+}
+
+.timeline-content p {
+    color: var(--text-color);
+    margin: 0;
+    line-height: 1.5;
+}
+
+/* Interactive Map Section */
+.map-section {
+    margin-bottom: 4rem;
+    text-align: center;
+}
+
+.map-intro {
+    color: var(--text-color);
+    margin-bottom: 2rem;
+}
+
+.acheulean-map-wrapper {
+    display: flex;
+    gap: 24px;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    text-align: left;
+}
+
+.india-map {
+    position: relative;
+    flex: 1;
+    min-width: 300px;
+    max-width: 400px;
+    aspect-ratio: 4 / 5;
+    background: var(--card-bg);
+    border-radius: 16px;
+    border: 1px solid var(--border-color);
+    overflow: hidden;
+    margin: 0 auto;
+}
+
+.india-outline {
+    width: 100%;
+    height: 100%;
+    color: var(--primary-color);
+}
+
+.map-marker {
+    position: absolute;
+    transform: translate(-50%, -50%);
+    cursor: pointer;
+    z-index: 2;
+    background: none;
+    border: none;
+    padding: 0;
+}
+
+.marker-dot {
+    display: block;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--marker-color, var(--accent-color));
+    border: 2px solid var(--card-bg);
+    box-shadow: 0 0 8px rgba(0,0,0,0.3);
+    margin: 0 auto;
+}
+
+.marker-label {
+    display: block;
+    font-size: 0.7rem;
+    font-weight: 600;
+    color: var(--heading-color);
+    text-shadow: 0 1px 3px rgba(0,0,0,0.4);
+    white-space: nowrap;
+    margin-top: 2px;
+    text-align: center;
+}
+
+.map-popup {
+    position: absolute;
+    bottom: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 12px 16px;
+    min-width: 200px;
+    z-index: 10;
+    box-shadow: 0 4px 16px rgba(0,0,0,0.3);
+    text-align: left;
+}
+
+.map-popup h4 {
+    margin: 0 0 4px;
+    font-size: 0.95rem;
+    color: var(--accent-color);
+}
+
+.map-popup p {
+    font-size: 0.8rem;
+    color: var(--text-color);
+    margin: 2px 0;
+    line-height: 1.4;
+}
+
+.map-legend {
+    flex: 0 0 260px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.legend-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+
+.legend-item:hover {
+    border-color: var(--accent-color);
+}
+
+.legend-color {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.legend-name {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: var(--heading-color);
+    flex: 1;
+}
+
+/* Accessibility Focus States */
+a:focus, button:focus, .timeline-content:focus {
+    outline: 2px dashed var(--accent-color);
+    outline-offset: 4px;
+}
+
+/* Responsive */
+@media (max-width: 1024px) {
+    .content-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    .hero-content h1 {
+        font-size: 2.5rem;
+    }
+
+    /* Reformat Timeline for Mobile */
+    .timeline-container::before {
+        left: 20px;
+    }
+
+    .timeline-item {
+        width: 100%;
+        padding-left: 50px !important;
+        padding-right: 0;
+        justify-content: flex-start;
+    }
+
+    .timeline-item::after, .timeline-item:nth-child(even)::after {
+        left: 12px;
+        right: auto;
+    }
+
+    .timeline-item:nth-child(even) {
+        align-self: flex-start;
+    }
+
+    .acheulean-map-wrapper {
+        flex-direction: column;
+        align-items: center;
+    }
+
+    .map-legend {
+        flex: 1 1 100%;
+        flex-direction: row;
+        flex-wrap: wrap;
+        width: 100%;
+    }
+}

--- a/frontend/didwana-stone-age-tools/index.html
+++ b/frontend/didwana-stone-age-tools/index.html
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            document.documentElement.setAttribute('data-theme', theme);
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Stone Age Tool Discoveries of Didwana | Prehistoric Rajasthan</title>
+    <link rel="stylesheet" href="../pages-common.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="didwana-page">
+    <header class="header">
+        <header class="navbar" id="navbar">
+    <div class="nav-container">
+        <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+            <span class="saffron">Incredible</span>
+            <span class="gold">India</span>
+            <span class="green">Explorer</span>
+        </a>
+        <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+            <span class="bar"></span>
+            <span class="bar"></span>
+            <span class="bar"></span>
+        </button>
+        <nav class="nav-menu" id="nav-menu">
+            <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+                    Safety ▾
+                </button>
+                <div class="dropdown-menu">
+                    <a
+                        href="../../frontend/emergency-assistance/emergency.html"
+                        class="dropdown-item"
+                    >
+                        🚨 Emergency Assistance
+                    </a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
+                    <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                    <a href="../../frontend/ancient-ports-explorer/index.html" class="dropdown-item">Ancient Ports of India</a>
+                    <a href="../../frontend/islands/islands.html" class="dropdown-item">Islands of India</a>
+                    <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    <a href="../../frontend/route-planner/route-planner.html" class="dropdown-item">Route Planner</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+                    <a href="../../frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
+                    <a href="../../frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
+                    <a href="../../frontend/event-discovery/index.html" class="dropdown-item">Festival & Event Discovery</a>
+                    <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
+                    <a href="../../frontend/national-symbols-gallery/national-symbols-gallery.html" class="dropdown-item">National Symbols</a>
+                    <a href="../../frontend/cuisine-discovery-hub/index.html" class="dropdown-item">UP Cuisine</a>
+                    <a href="../../frontend/handicrafts-showcase/index.html" class="dropdown-item">UP Handicrafts</a>
+                    <a href="../../frontend/national-days-calendar/index.html" class="dropdown-item">National Days</a>
+                    <a href="../../frontend/ganga-ghats-experience/index.html" class="dropdown-item">Ganga Ghats</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Nature ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/national-parks-explorer/index.html" class="dropdown-item">National Parks</a>
+                    <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                    <a href="../../frontend/wildlife-rescue/wildlife-rescue.html" class="dropdown-item">Wildlife Rescue</a>
+                    <a href="../../frontend/endemic-flora-fauna-explorer/index.html" class="dropdown-item">Endemic Flora & Fauna</a>
+                    <a href="../../frontend/harike-wetland/harike-wetland.html" class="dropdown-item">Harike Wetland</a>
+                    <a href="../../frontend/wular-lake/wular-lake.html" class="dropdown-item">Wular Lake</a>
+                    <a href="../../frontend/crowd-density/index.html" class="dropdown-item">Crowd Density Predictor</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Games ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/passport-quest/passport-quest.html" class="dropdown-item">Passport Quest</a>
+                    <a href="../../frontend/culinary-game/culinary-game.html" class="dropdown-item">Culinary Challenge</a>
+                    <a href="../../frontend/monsoon-game/monsoon-game.html" class="dropdown-item">Monsoon Game</a>
+                    <a href="../../frontend/river-game/river-game.html" class="dropdown-item">River Explorer</a>
+                    <a href="../../frontend/geo-guesser-india/index.html" class="dropdown-item">GeoGuesser</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Community ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/contributors/contributors.html" class="dropdown-item">Contributors</a>
+                    <a href="../../frontend/world-records-india/index.html" class="dropdown-item">World Records</a>
+                </div>
+            </div>
+
+            <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+        </nav>
+    </div>
+</header>
+    </header>
+
+    <main class="page-container" id="main-view">
+
+        <!-- Hero Section -->
+        <section class="hero-section" aria-labelledby="hero-heading">
+            <div class="hero-content">
+                <div class="unesco-badge">🪨 Prehistoric Archaeological Site</div>
+                <h1 id="hero-heading">Stone Age Tool Discoveries of Didwana</h1>
+                <p class="subtitle">Prehistoric Stone Tools from the Thar Desert Margin</p>
+                <p class="location">📍 Didwana, Nagaur District, Rajasthan, India</p>
+                <p class="hero-desc">Didwana, on the eastern margin of the Thar Desert near an ancient salt lake, is one of India's most important open-air Stone Age sites. Sand-dune sections here preserve stratified layers of Lower, Middle and Upper Palaeolithic tools, offering rare evidence of early human presence and adaptation in a desert environment.</p>
+            </div>
+        </section>
+
+        <!-- Content Grid -->
+        <div class="content-grid">
+
+            <!-- Archaeological Period -->
+            <section class="info-section">
+                <h2>Archaeological Period</h2>
+                <div class="info-card">
+                    <p>The Didwana dune sections contain a long, layered sequence spanning the <strong>Lower Palaeolithic</strong>, <strong>Middle Palaeolithic</strong>, and <strong>Upper Palaeolithic</strong> phases of the Stone Age.</p>
+                    <p>Because each period's tools lie in a distinct sand layer, Didwana is regarded as a rare "type site" for studying how stone tool technology changed over tens of thousands of years in a single desert-margin location.</p>
+                </div>
+            </section>
+
+            <!-- Discovery Context -->
+            <section class="info-section">
+                <h2>Discovery Context</h2>
+                <div class="info-card">
+                    <p>Tools were discovered eroding out of wind-blown sand-dune sections near the Didwana salt lake, first brought to wider attention through explorations and excavations from the 1970s onward.</p>
+                    <p>Researchers exposed vertical dune sections to record the tools layer by layer, allowing each tool type to be linked to a specific stratigraphic horizon rather than being found loose on the surface.</p>
+                </div>
+            </section>
+
+        </div>
+
+        <!-- Tool Types -->
+        <section class="discoveries-section" aria-labelledby="discoveries-heading">
+            <h2 id="discoveries-heading" class="section-title">Tool Types Discovered</h2>
+            <div class="discoveries-grid">
+                <div class="discovery-card">
+                    <h3>🪓 Hand Axes & Cleavers</h3>
+                    <p>Large bifacial hand axes and cleavers characteristic of the Lower Palaeolithic (Acheulian) tradition.</p>
+                </div>
+                <div class="discovery-card">
+                    <h3>🔪 Scrapers</h3>
+                    <p>Flake-based scrapers associated with the Middle Palaeolithic layers, used for processing hides and wood.</p>
+                </div>
+                <div class="discovery-card">
+                    <h3>🗡️ Points & Borers</h3>
+                    <p>Pointed flake tools and borers from the Middle Palaeolithic, likely used for piercing and hafting.</p>
+                </div>
+                <div class="discovery-card">
+                    <h3>🔻 Blades & Burins</h3>
+                    <p>Narrow blades and burins from the Upper Palaeolithic layers, marking a shift toward more refined flaking techniques.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Materials -->
+        <section class="facts-section" aria-labelledby="materials-heading">
+            <h2 id="materials-heading" class="section-title">Materials Used</h2>
+            <div class="facts-grid">
+                <div class="fact-card">
+                    <span class="fact-icon">🪨</span>
+                    <strong>Quartzite</strong>
+                    <p>The dominant raw material, chosen for its availability and toughness when knapped into tools.</p>
+                </div>
+                <div class="fact-card">
+                    <span class="fact-icon">🧱</span>
+                    <strong>Sandstone</strong>
+                    <p>Used alongside quartzite for larger, heavier tool forms such as hand axes.</p>
+                </div>
+                <div class="fact-card">
+                    <span class="fact-icon">⛏️</span>
+                    <strong>Chert & Chalcedony</strong>
+                    <p>Finer-grained stones favoured for smaller, more precise Upper Palaeolithic blade tools.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Scientific Significance -->
+        <section class="timeline-section" aria-labelledby="significance-heading">
+            <h2 id="significance-heading" class="section-title">Scientific Significance</h2>
+            <div class="content-grid" style="margin-bottom: 0;">
+                <section class="info-section">
+                    <div class="info-card">
+                        <p>Didwana's stacked dune layers let researchers apply <strong>thermoluminescence (TL) dating</strong> to the sand itself, giving age estimates for the tool layers rather than relying on the tools alone.</p>
+                    </div>
+                </section>
+                <section class="info-section">
+                    <div class="info-card">
+                        <p>The unbroken sequence from Lower to Upper Palaeolithic in one location makes Didwana valuable for tracing the gradual evolution of stone tool technology in South Asia.</p>
+                    </div>
+                </section>
+                <section class="info-section">
+                    <div class="info-card">
+                        <p>As a desert-margin site, Didwana also provides evidence of how prehistoric groups adapted to an arid, resource-scarce environment near an ancient saline lake.</p>
+                    </div>
+                </section>
+            </div>
+        </section>
+
+        <!-- Gallery Section -->
+        <section class="gallery-section" aria-labelledby="gallery-heading">
+            <h2 id="gallery-heading" class="section-title">Visual Gallery</h2>
+            <div class="gallery-grid" tabindex="0" aria-label="Image gallery of Didwana Stone Age tool discoveries">
+                <div class="gallery-item item-large">
+                    <div class="img-placeholder" style="background-color: #d6b98c;" role="img" aria-label="Wide view of the layered sand-dune section at Didwana where tools were found">Dune Section View</div>
+                </div>
+                <div class="gallery-item">
+                    <div class="img-placeholder" style="background-color: #a3785a;" role="img" aria-label="A Lower Palaeolithic quartzite hand axe from Didwana">Hand Axe</div>
+                </div>
+                <div class="gallery-item">
+                    <div class="img-placeholder" style="background-color: #c9a66b;" role="img" aria-label="Middle Palaeolithic flake scrapers and points">Scrapers & Points</div>
+                </div>
+                <div class="gallery-item">
+                    <div class="img-placeholder" style="background-color: #8d6e4a;" role="img" aria-label="Upper Palaeolithic blade and burin tools">Blades & Burins</div>
+                </div>
+                <div class="gallery-item item-wide">
+                    <div class="img-placeholder" style="background-color: #e0c9a6;" role="img" aria-label="The Didwana salt lake landscape near the archaeological site">Didwana Salt Lake</div>
+                </div>
+            </div>
+        </section>
+
+    </main>
+
+    <footer class="footer">
+        <div class="footer-content">
+            <p>&copy; 2026 Incredible India Explorer. Open Source Project.</p>
+        </div>
+    </footer>
+
+    <!-- Scripts -->
+    <script src="../app.js"></script>
+</body>
+</html>

--- a/frontend/didwana-stone-age-tools/style.css
+++ b/frontend/didwana-stone-age-tools/style.css
@@ -1,0 +1,293 @@
+/* Variables for Didwana Stone Age Page */
+:root {
+    --primary-color: #92400e; /* Earthy desert brown */
+    --accent-color: #d97706;
+    --hero-bg: #fefce8;
+    --card-bg: #ffffff;
+    --text-color: #334155;
+    --heading-color: #1e293b;
+    --border-color: #e2e8f0;
+    --timeline-line: #cbd5e1;
+}
+
+body:not(.light-theme) {
+    --primary-color: #fbbf24;
+    --accent-color: #f59e0b;
+    --hero-bg: #292524;
+    --card-bg: #1e293b;
+    --text-color: #cbd5e1;
+    --heading-color: #f8fafc;
+    --border-color: #334155;
+    --timeline-line: #475569;
+}
+
+.page-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+}
+
+.section-title {
+    color: var(--primary-color);
+    text-align: center;
+    margin-bottom: 2rem;
+    font-size: 2.2rem;
+    border-bottom: 2px solid var(--accent-color);
+    display: inline-block;
+    padding-bottom: 0.5rem;
+}
+
+/* Hero Section */
+.hero-section {
+    background-color: var(--hero-bg);
+    border: 2px solid var(--accent-color);
+    border-radius: 16px;
+    padding: 4rem 2rem;
+    text-align: center;
+    margin-bottom: 4rem;
+    position: relative;
+    overflow: hidden;
+}
+
+.unesco-badge {
+    display: inline-block;
+    background: var(--accent-color);
+    color: #fff;
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+body:not(.light-theme) .unesco-badge { color: #111; }
+
+.hero-content h1 {
+    font-size: 3.5rem;
+    color: var(--primary-color);
+    margin: 0 0 1rem;
+}
+
+.subtitle {
+    font-size: 1.4rem;
+    color: var(--heading-color);
+    margin-bottom: 1rem;
+    font-weight: 500;
+}
+
+.location {
+    font-size: 1.1rem;
+    color: var(--text-color);
+    font-style: italic;
+    margin-bottom: 1.5rem;
+}
+
+.hero-desc {
+    max-width: 800px;
+    margin: 0 auto;
+    font-size: 1.1rem;
+    color: var(--text-color);
+    line-height: 1.6;
+}
+
+/* Content Grid */
+.content-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    gap: 2.5rem;
+    margin-bottom: 4rem;
+}
+
+.info-section h2 {
+    color: var(--primary-color);
+    border-bottom: 2px solid var(--accent-color);
+    padding-bottom: 0.5rem;
+    margin-bottom: 1.5rem;
+    font-size: 1.6rem;
+}
+
+.info-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1.8rem;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+    height: 100%;
+    color: var(--text-color);
+    line-height: 1.7;
+    font-size: 1.05rem;
+}
+.info-card p {
+    margin-bottom: 1rem;
+}
+.info-card p:last-child {
+    margin-bottom: 0;
+}
+
+/* Discoveries Grid */
+.discoveries-section {
+    margin-bottom: 4rem;
+}
+
+.discoveries-section h2 {
+    text-align: center;
+}
+
+.discoveries-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+}
+
+.discovery-card {
+    background: var(--card-bg);
+    border-left: 4px solid var(--accent-color);
+    border-radius: 8px;
+    padding: 1.5rem;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+}
+
+.discovery-card h3 {
+    color: var(--heading-color);
+    margin-bottom: 0.5rem;
+    font-size: 1.2rem;
+}
+
+/* Scientific Significance (reuses timeline-section wrapper for spacing) */
+.timeline-section {
+    margin-bottom: 4rem;
+}
+
+.timeline-section h2 {
+    text-align: center;
+    color: var(--primary-color);
+    margin-bottom: 2rem;
+}
+
+/* Facts Grid */
+.facts-section {
+    margin-bottom: 4rem;
+}
+
+.facts-section h2 {
+    text-align: center;
+}
+
+.facts-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.5rem;
+}
+
+.fact-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1.5rem;
+    text-align: center;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+    transition: transform 0.3s;
+}
+
+.fact-card:hover {
+    transform: translateY(-5px);
+    border-color: var(--accent-color);
+}
+
+.fact-icon {
+    font-size: 2.5rem;
+    display: block;
+    margin-bottom: 1rem;
+}
+
+.fact-card strong {
+    display: block;
+    margin-bottom: 0.5rem;
+    color: var(--heading-color);
+}
+
+.fact-card p {
+    color: var(--text-color);
+    margin: 0;
+    line-height: 1.5;
+    font-size: 0.95rem;
+}
+
+/* Gallery - Masonry-like Grid */
+.gallery-section h2 {
+    text-align: center;
+}
+
+.gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    grid-auto-rows: 250px;
+    gap: 1.5rem;
+}
+
+.gallery-grid:focus {
+    outline: 2px solid var(--accent-color);
+    outline-offset: 4px;
+}
+
+.gallery-item {
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+    transition: transform 0.3s ease;
+}
+
+.gallery-item:hover, .gallery-item:focus-within {
+    transform: translateY(-5px);
+}
+
+.img-placeholder {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    color: #1f2937;
+    font-weight: 600;
+    font-size: 1.2rem;
+    text-align: center;
+    padding: 1rem;
+}
+
+@media (min-width: 768px) {
+    .item-large {
+        grid-column: span 2;
+        grid-row: span 2;
+    }
+    .item-wide {
+        grid-column: span 2;
+    }
+}
+
+/* Accessibility Focus States */
+a:focus, button:focus {
+    outline: 2px dashed var(--accent-color);
+    outline-offset: 4px;
+}
+
+/* Responsive */
+@media (max-width: 1024px) {
+    .content-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    .hero-content h1 {
+        font-size: 2.5rem;
+    }
+
+    .gallery-grid {
+        grid-auto-rows: 200px;
+    }
+    .item-large, .item-wide {
+        grid-column: span 1;
+        grid-row: span 1;
+    }
+}

--- a/frontend/paisra-prehistoric-site/index.html
+++ b/frontend/paisra-prehistoric-site/index.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function() {
+            const theme = localStorage.getItem('theme') || 'dark';
+            document.documentElement.setAttribute('data-theme', theme);
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Prehistoric Paisra Site | Palaeolithic Bihar</title>
+    <link rel="stylesheet" href="../pages-common.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="paisra-page">
+    <header class="header">
+        <header class="navbar" id="navbar">
+    <div class="nav-container">
+        <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+            <span class="saffron">Incredible</span>
+            <span class="gold">India</span>
+            <span class="green">Explorer</span>
+        </a>
+        <button class="menu-toggle" id="menu-toggle" aria-label="Toggle Menu">
+            <span class="bar"></span>
+            <span class="bar"></span>
+            <span class="bar"></span>
+        </button>
+        <nav class="nav-menu" id="nav-menu">
+            <a href="../../index.html#home" class="nav-link active" id="link-home">Home</a>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">
+                    Safety ▾
+                </button>
+                <div class="dropdown-menu">
+                    <a
+                        href="../../frontend/emergency-assistance/emergency.html"
+                        class="dropdown-item"
+                    >
+                        🚨 Emergency Assistance
+                    </a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Destinations ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../index.html#map" class="dropdown-item">Interactive Map</a>
+                    <a href="../../frontend/travel/travel.html" class="dropdown-item">Travel & Destinations</a>
+                    <a href="../../frontend/ancient-ports-explorer/index.html" class="dropdown-item">Ancient Ports of India</a>
+                    <a href="../../frontend/islands/islands.html" class="dropdown-item">Islands of India</a>
+                    <a href="../../frontend/heritage/heritage.html" class="dropdown-item">Heritage Sites</a>
+                    <a href="../../frontend/route-planner/route-planner.html" class="dropdown-item">Route Planner</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Culture ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/culture/culture.html" class="dropdown-item">Culture Overview</a>
+                    <a href="../../frontend/cuisine/cuisine.html" class="dropdown-item">Cuisine</a>
+                    <a href="../../frontend/festivals/festivals.html" class="dropdown-item">Festivals</a>
+                    <a href="../../frontend/event-discovery/index.html" class="dropdown-item">Festival & Event Discovery</a>
+                    <a href="../../frontend/historical-timeline/index.html" class="dropdown-item">Historical Timeline</a>
+                    <a href="../../frontend/national-symbols-gallery/national-symbols-gallery.html" class="dropdown-item">National Symbols</a>
+                    <a href="../../frontend/cuisine-discovery-hub/index.html" class="dropdown-item">UP Cuisine</a>
+                    <a href="../../frontend/handicrafts-showcase/index.html" class="dropdown-item">UP Handicrafts</a>
+                    <a href="../../frontend/national-days-calendar/index.html" class="dropdown-item">National Days</a>
+                    <a href="../../frontend/ganga-ghats-experience/index.html" class="dropdown-item">Ganga Ghats</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Nature ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/national-parks-explorer/index.html" class="dropdown-item">National Parks</a>
+                    <a href="../../frontend/wildlife/wildlife.html" class="dropdown-item">Nature & Wildlife</a>
+                    <a href="../../frontend/wildlife-rescue/wildlife-rescue.html" class="dropdown-item">Wildlife Rescue</a>
+                    <a href="../../frontend/endemic-flora-fauna-explorer/index.html" class="dropdown-item">Endemic Flora & Fauna</a>
+                    <a href="../../frontend/harike-wetland/harike-wetland.html" class="dropdown-item">Harike Wetland</a>
+                    <a href="../../frontend/wular-lake/wular-lake.html" class="dropdown-item">Wular Lake</a>
+                    <a href="../../frontend/crowd-density/index.html" class="dropdown-item">Crowd Density Predictor</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Games ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/passport-quest/passport-quest.html" class="dropdown-item">Passport Quest</a>
+                    <a href="../../frontend/culinary-game/culinary-game.html" class="dropdown-item">Culinary Challenge</a>
+                    <a href="../../frontend/monsoon-game/monsoon-game.html" class="dropdown-item">Monsoon Game</a>
+                    <a href="../../frontend/river-game/river-game.html" class="dropdown-item">River Explorer</a>
+                    <a href="../../frontend/geo-guesser-india/index.html" class="dropdown-item">GeoGuesser</a>
+                </div>
+            </div>
+
+            <div class="nav-dropdown">
+                <button class="nav-link dropdown-toggle" aria-haspopup="true" aria-expanded="false">Community ▾</button>
+                <div class="dropdown-menu">
+                    <a href="../../frontend/contributors/contributors.html" class="dropdown-item">Contributors</a>
+                    <a href="../../frontend/world-records-india/index.html" class="dropdown-item">World Records</a>
+                </div>
+            </div>
+
+            <button id="theme-toggle" class="btn-theme-toggle" aria-label="Toggle Dark/Light Mode">☀️</button>
+        </nav>
+    </div>
+</header>
+    </header>
+
+    <main class="page-container" id="main-view">
+
+        <!-- Hero Section -->
+        <section class="hero-section" aria-labelledby="hero-heading">
+            <div class="hero-content">
+                <div class="unesco-badge">🪨 Prehistoric Archaeological Site</div>
+                <h1 id="hero-heading">Prehistoric Paisra Site</h1>
+                <p class="subtitle">A Lower Palaeolithic Open-Air Settlement in the Kharagpur Hills</p>
+                <p class="location">📍 Paisra, Munger District, Bihar, India</p>
+                <p class="hero-desc">Paisra, set on the northern fringe of the Kharagpur hills in Bihar, is one of the few Lower Palaeolithic sites in India where the actual living surface of early hominins has been excavated, revealing tool-working areas alongside evidence interpreted as a possible hut arrangement.</p>
+            </div>
+        </section>
+
+        <!-- Content Grid -->
+        <div class="content-grid">
+
+            <!-- Location -->
+            <section class="info-section">
+                <h2>Location</h2>
+                <div class="info-card">
+                    <p>Paisra lies on the northern edge of the <strong>Kharagpur hills</strong> in Munger district, Bihar, along a small seasonal stream that once provided water and raw material to prehistoric groups.</p>
+                    <p>The site sits at the interface of the hill terrain and the surrounding plains, a setting typical of many Lower Palaeolithic open-air camps in the region.</p>
+                </div>
+            </section>
+
+            <!-- Regional Context -->
+            <section class="info-section">
+                <h2>Regional Context</h2>
+                <div class="info-card">
+                    <p>Paisra forms part of a wider cluster of Palaeolithic localities across the Kharagpur hills and the middle Ganga plain, linking Bihar into the broader story of Lower Palaeolithic occupation across peninsular and eastern India.</p>
+                    <p>Its stream-side setting and hill-margin location echo patterns seen at other Son and Belan valley sites, helping researchers compare hominin land-use across the wider Bihar–Jharkhand region.</p>
+                </div>
+            </section>
+
+        </div>
+
+        <!-- Archaeological Discoveries -->
+        <section class="discoveries-section" aria-labelledby="discoveries-heading">
+            <h2 id="discoveries-heading" class="section-title">Archaeological Discoveries</h2>
+            <div class="discoveries-grid">
+                <div class="discovery-card">
+                    <h3>🏕️ Living Surface</h3>
+                    <p>Excavations exposed an in-situ Lower Palaeolithic occupation surface, a rarity that lets researchers study tool-making activity where it actually happened.</p>
+                </div>
+                <div class="discovery-card">
+                    <h3>⭕ Possible Hut Feature</h3>
+                    <p>An arrangement of stones and post-hole-like features has been interpreted by excavators as a possible windbreak or hut base.</p>
+                </div>
+                <div class="discovery-card">
+                    <h3>🪨 Knapping Floors</h3>
+                    <p>Clusters of debitage and unfinished pieces mark spots where toolmakers sat and worked raw stone into finished tools.</p>
+                </div>
+                <div class="discovery-card">
+                    <h3>🧊 Raw Material Sources</h3>
+                    <p>Nearby stream gravels supplied the quartzite pebbles and cobbles used as the primary raw material for tool production.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Stone Tools -->
+        <section class="facts-section" aria-labelledby="tools-heading">
+            <h2 id="tools-heading" class="section-title">Stone Tools</h2>
+            <div class="facts-grid">
+                <div class="fact-card">
+                    <span class="fact-icon">🪓</span>
+                    <strong>Handaxes</strong>
+                    <p>Bifacially worked handaxes form the core of the Acheulian toolkit recovered at the site.</p>
+                </div>
+                <div class="fact-card">
+                    <span class="fact-icon">⚒️</span>
+                    <strong>Cleavers</strong>
+                    <p>Large flake-based cleavers, shaped for heavy-duty cutting and chopping tasks.</p>
+                </div>
+                <div class="fact-card">
+                    <span class="fact-icon">🔪</span>
+                    <strong>Scrapers & Cores</strong>
+                    <p>Flake scrapers and worked cores show the range of activities carried out at the settlement.</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Site Chronology -->
+        <section class="timeline-section" aria-labelledby="timeline-heading">
+            <h2 id="timeline-heading" class="section-title">Site Chronology</h2>
+            <div class="timeline-container">
+                <div class="timeline-item">
+                    <div class="timeline-year">Lower Palaeolithic</div>
+                    <div class="timeline-content">
+                        <strong>Initial Occupation</strong>
+                        <p>Early hominin groups settle near the stream at Paisra, drawn by water and quartzite raw material.</p>
+                    </div>
+                </div>
+                <div class="timeline-item">
+                    <div class="timeline-year">Occupation Phase</div>
+                    <div class="timeline-content">
+                        <strong>Tool Production & Habitation</strong>
+                        <p>Repeated visits form the knapping floors and the possible hut arrangement identified at the site.</p>
+                    </div>
+                </div>
+                <div class="timeline-item">
+                    <div class="timeline-year">1980s</div>
+                    <div class="timeline-content">
+                        <strong>Systematic Excavation</strong>
+                        <p>Archaeological excavations at Paisra expose the in-situ occupation surface and associated tool assemblages.</p>
+                    </div>
+                </div>
+                <div class="timeline-item">
+                    <div class="timeline-year">Present</div>
+                    <div class="timeline-content">
+                        <strong>Ongoing Research Value</strong>
+                        <p>Paisra remains a key reference site for understanding Lower Palaeolithic settlement behaviour in eastern India.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Map Section -->
+        <section class="map-section" aria-labelledby="map-heading">
+            <h2 id="map-heading" class="section-title">Location Map</h2>
+            <div class="paisra-map-wrapper">
+                <iframe
+                    title="Paisra Prehistoric Site Map"
+                    src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d117000.0!2d86.3500000!3d24.8300000!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x39f1c0000000001%3A0x0!2sMunger%2C%20Bihar!5e0!3m2!1sen!2sin!4v1700000000020!5m2!1sen!2sin"
+                    width="100%"
+                    height="450"
+                    allowfullscreen=""
+                    loading="lazy">
+                </iframe>
+            </div>
+        </section>
+
+    </main>
+
+    <footer class="footer">
+        <div class="footer-content">
+            <p>&copy; 2026 Incredible India Explorer. Open Source Project.</p>
+        </div>
+    </footer>
+
+    <!-- Scripts -->
+    <script src="../app.js"></script>
+</body>
+</html>

--- a/frontend/paisra-prehistoric-site/style.css
+++ b/frontend/paisra-prehistoric-site/style.css
@@ -1,0 +1,365 @@
+/* Variables for Paisra Prehistoric Site Page */
+:root {
+    --primary-color: #78350f; /* Earthy hill-brown */
+    --accent-color: #b45309;
+    --hero-bg: #fef3c7;
+    --card-bg: #ffffff;
+    --text-color: #334155;
+    --heading-color: #1e293b;
+    --border-color: #e2e8f0;
+    --timeline-line: #cbd5e1;
+}
+
+body:not(.light-theme) {
+    --primary-color: #fbbf24;
+    --accent-color: #d97706;
+    --hero-bg: #27190a;
+    --card-bg: #1e293b;
+    --text-color: #cbd5e1;
+    --heading-color: #f8fafc;
+    --border-color: #334155;
+    --timeline-line: #475569;
+}
+
+.page-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+}
+
+.section-title {
+    color: var(--primary-color);
+    text-align: center;
+    margin-bottom: 2rem;
+    font-size: 2.2rem;
+    border-bottom: 2px solid var(--accent-color);
+    display: inline-block;
+    padding-bottom: 0.5rem;
+}
+
+/* Hero Section */
+.hero-section {
+    background-color: var(--hero-bg);
+    border: 2px solid var(--accent-color);
+    border-radius: 16px;
+    padding: 4rem 2rem;
+    text-align: center;
+    margin-bottom: 4rem;
+    position: relative;
+    overflow: hidden;
+}
+
+.unesco-badge {
+    display: inline-block;
+    background: var(--accent-color);
+    color: #fff;
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin-bottom: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+body:not(.light-theme) .unesco-badge { color: #111; }
+
+.hero-content h1 {
+    font-size: 3.5rem;
+    color: var(--primary-color);
+    margin: 0 0 1rem;
+}
+
+.subtitle {
+    font-size: 1.4rem;
+    color: var(--heading-color);
+    margin-bottom: 1rem;
+    font-weight: 500;
+}
+
+.location {
+    font-size: 1.1rem;
+    color: var(--text-color);
+    font-style: italic;
+    margin-bottom: 1.5rem;
+}
+
+.hero-desc {
+    max-width: 800px;
+    margin: 0 auto;
+    font-size: 1.1rem;
+    color: var(--text-color);
+    line-height: 1.6;
+}
+
+/* Content Grid */
+.content-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    gap: 2.5rem;
+    margin-bottom: 4rem;
+}
+
+.info-section h2 {
+    color: var(--primary-color);
+    border-bottom: 2px solid var(--accent-color);
+    padding-bottom: 0.5rem;
+    margin-bottom: 1.5rem;
+    font-size: 1.6rem;
+}
+
+.info-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1.8rem;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+    height: 100%;
+    color: var(--text-color);
+    line-height: 1.7;
+    font-size: 1.05rem;
+}
+.info-card p {
+    margin-bottom: 1rem;
+}
+.info-card p:last-child {
+    margin-bottom: 0;
+}
+
+/* Discoveries Grid */
+.discoveries-section {
+    margin-bottom: 4rem;
+}
+
+.discoveries-section h2 {
+    text-align: center;
+}
+
+.discoveries-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.5rem;
+}
+
+.discovery-card {
+    background: var(--card-bg);
+    border-left: 4px solid var(--accent-color);
+    border-radius: 8px;
+    padding: 1.5rem;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+}
+
+.discovery-card h3 {
+    color: var(--heading-color);
+    margin-bottom: 0.5rem;
+    font-size: 1.2rem;
+}
+
+/* Facts Grid (Stone Tools) */
+.facts-section {
+    margin-bottom: 4rem;
+}
+
+.facts-section h2 {
+    text-align: center;
+}
+
+.facts-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.5rem;
+}
+
+.fact-card {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    padding: 1.5rem;
+    text-align: center;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+    transition: transform 0.3s;
+}
+
+.fact-card:hover {
+    transform: translateY(-5px);
+    border-color: var(--accent-color);
+}
+
+.fact-icon {
+    font-size: 2.5rem;
+    display: block;
+    margin-bottom: 1rem;
+}
+
+.fact-card strong {
+    display: block;
+    margin-bottom: 0.5rem;
+    color: var(--heading-color);
+}
+
+.fact-card p {
+    color: var(--text-color);
+    margin: 0;
+    line-height: 1.5;
+    font-size: 0.95rem;
+}
+
+/* Timeline Section (Site Chronology) */
+.timeline-section {
+    margin-bottom: 4rem;
+}
+
+.timeline-section h2 {
+    text-align: center;
+    color: var(--primary-color);
+    margin-bottom: 2rem;
+}
+
+.timeline-container {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    padding: 2rem 0;
+}
+
+.timeline-container::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 4px;
+    background-color: var(--timeline-line);
+    border-radius: 2px;
+}
+
+.timeline-item {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    width: 50%;
+    padding-right: 2rem;
+    margin-bottom: 2rem;
+    position: relative;
+}
+
+.timeline-item:nth-child(even) {
+    align-self: flex-end;
+    justify-content: flex-start;
+    padding-right: 0;
+    padding-left: 2rem;
+}
+
+.timeline-item::after {
+    content: "";
+    position: absolute;
+    right: -8px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 16px;
+    height: 16px;
+    background-color: var(--accent-color);
+    border: 4px solid var(--card-bg);
+    border-radius: 50%;
+    z-index: 1;
+}
+
+.timeline-item:nth-child(even)::after {
+    right: auto;
+    left: -8px;
+}
+
+.timeline-year {
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--primary-color);
+    margin-bottom: 0.5rem;
+}
+
+.timeline-content {
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    padding: 1.5rem;
+    border-radius: 12px;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+    width: 100%;
+}
+
+.timeline-content strong {
+    display: block;
+    font-size: 1.2rem;
+    color: var(--heading-color);
+    margin-bottom: 0.5rem;
+}
+
+.timeline-content p {
+    color: var(--text-color);
+    margin: 0;
+    line-height: 1.5;
+}
+
+/* Map Section */
+.map-section {
+    margin-bottom: 4rem;
+}
+
+.map-section h2 {
+    text-align: center;
+}
+
+.paisra-map-wrapper {
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+    border: 1px solid var(--border-color);
+    line-height: 0;
+}
+
+.paisra-map-wrapper iframe {
+    border: 0;
+    display: block;
+}
+
+/* Accessibility Focus States */
+a:focus, button:focus, .timeline-content:focus {
+    outline: 2px dashed var(--accent-color);
+    outline-offset: 4px;
+}
+
+/* Responsive */
+@media (max-width: 1024px) {
+    .content-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    .hero-content h1 {
+        font-size: 2.5rem;
+    }
+
+    /* Reformat Timeline for Mobile */
+    .timeline-container::before {
+        left: 20px;
+    }
+
+    .timeline-item {
+        width: 100%;
+        padding-left: 50px !important;
+        padding-right: 0;
+        justify-content: flex-start;
+    }
+
+    .timeline-item::after, .timeline-item:nth-child(even)::after {
+        left: 12px;
+        right: auto;
+    }
+
+    .timeline-item:nth-child(even) {
+        align-self: flex-start;
+    }
+
+    .paisra-map-wrapper iframe {
+        height: 300px;
+    }
+}

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -6514,5 +6514,13 @@ window.indiaSearchIndex = [
         description:
             "Explore the prehistoric Paisra site in Munger district, Bihar: its Kharagpur hills location, in-situ Lower Palaeolithic living surface and possible hut feature, handaxe and cleaver stone tools, site chronology, and regional context within eastern Indian Palaeolithic settlement.",
         url: "frontend/paisra-prehistoric-site/index.html"
+    },
+    // --- Acheulean Stone Technology in India (#3791) ---
+    {
+        title: "Acheulean Stone Technology in India \u2014 Prehistoric Overview",
+        category: "Archaeological Excavations",
+        description:
+            "Explore Acheulean stone tool technology across prehistoric India: handaxes, cleavers, major archaeological sites such as Attirampakkam, Hunsgi-Isampur, Bhimbetka, Chirki-Nevasa, Didwana and Paisra, a technology timeline, and an interactive map of key sites.",
+        url: "frontend/acheulean-stone-technology/index.html"
     }
 ];

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -6506,5 +6506,13 @@ window.indiaSearchIndex = [
         description:
             "Explore the Stone Age tool discoveries of Didwana, Rajasthan: Lower, Middle and Upper Palaeolithic tool types, quartzite and sandstone raw materials, dune-section discovery context, and their scientific significance for dating early human occupation in the Thar Desert.",
         url: "frontend/didwana-stone-age-tools/index.html"
+    },
+    // --- Prehistoric Paisra Site (#3789) ---
+    {
+        title: "Prehistoric Paisra Site \u2014 Palaeolithic Bihar",
+        category: "Archaeological Excavations",
+        description:
+            "Explore the prehistoric Paisra site in Munger district, Bihar: its Kharagpur hills location, in-situ Lower Palaeolithic living surface and possible hut feature, handaxe and cleaver stone tools, site chronology, and regional context within eastern Indian Palaeolithic settlement.",
+        url: "frontend/paisra-prehistoric-site/index.html"
     }
 ];

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -6498,5 +6498,13 @@ window.indiaSearchIndex = [
         description:
             "Explore the 2013 Uttarakhand flood disaster: extreme monsoon rainfall, Chorabari Tal glacial lake breach, Kedarnath devastation, Mandakini and Alaknanda valley impacts, Operation Surya Hope rescue, and disaster preparedness lessons.",
         url: "frontend/uttarakhand-floods-2013/index.html"
+    },
+    // --- Stone Age Tool Discoveries of Didwana (#3790) ---
+    {
+        title: "Stone Age Tool Discoveries of Didwana \u2014 Prehistoric Rajasthan",
+        category: "Archaeological Excavations",
+        description:
+            "Explore the Stone Age tool discoveries of Didwana, Rajasthan: Lower, Middle and Upper Palaeolithic tool types, quartzite and sandstone raw materials, dune-section discovery context, and their scientific significance for dating early human occupation in the Thar Desert.",
+        url: "frontend/didwana-stone-age-tools/index.html"
     }
 ];


### PR DESCRIPTION
## Description
Adds a new educational overview page on Acheulean stone tool technology
and its distribution across prehistoric India, as requested in issue #3791.

## Changes
- Added new page: frontend/acheulean-stone-technology/index.html
- Added new stylesheet: frontend/acheulean-stone-technology/style.css
- Added new script: frontend/acheulean-stone-technology/script.js
  (renders the interactive site map and marker popups)
- Registered the new page in frontend/search-index.js so it appears in
  site search under the "Archaeological Excavations" category

## Content covered
- Acheulean technology (overview of the bifacial tool tradition)
- Handaxes (form and stylistic development)
- Cleavers (form, function, regional variation)
- Major archaeological sites (Attirampakkam, Hunsgi-Isampur, Bhimbetka
  area, Chirki-Nevasa, Didwana, Paisra)
- Timeline (Early to Late Acheulean through to modern scientific dating)
- Interactive map (clickable India-outline map with popups summarising
  each major site, plus a linked legend)

## Testing
- Opened index.html locally in a browser to confirm layout, dark/light
  theme variables, navbar, and interactive map markers/popups work
  correctly on click
- Verified new entry appears in search-index.js array without breaking
  existing entries

Fixes #3791

@Eshajha19 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.