### PR TITLE
feat: add India before the Himalayas geological timeline

### DIFF
--- a/frontend/india-before-himalayas/index.html
+++ b/frontend/india-before-himalayas/index.html
@@ -1,0 +1,264 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function () {
+            const theme = localStorage.getItem("theme") || "dark";
+            if (theme === "light") {
+                document.documentElement.classList.add("light-theme");
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>India Before the Himalayas Formed | Incredible India Explorer</title>
+    <meta name="description" content="Visual geological timeline of the Indian plate: Gondwana, Tethys geography, collision with Eurasia, Himalayan formation, and maps of the journey.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&family=Playfair+Display:ital,wght@0,600;0,700;1,500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <a class="skip-link" href="#main">Skip to main content</a>
+
+    <header class="site-header">
+        <nav class="topnav" aria-label="Primary">
+            <a class="brand" href="../../index.html">Incredible India Explorer</a>
+            <div class="nav-links">
+                <a href="#plate">Plate</a>
+                <a href="#geography">Geography</a>
+                <a href="#collision">Collision</a>
+                <a href="#himalaya">Himalaya</a>
+                <a href="#timeline">Timeline</a>
+                <a href="#maps">Maps</a>
+                <a href="#sources">Sources</a>
+            </div>
+            <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Switch to light theme">☀️</button>
+        </nav>
+    </header>
+
+    <main id="main">
+        <header class="hero">
+            <p class="eyebrow">Plate tectonics · Tethys to Himalaya</p>
+            <h1>India Before the Himalayas Formed</h1>
+            <p class="hero-date">Gondwana · northward drift · collision ~50 Ma · still rising</p>
+            <p class="lede">Before the Himalaya existed, India was a Gondwanan landmass, then an island continent racing across a closing Tethys Ocean. This page is a visual timeline of that journey and of the collision that built the range.</p>
+            <dl class="hero-stats">
+                <div>
+                    <dt>Gondwana India</dt>
+                    <dd>~180 Ma</dd>
+                </div>
+                <div>
+                    <dt>Gap at ~80 Ma</dt>
+                    <dd>~6,400 km</dd>
+                </div>
+                <div>
+                    <dt>Collision onset</dt>
+                    <dd>~55–50 Ma</dd>
+                </div>
+                <div>
+                    <dt>Convergence today</dt>
+                    <dd>~4–5 cm/yr</dd>
+                </div>
+            </dl>
+        </header>
+
+        <section class="block" id="plate" aria-labelledby="plate-heading">
+            <div class="section-head">
+                <span class="tag">Tectonics</span>
+                <h2 id="plate-heading">Indian plate movement</h2>
+            </div>
+            <p>India sat with Africa, Madagascar, Antarctica, and Australia in Gondwana. After Pangaea began to break (~200 Ma), India rifted away in the Cretaceous and drove north as its own plate. By about 80 million years ago it still lay roughly 6,400 km south of Asia, moving at about 9–16 cm per year — among the fastest continental motions known. After Deccan volcanism (~66 Ma) the plate kept racing north until collision slowed it to about 4–6 cm per year. That northward flight is what closed the Tethys and stacked the Himalaya.</p>
+        </section>
+
+        <section class="block" id="geography" aria-labelledby="geography-heading">
+            <div class="section-head">
+                <span class="tag">Palaeogeography</span>
+                <h2 id="geography-heading">Ancient geography</h2>
+            </div>
+            <div class="grid-2">
+                <article class="card">
+                    <h3>No Himalayan wall</h3>
+                    <p>There was no high range along India’s north. The Tethys Ocean lay between India and Asia. What is now Spiti, Zanskar, and much of the Tethyan Himalaya was seafloor and a tropical shelf — ammonites and marine limestone sit today above 3,000 m.</p>
+                </article>
+                <article class="card">
+                    <h3>Island continent</h3>
+                    <p>After leaving Madagascar, India was isolated. Gondwana plants and animals travelled with it; Eurasian fauna could not walk in until a land corridor opened after collision. The modern monsoon and the Ganga–Brahmaputra foreland did not yet exist.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="block" id="collision" aria-labelledby="collision-heading">
+            <div class="section-head">
+                <span class="tag">Sutures</span>
+                <h2 id="collision-heading">Tectonic collisions</h2>
+            </div>
+            <p>Tethys crust first sank northward under Asia, like an Andean margin. An island-arc collision (Kohistan–Ladakh) marked the northern edge before the continents met. India then collided with Eurasia in the early Eocene, around 55–50 million years ago (some sections along the belt are closer to 40 Ma). Neither continent could sink, so crust thickened. The join is the Indus–Tsangpo (Yarlung) suture through Ladakh and southern Tibet. Later thrusts stepped south: Main Central Thrust, Main Boundary Thrust, and the Main Frontal Thrust at the Siwalik edge.</p>
+        </section>
+
+        <section class="block" id="himalaya" aria-labelledby="himalaya-heading">
+            <div class="section-head">
+                <span class="tag">Orogeny</span>
+                <h2 id="himalaya-heading">Himalayan formation</h2>
+            </div>
+            <p>Scraped Tethyan sediments and slices of Indian crust were stacked into Greater, Lesser, and Sub-Himalayan belts. Tibet rose as a high plateau of thickened crust. An early Eohimalayan phase (~50–25 Ma) was followed by stronger Miocene uplift that built the high peaks and dumped Siwalik molasse into the foreland. The range is still forming: India continues to underthrust Eurasia, earthquakes mark the frontal thrusts, and the mountains keep rising.</p>
+        </section>
+
+        <section class="block" id="timeline" aria-labelledby="timeline-heading">
+            <div class="section-head">
+                <span class="tag">Visual timeline</span>
+                <h2 id="timeline-heading">Before and during the Himalaya</h2>
+            </div>
+            <p class="lede">Select a stage. The diagram is a schematic palaeogeography — not a measured plate reconstruction.</p>
+            <div class="timeline-layout">
+                <ol class="timeline" id="timeline-steps">
+                    <li>
+                        <button type="button" class="timeline-btn is-active" data-stage="gondwana" aria-pressed="true">
+                            <span class="stage-year">~180 Ma</span>
+                            <span class="stage-title">Gondwana India</span>
+                        </button>
+                    </li>
+                    <li>
+                        <button type="button" class="timeline-btn" data-stage="drift" aria-pressed="false">
+                            <span class="stage-year">~80 Ma</span>
+                            <span class="stage-title">Island continent</span>
+                        </button>
+                    </li>
+                    <li>
+                        <button type="button" class="timeline-btn" data-stage="collision" aria-pressed="false">
+                            <span class="stage-year">~55–50 Ma</span>
+                            <span class="stage-title">Collision</span>
+                        </button>
+                    </li>
+                    <li>
+                        <button type="button" class="timeline-btn" data-stage="rise" aria-pressed="false">
+                            <span class="stage-year">~50–15 Ma</span>
+                            <span class="stage-title">Himalaya rises</span>
+                        </button>
+                    </li>
+                    <li>
+                        <button type="button" class="timeline-btn" data-stage="present" aria-pressed="false">
+                            <span class="stage-year">Today</span>
+                            <span class="stage-title">Still converging</span>
+                        </button>
+                    </li>
+                </ol>
+                <div>
+                    <div class="paleomap-frame" id="paleomap-frame">
+                        <svg id="map-gondwana" class="paleomap is-visible" viewBox="0 0 320 200" role="img" aria-labelledby="map-gondwana-title">
+                            <title id="map-gondwana-title">Schematic Gondwana with India attached in the south and Tethys to the north</title>
+                            <rect width="320" height="200" class="map-ocean"/>
+                            <text x="160" y="28" class="map-label">Tethys Ocean</text>
+                            <ellipse cx="70" cy="130" rx="50" ry="40" class="map-land"/>
+                            <text x="70" y="134" class="map-label-dark">Africa</text>
+                            <ellipse cx="145" cy="155" rx="28" ry="22" class="map-india"/>
+                            <text x="145" y="159" class="map-label-dark">India</text>
+                            <ellipse cx="210" cy="165" rx="40" ry="22" class="map-land"/>
+                            <text x="210" y="169" class="map-label-dark">Antarctica</text>
+                            <ellipse cx="265" cy="125" rx="32" ry="28" class="map-land"/>
+                            <text x="265" y="129" class="map-label-dark">Australia</text>
+                        </svg>
+                        <svg id="map-drift" class="paleomap" viewBox="0 0 320 200" role="img" aria-labelledby="map-drift-title">
+                            <title id="map-drift-title">Schematic India as an island continent south of Asia with Tethys between</title>
+                            <rect width="320" height="200" class="map-ocean"/>
+                            <path d="M40 28 H280 L260 70 H60 Z" class="map-land"/>
+                            <text x="160" y="54" class="map-label-dark">Eurasia</text>
+                            <text x="160" y="100" class="map-label">Tethys Ocean</text>
+                            <ellipse cx="160" cy="158" rx="36" ry="26" class="map-india"/>
+                            <text x="160" y="162" class="map-label-dark">India</text>
+                            <path d="M160 132 L160 88" class="map-arrow"/>
+                            <polygon points="160,80 154,92 166,92" class="map-arrow-head"/>
+                        </svg>
+                        <svg id="map-collision" class="paleomap" viewBox="0 0 320 200" role="img" aria-labelledby="map-collision-title">
+                            <title id="map-collision-title">Schematic India colliding with Eurasia as Tethys closes</title>
+                            <rect width="320" height="200" class="map-ocean"/>
+                            <path d="M30 20 H290 L270 90 H50 Z" class="map-land"/>
+                            <text x="160" y="48" class="map-label-dark">Eurasia</text>
+                            <ellipse cx="160" cy="118" rx="42" ry="28" class="map-india"/>
+                            <text x="160" y="122" class="map-label-dark">India</text>
+                            <path d="M70 88 L100 72 L130 90 L160 68 L190 90 L220 70 L250 88" class="map-suture"/>
+                            <text x="160" y="175" class="map-label">Tethys closing · suture forming</text>
+                        </svg>
+                        <svg id="map-rise" class="paleomap" viewBox="0 0 320 200" role="img" aria-labelledby="map-rise-title">
+                            <title id="map-rise-title">Schematic Himalaya and Tibetan Plateau rising after collision</title>
+                            <rect width="320" height="200" class="map-ocean"/>
+                            <path d="M20 20 H300 L280 70 H40 Z" class="map-land"/>
+                            <text x="160" y="42" class="map-label-dark">Tibetan Plateau</text>
+                            <path d="M50 78 L80 50 L110 82 L140 44 L170 80 L200 40 L230 78 L260 48 L290 80" class="map-peak"/>
+                            <text x="160" y="100" class="map-label">Himalaya</text>
+                            <ellipse cx="160" cy="148" rx="70" ry="32" class="map-india"/>
+                            <text x="160" y="152" class="map-label-dark">India</text>
+                        </svg>
+                        <svg id="map-present" class="paleomap" viewBox="0 0 320 200" role="img" aria-labelledby="map-present-title">
+                            <title id="map-present-title">Schematic present Himalaya with India still moving north</title>
+                            <rect width="320" height="200" class="map-ocean"/>
+                            <path d="M20 18 H300 L285 62 H35 Z" class="map-land"/>
+                            <path d="M45 70 L75 42 L105 74 L135 38 L165 72 L195 36 L225 70 L255 40 L285 72" class="map-peak"/>
+                            <rect x="40" y="78" width="240" height="14" class="map-siwalik"/>
+                            <text x="160" y="50" class="map-label-dark">Himalaya</text>
+                            <ellipse cx="155" cy="145" rx="72" ry="34" class="map-india"/>
+                            <text x="155" y="149" class="map-label-dark">India</text>
+                            <path d="M155 112 L155 92" class="map-arrow"/>
+                            <polygon points="155,84 149,96 161,96" class="map-arrow-head"/>
+                        </svg>
+                    </div>
+                    <div class="card map-info" id="stage-info" aria-live="polite">
+                        <h3 id="stage-info-title">Gondwana India</h3>
+                        <p id="stage-info-desc">India is joined to Africa, Madagascar, Antarctica, and Australia. A wide Tethys Ocean separates this southern cluster from Asia. No Himalaya exists.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="block" id="maps" aria-labelledby="maps-heading">
+            <div class="section-head">
+                <span class="tag">Evidence on the ground</span>
+                <h2 id="maps-heading">Maps</h2>
+            </div>
+            <p class="lede">Modern localities that record the old geography: Tethyan seafloor in Spiti, the Indus suture at Leh, Siwalik foreland at Dehradun, and the high range at Kangchenjunga.</p>
+            <div class="map-layout">
+                <div class="map-frame-wrap">
+                    <iframe
+                        id="evidence-map"
+                        title="Map of Himalayan geological evidence sites"
+                        src="https://www.openstreetmap.org/export/embed.html?bbox=77.4,31.8,78.8,32.6&amp;layer=mapnik&amp;marker=32.226,78.072"
+                        loading="lazy"
+                    ></iframe>
+                </div>
+                <div>
+                    <div class="map-buttons" role="group" aria-label="Map locations">
+                        <button type="button" class="map-btn is-active" data-place="spiti" aria-pressed="true">Spiti</button>
+                        <button type="button" class="map-btn" data-place="leh">Leh</button>
+                        <button type="button" class="map-btn" data-place="dehradun">Dehradun</button>
+                        <button type="button" class="map-btn" data-place="kangchenjunga">Kangchenjunga</button>
+                    </div>
+                    <div class="card map-info" id="map-info" aria-live="polite">
+                        <h3 id="map-info-title">Spiti Valley</h3>
+                        <p id="map-info-desc">Himachal Pradesh. Tethyan Himalayan sediments: marine limestone and ammonites now high in the range — seafloor from before the mountains existed.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="block sources" id="sources" aria-labelledby="sources-heading">
+            <div class="section-head">
+                <span class="tag">References</span>
+                <h2 id="sources-heading">Sources</h2>
+            </div>
+            <ol>
+                <li><a href="https://pubs.usgs.gov/gip/dynamic/himalaya.html" target="_blank" rel="noopener noreferrer">USGS — The Himalayas (This Dynamic Earth)</a></li>
+                <li><a href="https://www.geolsoc.org.uk/Plate-Tectonics/Chap3-Plate-Margins/Convergent/Continental-Collision.html" target="_blank" rel="noopener noreferrer">Geological Society — Continental collision</a></li>
+                <li><a href="https://en.wikipedia.org/wiki/Geology_of_the_Himalayas" target="_blank" rel="noopener noreferrer">Wikipedia — Geology of the Himalayas</a></li>
+                <li><a href="https://en.wikipedia.org/wiki/Indian_Plate" target="_blank" rel="noopener noreferrer">Wikipedia — Indian Plate</a></li>
+                <li><a href="https://en.wikipedia.org/wiki/Tethys_Ocean" target="_blank" rel="noopener noreferrer">Wikipedia — Tethys Ocean</a></li>
+            </ol>
+        </section>
+    </main>
+
+    <footer class="page-footer">
+        <p>Incredible India Explorer · India Before the Himalayas · <a href="../../index.html">Home</a></p>
+    </footer>
+
+    <script src="script.js" defer></script>
+</body>
+</html>

--- a/frontend/india-before-himalayas/script.js
+++ b/frontend/india-before-himalayas/script.js
@@ -1,0 +1,154 @@
+(function () {
+    const stages = {
+        gondwana: {
+            title: "Gondwana India",
+            desc: "India is joined to Africa, Madagascar, Antarctica, and Australia. A wide Tethys Ocean separates this southern cluster from Asia. No Himalaya exists.",
+            map: "map-gondwana"
+        },
+        drift: {
+            title: "Island continent",
+            desc: "By about 80 Ma India lies roughly 6,400 km south of Asia and moves north at about 9–16 cm per year. Tethys crust sinks under Asia. India is an isolated island continent.",
+            map: "map-drift"
+        },
+        collision: {
+            title: "Collision",
+            desc: "Around 55–50 Ma India meets Eurasia. Drift slows. Tethys closes along the Indus–Tsangpo suture. Neither continent can subduct, so crust begins to thicken.",
+            map: "map-collision"
+        },
+        rise: {
+            title: "Himalaya rises",
+            desc: "Thrust sheets stack into Greater, Lesser, and Sub-Himalayan belts. Tibet thickens into a plateau. Miocene uplift builds high peaks and dumps Siwalik sediment into the foreland.",
+            map: "map-rise"
+        },
+        present: {
+            title: "Still converging",
+            desc: "India still moves north at about 4–5 cm per year. The Himalaya and Tibetan Plateau keep rising. Earthquakes mark the Main Frontal Thrust at the Siwalik edge.",
+            map: "map-present"
+        }
+    };
+
+    const places = {
+        spiti: {
+            title: "Spiti Valley",
+            desc: "Himachal Pradesh. Tethyan Himalayan sediments: marine limestone and ammonites now high in the range — seafloor from before the mountains existed.",
+            lat: 32.226,
+            lon: 78.072,
+            bbox: [77.4, 31.8, 78.8, 32.6]
+        },
+        leh: {
+            title: "Leh (Indus suture)",
+            desc: "Ladakh. Near the Indus–Tsangpo suture where Tethys closed and Indian crust met the Kohistan–Ladakh arc and Asia.",
+            lat: 34.1526,
+            lon: 77.5771,
+            bbox: [77.1, 33.9, 78.1, 34.4]
+        },
+        dehradun: {
+            title: "Dehradun (Siwaliks)",
+            desc: "Uttarakhand. Sub-Himalayan Siwalik foothills and foreland basin — eroded Himalayan sediment dumped after the range began to rise.",
+            lat: 30.3165,
+            lon: 78.0322,
+            bbox: [77.6, 30.05, 78.5, 30.55]
+        },
+        kangchenjunga: {
+            title: "Kangchenjunga",
+            desc: "Sikkim–Nepal border. High Greater Himalayan crust stacked by collision. The peaks exist only because India is still underthrusting Eurasia.",
+            lat: 27.7025,
+            lon: 88.1475,
+            bbox: [87.7, 27.4, 88.6, 28.0]
+        }
+    };
+
+    function mapSrc(place) {
+        const box = place.bbox.join(",");
+        return "https://www.openstreetmap.org/export/embed.html?bbox=" +
+            encodeURIComponent(box) +
+            "&layer=mapnik&marker=" +
+            encodeURIComponent(place.lat + "," + place.lon);
+    }
+
+    function initThemeToggle() {
+        const button = document.getElementById("theme-toggle");
+        const root = document.documentElement;
+
+        function applyTheme(theme) {
+            const isLight = theme === "light";
+            root.classList.toggle("light-theme", isLight);
+            document.body.classList.toggle("light-theme", isLight);
+            button.textContent = isLight ? "🌙" : "☀️";
+            button.setAttribute("aria-label", isLight ? "Switch to dark theme" : "Switch to light theme");
+        }
+
+        applyTheme(localStorage.getItem("theme") === "light" ? "light" : "dark");
+
+        button.addEventListener("click", function () {
+            const next = document.body.classList.contains("light-theme") ? "dark" : "light";
+            localStorage.setItem("theme", next);
+            applyTheme(next);
+        });
+    }
+
+    function initTimeline() {
+        const buttons = document.querySelectorAll(".timeline-btn");
+        const titleEl = document.getElementById("stage-info-title");
+        const descEl = document.getElementById("stage-info-desc");
+        const maps = document.querySelectorAll(".paleomap");
+
+        function showStage(key) {
+            const stage = stages[key];
+            if (!stage) {
+                return;
+            }
+            titleEl.textContent = stage.title;
+            descEl.textContent = stage.desc;
+            maps.forEach(function (svg) {
+                svg.classList.toggle("is-visible", svg.id === stage.map);
+            });
+            buttons.forEach(function (btn) {
+                const active = btn.getAttribute("data-stage") === key;
+                btn.classList.toggle("is-active", active);
+                btn.setAttribute("aria-pressed", active ? "true" : "false");
+            });
+        }
+
+        buttons.forEach(function (btn) {
+            btn.addEventListener("click", function () {
+                showStage(btn.getAttribute("data-stage"));
+            });
+        });
+    }
+
+    function initMap() {
+        const frame = document.getElementById("evidence-map");
+        const titleEl = document.getElementById("map-info-title");
+        const descEl = document.getElementById("map-info-desc");
+        const buttons = document.querySelectorAll(".map-btn");
+
+        function showPlace(key) {
+            const place = places[key];
+            if (!place) {
+                return;
+            }
+            frame.src = mapSrc(place);
+            titleEl.textContent = place.title;
+            descEl.textContent = place.desc;
+            buttons.forEach(function (btn) {
+                const active = btn.getAttribute("data-place") === key;
+                btn.classList.toggle("is-active", active);
+                btn.setAttribute("aria-pressed", active ? "true" : "false");
+            });
+        }
+
+        buttons.forEach(function (btn) {
+            btn.setAttribute("aria-pressed", btn.classList.contains("is-active") ? "true" : "false");
+            btn.addEventListener("click", function () {
+                showPlace(btn.getAttribute("data-place"));
+            });
+        });
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+        initThemeToggle();
+        initTimeline();
+        initMap();
+    });
+})();

--- a/frontend/india-before-himalayas/style.css
+++ b/frontend/india-before-himalayas/style.css
@@ -1,0 +1,442 @@
+:root {
+    --bg: #0e141c;
+    --bg-alt: #141c26;
+    --surface: #1c2836;
+    --line: #334556;
+    --text: #eef4fa;
+    --muted: #b8c8d6;
+    --dim: #7e92a6;
+    --accent: #7eb8e0;
+    --accent-2: #d4b06a;
+    --heading: "Playfair Display", Georgia, serif;
+    --body: "Outfit", system-ui, sans-serif;
+}
+
+body.light-theme,
+html.light-theme,
+html.light-theme body {
+    --bg: #eef3f8;
+    --bg-alt: #e2eaf2;
+    --surface: #ffffff;
+    --line: #c4d0dc;
+    --text: #14202c;
+    --muted: #3a4c5c;
+    --dim: #5c7080;
+    --accent: #1e5a86;
+    --accent-2: #8a6410;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--body);
+    line-height: 1.65;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
+
+    * {
+        animation: none !important;
+        transition: none !important;
+    }
+}
+
+a {
+    color: var(--accent);
+}
+
+a:focus-visible,
+button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+}
+
+.skip-link {
+    position: absolute;
+    left: -999px;
+    top: 0;
+    background: var(--accent);
+    color: #111;
+    padding: 0.5rem 1rem;
+    z-index: 1000;
+}
+
+.skip-link:focus {
+    left: 8px;
+    top: 8px;
+}
+
+.topnav {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.85rem 1.25rem;
+    background: var(--bg);
+    border-bottom: 1px solid var(--line);
+    overflow-x: auto;
+}
+
+.brand {
+    font-weight: 700;
+    text-decoration: none;
+    color: var(--text);
+    white-space: nowrap;
+}
+
+.nav-links {
+    display: flex;
+    gap: 0.9rem;
+    font-size: 0.85rem;
+}
+
+.nav-links a {
+    color: var(--muted);
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.nav-links a:hover {
+    color: var(--text);
+}
+
+.theme-toggle {
+    margin-left: auto;
+    border: 1px solid var(--line);
+    background: var(--surface);
+    color: var(--text);
+    border-radius: 999px;
+    width: 2.4rem;
+    height: 2.4rem;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.hero {
+    padding: 4.5rem 8vw 3.5rem;
+    background:
+        radial-gradient(900px 420px at 12% -20%, rgba(126, 184, 224, 0.18), transparent 55%),
+        var(--bg);
+    border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+    font-size: 0.78rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent-2);
+    margin: 0 0 1rem;
+}
+
+h1 {
+    font-family: var(--heading);
+    font-size: clamp(2rem, 5vw, 3.4rem);
+    line-height: 1.1;
+    margin: 0 0 0.75rem;
+    max-width: 16ch;
+}
+
+.hero-date {
+    color: var(--accent);
+    font-weight: 600;
+    margin: 0 0 1.25rem;
+}
+
+.lede {
+    max-width: 68ch;
+    color: var(--muted);
+    font-size: 1.05rem;
+}
+
+.hero-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2rem;
+    margin: 2.5rem 0 0;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--line);
+}
+
+.hero-stats dt {
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--dim);
+}
+
+.hero-stats dd {
+    margin: 0.2rem 0 0;
+    font-family: var(--heading);
+    font-size: 1.6rem;
+    font-weight: 600;
+}
+
+.block {
+    padding: 4.5rem 8vw;
+    border-bottom: 1px solid var(--line);
+}
+
+.block:nth-child(even) {
+    background: var(--bg-alt);
+}
+
+.section-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.tag {
+    font-size: 0.72rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--accent);
+    border: 1px solid var(--line);
+    padding: 0.2rem 0.6rem;
+}
+
+h2 {
+    font-family: var(--heading);
+    font-size: clamp(1.5rem, 3vw, 2.1rem);
+    margin: 0;
+}
+
+.grid-2 {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+}
+
+.card {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 1.35rem 1.4rem;
+}
+
+.card h3 {
+    margin: 0 0 0.6rem;
+    font-size: 1.05rem;
+}
+
+.card p {
+    color: var(--muted);
+    margin: 0;
+}
+
+.timeline-layout {
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    gap: 1.5rem;
+    align-items: start;
+}
+
+.timeline {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    border-left: 2px solid var(--line);
+}
+
+.timeline li {
+    margin: 0;
+}
+
+.timeline-btn {
+    display: block;
+    width: 100%;
+    text-align: left;
+    background: transparent;
+    border: 0;
+    border-radius: 0 8px 8px 0;
+    color: var(--text);
+    cursor: pointer;
+    font-family: inherit;
+    padding: 0.7rem 0.9rem 0.7rem 1.1rem;
+}
+
+.timeline-btn.is-active {
+    background: var(--surface);
+    box-shadow: inset 3px 0 0 var(--accent);
+}
+
+.stage-year {
+    display: block;
+    font-size: 0.75rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent);
+}
+
+.stage-title {
+    display: block;
+    font-weight: 600;
+    margin-top: 0.15rem;
+}
+
+.paleomap-frame {
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    overflow: hidden;
+    background: var(--surface);
+}
+
+.paleomap {
+    display: none;
+    width: 100%;
+    height: auto;
+}
+
+.paleomap.is-visible {
+    display: block;
+}
+
+.map-ocean {
+    fill: var(--bg-alt);
+}
+
+.map-land {
+    fill: var(--dim);
+    opacity: 0.55;
+}
+
+.map-india {
+    fill: var(--accent-2);
+}
+
+.map-siwalik {
+    fill: var(--accent);
+    opacity: 0.35;
+}
+
+.map-label {
+    fill: var(--muted);
+    font-size: 11px;
+    text-anchor: middle;
+    font-family: var(--body);
+}
+
+.map-label-dark {
+    fill: var(--text);
+    font-size: 11px;
+    text-anchor: middle;
+    font-family: var(--body);
+}
+
+.map-arrow,
+.map-suture,
+.map-peak {
+    fill: none;
+    stroke: var(--accent);
+    stroke-width: 3;
+}
+
+.map-arrow-head {
+    fill: var(--accent);
+}
+
+.map-layout {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr;
+    gap: 1.25rem;
+    align-items: start;
+}
+
+.map-frame-wrap {
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    overflow: hidden;
+    min-height: 320px;
+    background: var(--surface);
+}
+
+.map-frame-wrap iframe {
+    display: block;
+    width: 100%;
+    height: 360px;
+    border: 0;
+}
+
+.map-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 0.9rem;
+}
+
+.map-btn {
+    border: 1px solid var(--line);
+    background: var(--surface);
+    color: var(--text);
+    border-radius: 999px;
+    padding: 0.35rem 0.8rem;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.85rem;
+}
+
+.map-btn.is-active,
+.map-btn:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.sources ol {
+    max-width: 75ch;
+    padding-left: 1.2rem;
+}
+
+.sources li + li {
+    margin-top: 0.55rem;
+}
+
+.page-footer {
+    padding: 1.5rem 8vw;
+    color: var(--dim);
+    font-size: 0.9rem;
+}
+
+.page-footer a {
+    color: var(--muted);
+}
+
+@media (max-width: 768px) {
+    .grid-2,
+    .map-layout,
+    .timeline-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .hero,
+    .block {
+        padding: 3rem 1.25rem;
+    }
+
+    .topnav {
+        flex-wrap: wrap;
+    }
+
+    .nav-links {
+        order: 3;
+        width: 100%;
+        padding-top: 0.35rem;
+    }
+}

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -6599,5 +6599,14 @@ window.indiaSearchIndex = [
         description:
             "Explore the traditional story of Pundalik and Vithoba: the waiting Lord on the brick, Pandharpur on the Chandrabhaga, and the Warkari pilgrimage.",
         url: "frontend/pundalik-vithoba-story/index.html"
+    },
+
+    // --- India Before the Himalayas (#3817) ---
+    {
+        title: "India Before the Himalayas Formed \u2014 Plate Timeline",
+        category: "Geology & Disasters",
+        description:
+            "Visual geological timeline of the Indian plate: Gondwana geography, northward drift, Tethys closure, collision with Eurasia, Himalayan formation, and maps.",
+        url: "frontend/india-before-himalayas/index.html"
     }
 ];


### PR DESCRIPTION
## Description

Adds a visual geological timeline of India before and during Himalayan formation: Indian plate movement from Gondwana, Tethys palaeogeography, India–Eurasia collision, Himalayan orogeny, schematic palaeomaps, and an evidence-site map.

Fixes #3817

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feure that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Tested locally in browser
- [x] Tested in both dark and light themes
- [x] Tested at mobile viewport widths
- [x] Verified no console errors

## Checklist

- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an educational page exploring India’s geological history before and during Himalayan formation.
  * Added an interactive timeline with tectonic explanations, schematic maps, and geological evidence locations.
  * Added an embedded map for exploring evidence sites.
  * Added light and dark themes, responsive layouts, accessible navigation, and reduced-motion support.
  * Added the page to site search under Geology & Disasters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->