### PR TITLE
feat: add fossil forests of India profile

### DIFF
--- a/frontend/fossil-forests-india/index.html
+++ b/frontend/fossil-forests-india/index.html
@@ -1,0 +1,258 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function () {
+            const theme = localStorage.getItem("theme") || "dark";
+            if (theme === "light") {
+                document.documentElement.classList.add("light-theme");
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Fossil Forests of India | Incredible India Explorer</title>
+    <meta name="description" content="Educational profile of India’s fossil forests and plant remains: GSI wood parks, Gondwana Glossopteris flora, geological ages, ancient environments, and a site map.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&family=Playfair+Display:ital,wght@0,600;0,700;1,500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <a class="skip-link" href="#main">Skip to main content</a>
+
+    <header class="site-header">
+        <nav class="topnav" aria-label="Primary">
+            <a class="brand" href="../../index.html">Incredible India Explorer</a>
+            <div class="nav-links">
+                <a href="#locations">Locations</a>
+                <a href="#fossils">Plant fossils</a>
+                <a href="#age">Age</a>
+                <a href="#environments">Environments</a>
+                <a href="#significance">Significance</a>
+                <a href="#images">Images</a>
+                <a href="#map">Map</a>
+                <a href="#sources">Sources</a>
+            </div>
+            <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Switch to light theme">☀️</button>
+        </nav>
+    </header>
+
+    <main id="main">
+        <header class="hero">
+            <p class="eyebrow">Geoheritage · Palaeobotany</p>
+            <h1>Fossil Forests of India</h1>
+            <p class="hero-date">Petrified wood parks · Gondwana flora · Deccan intertrappeans</p>
+            <p class="lede">Silicified trunks, leaf impressions, and coal-swamp plants record forests that once stood on the Indian plate — from Permian Gondwana swamps to Miocene river woods now set in sandstone.</p>
+            <dl class="hero-stats">
+                <div>
+                    <dt>Oldest flora here</dt>
+                    <dd>~299–252 Ma</dd>
+                </div>
+                <div>
+                    <dt>Youngest wood parks</dt>
+                    <dd>~20 Ma</dd>
+                </div>
+                <div>
+                    <dt>GSI wood parks</dt>
+                    <dd>3 named</dd>
+                </div>
+                <div>
+                    <dt>Ghughua park</dt>
+                    <dd>1983</dd>
+                </div>
+            </dl>
+        </header>
+
+        <section class="block" id="locations" aria-labelledby="locations-heading">
+            <div class="section-head">
+                <span class="tag">Sites</span>
+                <h2 id="locations-heading">Fossil forest locations</h2>
+            </div>
+            <p class="lede">The Geological Survey of India protects several National Geological Monuments for petrified wood. Other well-studied floras sit in Gondwana coalfields, Rajmahal intertrappean beds, and Deccan volcanic sediments.</p>
+            <div class="grid-2">
+                <article class="card">
+                    <h3>Akal Wood Fossil Park, Rajasthan</h3>
+                    <p>A 21-hectare GSI monument near Jaisalmer (notified 1977). Lower Jurassic (~180 Ma) tree trunks lie in the Lathi Formation. The park is now managed with Desert National Park.</p>
+                </article>
+                <article class="card">
+                    <h3>Tiruvakkarai Fossil Wood Park, Tamil Nadu</h3>
+                    <p>Villupuram district. Notified 1951. About 100 hectares of Cuddalore Sandstone hold horizontal silicified trunks, some tens of metres long, dated to the Miocene–Pliocene (~20 Ma).</p>
+                </article>
+                <article class="card">
+                    <h3>Sathanur Fossil Wood Park, Tamil Nadu</h3>
+                    <p>Perambalur district. A Late Cretaceous gymnosperm trunk about 18 m long (Sathanur kalmaram), documented by GSI geologist M. S. Krishnan. Nearby villages hold similar logs.</p>
+                </article>
+                <article class="card">
+                    <h3>Ghughua Fossil Park, Madhya Pradesh</h3>
+                    <p>Dindori district, on the Maikal range. A 1983 national park preserving Late Cretaceous plant fossils in Deccan intertrappean beds — trunks, fruits, seeds, and leaf impressions.</p>
+                </article>
+                <article class="card">
+                    <h3>Rajmahal Hills, Jharkhand</h3>
+                    <p>Intertrappean beds of the Rajmahal Formation (Jurassic–Cretaceous) near Mandro, Sahibganj, yield the classic <em>Ptilophyllum</em> flora of cycad-like and conifer plants between lava flows.</p>
+                </article>
+                <article class="card">
+                    <h3>Gondwana coalfields, Damodar valley</h3>
+                    <p>Permian Barakar and Raniganj measures (Jharkhand–West Bengal) are not standing petrified groves, but they lock the <em>Glossopteris</em> swamp forests that became India’s Gondwana coal.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="block" id="fossils" aria-labelledby="fossils-heading">
+            <div class="section-head">
+                <span class="tag">Palaeobotany</span>
+                <h2 id="fossils-heading">Plant fossils</h2>
+            </div>
+            <ul class="fact-list">
+                <li><strong>Petrified wood</strong> — silica replaced the original tissue, keeping growth rings and cell walls. Akal, Tiruvakkarai, Sathanur, and Ghughua are dominated by silicified trunks (conifers, palms, and dicots depending on the site).</li>
+                <li><strong>Glossopteris</strong> — tongue-shaped Gondwana leaves, the index plant of Permian coal forests in the Damodar and other peninsular basins.</li>
+                <li><strong>Ptilophyllum flora</strong> — Bennettitalean and cycad-like fronds of the Rajmahal intertrappeans, with conifers in the same beds.</li>
+                <li><strong>Deccan intertrappean plants</strong> — palms, dicot woods, fruits, and seeds at Ghughua, recording vegetation that grew between lava flows near the end of the Cretaceous.</li>
+                <li><strong>Tiruvakkarai woods</strong> — often assigned to gymnosperm and angiosperm form-genera (including <em>Mesembrioxylon</em>); trunks usually lack branches and leaves because they were flood-transported before burial.</li>
+            </ul>
+        </section>
+
+        <section class="block" id="age" aria-labelledby="age-heading">
+            <div class="section-head">
+                <span class="tag">Chronology</span>
+                <h2 id="age-heading">Geological age</h2>
+            </div>
+            <ol class="fact-list">
+                <li><strong>Permian (~299–252 Ma)</strong> — Gondwana coal measures; <em>Glossopteris</em> forests.</li>
+                <li><strong>Early Jurassic (~180 Ma)</strong> — Akal petrified wood, Lathi Formation, western Rajasthan.</li>
+                <li><strong>Jurassic–Cretaceous</strong> — Rajmahal traps and intertrappean plant beds of eastern India.</li>
+                <li><strong>Late Cretaceous (~100–66 Ma)</strong> — Sathanur gymnosperm wood; Ghughua Deccan intertrappean flora.</li>
+                <li><strong>Miocene–Pliocene (~20 Ma)</strong> — Tiruvakkarai trunks in Cuddalore Sandstone.</li>
+            </ol>
+        </section>
+
+        <section class="block" id="environments" aria-labelledby="environments-heading">
+            <div class="section-head">
+                <span class="tag">Palaeoecology</span>
+                <h2 id="environments-heading">Ancient environments</h2>
+            </div>
+            <div class="grid-2">
+                <article class="card">
+                    <h3>Gondwana swamps</h3>
+                    <p>Permian peat-forming forests grew on a cooler southern supercontinent. Their leaves and wood became the coal seams of eastern and central India after burial and heating.</p>
+                </article>
+                <article class="card">
+                    <h3>Jurassic coastal woods</h3>
+                    <p>Akal’s trees grew in a warm, humid setting near a seaway. Rapid burial and silica-rich groundwater turned trunks to stone; the same ground is now Thar Desert.</p>
+                </article>
+                <article class="card">
+                    <h3>Volcanic pauses</h3>
+                    <p>Rajmahal and Deccan intertrappean plants colonised soils and lakes between lava flows — short windows of forest in an otherwise volcanic landscape.</p>
+                </article>
+                <article class="card">
+                    <h3>Cenozoic rivers</h3>
+                    <p>Tiruvakkarai woods were carried by floods into coastal sandstone. The Cuddalore beds record tropical river and delta plains, not trees rooted where they now lie.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="block" id="significance" aria-labelledby="significance-heading">
+            <div class="section-head">
+                <span class="tag">Why it matters</span>
+                <h2 id="significance-heading">Scientific significance</h2>
+            </div>
+            <p><em>Glossopteris</em> on India, Africa, Australia, Antarctica, and South America was early evidence that those lands once formed Gondwana. Petrified parks show how climate and latitude have shifted: Jurassic humid forest at Akal versus today’s arid Jaisalmer. Deccan intertrappean plants date vegetation around the end-Cretaceous eruptions. GSI monuments at Tiruvakkarai, Sathanur, and Akal keep the wood in place for stratigraphy, palaeobotany, and public geoheritage.</p>
+        </section>
+
+        <section class="block" id="images" aria-labelledby="images-heading">
+            <div class="section-head">
+                <span class="tag">Visual</span>
+                <h2 id="images-heading">Images</h2>
+            </div>
+            <p class="lede">Simple diagrams of how these fossils are usually drawn — not photographs of any one specimen.</p>
+            <div class="art-grid">
+                <figure class="illustration card">
+                    <svg viewBox="0 0 200 140" role="img" aria-labelledby="art1-title">
+                        <title id="art1-title">Petrified tree trunk in sandstone</title>
+                        <rect width="200" height="140" class="ill-bg"/>
+                        <rect x="10" y="88" width="180" height="42" class="ill-ground"/>
+                        <ellipse cx="100" cy="78" rx="78" ry="16" class="ill-log"/>
+                        <ellipse cx="28" cy="78" rx="10" ry="16" class="ill-log-end"/>
+                        <path d="M50 70 Q70 78 90 70 T130 70 T170 72" class="ill-stroke"/>
+                    </svg>
+                    <figcaption>Silicified trunk lying in sandstone, as at the wood parks.</figcaption>
+                </figure>
+                <figure class="illustration card">
+                    <svg viewBox="0 0 200 140" role="img" aria-labelledby="art2-title">
+                        <title id="art2-title">Glossopteris leaf outline</title>
+                        <rect width="200" height="140" class="ill-bg"/>
+                        <path d="M100 18 Q138 50 128 118 Q100 132 72 118 Q62 50 100 18 Z" class="ill-leaf"/>
+                        <path d="M100 22 L100 124" class="ill-stroke"/>
+                    </svg>
+                    <figcaption>Tongue-shaped <em>Glossopteris</em> leaf of the Gondwana coal forests.</figcaption>
+                </figure>
+                <figure class="illustration card">
+                    <svg viewBox="0 0 200 140" role="img" aria-labelledby="art3-title">
+                        <title id="art3-title">Palm-like fossil among lava beds</title>
+                        <rect width="200" height="140" class="ill-bg"/>
+                        <rect x="0" y="100" width="200" height="18" class="ill-lava"/>
+                        <rect x="0" y="48" width="200" height="14" class="ill-lava"/>
+                        <rect x="92" y="62" width="16" height="38" class="ill-trunk"/>
+                        <path d="M100 62 L70 28 M100 62 L100 20 M100 62 L130 28" class="ill-stroke"/>
+                    </svg>
+                    <figcaption>Palm-like plants between lava sheets — Deccan and Rajmahal settings.</figcaption>
+                </figure>
+            </div>
+        </section>
+
+        <section class="block" id="map" aria-labelledby="map-heading">
+            <div class="section-head">
+                <span class="tag">Geography</span>
+                <h2 id="map-heading">Map</h2>
+            </div>
+            <p class="lede">Select a site to move the marker. Parks are GSI or state-protected; collection of fossils is not allowed.</p>
+            <div class="map-layout">
+                <div class="map-frame-wrap">
+                    <iframe
+                        id="fossil-map"
+                        title="Map of fossil forest sites in India"
+                        src="https://www.openstreetmap.org/export/embed.html?bbox=70.3,26.3,71.8,27.4&amp;layer=mapnik&amp;marker=26.825,71.04"
+                        loading="lazy"
+                    ></iframe>
+                </div>
+                <div>
+                    <div class="map-buttons" role="group" aria-label="Map locations">
+                        <button type="button" class="map-btn is-active" data-place="akal" aria-pressed="true">Akal</button>
+                        <button type="button" class="map-btn" data-place="tiruvakkarai">Tiruvakkarai</button>
+                        <button type="button" class="map-btn" data-place="sathanur">Sathanur</button>
+                        <button type="button" class="map-btn" data-place="ghughua">Ghughua</button>
+                        <button type="button" class="map-btn" data-place="rajmahal">Rajmahal</button>
+                        <button type="button" class="map-btn" data-place="raniganj">Raniganj</button>
+                    </div>
+                    <div class="card map-info" id="map-info" aria-live="polite">
+                        <h3 id="map-info-title">Akal Wood Fossil Park</h3>
+                        <p id="map-info-desc">Jaisalmer district, Rajasthan. Lower Jurassic petrified trunks in the Lathi Formation, about 17 km from Jaisalmer town.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="block sources" id="sources" aria-labelledby="sources-heading">
+            <div class="section-head">
+                <span class="tag">References</span>
+                <h2 id="sources-heading">Sources</h2>
+            </div>
+            <ol>
+                <li><a href="https://en.wikipedia.org/wiki/National_Geological_Monuments_of_India" target="_blank" rel="noopener noreferrer">Wikipedia — National Geological Monuments of India</a></li>
+                <li><a href="https://en.wikipedia.org/wiki/Akal_Wood_Fossil_Park" target="_blank" rel="noopener noreferrer">Wikipedia — Akal Wood Fossil Park</a></li>
+                <li><a href="https://en.wikipedia.org/wiki/National_Fossil_Wood_Park,_Tiruvakkarai" target="_blank" rel="noopener noreferrer">Wikipedia — National Fossil Wood Park, Tiruvakkarai</a></li>
+                <li><a href="https://en.wikipedia.org/wiki/National_Fossil_Wood_Park,_Sathanur" target="_blank" rel="noopener noreferrer">Wikipedia — National Fossil Wood Park, Sathanur</a></li>
+                <li><a href="https://en.wikipedia.org/wiki/Mandla_Plant_Fossils_National_Park" target="_blank" rel="noopener noreferrer">Wikipedia — Mandla Plant Fossils National Park (Ghughua)</a></li>
+                <li><a href="https://en.wikipedia.org/wiki/Rajmahal_Traps" target="_blank" rel="noopener noreferrer">Wikipedia — Rajmahal Traps</a></li>
+                <li><a href="https://en.wikipedia.org/wiki/Glossopteris" target="_blank" rel="noopener noreferrer">Wikipedia — Glossopteris</a></li>
+            </ol>
+        </section>
+    </main>
+
+    <footer class="page-footer">
+        <p>Incredible India Explorer · Fossil Forests of India · <a href="../../index.html">Home</a></p>
+    </footer>
+
+    <script src="script.js" defer></script>
+</body>
+</html>

--- a/frontend/fossil-forests-india/script.js
+++ b/frontend/fossil-forests-india/script.js
@@ -1,0 +1,109 @@
+(function () {
+    const places = {
+        akal: {
+            title: "Akal Wood Fossil Park",
+            desc: "Jaisalmer district, Rajasthan. Lower Jurassic petrified trunks in the Lathi Formation, about 17 km from Jaisalmer town.",
+            lat: 26.825,
+            lon: 71.04,
+            bbox: [70.3, 26.3, 71.8, 27.4]
+        },
+        tiruvakkarai: {
+            title: "Tiruvakkarai Fossil Wood Park",
+            desc: "Villupuram district, Tamil Nadu. Miocene–Pliocene silicified trunks in Cuddalore Sandstone; a GSI monument since 1951.",
+            lat: 12.01917,
+            lon: 79.65333,
+            bbox: [78.9, 11.4, 80.4, 12.6]
+        },
+        sathanur: {
+            title: "Sathanur Fossil Wood Park",
+            desc: "Perambalur district, Tamil Nadu. Late Cretaceous gymnosperm trunk about 18 m long, with similar logs in nearby villages.",
+            lat: 11.161139,
+            lon: 78.976417,
+            bbox: [78.2, 10.6, 79.7, 11.7]
+        },
+        ghughua: {
+            title: "Ghughua Fossil Park",
+            desc: "Dindori district, Madhya Pradesh. Late Cretaceous Deccan intertrappean plants: woods, fruits, and leaves in a 1983 national park.",
+            lat: 23.12,
+            lon: 80.62,
+            bbox: [79.8, 22.5, 81.4, 23.7]
+        },
+        rajmahal: {
+            title: "Rajmahal Hills (Mandro)",
+            desc: "Sahibganj district, Jharkhand. Jurassic–Cretaceous intertrappean beds with the Ptilophyllum flora between Rajmahal lava flows.",
+            lat: 25.15,
+            lon: 87.51,
+            bbox: [86.7, 24.5, 88.3, 25.8]
+        },
+        raniganj: {
+            title: "Raniganj coalfield",
+            desc: "Paschim Bardhaman, West Bengal. Permian Gondwana measures preserving Glossopteris swamp-forest plants as coal and impressions.",
+            lat: 23.616,
+            lon: 87.125,
+            bbox: [86.4, 23.1, 87.9, 24.1]
+        }
+    };
+
+    function mapSrc(place) {
+        const box = place.bbox.join(",");
+        return "https://www.openstreetmap.org/export/embed.html?bbox=" +
+            encodeURIComponent(box) +
+            "&layer=mapnik&marker=" +
+            encodeURIComponent(place.lat + "," + place.lon);
+    }
+
+    function initThemeToggle() {
+        const button = document.getElementById("theme-toggle");
+        const root = document.documentElement;
+
+        function applyTheme(theme) {
+            const isLight = theme === "light";
+            root.classList.toggle("light-theme", isLight);
+            document.body.classList.toggle("light-theme", isLight);
+            button.textContent = isLight ? "🌙" : "☀️";
+            button.setAttribute("aria-label", isLight ? "Switch to dark theme" : "Switch to light theme");
+        }
+
+        applyTheme(localStorage.getItem("theme") === "light" ? "light" : "dark");
+
+        button.addEventListener("click", function () {
+            const next = document.body.classList.contains("light-theme") ? "dark" : "light";
+            localStorage.setItem("theme", next);
+            applyTheme(next);
+        });
+    }
+
+    function initMap() {
+        const frame = document.getElementById("fossil-map");
+        const titleEl = document.getElementById("map-info-title");
+        const descEl = document.getElementById("map-info-desc");
+        const buttons = document.querySelectorAll(".map-btn");
+
+        function showPlace(key) {
+            const place = places[key];
+            if (!place) {
+                return;
+            }
+            frame.src = mapSrc(place);
+            titleEl.textContent = place.title;
+            descEl.textContent = place.desc;
+            buttons.forEach(function (btn) {
+                const active = btn.getAttribute("data-place") === key;
+                btn.classList.toggle("is-active", active);
+                btn.setAttribute("aria-pressed", active ? "true" : "false");
+            });
+        }
+
+        buttons.forEach(function (btn) {
+            btn.setAttribute("aria-pressed", btn.classList.contains("is-active") ? "true" : "false");
+            btn.addEventListener("click", function () {
+                showPlace(btn.getAttribute("data-place"));
+            });
+        });
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+        initThemeToggle();
+        initMap();
+    });
+})();

--- a/frontend/fossil-forests-india/style.css
+++ b/frontend/fossil-forests-india/style.css
@@ -1,0 +1,394 @@
+:root {
+    --bg: #16120e;
+    --bg-alt: #1e1914;
+    --surface: #2a231c;
+    --line: #4a3c30;
+    --text: #f3ebe2;
+    --muted: #cbb9a6;
+    --dim: #9a8876;
+    --accent: #c9843c;
+    --accent-2: #7a9e5c;
+    --heading: "Playfair Display", Georgia, serif;
+    --body: "Outfit", system-ui, sans-serif;
+}
+
+body.light-theme,
+html.light-theme,
+html.light-theme body {
+    --bg: #f5efe6;
+    --bg-alt: #ebe3d4;
+    --surface: #ffffff;
+    --line: #d4c4ae;
+    --text: #241c14;
+    --muted: #544636;
+    --dim: #7a6b5a;
+    --accent: #8a4e14;
+    --accent-2: #3d5c28;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--body);
+    line-height: 1.65;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
+
+    * {
+        animation: none !important;
+        transition: none !important;
+    }
+}
+
+a {
+    color: var(--accent);
+}
+
+a:focus-visible,
+button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+}
+
+.skip-link {
+    position: absolute;
+    left: -999px;
+    top: 0;
+    background: var(--accent);
+    color: #111;
+    padding: 0.5rem 1rem;
+    z-index: 1000;
+}
+
+.skip-link:focus {
+    left: 8px;
+    top: 8px;
+}
+
+.topnav {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.85rem 1.25rem;
+    background: var(--bg);
+    border-bottom: 1px solid var(--line);
+    overflow-x: auto;
+}
+
+.brand {
+    font-weight: 700;
+    text-decoration: none;
+    color: var(--text);
+    white-space: nowrap;
+}
+
+.nav-links {
+    display: flex;
+    gap: 0.9rem;
+    font-size: 0.85rem;
+}
+
+.nav-links a {
+    color: var(--muted);
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.nav-links a:hover {
+    color: var(--text);
+}
+
+.theme-toggle {
+    margin-left: auto;
+    border: 1px solid var(--line);
+    background: var(--surface);
+    color: var(--text);
+    border-radius: 999px;
+    width: 2.4rem;
+    height: 2.4rem;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.hero {
+    padding: 4.5rem 8vw 3.5rem;
+    background:
+        radial-gradient(900px 420px at 12% -20%, rgba(201, 132, 60, 0.2), transparent 55%),
+        var(--bg);
+    border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+    font-size: 0.78rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent-2);
+    margin: 0 0 1rem;
+}
+
+h1 {
+    font-family: var(--heading);
+    font-size: clamp(2rem, 5vw, 3.4rem);
+    line-height: 1.1;
+    margin: 0 0 0.75rem;
+    max-width: 16ch;
+}
+
+.hero-date {
+    color: var(--accent);
+    font-weight: 600;
+    margin: 0 0 1.25rem;
+}
+
+.lede {
+    max-width: 68ch;
+    color: var(--muted);
+    font-size: 1.05rem;
+}
+
+.hero-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2rem;
+    margin: 2.5rem 0 0;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--line);
+}
+
+.hero-stats dt {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--dim);
+}
+
+.hero-stats dd {
+    margin: 0.2rem 0 0;
+    font-family: var(--heading);
+    font-size: 1.6rem;
+    font-weight: 600;
+}
+
+.block {
+    padding: 4.5rem 8vw;
+    border-bottom: 1px solid var(--line);
+}
+
+.block:nth-child(even) {
+    background: var(--bg-alt);
+}
+
+.section-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.tag {
+    font-size: 0.72rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--accent);
+    border: 1px solid var(--line);
+    padding: 0.2rem 0.6rem;
+}
+
+h2 {
+    font-family: var(--heading);
+    font-size: clamp(1.5rem, 3vw, 2.1rem);
+    margin: 0;
+}
+
+.grid-2 {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+}
+
+.art-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.25rem;
+}
+
+.card {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 1.35rem 1.4rem;
+}
+
+.card h3 {
+    margin: 0 0 0.6rem;
+    font-size: 1.05rem;
+}
+
+.card p,
+.card li {
+    color: var(--muted);
+    margin: 0;
+}
+
+.fact-list {
+    margin: 0;
+    padding-left: 1.15rem;
+    max-width: 75ch;
+}
+
+.fact-list li + li {
+    margin-top: 0.7rem;
+}
+
+.illustration {
+    margin: 0;
+}
+
+.illustration svg {
+    display: block;
+    width: 100%;
+    height: auto;
+    border-radius: 8px;
+    border: 1px solid var(--line);
+}
+
+.illustration figcaption {
+    margin-top: 0.6rem;
+    font-size: 0.9rem;
+    color: var(--dim);
+}
+
+.ill-bg {
+    fill: var(--bg-alt);
+}
+
+.ill-ground,
+.ill-lava,
+.ill-leaf {
+    fill: var(--accent-2);
+    opacity: 0.45;
+}
+
+.ill-log,
+.ill-log-end,
+.ill-trunk {
+    fill: var(--accent);
+}
+
+.ill-stroke {
+    stroke: var(--accent);
+    fill: none;
+    stroke-width: 2;
+}
+
+.map-layout {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr;
+    gap: 1.25rem;
+    align-items: start;
+}
+
+.map-frame-wrap {
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    overflow: hidden;
+    min-height: 320px;
+    background: var(--surface);
+}
+
+.map-frame-wrap iframe {
+    display: block;
+    width: 100%;
+    height: 360px;
+    border: 0;
+}
+
+.map-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 0.9rem;
+}
+
+.map-btn {
+    border: 1px solid var(--line);
+    background: var(--surface);
+    color: var(--text);
+    border-radius: 999px;
+    padding: 0.35rem 0.8rem;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.85rem;
+}
+
+.map-btn.is-active,
+.map-btn:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.sources ol {
+    max-width: 75ch;
+    padding-left: 1.2rem;
+}
+
+.sources li + li {
+    margin-top: 0.55rem;
+}
+
+.page-footer {
+    padding: 1.5rem 8vw;
+    color: var(--dim);
+    font-size: 0.9rem;
+}
+
+.page-footer a {
+    color: var(--muted);
+}
+
+@media (max-width: 900px) {
+    .art-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 768px) {
+    .grid-2,
+    .map-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .hero,
+    .block {
+        padding: 3rem 1.25rem;
+    }
+
+    .topnav {
+        flex-wrap: wrap;
+    }
+
+    .nav-links {
+        order: 3;
+        width: 100%;
+        padding-top: 0.35rem;
+    }
+}

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -6590,5 +6590,14 @@ window.indiaSearchIndex = [
         description:
             "Explore the legendary story of Hanuman and Sanjeevani \u2014 the desperate quest across the Himalayas to retrieve the life-saving herb and revive Lakshmana.",
         url: "frontend/hanuman-sanjeevani-story/index.html"
+    },
+
+    // --- Fossil Forests of India (#3814) ---
+    {
+        title: "Fossil Forests of India \u2014 Petrified Wood & Ancient Plants",
+        category: "Geology & Disasters",
+        description:
+            "Explore India's fossil forests and plant remains: Akal, Tiruvakkarai, Sathanur, Ghughua, Rajmahal, and Gondwana Glossopteris floras, with ages, ancient environments, and a site map.",
+        url: "frontend/fossil-forests-india/index.html"
     }
 ];


### PR DESCRIPTION
## Description

Adds an educational profile of India’s fossil forests and ancient plant remains: Akal, Tiruvakkarai, Sathanur, Ghughua, Rajmahal, and Gondwana Glossopteris floras, with plant fossils, geological ages, ancient environments, scientific significance, diagrams, and a site map.

Fixes #3814

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (x or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Tested locally in browser
- [x] Tested in both dark and light themes
- [x] Tested at mobile viewport widths
- [x] Verified no console errors

## Checklist

- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an educational page about India’s fossil forests, covering locations, fossils, geological history, ancient environments, and scientific importance.
  * Added interactive fossil site maps with selectable locations and map embeds.
  * Added dark/light theme switching with saved preferences.
  * Added responsive layouts, accessibility enhancements, diagrams, references, and navigation.
  * Added the page to the site’s search index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->