### PR TITLE
feat: add Deccan volcanic landscape profile

### DIFF
--- a/frontend/deccan-volcanic-landscape/index.html
+++ b/frontend/deccan-volcanic-landscape/index.html
@@ -1,0 +1,183 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function () {
+            const theme = localStorage.getItem("theme") || "dark";
+            if (theme === "light") {
+                document.documentElement.classList.add("light-theme");
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Deccan Volcanic Landscape | Incredible India Explorer</title>
+    <meta name="description" content="Educational profile of the Deccan Traps: flood-basalt history, Western Ghats stratigraphy, timeline around 66 Ma, intertrappean fossils, and the stepped plateau landscape.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&family=Playfair+Display:ital,wght@0,600;0,700;1,500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <a class="skip-link" href="#main">Skip to main content</a>
+
+    <header class="site-header">
+        <nav class="topnav" aria-label="Primary">
+            <a class="brand" href="../../index.html">Incredible India Explorer</a>
+            <div class="nav-links">
+                <a href="#history">History</a>
+                <a href="#basalt">Basalt</a>
+                <a href="#timeline">Timeline</a>
+                <a href="#fossils">Fossils</a>
+                <a href="#landscape">Landscape</a>
+                <a href="#map">Map</a>
+                <a href="#sources">Sources</a>
+            </div>
+            <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Switch to light theme">☀️</button>
+        </nav>
+    </header>
+
+    <main id="main">
+        <header class="hero">
+            <p class="eyebrow">Large igneous province · Late Cretaceous–Paleocene</p>
+            <h1>The Deccan Volcanic Landscape</h1>
+            <p class="hero-date">Flood basalts · Western Ghats · K–Pg boundary ~66 Ma</p>
+            <p class="lede">The Deccan Traps are one of Earth’s largest volcanic provinces. Layered lava built a plateau that still shapes western and central India, and the eruptions overlap the end-Cretaceous extinction that closed the age of non-avian dinosaurs.</p>
+            <dl class="hero-stats">
+                <div>
+                    <dt>Present area</dt>
+                    <dd>~500,000 km²</dd>
+                </div>
+                <div>
+                    <dt>Original cover</dt>
+                    <dd>~1.5 million km²</dd>
+                </div>
+                <div>
+                    <dt>Stack thickness</dt>
+                    <dd>&gt;2 km</dd>
+                </div>
+                <div>
+                    <dt>Main pulse</dt>
+                    <dd>~66–65 Ma</dd>
+                </div>
+            </dl>
+        </header>
+
+        <section class="block" id="history" aria-labelledby="history-heading">
+            <div class="section-head">
+                <span class="tag">Volcanism</span>
+                <h2 id="history-heading">Volcanic history</h2>
+            </div>
+            <p>As the Indian plate drifted over a mantle plume (the Réunion hotspot), fissures poured tholeiitic flood basalt rather than building a single cone. The main Deccan, Malwa Plateau, Mandla lobe, and Saurashtra plateau are sub-provinces of the same event. Most of the volume erupted in the Western Ghats around 66–65 million years ago, in pulses short enough that some flow packages may represent only tens of thousands of years. Distal sheets reached the east coast as the Rajahmundry Traps. India was then an island continent; the lavas altered climate and habitat at the close of the Cretaceous.</p>
+        </section>
+
+        <section class="block" id="basalt" aria-labelledby="basalt-heading">
+            <div class="section-head">
+                <span class="tag">Rock</span>
+                <h2 id="basalt-heading">Basalt formations</h2>
+            </div>
+            <div class="grid-2">
+                <article class="card">
+                    <h3>Flood-basalt flows</h3>
+                    <p>Compound pāhoehoe lobes dominate the thick Western Ghats pile; simpler ʻaʻā sheets are more common toward the thinner margins. Red boles (weathered tops and thin soils) mark pauses between eruptions.</p>
+                </article>
+                <article class="card">
+                    <h3>Western Ghats subgroups</h3>
+                    <p>The Deccan Basalt Group is mapped as Kalsubai (base: Jawhar to Bhimashankar), Lonavala (Khandala, Bushe), and Wai (Poladpur to Desur, including Mahabaleshwar). Twelve formations stack from north of Nashik toward Belgaum.</p>
+                </article>
+                <article class="card">
+                    <h3>Columnar jointing</h3>
+                    <p>Slow-cooled interiors crack into columns. Gilbert Hill in Mumbai and St. Mary’s Island off Udupi are well-known Deccan examples of hexagonal jointing in the same lava province.</p>
+                </article>
+                <article class="card">
+                    <h3>Dykes and laterite</h3>
+                    <p>Feeder dykes, especially along the Narmada–Tapi zone, record the fissures. Deep weathering of plateau basalt produces laterite caps and the black cotton (regur) soils of the Deccan.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="block" id="timeline" aria-labelledby="timeline-heading">
+            <div class="section-head">
+                <span class="tag">Chronology</span>
+                <h2 id="timeline-heading">Geological timeline</h2>
+            </div>
+            <ol class="fact-list">
+                <li><strong>Before the main pile</strong> — Maastrichtian Lameta (infratrappean) sediments: river and lake deposits with dinosaurs, eggs, and freshwater molluscs on the Indian Shield.</li>
+                <li><strong>~66.25 Ma</strong> — Deccan eruptions well underway; Kalsubai and Lonavala subgroups build the lower Western Ghats stack.</li>
+                <li><strong>~66.05 Ma (K–Pg)</strong> — The Cretaceous–Paleogene boundary sits near the Lonavala–Wai transition (Bushe to Poladpur in many Western Ghats sections). Chicxulub and Deccan overlap in time; their relative roles in the extinction remain debated.</li>
+                <li><strong>~66–65 Ma</strong> — Voluminous Wai Subgroup flows, including Mahabaleshwar; Rajahmundry Traps on the Godavari coast correlate with this upper package.</li>
+                <li><strong>After the lavas</strong> — Erosion cuts the Western Ghats escarpment; laterite and black soils form; much later, the Lonar meteorite punches a crater in the basalt plateau.</li>
+            </ol>
+        </section>
+
+        <section class="block" id="fossils" aria-labelledby="fossils-heading">
+            <div class="section-head">
+                <span class="tag">Palaeontology</span>
+                <h2 id="fossils-heading">Fossil connections</h2>
+            </div>
+            <p>Beds between and beneath the lavas are the main window on India’s end-Cretaceous environment. Infratrappean Lameta rocks around Jabalpur and the Narmada hold titanosaur bones, nests, and the abelisaurid <em>Rajasaurus</em> from nearby horizons. Intertrappean lakes and soils preserve plants (as at Ghughua), frogs such as <em>Indobatrachus</em>, turtles, crocodilians, and freshwater molluscs. Those fossils show forests and wetlands returning between eruptions — a prehistoric landscape repeatedly reset by lava, then recolonised, until the plateau sealed over much of west-central India.</p>
+        </section>
+
+        <section class="block" id="landscape" aria-labelledby="landscape-heading">
+            <div class="section-head">
+                <span class="tag">Geomorphology</span>
+                <h2 id="landscape-heading">Landscape formation</h2>
+            </div>
+            <p><em>Trap</em> is from a word for stair: each flow weathers to a bench, so the Western Ghats and Maharashtra plateaus look stepped. Headward erosion of the west-facing escarpment and rivers cutting east across the pile produced mesas, gorges, and waterfall lines on flow tops. Ajanta and Ellora are excavated in these basalts. Lonar is a later impact bowl in the same rock. The high lava pile also set the drainage divide of the northern Western Ghats and the black-soil plains that still farm the weathered flows.</p>
+        </section>
+
+        <section class="block" id="map" aria-labelledby="map-heading">
+            <div class="section-head">
+                <span class="tag">Geography</span>
+                <h2 id="map-heading">Interactive map</h2>
+            </div>
+            <p class="lede">Select a locality to move the marker across the Deccan province, from the thick Western Ghats stack to distal eastern flows and the Lameta fossil belt.</p>
+            <div class="map-layout">
+                <div class="map-frame-wrap">
+                    <iframe
+                        id="deccan-map"
+                        title="Map of Deccan volcanic landscape sites"
+                        src="https://www.openstreetmap.org/export/embed.html?bbox=73.2,17.5,74.1,18.3&amp;layer=mapnik&amp;marker=17.9307,73.6477"
+                        loading="lazy"
+                    ></iframe>
+                </div>
+                <div>
+                    <div class="map-buttons" role="group" aria-label="Map locations">
+                        <button type="button" class="map-btn is-active" data-place="mahabaleshwar" aria-pressed="true">Mahabaleshwar</button>
+                        <button type="button" class="map-btn" data-place="kalsubai">Kalsubai</button>
+                        <button type="button" class="map-btn" data-place="gilbert">Gilbert Hill</button>
+                        <button type="button" class="map-btn" data-place="lonar">Lonar</button>
+                        <button type="button" class="map-btn" data-place="jabalpur">Jabalpur</button>
+                        <button type="button" class="map-btn" data-place="rajahmundry">Rajahmundry</button>
+                    </div>
+                    <div class="card map-info" id="map-info" aria-live="polite">
+                        <h3 id="map-info-title">Mahabaleshwar</h3>
+                        <p id="map-info-desc">Western Ghats, Maharashtra. Type area for the upper Wai Subgroup. Stepped trap benches and a thick flood-basalt section near the crest of the plateau.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="block sources" id="sources" aria-labelledby="sources-heading">
+            <div class="section-head">
+                <span class="tag">References</span>
+                <h2 id="sources-heading">Sources</h2>
+            </div>
+            <ol>
+                <li><a href="https://en.wikipedia.org/wiki/Deccan_Traps" target="_blank" rel="noopener noreferrer">Wikipedia — Deccan Traps</a></li>
+                <li><a href="https://www.geosocindia.org/index.php/jgsi/article/view/153479" target="_blank" rel="noopener noreferrer">Journal of the Geological Society of India — Deccan Volcanic Province review</a></li>
+                <li><a href="https://doi.org/10.1126/science.aac7549" target="_blank" rel="noopener noreferrer">Renne et al., Science — Deccan volcanism at the K–Pg boundary</a></li>
+                <li><a href="https://en.wikipedia.org/wiki/Lameta_Formation" target="_blank" rel="noopener noreferrer">Wikipedia — Lameta Formation</a></li>
+                <li><a href="https://en.wikipedia.org/wiki/Lonar_Lake" target="_blank" rel="noopener noreferrer">Wikipedia — Lonar Lake</a></li>
+                <li><a href="https://en.wikipedia.org/wiki/Gilbert_Hill" target="_blank" rel="noopener noreferrer">Wikipedia — Gilbert Hill</a></li>
+            </ol>
+        </section>
+    </main>
+
+    <footer class="page-footer">
+        <p>Incredible India Explorer · Deccan Volcanic Landscape · <a href="../../index.html">Home</a></p>
+    </footer>
+
+    <script src="script.js" defer></script>
+</body>
+</html>

--- a/frontend/deccan-volcanic-landscape/script.js
+++ b/frontend/deccan-volcanic-landscape/script.js
@@ -1,0 +1,109 @@
+(function () {
+    const places = {
+        mahabaleshwar: {
+            title: "Mahabaleshwar",
+            desc: "Western Ghats, Maharashtra. Type area for the upper Wai Subgroup. Stepped trap benches and a thick flood-basalt section near the crest of the plateau.",
+            lat: 17.9307,
+            lon: 73.6477,
+            bbox: [73.2, 17.5, 74.1, 18.3]
+        },
+        kalsubai: {
+            title: "Kalsubai",
+            desc: "Highest peak in Maharashtra (1,646 m), in the Kalsubai Subgroup at the base of the Western Ghats lava pile north of Nashik.",
+            lat: 19.6013,
+            lon: 73.709,
+            bbox: [73.3, 19.3, 74.1, 19.9]
+        },
+        gilbert: {
+            title: "Gilbert Hill",
+            desc: "Andheri, Mumbai. A ~61 m columnar-basalt monolith in Deccan lava, a Grade II heritage site showing hexagonal jointing.",
+            lat: 19.1306,
+            lon: 72.842,
+            bbox: [72.7, 19.0, 73.0, 19.26]
+        },
+        lonar: {
+            title: "Lonar crater",
+            desc: "Buldhana district, Maharashtra. A meteorite crater in Deccan flood basalt, with a saline lake on the floor. Impact age estimates vary (tens of thousands of years).",
+            lat: 19.9767,
+            lon: 76.5083,
+            bbox: [76.2, 19.75, 76.8, 20.2]
+        },
+        jabalpur: {
+            title: "Jabalpur (Lameta)",
+            desc: "Madhya Pradesh. Infratrappean Lameta beds along the Narmada: Maastrichtian dinosaurs, eggs, and lake-river fossils beneath and beside Deccan lava.",
+            lat: 23.101,
+            lon: 79.932,
+            bbox: [79.5, 22.85, 80.35, 23.35]
+        },
+        rajahmundry: {
+            title: "Rajahmundry Traps",
+            desc: "East Godavari, Andhra Pradesh. Distal eastern Deccan flows correlated with the Wai Subgroup, showing lava reached the Bay of Bengal margin.",
+            lat: 17.0,
+            lon: 81.78,
+            bbox: [81.3, 16.6, 82.3, 17.4]
+        }
+    };
+
+    function mapSrc(place) {
+        const box = place.bbox.join(",");
+        return "https://www.openstreetmap.org/export/embed.html?bbox=" +
+            encodeURIComponent(box) +
+            "&layer=mapnik&marker=" +
+            encodeURIComponent(place.lat + "," + place.lon);
+    }
+
+    function initThemeToggle() {
+        const button = document.getElementById("theme-toggle");
+        const root = document.documentElement;
+
+        function applyTheme(theme) {
+            const isLight = theme === "light";
+            root.classList.toggle("light-theme", isLight);
+            document.body.classList.toggle("light-theme", isLight);
+            button.textContent = isLight ? "🌙" : "☀️";
+            button.setAttribute("aria-label", isLight ? "Switch to dark theme" : "Switch to light theme");
+        }
+
+        applyTheme(localStorage.getItem("theme") === "light" ? "light" : "dark");
+
+        button.addEventListener("click", function () {
+            const next = document.body.classList.contains("light-theme") ? "dark" : "light";
+            localStorage.setItem("theme", next);
+            applyTheme(next);
+        });
+    }
+
+    function initMap() {
+        const frame = document.getElementById("deccan-map");
+        const titleEl = document.getElementById("map-info-title");
+        const descEl = document.getElementById("map-info-desc");
+        const buttons = document.querySelectorAll(".map-btn");
+
+        function showPlace(key) {
+            const place = places[key];
+            if (!place) {
+                return;
+            }
+            frame.src = mapSrc(place);
+            titleEl.textContent = place.title;
+            descEl.textContent = place.desc;
+            buttons.forEach(function (btn) {
+                const active = btn.getAttribute("data-place") === key;
+                btn.classList.toggle("is-active", active);
+                btn.setAttribute("aria-pressed", active ? "true" : "false");
+            });
+        }
+
+        buttons.forEach(function (btn) {
+            btn.setAttribute("aria-pressed", btn.classList.contains("is-active") ? "true" : "false");
+            btn.addEventListener("click", function () {
+                showPlace(btn.getAttribute("data-place"));
+            });
+        });
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+        initThemeToggle();
+        initMap();
+    });
+})();

--- a/frontend/deccan-volcanic-landscape/style.css
+++ b/frontend/deccan-volcanic-landscape/style.css
@@ -1,0 +1,340 @@
+:root {
+    --bg: #140e0c;
+    --bg-alt: #1c1410;
+    --surface: #2a1c16;
+    --line: #4e3228;
+    --text: #f4ece6;
+    --muted: #d0b8a8;
+    --dim: #9a7e70;
+    --accent: #e06030;
+    --accent-2: #d4a04a;
+    --heading: "Playfair Display", Georgia, serif;
+    --body: "Outfit", system-ui, sans-serif;
+}
+
+body.light-theme,
+html.light-theme,
+html.light-theme body {
+    --bg: #f6efe8;
+    --bg-alt: #ebe0d4;
+    --surface: #ffffff;
+    --line: #d4c0b0;
+    --text: #241410;
+    --muted: #5c4034;
+    --dim: #7a5c4e;
+    --accent: #b43c14;
+    --accent-2: #8a5a10;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--body);
+    line-height: 1.65;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
+
+    * {
+        animation: none !important;
+        transition: none !important;
+    }
+}
+
+a {
+    color: var(--accent);
+}
+
+a:focus-visible,
+button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+}
+
+.skip-link {
+    position: absolute;
+    left: -999px;
+    top: 0;
+    background: var(--accent);
+    color: #111;
+    padding: 0.5rem 1rem;
+    z-index: 1000;
+}
+
+.skip-link:focus {
+    left: 8px;
+    top: 8px;
+}
+
+.topnav {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.85rem 1.25rem;
+    background: var(--bg);
+    border-bottom: 1px solid var(--line);
+    overflow-x: auto;
+}
+
+.brand {
+    font-weight: 700;
+    text-decoration: none;
+    color: var(--text);
+    white-space: nowrap;
+}
+
+.nav-links {
+    display: flex;
+    gap: 0.9rem;
+    font-size: 0.85rem;
+}
+
+.nav-links a {
+    color: var(--muted);
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.nav-links a:hover {
+    color: var(--text);
+}
+
+.theme-toggle {
+    margin-left: auto;
+    border: 1px solid var(--line);
+    background: var(--surface);
+    color: var(--text);
+    border-radius: 999px;
+    width: 2.4rem;
+    height: 2.4rem;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.hero {
+    padding: 4.5rem 8vw 3.5rem;
+    background:
+        radial-gradient(900px 420px at 12% -20%, rgba(224, 96, 48, 0.22), transparent 55%),
+        var(--bg);
+    border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+    font-size: 0.78rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent-2);
+    margin: 0 0 1rem;
+}
+
+h1 {
+    font-family: var(--heading);
+    font-size: clamp(2rem, 5vw, 3.4rem);
+    line-height: 1.1;
+    margin: 0 0 0.75rem;
+    max-width: 16ch;
+}
+
+.hero-date {
+    color: var(--accent);
+    font-weight: 600;
+    margin: 0 0 1.25rem;
+}
+
+.lede {
+    max-width: 68ch;
+    color: var(--muted);
+    font-size: 1.05rem;
+}
+
+.hero-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2rem;
+    margin: 2.5rem 0 0;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--line);
+}
+
+.hero-stats dt {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--dim);
+}
+
+.hero-stats dd {
+    margin: 0.2rem 0 0;
+    font-family: var(--heading);
+    font-size: 1.6rem;
+    font-weight: 600;
+}
+
+.block {
+    padding: 4.5rem 8vw;
+    border-bottom: 1px solid var(--line);
+}
+
+.block:nth-child(even) {
+    background: var(--bg-alt);
+}
+
+.section-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.tag {
+    font-size: 0.72rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--accent);
+    border: 1px solid var(--line);
+    padding: 0.2rem 0.6rem;
+}
+
+h2 {
+    font-family: var(--heading);
+    font-size: clamp(1.5rem, 3vw, 2.1rem);
+    margin: 0;
+}
+
+.grid-2 {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+}
+
+.card {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 1.35rem 1.4rem;
+}
+
+.card h3 {
+    margin: 0 0 0.6rem;
+    font-size: 1.05rem;
+}
+
+.card p {
+    color: var(--muted);
+    margin: 0;
+}
+
+.fact-list {
+    margin: 0;
+    padding-left: 1.15rem;
+    max-width: 75ch;
+}
+
+.fact-list li + li {
+    margin-top: 0.7rem;
+}
+
+.map-layout {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr;
+    gap: 1.25rem;
+    align-items: start;
+}
+
+.map-frame-wrap {
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    overflow: hidden;
+    min-height: 320px;
+    background: var(--surface);
+}
+
+.map-frame-wrap iframe {
+    display: block;
+    width: 100%;
+    height: 360px;
+    border: 0;
+}
+
+.map-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 0.9rem;
+}
+
+.map-btn {
+    border: 1px solid var(--line);
+    background: var(--surface);
+    color: var(--text);
+    border-radius: 999px;
+    padding: 0.35rem 0.8rem;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.85rem;
+}
+
+.map-btn.is-active,
+.map-btn:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.sources ol {
+    max-width: 75ch;
+    padding-left: 1.2rem;
+}
+
+.sources li + li {
+    margin-top: 0.55rem;
+}
+
+.page-footer {
+    padding: 1.5rem 8vw;
+    color: var(--dim);
+    font-size: 0.9rem;
+}
+
+.page-footer a {
+    color: var(--muted);
+}
+
+@media (max-width: 768px) {
+    .grid-2,
+    .map-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .hero,
+    .block {
+        padding: 3rem 1.25rem;
+    }
+
+    .topnav {
+        flex-wrap: wrap;
+    }
+
+    .nav-links {
+        order: 3;
+        width: 100%;
+        padding-top: 0.35rem;
+    }
+}

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -6599,5 +6599,14 @@ window.indiaSearchIndex = [
         description:
             "Explore the traditional story of Pundalik and Vithoba: the waiting Lord on the brick, Pandharpur on the Chandrabhaga, and the Warkari pilgrimage.",
         url: "frontend/pundalik-vithoba-story/index.html"
+    },
+
+    // --- Deccan Volcanic Landscape (#3816) ---
+    {
+        title: "Deccan Volcanic Landscape \u2014 Flood Basalts & Prehistoric India",
+        category: "Geology & Disasters",
+        description:
+            "Explore the Deccan Traps: flood-basalt history, Western Ghats stratigraphy, a ~66 Ma timeline, intertrappean fossils, trap landscape, and an interactive site map.",
+        url: "frontend/deccan-volcanic-landscape/index.html"
     }
 ];


### PR DESCRIPTION
## Description

Adds an educational profile of the Deccan Traps: flood-basalt history, basalt formations and Western Ghats subgroups, a geological timeline around 66 Ma, intertrappean and Lameta fossil connections, trap-step landscape, and an interactive site map.

Fixes #3816

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking cnge (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Tested locally in browser
- [x] Tested in both dark and light themes
- [x] Tested at mobile viewport widths
- [x] Verified no console errors

## Checklist

- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)