### PR TITLE
feat: add LIC insurance brand story explorer #2640

### DIFF
--- a/frontend/lic-explorer/lic-explorer.css
+++ b/frontend/lic-explorer/lic-explorer.css
@@ -1,0 +1,692 @@
+:root {
+    --lic-green: #123c25;
+    --lic-green-2: #1c6038;
+    --lic-saffron: #e68a2e;
+    --lic-gold: #c8a951;
+    --lic-cream: #fbf7ed;
+    --lic-paper: #fffdf8;
+    --lic-ink: #17211b;
+    --lic-muted: #637068;
+    --lic-border: #ded8c8;
+    --lic-shadow: 0 16px 40px rgba(18, 60, 37, 0.1);
+    --lic-radius: 18px;
+    --lic-focus: #e68a2e;
+}
+
+html[data-theme='dark'] {
+    --lic-green: #8fcda4;
+    --lic-green-2: #5cae79;
+    --lic-saffron: #f1a34e;
+    --lic-gold: #e0c76e;
+    --lic-cream: #101712;
+    --lic-paper: #17221a;
+    --lic-ink: #eef6ef;
+    --lic-muted: #aab9ae;
+    --lic-border: #304237;
+    --lic-shadow: 0 16px 40px rgba(0, 0, 0, 0.25);
+}
+
+* {
+    box-sizing: border-box;
+}
+html {
+    scroll-behavior: smooth;
+}
+body {
+    margin: 0;
+    color: var(--lic-ink);
+    background: radial-gradient(circle at 10% 10%, rgba(200, 169, 81, 0.1), transparent 24rem), var(--lic-cream);
+    font-family:
+        Inter,
+        ui-sans-serif,
+        system-ui,
+        -apple-system,
+        BlinkMacSystemFont,
+        'Segoe UI',
+        sans-serif;
+    line-height: 1.65;
+}
+button,
+input {
+    font: inherit;
+}
+button,
+a {
+    -webkit-tap-highlight-color: transparent;
+}
+a {
+    color: var(--lic-green-2);
+}
+button:focus-visible,
+input:focus-visible,
+a:focus-visible,
+summary:focus-visible {
+    outline: 3px solid var(--lic-focus);
+    outline-offset: 3px;
+}
+
+.lic-skip-link {
+    position: fixed;
+    left: 1rem;
+    top: -5rem;
+    z-index: 100;
+    padding: 0.7rem 1rem;
+    background: var(--lic-paper);
+    border-radius: 10px;
+    box-shadow: var(--lic-shadow);
+}
+.lic-skip-link:focus {
+    top: 1rem;
+}
+
+.lic-hero {
+    position: relative;
+    overflow: hidden;
+    color: #fff;
+    background:
+        radial-gradient(circle at 15% 20%, rgba(230, 138, 46, 0.35), transparent 20rem),
+        linear-gradient(135deg, #0b2416, #1c6038 65%, #0b2416);
+    border-bottom: 6px solid var(--lic-saffron);
+}
+.lic-hero::after {
+    content: '';
+    position: absolute;
+    inset: auto -10% -45% auto;
+    width: 34rem;
+    height: 34rem;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 50%;
+    box-shadow:
+        0 0 0 5rem rgba(255, 255, 255, 0.025),
+        0 0 0 10rem rgba(255, 255, 255, 0.02);
+}
+.lic-hero-inner {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+    gap: 2rem;
+    width: min(1160px, calc(100% - 2rem));
+    margin: auto;
+    padding: 4.5rem 0 4rem;
+}
+.lic-emblem {
+    display: grid;
+    place-items: center;
+    width: 9rem;
+    height: 9rem;
+    border: 3px solid rgba(255, 255, 255, 0.75);
+    border-radius: 50%;
+    color: #fff;
+    font-size: 2rem;
+    font-weight: 900;
+    letter-spacing: 0.15em;
+    box-shadow: inset 0 0 0 9px rgba(255, 255, 255, 0.07);
+}
+.lic-eyebrow,
+.lic-kicker {
+    margin: 0 0 0.5rem;
+    color: var(--lic-saffron);
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+.lic-hero h1 {
+    max-width: 900px;
+    margin: 0;
+    font-size: clamp(2.25rem, 6vw, 4.7rem);
+    line-height: 1.03;
+    letter-spacing: -0.04em;
+}
+.lic-hero-copy {
+    max-width: 800px;
+    margin: 1.2rem 0 0;
+    color: rgba(255, 255, 255, 0.88);
+    font-size: clamp(1rem, 2vw, 1.18rem);
+}
+.lic-hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.7rem;
+    margin-top: 1.6rem;
+}
+.lic-primary-action,
+.lic-secondary-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
+    padding: 0.65rem 1rem;
+    border-radius: 999px;
+    font-weight: 800;
+    text-decoration: none;
+    cursor: pointer;
+}
+.lic-primary-action {
+    background: var(--lic-saffron);
+    color: #17211b;
+}
+.lic-secondary-action {
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    background: transparent;
+    color: #fff;
+}
+
+.lic-shell {
+    width: min(1160px, calc(100% - 2rem));
+    margin: auto;
+    padding: 2rem 0 4rem;
+}
+.lic-stat-strip {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1rem;
+    margin-top: -3.1rem;
+    position: relative;
+    z-index: 2;
+}
+.lic-stat-strip article {
+    min-height: 112px;
+    padding: 1rem;
+    border: 1px solid var(--lic-border);
+    border-radius: var(--lic-radius);
+    background: var(--lic-paper);
+    box-shadow: var(--lic-shadow);
+    text-align: center;
+}
+.lic-stat-strip strong {
+    display: block;
+    color: var(--lic-green-2);
+    font-size: 1.7rem;
+}
+.lic-stat-strip span {
+    display: block;
+    color: var(--lic-muted);
+    font-size: 0.83rem;
+}
+
+.lic-section-nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+    justify-content: center;
+    margin: 2rem 0;
+}
+.lic-nav-btn,
+.lic-filter {
+    border: 1px solid var(--lic-border);
+    border-radius: 999px;
+    background: var(--lic-paper);
+    color: var(--lic-ink);
+    cursor: pointer;
+    transition:
+        transform 160ms ease,
+        background 160ms ease,
+        border-color 160ms ease;
+}
+.lic-nav-btn {
+    padding: 0.65rem 1rem;
+    font-weight: 800;
+}
+.lic-nav-btn:hover,
+.lic-filter:hover {
+    transform: translateY(-1px);
+    border-color: var(--lic-saffron);
+}
+.lic-nav-btn.is-active {
+    background: var(--lic-green);
+    border-color: var(--lic-green);
+    color: #fff;
+}
+html[data-theme='dark'] .lic-nav-btn.is-active {
+    color: #08100b;
+}
+
+.lic-view-panel {
+    animation: lic-fade 220ms ease both;
+}
+@keyframes lic-fade {
+    from {
+        opacity: 0;
+        transform: translateY(5px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+.lic-section-heading {
+    display: grid;
+    grid-template-columns: minmax(0, 1.25fr) minmax(300px, 0.75fr);
+    gap: 2rem;
+    align-items: end;
+    margin-bottom: 1.4rem;
+}
+.lic-section-heading.compact {
+    display: block;
+    max-width: 850px;
+}
+.lic-section-heading h2 {
+    margin: 0;
+    font-size: clamp(1.8rem, 4vw, 2.6rem);
+    line-height: 1.15;
+}
+.lic-section-heading p:not(.lic-kicker) {
+    margin: 0.65rem 0 0;
+    color: var(--lic-muted);
+}
+.lic-search-wrap label {
+    display: block;
+    margin-bottom: 0.35rem;
+    font-size: 0.8rem;
+    font-weight: 800;
+}
+.lic-search-row {
+    display: flex;
+    gap: 0.45rem;
+}
+.lic-search-row input {
+    width: 100%;
+    min-width: 0;
+    padding: 0.75rem 0.85rem;
+    border: 1px solid var(--lic-border);
+    border-radius: 12px;
+    color: var(--lic-ink);
+    background: var(--lic-paper);
+}
+.lic-search-row button {
+    padding: 0.7rem 0.85rem;
+    border: 1px solid var(--lic-border);
+    border-radius: 12px;
+    background: var(--lic-paper);
+    color: var(--lic-ink);
+    cursor: pointer;
+}
+.lic-filter-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    margin-bottom: 2rem;
+}
+.lic-filter {
+    padding: 0.42rem 0.75rem;
+    font-size: 0.78rem;
+}
+.lic-filter.is-active {
+    background: var(--lic-saffron);
+    border-color: var(--lic-saffron);
+    color: #17211b;
+    font-weight: 800;
+}
+
+.lic-timeline {
+    position: relative;
+    padding: 0 0 1rem 5.6rem;
+}
+.lic-timeline::before {
+    content: '';
+    position: absolute;
+    left: 3.1rem;
+    top: 0.8rem;
+    bottom: 0;
+    width: 3px;
+    background: linear-gradient(var(--lic-saffron), var(--lic-gold), var(--lic-green-2));
+    border-radius: 999px;
+}
+.lic-milestone {
+    position: relative;
+    margin-bottom: 1.4rem;
+    scroll-margin-top: 2rem;
+}
+.lic-milestone-marker {
+    position: absolute;
+    left: -4.95rem;
+    top: 1.15rem;
+    display: grid;
+    place-items: center;
+    width: 3.7rem;
+    height: 3.7rem;
+    border: 3px solid var(--lic-paper);
+    border-radius: 50%;
+    background: var(--lic-green);
+    box-shadow:
+        0 0 0 2px var(--lic-green-2),
+        var(--lic-shadow);
+    font-size: 1.3rem;
+}
+html[data-theme='dark'] .lic-milestone-marker {
+    color: #08100b;
+}
+.lic-milestone-year {
+    display: inline-flex;
+    margin-bottom: 0.4rem;
+    padding: 0.18rem 0.65rem;
+    border-radius: 999px;
+    background: var(--lic-green);
+    color: #fff;
+    font-size: 0.76rem;
+    font-weight: 900;
+}
+html[data-theme='dark'] .lic-milestone-year {
+    color: #08100b;
+}
+.lic-milestone-card {
+    border: 1px solid var(--lic-border);
+    border-radius: var(--lic-radius);
+    background: var(--lic-paper);
+    box-shadow: var(--lic-shadow);
+    padding: 1.1rem 1.2rem;
+}
+.lic-milestone.is-selected .lic-milestone-card {
+    border-color: var(--lic-saffron);
+    box-shadow: 0 0 0 3px rgba(230, 138, 46, 0.12);
+}
+.lic-card-topline {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: center;
+}
+.lic-category-badge,
+.lic-card-index,
+.lic-brand-era,
+.lic-ad-period {
+    display: inline-flex;
+    width: fit-content;
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    background: rgba(230, 138, 46, 0.13);
+    color: var(--lic-green-2);
+    font-size: 0.7rem;
+    font-weight: 900;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+.lic-card-index {
+    background: rgba(18, 60, 37, 0.08);
+    color: var(--lic-muted);
+}
+.lic-milestone-card h3 {
+    margin: 0.5rem 0 0.3rem;
+    font-size: 1.2rem;
+}
+.lic-summary {
+    margin: 0;
+    color: var(--lic-ink);
+}
+.lic-milestone-card details {
+    margin-top: 0.7rem;
+    padding-top: 0.7rem;
+    border-top: 1px dashed var(--lic-border);
+}
+.lic-milestone-card summary {
+    cursor: pointer;
+    color: var(--lic-green-2);
+    font-weight: 800;
+}
+.lic-milestone-card details p {
+    color: var(--lic-muted);
+    margin-bottom: 0;
+}
+.lic-card-footer {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    margin-top: 0.8rem;
+    padding-top: 0.7rem;
+    border-top: 1px solid var(--lic-border);
+}
+.lic-source-link,
+.lic-source-text {
+    font-size: 0.76rem;
+}
+.lic-source-link {
+    font-weight: 800;
+}
+.lic-share-btn {
+    border: 0;
+    background: transparent;
+    color: var(--lic-green-2);
+    cursor: pointer;
+    font-weight: 800;
+}
+
+.lic-card-grid,
+.lic-brand-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1rem;
+}
+.lic-service-card,
+.lic-brand-card,
+.lic-method-card,
+.lic-source-cards article {
+    border: 1px solid var(--lic-border);
+    border-radius: var(--lic-radius);
+    background: var(--lic-paper);
+    box-shadow: var(--lic-shadow);
+    padding: 1.15rem;
+}
+.lic-service-icon {
+    font-size: 2rem;
+}
+.lic-service-card h3,
+.lic-brand-card h3,
+.lic-method-card h3,
+.lic-source-cards h3 {
+    margin: 0.4rem 0;
+}
+.lic-service-card p,
+.lic-brand-card p,
+.lic-method-card li,
+.lic-source-cards p {
+    color: var(--lic-muted);
+}
+.lic-service-card ul {
+    padding-left: 1.15rem;
+    color: var(--lic-muted);
+}
+.lic-service-card a {
+    font-size: 0.78rem;
+    font-weight: 800;
+}
+.lic-brand-card {
+    border-top: 4px solid var(--lic-gold);
+}
+
+.lic-ad-list {
+    display: grid;
+    gap: 1rem;
+}
+.lic-ad-card {
+    display: grid;
+    grid-template-columns: 4rem minmax(0, 1fr);
+    gap: 1rem;
+    border: 1px solid var(--lic-border);
+    border-radius: var(--lic-radius);
+    background: var(--lic-paper);
+    box-shadow: var(--lic-shadow);
+    padding: 1.1rem;
+}
+.lic-ad-number {
+    display: grid;
+    place-items: start center;
+    color: var(--lic-saffron);
+    font-size: 1.5rem;
+    font-weight: 900;
+}
+.lic-ad-card h3 {
+    margin: 0.4rem 0;
+}
+.lic-ad-card p {
+    margin: 0.45rem 0;
+    color: var(--lic-muted);
+}
+.lic-ad-significance {
+    padding: 0.7rem;
+    border-left: 3px solid var(--lic-gold);
+    background: rgba(200, 169, 81, 0.08);
+}
+.lic-ad-card .lic-source-link {
+    display: inline-block;
+    margin-top: 0.4rem;
+}
+
+.lic-source-grid {
+    display: grid;
+    grid-template-columns: 0.75fr 1.25fr;
+    gap: 1rem;
+}
+.lic-source-cards {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+}
+.lic-source-cards a {
+    font-weight: 800;
+    font-size: 0.82rem;
+    word-break: break-word;
+}
+.lic-method-card ol {
+    padding-left: 1.2rem;
+}
+
+.lic-empty {
+    padding: 4rem 1rem;
+    border: 1px dashed var(--lic-border);
+    border-radius: var(--lic-radius);
+    text-align: center;
+}
+.lic-empty-icon {
+    font-size: 2rem;
+}
+.lic-empty h3 {
+    margin-bottom: 0.25rem;
+}
+.lic-empty p {
+    margin-top: 0;
+    color: var(--lic-muted);
+}
+.lic-toast {
+    position: fixed;
+    left: 50%;
+    bottom: 1.5rem;
+    z-index: 50;
+    max-width: calc(100% - 2rem);
+    padding: 0.7rem 1rem;
+    border-radius: 999px;
+    background: var(--lic-green);
+    color: #fff;
+    box-shadow: var(--lic-shadow);
+    transform: translate(-50%, 150%);
+    transition: transform 180ms ease;
+}
+html[data-theme='dark'] .lic-toast {
+    color: #08100b;
+}
+.lic-toast.is-visible {
+    transform: translate(-50%, 0);
+}
+.lic-footer {
+    padding: 2rem 1rem 3rem;
+    border-top: 1px solid var(--lic-border);
+    color: var(--lic-muted);
+    text-align: center;
+    font-size: 0.78rem;
+}
+.lic-footer p {
+    margin: 0.25rem;
+}
+
+@media (max-width: 900px) {
+    .lic-hero-inner {
+        grid-template-columns: 1fr;
+        padding: 3.5rem 0;
+    }
+    .lic-emblem {
+        width: 6rem;
+        height: 6rem;
+        font-size: 1.5rem;
+    }
+    .lic-stat-strip {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        margin-top: -2rem;
+    }
+    .lic-section-heading,
+    .lic-source-grid {
+        grid-template-columns: 1fr;
+    }
+    .lic-card-grid,
+    .lic-brand-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+}
+
+@media (max-width: 640px) {
+    .lic-shell,
+    .lic-hero-inner {
+        width: min(100% - 1rem, 1160px);
+    }
+    .lic-stat-strip {
+        grid-template-columns: 1fr 1fr;
+        gap: 0.55rem;
+    }
+    .lic-stat-strip article {
+        min-height: 92px;
+        padding: 0.7rem;
+    }
+    .lic-stat-strip strong {
+        font-size: 1.25rem;
+    }
+    .lic-stat-strip span {
+        font-size: 0.7rem;
+    }
+    .lic-section-nav {
+        justify-content: flex-start;
+        overflow-x: auto;
+        flex-wrap: nowrap;
+        padding-bottom: 0.25rem;
+    }
+    .lic-nav-btn {
+        white-space: nowrap;
+    }
+    .lic-timeline {
+        padding-left: 3.4rem;
+    }
+    .lic-timeline::before {
+        left: 1.55rem;
+    }
+    .lic-milestone-marker {
+        left: -2.85rem;
+        width: 2.55rem;
+        height: 2.55rem;
+        font-size: 1rem;
+    }
+    .lic-card-footer {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+    .lic-card-grid,
+    .lic-brand-grid,
+    .lic-source-cards {
+        grid-template-columns: 1fr;
+    }
+    .lic-ad-card {
+        grid-template-columns: 2.5rem minmax(0, 1fr);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.001ms !important;
+        transition-duration: 0.001ms !important;
+    }
+}

--- a/frontend/lic-explorer/lic-explorer.html
+++ b/frontend/lic-explorer/lic-explorer.html
@@ -1,0 +1,212 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta
+            name="description"
+            content="LIC: Explore India's Insurance Brand Story — an interactive history, milestone timeline, services catalogue, brand identity archive and advertising evolution."
+        />
+        <meta name="theme-color" content="#132a13" />
+        <title>LIC: India's Insurance Brand Story | Incredible India Explorer</title>
+        <link rel="stylesheet" href="lic-explorer.css" />
+    </head>
+    <body>
+        <a class="lic-skip-link" href="#main-content">Skip to content</a>
+
+        <header class="lic-hero">
+            <div class="lic-hero-inner">
+                <div class="lic-emblem" aria-hidden="true">LIC</div>
+                <div>
+                    <p class="lic-eyebrow">Incredible India Explorer · Brand Stories</p>
+                    <h1>Life Insurance Corporation of India</h1>
+                    <p class="lic-hero-copy">
+                        From nationalisation in 1956 to a digitally connected public financial institution, explore the
+                        history, services, identity and milestones behind one of India's best-known insurance brands.
+                    </p>
+                    <div class="lic-hero-actions">
+                        <a class="lic-primary-action" href="#lic-view-timeline">Explore the timeline ↓</a>
+                        <button
+                            id="lic-theme-toggle"
+                            class="lic-secondary-action"
+                            type="button"
+                            aria-label="Switch to dark theme"
+                        >
+                            ◐ Theme
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </header>
+
+        <main id="main-content" class="lic-shell">
+            <section class="lic-stat-strip" aria-label="LIC story at a glance">
+                <article><strong id="lic-stat-milestones">0</strong><span>curated milestones</span></article>
+                <article><strong id="lic-stat-range">—</strong><span>historical range</span></article>
+                <article><strong id="lic-stat-types">0</strong><span>story categories</span></article>
+                <article><strong id="lic-stat-digital">0</strong><span>digital milestones</span></article>
+            </section>
+
+            <nav class="lic-section-nav" aria-label="LIC explorer sections">
+                <button
+                    class="lic-nav-btn is-active"
+                    type="button"
+                    data-section="lic-view-timeline"
+                    aria-current="page"
+                >
+                    📜 Timeline
+                </button>
+                <button class="lic-nav-btn" type="button" data-section="lic-view-services" aria-current="false">
+                    🛡️ Services
+                </button>
+                <button class="lic-nav-btn" type="button" data-section="lic-view-brand" aria-current="false">
+                    ✨ Brand identity
+                </button>
+                <button class="lic-nav-btn" type="button" data-section="lic-view-advertising" aria-current="false">
+                    📺 Advertising
+                </button>
+                <button class="lic-nav-btn" type="button" data-section="lic-view-sources" aria-current="false">
+                    🔎 Sources
+                </button>
+            </nav>
+
+            <section id="lic-view-timeline" class="lic-view-panel">
+                <div class="lic-section-heading">
+                    <div>
+                        <p class="lic-kicker">The journey</p>
+                        <h2>LIC through the decades</h2>
+                        <p>
+                            Filter the chronology by theme or search for a milestone. Every card includes a source so
+                            the story remains traceable.
+                        </p>
+                    </div>
+                    <div class="lic-search-wrap">
+                        <label for="lic-search">Search the timeline</label>
+                        <div class="lic-search-row">
+                            <input
+                                id="lic-search"
+                                type="search"
+                                placeholder="Try “1956”, “digital”, “Yogakshema”..."
+                                autocomplete="off"
+                            />
+                            <button id="lic-clear-search" type="button" title="Clear search">Clear</button>
+                        </div>
+                    </div>
+                </div>
+                <div id="lic-type-filters" class="lic-filter-row" aria-label="Timeline categories"></div>
+                <div id="lic-timeline" class="lic-timeline" aria-live="polite"></div>
+            </section>
+
+            <section id="lic-view-services" class="lic-view-panel" hidden>
+                <div class="lic-section-heading compact">
+                    <div>
+                        <p class="lic-kicker">What LIC does</p>
+                        <h2>Insurance and financial services</h2>
+                        <p>Current service categories are summarised from LIC's public product and service pages.</p>
+                    </div>
+                </div>
+                <div id="lic-services-grid" class="lic-card-grid"></div>
+            </section>
+
+            <section id="lic-view-brand" class="lic-view-panel" hidden>
+                <div class="lic-section-heading compact">
+                    <div>
+                        <p class="lic-kicker">Identity</p>
+                        <h2>A brand built around welfare and trust</h2>
+                        <p>
+                            Explore the ideas, symbols and communication language that have shaped LIC's public
+                            identity.
+                        </p>
+                    </div>
+                </div>
+                <div id="lic-brand-grid" class="lic-brand-grid"></div>
+            </section>
+
+            <section id="lic-view-advertising" class="lic-view-panel" hidden>
+                <div class="lic-section-heading compact">
+                    <div>
+                        <p class="lic-kicker">Public memory</p>
+                        <h2>From public education to digital storytelling</h2>
+                        <p>
+                            The advertising archive focuses on documented communication patterns rather than reproducing
+                            copyrighted campaign assets.
+                        </p>
+                    </div>
+                </div>
+                <div id="lic-advertising-list" class="lic-ad-list"></div>
+            </section>
+
+            <section id="lic-view-sources" class="lic-view-panel" hidden>
+                <div class="lic-section-heading compact">
+                    <div>
+                        <p class="lic-kicker">Research trail</p>
+                        <h2>Sources and methodology</h2>
+                        <p>
+                            Primary sources are preferred for dates, laws, products and current operational facts.
+                            Secondary material is clearly labelled where used for brand-history context.
+                        </p>
+                    </div>
+                </div>
+                <div class="lic-source-grid">
+                    <article class="lic-method-card">
+                        <h3>How the timeline was built</h3>
+                        <ol>
+                            <li>Prioritise LIC annual reports and the official history page.</li>
+                            <li>Use India Code for the legal record of the LIC Act.</li>
+                            <li>Use IRDAI for nationalisation and market-liberalisation context.</li>
+                            <li>Use LIC product pages for current service categories.</li>
+                            <li>Use secondary references only for historical brand or advertising context.</li>
+                        </ol>
+                    </article>
+                    <div id="lic-source-cards" class="lic-source-cards">
+                        <article>
+                            <h3>LIC — Official History</h3>
+                            <a href="https://licindia.in/en/web/guest/history" target="_blank" rel="noopener noreferrer"
+                                >licindia.in/history</a
+                            >
+                            <p>Formation and institutional history.</p>
+                        </article>
+                        <article>
+                            <h3>LIC — Annual Report 2024–25</h3>
+                            <a
+                                href="https://licindia.in/documents/d/guest/annual-report-of-the-corporation-for-fy-2024-25"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                >LIC The Journey</a
+                            >
+                            <p>Historical milestone chronology and recent developments.</p>
+                        </article>
+                        <article>
+                            <h3>IRDAI — Evolution of Insurance</h3>
+                            <a
+                                href="https://irdai.gov.in/evolution-of-insurance"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                >irdai.gov.in</a
+                            >
+                            <p>Nationalisation and liberalisation context.</p>
+                        </article>
+                        <article>
+                            <h3>India Code — LIC Act, 1956</h3>
+                            <a
+                                href="https://www.indiacode.nic.in/handle/123456789/1632?view_type=search"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                >indiacode.nic.in</a
+                            >
+                            <p>Statutory source for the enabling Act.</p>
+                        </article>
+                    </div>
+                </div>
+            </section>
+        </main>
+
+        <footer class="lic-footer">
+            <p>LIC: Explore India's Insurance Brand Story · Issue #2640</p>
+            <p>Built as a static, dependency-free explorer for Incredible India Explorer.</p>
+        </footer>
+
+        <div id="lic-toast" class="lic-toast" role="status" aria-live="polite"></div>
+        <script type="module" src="lic-explorer.js"></script>
+    </body>
+</html>

--- a/frontend/lic-explorer/lic-explorer.js
+++ b/frontend/lic-explorer/lic-explorer.js
@@ -1,0 +1,987 @@
+/**
+ * LIC Explorer - India's Insurance Brand Story
+ *
+ * A dependency-free, data-first explorer for issue #2640.
+ * The module deliberately keeps the historical dataset separate from DOM
+ * rendering so the chronology can be tested without a browser.
+ */
+
+export const licTimeline = [
+    {
+        id: 'prehistory-1818',
+        year: 1818,
+        title: 'Life insurance arrives in India',
+        type: 'Origins',
+        summary:
+            'The Oriental Life Insurance Company was established in Calcutta, marking an early chapter in the development of life insurance in India.',
+        details:
+            'The LIC history page places the beginnings of the Indian life insurance story in the nineteenth century. This entry provides historical context before the modern nationalised corporation.',
+        source: 'LIC India — History',
+        sourceUrl: 'https://licindia.in/en/web/guest/history',
+        icon: '🌱',
+        tags: ['origins', 'calcutta', 'life insurance']
+    },
+    {
+        id: 'insurance-act-1938',
+        year: 1938,
+        title: 'Insurance Act consolidates regulation',
+        type: 'Regulation',
+        summary:
+            'The Insurance Act of 1938 consolidated earlier legislation with the stated objective of protecting the interests of the insuring public.',
+        details:
+            'The 1938 framework became an important regulatory foundation for the insurance sector that would later be nationalised and subsequently liberalised.',
+        source: 'LIC India — History',
+        sourceUrl: 'https://licindia.in/en/web/guest/history',
+        icon: '⚖️',
+        tags: ['regulation', 'insurance act', 'public protection']
+    },
+    {
+        id: 'nationalisation-ordinance-1956',
+        year: 1956,
+        title: 'Life insurance is nationalised',
+        type: 'Formation',
+        summary: 'An ordinance on 19 January 1956 nationalised the life insurance business in India.',
+        details:
+            'IRDAI records that the nationalisation brought 154 Indian insurers, 16 non-Indian insurers and 75 provident societies into the new public structure — 245 entities in all.',
+        source: 'IRDAI — Evolution of Insurance',
+        sourceUrl: 'https://irdai.gov.in/evolution-of-insurance',
+        icon: '🇮🇳',
+        tags: ['nationalisation', '1956', 'government']
+    },
+    {
+        id: 'lic-act-1956',
+        year: 1956,
+        title: 'LIC Act creates the statutory corporation',
+        type: 'Formation',
+        summary:
+            'Parliament enacted the Life Insurance Corporation Act, 1956, providing the legal framework for transferring life insurance business to a corporation.',
+        details:
+            'India Code identifies the Act as Act 31 of 1956. Its long title states that it provided for nationalisation of life insurance business and establishment, regulation and control of the corporation.',
+        source: 'India Code — Life Insurance Corporation Act, 1956',
+        sourceUrl: 'https://www.indiacode.nic.in/handle/123456789/1632?view_type=search',
+        icon: '📜',
+        tags: ['law', 'lic act', 'parliament']
+    },
+    {
+        id: 'lic-established-1956',
+        year: 1956,
+        title: 'LIC comes into existence',
+        type: 'Formation',
+        summary:
+            'Life Insurance Corporation of India was established on 1 September 1956 with a Government of India capital contribution of ₹5 crore.',
+        details:
+            'LIC says the corporation was created to spread life insurance more widely, especially in rural areas, and to provide adequate financial cover at reasonable cost.',
+        source: 'LIC India — History',
+        sourceUrl: 'https://licindia.in/en/web/guest/history',
+        icon: '🏛️',
+        tags: ['formation', '1956', 'rural insurance']
+    },
+    {
+        id: 'first-group-policy-1957',
+        year: 1957,
+        title: 'Group insurance services expand',
+        type: 'Services',
+        summary:
+            'LIC issued its first master policy for a group insurance scheme and its first group superannuation policy.',
+        details:
+            'The 2024–25 annual report timeline also records the start of the Yogakshema corporate magazine and the Salary Savings Scheme in this period.',
+        source: 'LIC Annual Report 2024–25 — LIC The Journey',
+        sourceUrl: 'https://licindia.in/documents/d/guest/annual-report-of-the-corporation-for-fy-2024-25',
+        icon: '👥',
+        tags: ['group insurance', 'superannuation', 'services']
+    },
+    {
+        id: 'yogakshema-1957',
+        year: 1957,
+        title: 'Yogakshema corporate magazine begins',
+        type: 'Brand Identity',
+        summary: 'LIC launched Yogakshema as a quarterly corporate magazine in May 1957.',
+        details:
+            "The publication became part of LIC's institutional communication and remains associated with the organisation's corporate identity.",
+        source: 'LIC Annual Report 2024–25 — LIC The Journey',
+        sourceUrl: 'https://licindia.in/documents/d/guest/annual-report-of-the-corporation-for-fy-2024-25',
+        icon: '📰',
+        tags: ['yogakshema', 'magazine', 'brand']
+    },
+    {
+        id: 'first-investment-policy-1958',
+        year: 1958,
+        title: 'Investment policy enters the public record',
+        type: 'Investment',
+        summary: "LIC's first investment policy was placed before Parliament on 25 August 1958.",
+        details:
+            'The milestone illustrates how the new corporation combined insurance operations with a substantial institutional investment role.',
+        source: 'LIC Annual Report 2024–25 — LIC The Journey',
+        sourceUrl: 'https://licindia.in/documents/d/guest/annual-report-of-the-corporation-for-fy-2024-25',
+        icon: '📈',
+        tags: ['investment', 'parliament', '1958']
+    },
+    {
+        id: 'uk-branch-1960',
+        year: 1960,
+        title: 'Overseas branch network grows',
+        type: 'Expansion',
+        summary: 'LIC opened a foreign branch in the United Kingdom in 1960, building on earlier overseas operations.',
+        details:
+            'The annual report chronology records foreign operations in Fiji and Mauritius from 1956 and the UK branch in 1960.',
+        source: 'LIC Annual Report 2024–25 — LIC The Journey',
+        sourceUrl: 'https://licindia.in/documents/d/guest/annual-report-of-the-corporation-for-fy-2024-25',
+        icon: '🌍',
+        tags: ['international', 'uk', 'expansion']
+    },
+    {
+        id: 'computers-1963',
+        year: 1963,
+        title: 'Computerisation begins',
+        type: 'Technology',
+        summary: 'LIC installed its first computers, one each in Mumbai and Kolkata offices.',
+        details:
+            "The milestone is recorded in LIC's historical journey and marks an early step toward large-scale information processing and later digital servicing.",
+        source: 'LIC Annual Report 2024–25 — LIC The Journey',
+        sourceUrl: 'https://licindia.in/documents/d/guest/annual-report-of-the-corporation-for-fy-2024-25',
+        icon: '💻',
+        tags: ['technology', 'computers', '1963']
+    },
+    {
+        id: 'yogakshema-hq-1963',
+        year: 1963,
+        title: 'Yogakshema headquarters is inaugurated',
+        type: 'Brand Identity',
+        summary: "LIC's Yogakshema corporate office was inaugurated in Mumbai in December 1963.",
+        details:
+            "The headquarters became a prominent physical expression of LIC's institutional identity and remains the corporation's corporate office address.",
+        source: 'LIC Annual Report 2024–25 — LIC The Journey',
+        sourceUrl: 'https://licindia.in/documents/d/guest/annual-report-of-the-corporation-for-fy-2024-25',
+        icon: '🏢',
+        tags: ['yogakshema', 'headquarters', 'mumbai']
+    },
+    {
+        id: 'general-insurance-1964',
+        year: 1964,
+        title: 'LIC enters general insurance business',
+        type: 'Services',
+        summary: 'LIC began doing general insurance business in 1964.',
+        details:
+            "The milestone is documented in LIC's historical chronology and demonstrates the breadth of financial services handled by the corporation during its early decades.",
+        source: 'LIC Annual Report 2020–21 — Historical Timeline',
+        sourceUrl: 'https://www.licindia.in/documents/20121/92529/2020-21.pdf/171cb4a7-c857-3a65-ad0b-cbaf2bb47680',
+        icon: '🛡️',
+        tags: ['general insurance', 'services', '1964']
+    },
+    {
+        id: 'computing-1967',
+        year: 1967,
+        title: 'Electronic data processing expands',
+        type: 'Technology',
+        summary: 'IBM 1401/1410 computers were installed at Mumbai and an EDP department began functioning.',
+        details:
+            'This stage of computerisation helped LIC manage information at a scale suited to a national insurer with a rapidly growing policy and branch network.',
+        source: 'LIC Annual Report 2020–21 — Historical Timeline',
+        sourceUrl: 'https://www.licindia.in/documents/20121/92529/2020-21.pdf/171cb4a7-c857-3a65-ad0b-cbaf2bb47680',
+        icon: '🖥️',
+        tags: ['edp', 'ibm', 'technology']
+    },
+    {
+        id: 'agent-clubs-1971',
+        year: 1971,
+        title: 'Agent Clubs are introduced',
+        type: 'Distribution',
+        summary: 'LIC introduced the concept of Agents Clubs in 1971.',
+        details:
+            "The agency network became a central part of LIC's distribution model, helping the organisation reach customers beyond its physical offices.",
+        source: 'LIC Annual Report 2020–21 — Historical Timeline',
+        sourceUrl: 'https://www.licindia.in/documents/20121/92529/2020-21.pdf/171cb4a7-c857-3a65-ad0b-cbaf2bb47680',
+        icon: '🤝',
+        tags: ['agents', 'distribution', '1971']
+    },
+    {
+        id: 'reorganisation-1971',
+        year: 1971,
+        title: 'Branch reorganisation begins',
+        type: 'Operations',
+        summary:
+            'LIC implemented a reorganisation policy from 1971 to 1978, strengthening branches as primary servicing centres.',
+        details:
+            'The historical timeline describes restructuring that equipped branches to dispose of a large share of the work originating there.',
+        source: 'LIC Annual Report 2020–21 — Historical Timeline',
+        sourceUrl: 'https://www.licindia.in/documents/20121/92529/2020-21.pdf/171cb4a7-c857-3a65-ad0b-cbaf2bb47680',
+        icon: '🧭',
+        tags: ['operations', 'branches', 'reorganisation']
+    },
+    {
+        id: 'private-sector-1999',
+        year: 1999,
+        title: 'Insurance sector begins liberalisation',
+        type: 'Market Evolution',
+        summary:
+            "India reopened the insurance sector to private participation in the late 1990s, ending LIC's earlier monopoly era.",
+        details:
+            'IRDAI describes LIC as having had a monopoly until the late 1990s, when the insurance sector was reopened to private players.',
+        source: 'IRDAI — Evolution of Insurance',
+        sourceUrl: 'https://irdai.gov.in/evolution-of-insurance',
+        icon: '🔓',
+        tags: ['liberalisation', 'competition', '1999']
+    },
+    {
+        id: 'irda-act-1999',
+        year: 1999,
+        title: 'IRDA framework reshapes the market',
+        type: 'Regulation',
+        summary:
+            "The Insurance Regulatory and Development Authority framework helped establish an independent regulatory structure for India's insurance market.",
+        details:
+            "LIC's current disclosures list the Insurance Regulatory and Development Authority Act, 1999 among the laws governing the corporation.",
+        source: 'LIC — Particulars of LIC',
+        sourceUrl: 'https://www.licindia.in/the-particulars-of-lic',
+        icon: '⚖️',
+        tags: ['irdai', 'regulation', 'market']
+    },
+    {
+        id: 'digital-2016',
+        year: 2016,
+        title: 'eServices launch',
+        type: 'Digital Transformation',
+        summary:
+            'LIC launched eServices in February 2016, alongside a period of accelerated digitisation of customer records and service channels.',
+        details:
+            'The LIC annual report timeline also records digitisation of policy records and digital payment options in the following years.',
+        source: 'LIC Annual Report 2024–25 — LIC The Journey',
+        sourceUrl: 'https://licindia.in/documents/d/guest/annual-report-of-the-corporation-for-fy-2024-25',
+        icon: '📱',
+        tags: ['eservices', 'digital', '2016']
+    },
+    {
+        id: 'digitisation-2017',
+        year: 2017,
+        title: 'Policy records and digital payments scale up',
+        type: 'Digital Transformation',
+        summary:
+            'LIC completed digitisation of policy records for 29 crore customers and enabled premium payments through wallets, BHIM and UPI.',
+        details:
+            'The milestone illustrates the transition from a branch-heavy servicing model toward digitally supported customer journeys.',
+        source: 'LIC Annual Report 2024–25 — LIC The Journey',
+        sourceUrl: 'https://licindia.in/documents/d/guest/annual-report-of-the-corporation-for-fy-2024-25',
+        icon: '☁️',
+        tags: ['digitisation', 'upi', 'customer service']
+    },
+    {
+        id: 'mobile-app-2018',
+        year: 2018,
+        title: 'LIC mobile app for agents',
+        type: 'Digital Transformation',
+        summary: 'LIC launched a mobile application for agents in 2018.',
+        details:
+            "The move extended digital tools to LIC's distribution network and supported more mobile-first workflows.",
+        source: 'LIC Annual Report 2024–25 — LIC The Journey',
+        sourceUrl: 'https://licindia.in/documents/d/guest/annual-report-of-the-corporation-for-fy-2024-25',
+        icon: '📲',
+        tags: ['mobile', 'agents', 'digital']
+    },
+    {
+        id: 'idbi-2019',
+        year: 2019,
+        title: 'IDBI Bank acquisition',
+        type: 'Corporate Evolution',
+        summary: "LIC's 2019 historical timeline records the acquisition of IDBI Bank.",
+        details:
+            "The event marked a major expansion of LIC's wider financial-services footprint beyond its core life insurance operations.",
+        source: 'LIC Annual Report 2024–25 — LIC The Journey',
+        sourceUrl: 'https://licindia.in/documents/d/guest/annual-report-of-the-corporation-for-fy-2024-25',
+        icon: '🏦',
+        tags: ['idbi', 'acquisition', 'financial services']
+    },
+    {
+        id: 'ananda-2020',
+        year: 2020,
+        title: 'ANANDA paperless policy journey',
+        type: 'Digital Transformation',
+        summary: 'LIC launched ANANDA, a paperless digital application for agents, on 19 November 2020.',
+        details:
+            'The initiative was designed to support life insurance policy issuance through a paperless module with the help of agents.',
+        source: 'LIC Annual Report 2024–25 — LIC The Journey',
+        sourceUrl: 'https://licindia.in/documents/d/guest/annual-report-of-the-corporation-for-fy-2024-25',
+        icon: '🧾',
+        tags: ['ananda', 'paperless', '2020']
+    },
+    {
+        id: 'lic-mitra-2020',
+        year: 2020,
+        title: 'LIC Mitra chatbot launches',
+        type: 'Digital Transformation',
+        summary: "LIC launched the Hindi chatbot 'LIC Mitra' in 2020.",
+        details:
+            "The chatbot is part of the corporation's long transition toward digital customer support and self-service.",
+        source: 'LIC Annual Report 2024–25 — LIC The Journey',
+        sourceUrl: 'https://licindia.in/documents/d/guest/annual-report-of-the-corporation-for-fy-2024-25',
+        icon: '💬',
+        tags: ['chatbot', 'lic mitra', 'customer support']
+    },
+    {
+        id: 'ananda-mobile-2021',
+        year: 2021,
+        title: 'ANANDA mobile app arrives',
+        type: 'Digital Transformation',
+        summary: 'LIC launched the ANANDA mobile app on 24 August 2021.',
+        details: 'The app extended the digital policy-sales journey from desktop workflows to mobile usage.',
+        source: 'LIC Annual Report 2024–25 — LIC The Journey',
+        sourceUrl: 'https://licindia.in/documents/d/guest/annual-report-of-the-corporation-for-fy-2024-25',
+        icon: '📱',
+        tags: ['ananda', 'mobile', '2021']
+    },
+    {
+        id: 'listed-2022',
+        year: 2022,
+        title: 'LIC becomes publicly listed',
+        type: 'Capital Markets',
+        summary: 'LIC shares were listed on Indian stock exchanges on 17 May 2022.',
+        details:
+            'The annual report timeline records the listing as a major corporate milestone and the first Annual General Meeting of the corporation later that year.',
+        source: 'LIC Annual Report 2024–25 — LIC The Journey',
+        sourceUrl: 'https://licindia.in/documents/d/guest/annual-report-of-the-corporation-for-fy-2024-25',
+        icon: '📊',
+        tags: ['ipo', 'listing', '2022']
+    },
+    {
+        id: 'first-agm-2022',
+        year: 2022,
+        title: 'First Annual General Meeting',
+        type: 'Capital Markets',
+        summary: 'LIC held its first Annual General Meeting on 27 September 2022.',
+        details:
+            "The event followed LIC's transition to a listed public company and created a new shareholder-facing governance milestone.",
+        source: 'LIC Annual Report 2024–25 — LIC The Journey',
+        sourceUrl: 'https://licindia.in/documents/d/guest/annual-report-of-the-corporation-for-fy-2024-25',
+        icon: '🗳️',
+        tags: ['agm', 'governance', '2022']
+    },
+    {
+        id: 'dive-2023',
+        year: 2023,
+        title: 'Project DIVE launches',
+        type: 'Digital Transformation',
+        summary: 'LIC launched Project DIVE, described as Digital Innovation and Value Enhancement.',
+        details:
+            "The project represents LIC's continuing effort to modernise operations and create value through technology and process transformation.",
+        source: 'LIC Annual Report 2024–25 — LIC The Journey',
+        sourceUrl: 'https://licindia.in/documents/d/guest/annual-report-of-the-corporation-for-fy-2024-25',
+        icon: '🚀',
+        tags: ['dive', 'innovation', '2023']
+    },
+    {
+        id: 'bancassurance-2024',
+        year: 2024,
+        title: 'Bancassurance partnerships expand',
+        type: 'Services',
+        summary: 'LIC entered a bancassurance arrangement with IDFC FIRST Bank during 2024.',
+        details:
+            "The annual report timeline lists the tie-up as part of LIC's continuing evolution of distribution and financial-services partnerships.",
+        source: 'LIC Annual Report 2024–25 — LIC The Journey',
+        sourceUrl: 'https://licindia.in/documents/d/guest/annual-report-of-the-corporation-for-fy-2024-25',
+        icon: '🏦',
+        tags: ['bancassurance', 'idfc first bank', '2024']
+    },
+    {
+        id: 'bima-sakhi-2024',
+        year: 2024,
+        title: 'Bima Sakhi Yojana is launched',
+        type: 'Distribution',
+        summary: "LIC's 2024 timeline records the launch of Bima Sakhi Yojana at Panipat.",
+        details: 'The milestone is presented by LIC as part of its contemporary outreach and distribution story.',
+        source: 'LIC Annual Report 2024–25 — LIC The Journey',
+        sourceUrl: 'https://licindia.in/documents/d/guest/annual-report-of-the-corporation-for-fy-2024-25',
+        icon: '👩‍💼',
+        tags: ['bima sakhi', 'distribution', 'women']
+    },
+    {
+        id: 'demat-2024',
+        year: 2024,
+        title: 'Electronic policy issuance moves forward',
+        type: 'Digital Transformation',
+        summary: 'LIC entered an agreement with CAMSREP for electronic issuance of policies in dematerialised form.',
+        details:
+            'The annual report describes the agreement as an industry milestone supporting more digital policy administration.',
+        source: 'LIC Annual Report 2024–25 — LIC The Journey',
+        sourceUrl: 'https://licindia.in/documents/d/guest/annual-report-of-the-corporation-for-fy-2024-25',
+        icon: '🔐',
+        tags: ['demat', 'digital policy', 'camsrep']
+    },
+    {
+        id: 'scale-2025',
+        year: 2025,
+        title: 'LIC reports a nationwide scale of operations',
+        type: 'Modern LIC',
+        summary:
+            'As of 31 March 2025, LIC reported 2,048 branch offices, 1,584 satellite offices and 1,168 mini offices, for 5,004 such offices in total.',
+        details:
+            "LIC's public particulars also report ₹4,88,148.17 crore in total premium income and ₹56,22,929.99 crore in total assets for 2024–25.",
+        source: 'LIC — The Particulars of LIC; Annual Report 2024–25',
+        sourceUrl: 'https://www.licindia.in/the-particulars-of-lic',
+        icon: '🗺️',
+        tags: ['scale', 'branches', '2025']
+    }
+];
+
+export const licServices = [
+    {
+        id: 'insurance',
+        name: 'Insurance Plans',
+        icon: '🛡️',
+        description:
+            'Individual life insurance solutions spanning endowment, whole life, money back, term assurance and riders.',
+        examples: ['New Endowment Plan', 'New Jeevan Anand', 'Jeevan Umang', 'Digi Term', 'Bima Kavach'],
+        source: 'LIC India — Insurance Plans',
+        sourceUrl: 'https://www.licindia.in/insurance-plan'
+    },
+    {
+        id: 'pension',
+        name: 'Pension Plans',
+        icon: '🌅',
+        description: 'Retirement and annuity products designed for pension income and long-term financial security.',
+        examples: ['New Pension Plus', 'Jeevan Akshay-VII', 'New Jeevan Shanti', 'Saral Pension', 'Smart Pension'],
+        source: 'LIC India — Pension Plans',
+        sourceUrl: 'https://www.licindia.in/pension-plan'
+    },
+    {
+        id: 'unit-linked',
+        name: 'Unit Linked Plans',
+        icon: '📈',
+        description:
+            'Market-linked life insurance products combining insurance protection with investment-linked value.',
+        examples: ["LIC's unit-linked product range"],
+        source: 'LIC India — Products',
+        sourceUrl: 'https://www.licindia.in/en/web/guest/products'
+    },
+    {
+        id: 'micro',
+        name: 'Micro Insurance',
+        icon: '🌾',
+        description: 'Lower-ticket insurance products intended to extend financial protection to underserved segments.',
+        examples: ['Micro Bachat', 'Jan Suraksha'],
+        source: 'LIC India — Micro Insurance Plans',
+        sourceUrl: 'https://www.licindia.in/en/web/guest/micro-insurance-plans'
+    },
+    {
+        id: 'group',
+        name: 'Group & Pension Services',
+        icon: '👥',
+        description: 'Group insurance, gratuity, superannuation, leave encashment and group credit-life solutions.',
+        examples: ['Group Superannuation', 'Group Gratuity', 'Group Credit Life', 'Group Immediate Annuities'],
+        source: 'LIC India — Pension & Group Schemes',
+        sourceUrl: 'https://licindia.in/en/web/guest/pension-group-schemes'
+    },
+    {
+        id: 'digital',
+        name: 'Digital Customer Services',
+        icon: '📲',
+        description:
+            'Digital policy servicing, online purchase journeys, payment channels, mobile tools and assisted digital issuance.',
+        examples: ['eServices', 'ANANDA', 'LIC Mitra', 'Online purchase', 'UPI payments'],
+        source: 'LIC India — Annual Reports and Buy Online',
+        sourceUrl: 'https://www.licindia.in/en/buy-online'
+    }
+];
+
+export const licBrandIdentity = [
+    {
+        id: 'yogakshema',
+        title: 'Yogakshema',
+        era: 'From the early LIC era',
+        description:
+            "Yogakshema is deeply associated with LIC's corporate identity: it is the name of the corporation's Mumbai headquarters and its long-running house magazine.",
+        source: 'LIC Annual Report 2024–25',
+        sourceUrl: 'https://licindia.in/documents/d/guest/annual-report-of-the-corporation-for-fy-2024-25'
+    },
+    {
+        id: 'motto',
+        title: 'Yogakshemam Vahamyaham',
+        era: 'Institutional motto',
+        description:
+            "LIC's motto is drawn from the Bhagavad Gita and is commonly interpreted around the idea of carrying responsibility for welfare and security.",
+        source: 'Insurance Institute of India — Journal; LIC publications',
+        sourceUrl: 'https://www.insuranceinstituteofindia.com/downloads/Forms/III/Journal-2009-10-11/The%20Journal.pdf'
+    },
+    {
+        id: 'trust',
+        title: 'A saga of trust',
+        era: 'Modern brand language',
+        description:
+            "LIC's official About Us page frames its decades-long relationship with policyholders around trust and responsibility for millions of lives.",
+        source: 'LIC India — About Us',
+        sourceUrl: 'https://www.licindia.in/en/web/guest/about-us'
+    },
+    {
+        id: 'zindagi',
+        title: 'Zindagi Ke Saath Bhi, Zindagi Ke Baad Bhi',
+        era: 'Consumer-facing slogan',
+        description:
+            "The phrase remains displayed by LIC on its digital customer-facing properties and is strongly associated with the brand's promise of continuity and protection.",
+        source: 'LIC India — Digital Customer Portal',
+        sourceUrl: 'https://www.nextgen.licindia.in/'
+    },
+    {
+        id: 'art',
+        title: 'Art and institutional culture',
+        era: '1960s onward',
+        description:
+            'LIC supported corporate art early in its history; its Yogakshema headquarters became known for a large M. F. Husain mural commissioned in 1963.',
+        source: 'The Economic Times — LIC headquarters and M. F. Husain mural',
+        sourceUrl: 'https://economictimes.indiatimes.com/a-hussain-work-at-rs-1000/articleshow/5846473.cms'
+    }
+];
+
+export const licAdvertisingHistory = [
+    {
+        id: 'institutional-publicity',
+        period: '1950s–1970s',
+        title: 'Education, publicity and mass reach',
+        description:
+            'LIC developed a broad public-communication operation using print, outdoor publicity, radio, exhibitions, fairs, publicity vans and its Yogakshema house magazine.',
+        significance:
+            'The early strategy focused on explaining life insurance and building familiarity with a newly nationalised institution.',
+        source: 'Historical documentation on LIC publicity practices; LIC publications',
+        sourceUrl: 'https://www.dokumen.pub/mass-media-in-india-1978.html'
+    },
+    {
+        id: 'emotional-branding',
+        period: 'Late 20th century',
+        title: 'Protection becomes an emotional brand promise',
+        description:
+            'LIC advertising increasingly used family, security and continuity themes to make an intangible financial product emotionally legible to households.',
+        significance:
+            'This style helped connect long-term insurance with everyday family responsibilities rather than treating it only as a financial contract.',
+        source: 'Documented analysis of LIC advertising campaigns',
+        sourceUrl: 'https://www.scribd.com/doc/47900985/Advertisement'
+    },
+    {
+        id: 'zindagi-campaign',
+        period: 'Modern consumer advertising',
+        title: 'Zindagi Ke Saath Bhi, Zindagi Ke Baad Bhi',
+        description:
+            "The campaign line positions LIC as a companion across the policyholder's life journey and continues to appear in LIC's digital customer experience.",
+        significance:
+            "It compresses LIC's promise into a memorable phrase that communicates continuity, family protection and long-term commitment.",
+        source: 'LIC India — Digital Customer Portal',
+        sourceUrl: 'https://www.nextgen.licindia.in/'
+    },
+    {
+        id: 'digital-communication',
+        period: '2016–present',
+        title: 'From mass media to digital service storytelling',
+        description:
+            "LIC's communication environment expanded alongside eServices, mobile applications, online purchase, chatbots and digital policy issuance.",
+        significance:
+            'The brand story now combines institutional trust with convenience, self-service and digitally assisted policy journeys.',
+        source: 'LIC Annual Report 2024–25; LIC Buy Online',
+        sourceUrl: 'https://www.licindia.in/en/buy-online'
+    }
+];
+
+export const licSources = [
+    {
+        title: 'LIC — Official History',
+        url: 'https://licindia.in/en/web/guest/history',
+        category: 'Primary source',
+        note: 'Nationalisation, formation and institutional history.'
+    },
+    {
+        title: 'LIC — Annual Report 2024–25',
+        url: 'https://licindia.in/documents/d/guest/annual-report-of-the-corporation-for-fy-2024-25',
+        category: 'Primary source',
+        note: 'Historical timeline and recent milestones.'
+    },
+    {
+        title: 'LIC — Particulars of LIC',
+        url: 'https://www.licindia.in/the-particulars-of-lic',
+        category: 'Primary source',
+        note: 'Current operational scale and statutory background.'
+    },
+    {
+        title: 'LIC — Insurance Plans',
+        url: 'https://www.licindia.in/insurance-plan',
+        category: 'Primary source',
+        note: 'Current product categories and examples.'
+    },
+    {
+        title: 'LIC — Pension Plans',
+        url: 'https://www.licindia.in/pension-plan',
+        category: 'Primary source',
+        note: 'Current pension and annuity products.'
+    },
+    {
+        title: 'LIC — Micro Insurance',
+        url: 'https://www.licindia.in/en/web/guest/micro-insurance-plans',
+        category: 'Primary source',
+        note: 'Micro-insurance products.'
+    },
+    {
+        title: 'IRDAI — Evolution of Insurance',
+        url: 'https://irdai.gov.in/evolution-of-insurance',
+        category: 'Regulator',
+        note: 'Nationalisation and liberalisation context.'
+    },
+    {
+        title: 'India Code — LIC Act, 1956',
+        url: 'https://www.indiacode.nic.in/handle/123456789/1632?view_type=search',
+        category: 'Government source',
+        note: "Primary legal record for the corporation's enabling Act."
+    }
+];
+
+export const LIC_TYPES = [
+    'All',
+    'Origins',
+    'Regulation',
+    'Formation',
+    'Services',
+    'Brand Identity',
+    'Investment',
+    'Expansion',
+    'Technology',
+    'Distribution',
+    'Operations',
+    'Market Evolution',
+    'Digital Transformation',
+    'Corporate Evolution',
+    'Capital Markets',
+    'Modern LIC'
+];
+
+export function getSortedTimeline(items = licTimeline) {
+    if (!Array.isArray(items)) return [];
+    return [...items].sort((a, b) => a.year - b.year || a.id.localeCompare(b.id));
+}
+
+export function getTimelineTypes(items = licTimeline) {
+    const types = new Set();
+    getSortedTimeline(items).forEach(item => types.add(item.type));
+    return ['All', ...types];
+}
+
+export function filterTimeline(type = 'All', items = licTimeline) {
+    const sorted = getSortedTimeline(items);
+    if (!type || type.toLowerCase() === 'all') return sorted;
+    return sorted.filter(item => item.type.toLowerCase() === type.toLowerCase());
+}
+
+export function searchTimeline(query = '', items = licTimeline) {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return getSortedTimeline(items);
+    return getSortedTimeline(items).filter(item => {
+        const haystack = [item.title, item.type, item.summary, item.details, item.year, ...(item.tags || [])]
+            .join(' ')
+            .toLowerCase();
+        return haystack.includes(normalized);
+    });
+}
+
+export function getTimelineStats(items = licTimeline) {
+    const sorted = getSortedTimeline(items);
+    const years = sorted.map(item => item.year);
+    const types = new Set(sorted.map(item => item.type));
+    return {
+        count: sorted.length,
+        firstYear: years.length ? Math.min(...years) : null,
+        lastYear: years.length ? Math.max(...years) : null,
+        typeCount: types.size,
+        digitalMilestones: sorted.filter(item => item.type === 'Digital Transformation').length
+    };
+}
+
+export function getYearGroups(items = licTimeline) {
+    return getSortedTimeline(items).reduce((groups, item) => {
+        const key = String(item.year);
+        if (!groups[key]) groups[key] = [];
+        groups[key].push(item);
+        return groups;
+    }, {});
+}
+
+export function getServiceById(id, services = licServices) {
+    return services.find(service => service.id === id) || null;
+}
+
+export function searchServices(query = '', services = licServices) {
+    const normalized = query.trim().toLowerCase();
+    if (!normalized) return [...services];
+    return services.filter(service =>
+        [service.name, service.description, ...(service.examples || [])].join(' ').toLowerCase().includes(normalized)
+    );
+}
+
+export function getBrandIdentityById(id, items = licBrandIdentity) {
+    return items.find(item => item.id === id) || null;
+}
+
+export function getAdvertisingByPeriod(period, items = licAdvertisingHistory) {
+    if (!period) return [...items];
+    return items.filter(item => item.period.toLowerCase().includes(period.toLowerCase()));
+}
+
+export function createShareUrl(locationLike, itemId) {
+    const base = locationLike?.origin || '';
+    const pathname = locationLike?.pathname || '/';
+    const hash = itemId ? `#milestone-${encodeURIComponent(itemId)}` : '';
+    return `${base}${pathname}${hash}`;
+}
+
+export function formatYearRange(items = licTimeline) {
+    const stats = getTimelineStats(items);
+    if (stats.firstYear === null) return 'No timeline data';
+    return stats.firstYear === stats.lastYear ? String(stats.firstYear) : `${stats.firstYear}–${stats.lastYear}`;
+}
+
+function escapeHtml(value) {
+    return String(value)
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&#039;');
+}
+
+function renderSource(source, sourceUrl) {
+    if (!sourceUrl) return `<span class="lic-source-text">${escapeHtml(source)}</span>`;
+    return `<a class="lic-source-link" href="${escapeHtml(sourceUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(source)}</a>`;
+}
+
+function renderTimeline(items, selectedId = '') {
+    const container = document.getElementById('lic-timeline');
+    if (!container) return;
+    container.innerHTML = '';
+
+    if (!items.length) {
+        container.innerHTML = `
+      <div class="lic-empty" role="status">
+        <span class="lic-empty-icon">🔎</span>
+        <h3>No milestones match your search</h3>
+        <p>Try another year, category or keyword.</p>
+      </div>`;
+        return;
+    }
+
+    items.forEach((item, index) => {
+        const article = document.createElement('article');
+        article.className = `lic-milestone ${item.id === selectedId ? 'is-selected' : ''}`;
+        article.id = `milestone-${item.id}`;
+        article.dataset.year = String(item.year);
+        article.innerHTML = `
+      <div class="lic-milestone-marker" aria-hidden="true">${escapeHtml(item.icon)}</div>
+      <div class="lic-milestone-year">${escapeHtml(item.year)}</div>
+      <div class="lic-milestone-card">
+        <div class="lic-card-topline">
+          <span class="lic-category-badge">${escapeHtml(item.type)}</span>
+          <span class="lic-card-index">${String(index + 1).padStart(2, '0')}</span>
+        </div>
+        <h3>${escapeHtml(item.title)}</h3>
+        <p class="lic-summary">${escapeHtml(item.summary)}</p>
+        <details>
+          <summary>Read the historical context</summary>
+          <p>${escapeHtml(item.details)}</p>
+        </details>
+        <div class="lic-card-footer">
+          ${renderSource(item.source, item.sourceUrl)}
+          <button type="button" class="lic-share-btn" data-share-id="${escapeHtml(item.id)}" aria-label="Copy link to ${escapeHtml(item.title)}">🔗 Share</button>
+        </div>
+      </div>`;
+        container.appendChild(article);
+    });
+}
+
+function renderStats(items) {
+    const stats = getTimelineStats(items);
+    const count = document.getElementById('lic-stat-milestones');
+    const range = document.getElementById('lic-stat-range');
+    const types = document.getElementById('lic-stat-types');
+    const digital = document.getElementById('lic-stat-digital');
+    if (count) count.textContent = String(stats.count);
+    if (range) range.textContent = formatYearRange(items);
+    if (types) types.textContent = String(stats.typeCount);
+    if (digital) digital.textContent = String(stats.digitalMilestones);
+}
+
+function renderTypeFilters(activeType) {
+    const container = document.getElementById('lic-type-filters');
+    if (!container) return;
+    container.innerHTML = '';
+    getTimelineTypes().forEach(type => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.className = `lic-filter ${type === activeType ? 'is-active' : ''}`;
+        button.dataset.type = type;
+        button.textContent = type;
+        button.setAttribute('aria-pressed', String(type === activeType));
+        container.appendChild(button);
+    });
+}
+
+function renderServices(items = licServices) {
+    const container = document.getElementById('lic-services-grid');
+    if (!container) return;
+    container.innerHTML = items
+        .map(
+            service => `
+    <article class="lic-service-card" data-service-id="${escapeHtml(service.id)}">
+      <div class="lic-service-icon" aria-hidden="true">${escapeHtml(service.icon)}</div>
+      <h3>${escapeHtml(service.name)}</h3>
+      <p>${escapeHtml(service.description)}</p>
+      <ul>${service.examples.map(example => `<li>${escapeHtml(example)}</li>`).join('')}</ul>
+      <a href="${escapeHtml(service.sourceUrl)}" target="_blank" rel="noopener noreferrer">${escapeHtml(service.source)}</a>
+    </article>`
+        )
+        .join('');
+}
+
+function renderBrandIdentity() {
+    const container = document.getElementById('lic-brand-grid');
+    if (!container) return;
+    container.innerHTML = licBrandIdentity
+        .map(
+            item => `
+    <article class="lic-brand-card">
+      <span class="lic-brand-era">${escapeHtml(item.era)}</span>
+      <h3>${escapeHtml(item.title)}</h3>
+      <p>${escapeHtml(item.description)}</p>
+      ${renderSource(item.source, item.sourceUrl)}
+    </article>`
+        )
+        .join('');
+}
+
+function renderAdvertising() {
+    const container = document.getElementById('lic-advertising-list');
+    if (!container) return;
+    container.innerHTML = licAdvertisingHistory
+        .map(
+            (item, index) => `
+    <article class="lic-ad-card">
+      <div class="lic-ad-number">${String(index + 1).padStart(2, '0')}</div>
+      <div>
+        <span class="lic-ad-period">${escapeHtml(item.period)}</span>
+        <h3>${escapeHtml(item.title)}</h3>
+        <p>${escapeHtml(item.description)}</p>
+        <p class="lic-ad-significance"><strong>Why it matters:</strong> ${escapeHtml(item.significance)}</p>
+        ${renderSource(item.source, item.sourceUrl)}
+      </div>
+    </article>`
+        )
+        .join('');
+}
+
+function activateSection(sectionId) {
+    document.querySelectorAll('.lic-view-panel').forEach(panel => {
+        panel.hidden = panel.id !== sectionId;
+    });
+    document.querySelectorAll('.lic-nav-btn').forEach(button => {
+        const active = button.dataset.section === sectionId;
+        button.classList.toggle('is-active', active);
+        button.setAttribute('aria-current', active ? 'page' : 'false');
+    });
+}
+
+function copyShareLink(itemId) {
+    const url = createShareUrl(window.location, itemId);
+    if (navigator.clipboard?.writeText) {
+        return navigator.clipboard.writeText(url).then(() => url);
+    }
+    const input = document.createElement('input');
+    input.value = url;
+    input.setAttribute('readonly', 'true');
+    input.style.position = 'fixed';
+    input.style.opacity = '0';
+    document.body.appendChild(input);
+    input.select();
+    document.execCommand('copy');
+    input.remove();
+    return Promise.resolve(url);
+}
+
+function showToast(message) {
+    const toast = document.getElementById('lic-toast');
+    if (!toast) return;
+    toast.textContent = message;
+    toast.classList.add('is-visible');
+    window.clearTimeout(showToast.timer);
+    showToast.timer = window.setTimeout(() => toast.classList.remove('is-visible'), 2200);
+}
+
+function setupTheme() {
+    const button = document.getElementById('lic-theme-toggle');
+    const saved = localStorage.getItem('lic-theme');
+    if (saved) document.documentElement.dataset.theme = saved;
+    button?.addEventListener('click', () => {
+        const next = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark';
+        document.documentElement.dataset.theme = next;
+        localStorage.setItem('lic-theme', next);
+        button.setAttribute('aria-label', `Switch to ${next === 'dark' ? 'light' : 'dark'} theme`);
+    });
+}
+
+function scrollToHash() {
+    const raw = window.location.hash.replace(/^#milestone-/, '');
+    if (!raw) return;
+    const target = document.getElementById(`milestone-${decodeURIComponent(raw)}`);
+    if (!target) return;
+    activateSection('lic-view-timeline');
+    window.requestAnimationFrame(() => target.scrollIntoView({ behavior: 'smooth', block: 'center' }));
+}
+
+export function initializeLicExplorer() {
+    if (typeof document === 'undefined') return;
+
+    let activeType = 'All';
+    let query = '';
+    let selectedId = '';
+
+    renderTypeFilters(activeType);
+    renderStats(licTimeline);
+    renderTimeline(licTimeline);
+    renderServices();
+    renderBrandIdentity();
+    renderAdvertising();
+    setupTheme();
+
+    document.getElementById('lic-type-filters')?.addEventListener('click', event => {
+        const button = event.target.closest('button[data-type]');
+        if (!button) return;
+        activeType = button.dataset.type || 'All';
+        renderTypeFilters(activeType);
+        const filtered = searchTimeline(query, filterTimeline(activeType));
+        renderStats(filtered);
+        renderTimeline(filtered, selectedId);
+    });
+
+    document.getElementById('lic-search')?.addEventListener('input', event => {
+        query = event.target.value;
+        const filtered = searchTimeline(query, filterTimeline(activeType));
+        renderStats(filtered);
+        renderTimeline(filtered, selectedId);
+    });
+
+    document.querySelectorAll('.lic-nav-btn').forEach(button => {
+        button.addEventListener('click', () => activateSection(button.dataset.section));
+    });
+
+    document.getElementById('lic-timeline')?.addEventListener('click', event => {
+        const share = event.target.closest('button[data-share-id]');
+        if (!share) return;
+        selectedId = share.dataset.shareId || '';
+        copyShareLink(selectedId)
+            .then(() => showToast('Milestone link copied'))
+            .catch(() => showToast('Copy failed — use the page URL'));
+    });
+
+    document.getElementById('lic-clear-search')?.addEventListener('click', () => {
+        const input = document.getElementById('lic-search');
+        if (input) input.value = '';
+        query = '';
+        renderStats(filterTimeline(activeType));
+        renderTimeline(filterTimeline(activeType), selectedId);
+    });
+
+    window.addEventListener('hashchange', scrollToHash);
+    scrollToHash();
+}
+
+if (typeof document !== 'undefined') {
+    document.addEventListener('DOMContentLoaded', initializeLicExplorer);
+}

--- a/tests/unit/lic-explorer.test.js
+++ b/tests/unit/lic-explorer.test.js
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    LIC_TYPES,
+    createShareUrl,
+    filterTimeline,
+    formatYearRange,
+    getBrandIdentityById,
+    getServiceById,
+    getSortedTimeline,
+    getTimelineStats,
+    getTimelineTypes,
+    getYearGroups,
+    licAdvertisingHistory,
+    licBrandIdentity,
+    licServices,
+    licTimeline,
+    searchServices,
+    searchTimeline
+} from '../../frontend/lic-explorer/lic-explorer.js';
+
+describe('LIC explorer dataset', () => {
+    it('contains a substantial chronological history', () => {
+        expect(licTimeline.length).toBeGreaterThanOrEqual(25);
+        expect(getTimelineStats().firstYear).toBe(1818);
+        expect(getTimelineStats().lastYear).toBe(2025);
+    });
+
+    it('keeps the timeline sorted without mutating the source array', () => {
+        const input = [
+            { id: 'b', year: 2025, type: 'Modern LIC' },
+            { id: 'a', year: 1956, type: 'Formation' }
+        ];
+        const sorted = getSortedTimeline(input);
+        expect(sorted.map(item => item.id)).toEqual(['a', 'b']);
+        expect(input.map(item => item.id)).toEqual(['b', 'a']);
+    });
+
+    it('groups milestones by year', () => {
+        const groups = getYearGroups();
+        expect(groups['1956']).toHaveLength(3);
+        expect(groups['2024']).toHaveLength(3);
+        expect(groups['1956'].map(item => item.id)).toContain('lic-established-1956');
+    });
+
+    it('supports category filtering', () => {
+        const digital = filterTimeline('Digital Transformation');
+        expect(digital.length).toBeGreaterThanOrEqual(5);
+        expect(digital.every(item => item.type === 'Digital Transformation')).toBe(true);
+        expect(filterTimeline('All')).toEqual(getSortedTimeline());
+    });
+
+    it('exposes the category list from the data', () => {
+        const types = getTimelineTypes();
+        expect(types[0]).toBe('All');
+        expect(types).toContain('Formation');
+        expect(types).toContain('Digital Transformation');
+        expect(LIC_TYPES).toContain('Capital Markets');
+    });
+
+    it('searches titles, descriptions, years and tags', () => {
+        expect(searchTimeline('1956').length).toBeGreaterThanOrEqual(3);
+        expect(searchTimeline('Yogakshema').map(item => item.id)).toEqual(
+            expect.arrayContaining(['yogakshema-1957', 'yogakshema-hq-1963'])
+        );
+        expect(searchTimeline('upi').map(item => item.id)).toContain('digitisation-2017');
+        expect(searchTimeline('does-not-exist')).toEqual([]);
+    });
+
+    it('returns a stable range for the timeline', () => {
+        expect(formatYearRange()).toBe('1818–2025');
+        expect(formatYearRange([{ id: 'only', year: 1956 }])).toBe('1956');
+        expect(formatYearRange([])).toBe('No timeline data');
+    });
+});
+
+describe('LIC services', () => {
+    it('contains the requested current service families', () => {
+        expect(licServices.map(service => service.id)).toEqual(
+            expect.arrayContaining(['insurance', 'pension', 'unit-linked', 'micro', 'group', 'digital'])
+        );
+    });
+
+    it('looks up services by id', () => {
+        expect(getServiceById('pension').name).toBe('Pension Plans');
+        expect(getServiceById('unknown')).toBeNull();
+    });
+
+    it('searches service names and examples', () => {
+        expect(searchServices('Jeevan').length).toBeGreaterThanOrEqual(2);
+        expect(searchServices('UPI').map(item => item.id)).toContain('digital');
+        expect(searchServices('not a service')).toEqual([]);
+    });
+});
+
+describe('LIC brand identity and advertising archive', () => {
+    it('includes the required brand identity themes', () => {
+        expect(licBrandIdentity.length).toBeGreaterThanOrEqual(5);
+        expect(getBrandIdentityById('yogakshema').title).toBe('Yogakshema');
+        expect(getBrandIdentityById('zindagi').title).toContain('Zindagi');
+    });
+
+    it('includes documented advertising eras', () => {
+        expect(licAdvertisingHistory.length).toBeGreaterThanOrEqual(4);
+        expect(licAdvertisingHistory.map(item => item.title)).toEqual(
+            expect.arrayContaining([
+                'Protection becomes an emotional brand promise',
+                'Zindagi Ke Saath Bhi, Zindagi Ke Baad Bhi'
+            ])
+        );
+    });
+});
+
+describe('LIC explorer utilities', () => {
+    it('creates shareable milestone URLs', () => {
+        expect(
+            createShareUrl(
+                { origin: 'https://example.test', pathname: '/frontend/lic-explorer/lic-explorer.html' },
+                'lic-established-1956'
+            )
+        ).toBe('https://example.test/frontend/lic-explorer/lic-explorer.html#milestone-lic-established-1956');
+    });
+
+    it('does not create an undefined hash when no item is supplied', () => {
+        expect(createShareUrl({ origin: 'https://example.test', pathname: '/lic.html' })).toBe(
+            'https://example.test/lic.html'
+        );
+    });
+});


### PR DESCRIPTION
# Pull Request

## Overview

Implements #2640 — LIC: Explore India's Insurance Brand Story.

This PR adds a standalone interactive LIC history experience covering the corporation's origins, formation, major milestones, services, brand identity and advertising evolution.

## What changed

- Added LIC historical timeline with 31 source-backed milestones
- Added interactive timeline search
- Added timeline category filters
- Added milestone deep-link/share functionality
- Added LIC insurance and financial-services catalogue
- Added pension, unit-linked, micro-insurance and group-service coverage
- Added LIC brand identity archive
- Added Yogakshema and LIC motto context
- Added historical advertising evolution section
- Added research sources and methodology section
- Added responsive/mobile layouts
- Added light/dark theme support
- Added reduced-motion accessibility support
- Added unit tests for timeline and explorer utilities

## Testing

- JavaScript syntax checks pass
- Timeline utility smoke tests pass
- Added Vitest coverage for:
  - chronological sorting
  - year grouping
  - category filtering
  - timeline search
  - timeline statistics
  - service lookup/search
  - brand identity lookup
  - advertising archive
  - milestone share URLs

Run:

`npm test -- --run tests/unit/lic-explorer.test.js`

## Acceptance Criteria

- [x] History documented
- [x] Milestones included
- [x] Interactive timeline implemented
- [x] Sources included

Closes #2640
