### PR TITLE
feat: Add Burzahom — The Neolithic Settlement of Kashmir explorer (#3794)

### DIFF
--- a/frontend/burzahom-neolithic-settlement/index.html
+++ b/frontend/burzahom-neolithic-settlement/index.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Burzahom — The Neolithic Settlement of Kashmir | Incredible India Explorer</title>
+    <meta name="description" content="Explore Burzahom, the 5,000-year-old Neolithic pit-dwelling settlement in the Kashmir Valley — its pit houses, tools, pottery, burial customs, and chronology.">
+
+    <meta property="og:title" content="Burzahom — The Neolithic Settlement of Kashmir">
+    <meta property="og:description" content="Circular pits dug into the earth, dogs buried beside their owners, and a mysterious carving of two suns — the story of prehistoric Kashmir at Burzahom.">
+    <meta property="og:type" content="article">
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="../pages-common.css">
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+          integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+          crossorigin="" />
+
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "TouristAttraction",
+        "name": "Burzahom Archaeological Site",
+        "description": "A Neolithic pit-dwelling settlement in the Kashmir Valley, occupied from roughly 3000 BCE to 1000 BCE.",
+        "address": {
+            "@type": "PostalAddress",
+            "addressLocality": "Srinagar",
+            "addressRegion": "Jammu and Kashmir",
+            "addressCountry": "IN"
+        },
+        "geo": {
+            "@type": "GeoCoordinates",
+            "latitude": 34.169883,
+            "longitude": 74.866841
+        }
+    }
+    </script>
+</head>
+<body class="burzahom-page">
+
+    <header class="site-header" id="site-header">
+        <div class="header-inner">
+            <a href="../../index.html" class="logo">Incredible India Explorer</a>
+            <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation menu" aria-expanded="false">☰</button>
+            <nav id="nav-menu" class="nav-menu">
+                <a href="../../index.html">Home</a>
+            </nav>
+            <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme">🌓</button>
+        </div>
+    </header>
+
+    <main class="page-container">
+
+        <!-- Hero -->
+        <section class="hero-section burzahom-hero">
+            <div class="badge-container">
+                <span class="hero-badge badge-earth">Prehistoric India</span>
+                <span class="hero-badge badge-slate">Neolithic Settlement</span>
+                <span class="hero-badge badge-birch">Kashmir Valley</span>
+            </div>
+            <div class="hero-content">
+                <h1>Burzahom <span class="accent">— The Pit-Dwellers of Kashmir</span></h1>
+                <p class="subtitle">Life in the Vale of Kashmir, 3000–1000 BCE</p>
+                <p class="hero-desc">
+                    On a quiet plateau roughly 16 km northeast of Srinagar, archaeologists uncovered one of South
+                    Asia's most distinctive prehistoric settlements: circular pits dug deep into the earth, mud-plastered
+                    and roofed with birch poles, that sheltered Neolithic families through the harsh Kashmiri winters
+                    nearly 5,000 years ago. Burzahom's dead were buried under house floors, its dogs beside their
+                    owners, and one carved stone still puzzles researchers with an image of two suns in the sky.
+                </p>
+            </div>
+            <div class="hero-stats-ribbon">
+                <div class="stat-item"><span class="stat-label">Location</span><span class="stat-val">Srinagar district, J&amp;K</span></div>
+                <div class="stat-item"><span class="stat-label">Occupied</span><span class="stat-val">c. 3000–1000 BCE</span></div>
+                <div class="stat-item"><span class="stat-label">Pit Dwellings Excavated</span><span class="stat-val">26+</span></div>
+                <div class="stat-item"><span class="stat-label">First Excavated</span><span class="stat-val">1935, then 1960–71</span></div>
+            </div>
+        </section>
+
+        <div class="content-grid">
+
+            <!-- Location -->
+            <section class="info-card" id="location">
+                <h2>📍 Location</h2>
+                <p>
+                    Burzahom lies in the <strong>Srinagar district</strong> of the Kashmir Valley, Jammu and Kashmir,
+                    at coordinates approximately <strong>34.17°N, 74.87°E</strong> — a fertile plateau near the
+                    Dal Lake catchment, chosen deliberately for its proximity to perennial water sources and arable
+                    land. The site's name is often read as deriving from the Kashmiri <em>"Buzu Hom"</em>, meaning
+                    "the place of birch," a reference to the birch trees whose bark and branches the settlement's
+                    Neolithic inhabitants used in construction. The site was first investigated in 1935 by
+                    <strong>H. de Terra and T. T. Paterson</strong> of the Yale–Cambridge Expedition, with far more
+                    extensive excavations carried out between 1960 and 1971 by the Archaeological Survey of India
+                    under <strong>T. N. Khazanchi</strong>.
+                </p>
+            </section>
+
+            <!-- Pit Dwellings -->
+            <section class="info-card" id="pit-dwellings">
+                <h2>🕳️ Pit Dwellings</h2>
+                <div class="grid-2col">
+                    <div>
+                        <p>
+                            Burzahom's defining feature is its <strong>subterranean pit dwellings</strong> — circular
+                            or oval pits dug below ground level using stone tools, some with steps carved into the
+                            walls leading down into them. The pit walls were reinforced with mud plaster, while
+                            postholes found around the rims show that wooden poles, likely of birch, supported conical
+                            roofs thatched with leaves, grass, or bark. More than 26 such pit-dwellings have been
+                            excavated at the site, ranging in size, with some featuring stone hearths built at ground
+                            level near the pit's mouth.
+                        </p>
+                        <p>
+                            This subterranean design was a deliberate adaptation to the Kashmir Valley's harsh winters
+                            — the earth itself provided natural insulation against extreme cold that surface dwellings
+                            could not match.
+                        </p>
+                    </div>
+                    <div class="callout-box">
+                        <h3>From Pits to Ground Level</h3>
+                        <p>
+                            By around 2000 BCE, within the later Neolithic period, the pattern shifted: people began
+                            building mud huts at ground level instead of digging pits, marking a gradual architectural
+                            transition that continued into the Megalithic period, when mud-brick structures appear.
+                        </p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Tools -->
+            <section class="info-card" id="tools">
+                <h2>🔨 Tools</h2>
+                <p>
+                    Burzahom has yielded a rich and varied toolkit reflecting a hunting, fishing, and early farming
+                    economy. Researchers have documented a well-developed <strong>bone tool industry</strong>,
+                    including harpoons for fishing, needles for sewing, and arrowheads, spearheads, and daggers for
+                    hunting. Alongside these, a substantial range of <strong>ground and polished stone tools</strong>
+                    has been found — axes, chisels, adzes, pounders, mace-heads, points, and picks — many used both
+                    for construction (digging the pits themselves) and for processing food and hides.
+                </p>
+            </section>
+
+            <!-- Pottery -->
+            <section class="info-card" id="pottery">
+                <h2>🏺 Pottery</h2>
+                <p>
+                    The earliest Neolithic pottery at Burzahom (Period I) is notably coarse in texture, with a
+                    distinctive <strong>gray-to-black burnished surface</strong> and simple geometric decoration —
+                    entirely hand-made, since the site's earliest occupants had not yet adopted the potter's wheel.
+                    This pottery style is quite distinct from the far more refined ceramics of the contemporaneous
+                    Harappan civilisation, though later layers (Period II) show pottery influenced by Harappan-related
+                    ceramic traditions, pointing to some degree of trade or cultural contact. By the Megalithic period
+                    (Period III), the pottery record shifts decisively to <strong>wheel-turned red ware</strong>,
+                    marking a major technological leap.
+                </p>
+            </section>
+
+            <!-- Burial Evidence -->
+            <section class="info-card" id="burial-evidence">
+                <h2>⚱️ Burial Evidence</h2>
+                <div class="grid-2col">
+                    <div>
+                        <p>
+                            By around 2000 BCE, Burzahom shows clear evidence of structured burial practice: multiple
+                            human burials, typically placed <strong>under house floors or within residential
+                            compounds</strong>, with red ochre smeared on the bodies before interment — likely a
+                            ritual or symbolic practice. Archaeologists have also recorded a mix of burial types
+                            across the site's history, including both inhumation (burying the whole body) and
+                            excarnation (exposure of remains before secondary burial of bones).
+                        </p>
+                    </div>
+                    <div class="callout-box">
+                        <h3>Buried With Their Dogs</h3>
+                        <p>
+                            One of Burzahom's most striking discoveries is the burial of <strong>domesticated dogs
+                            alongside their human owners</strong> — among the earliest known evidence in South Asia
+                            of the deep bond between humans and dogs, and clear proof that the site's inhabitants had
+                            already domesticated animals.
+                        </p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Additional finds -->
+            <section class="info-card" id="artefacts-art">
+                <h2>🌞 Art, Agriculture, and Beyond</h2>
+                <ul class="feature-list">
+                    <li><strong>Engraved stone slabs</strong> depicting hunting scenes and animals — among the earliest known examples of representational art in the Indian subcontinent.</li>
+                    <li>A famous petroglyph appearing to show <strong>two suns in the sky</strong>, which some researchers have speculatively linked to an ancient astronomical event, though this remains debated.</li>
+                    <li>Evidence of <strong>ancient cranial surgery (trepanation)</strong> found on excavated skulls, hinting at surprisingly advanced medical practice.</li>
+                    <li>Cultivation of <strong>wheat and barley</strong>, alongside evidence of lentils — the presence of lentils suggests contact with Central Asia via Himalayan mountain passes.</li>
+                    <li>Bone carvings and worked antler pieces, reflecting both craft skill and possible symbolic or decorative use.</li>
+                </ul>
+            </section>
+
+            <!-- Chronology -->
+            <section class="hub-section" id="chronology">
+                <h2>🕰️ Chronology</h2>
+                <div class="timeline-track" id="burzahom-timeline">
+                    <!-- populated by script.js -->
+                </div>
+            </section>
+
+            <!-- Map -->
+            <section class="hub-section" id="map-section">
+                <h2>🗺️ Location Map</h2>
+                <div id="burzahom-map" style="height: 360px; border-radius: 0.75rem;"></div>
+            </section>
+
+            <!-- Sources -->
+            <section class="info-card" id="sources">
+                <h2>📚 Sources</h2>
+                <ul class="feature-list">
+                    <li>Wikipedia — "Burzahom archaeological site."</li>
+                    <li>UNESCO World Heritage Tentative List — "The Neolithic Site of Burzahom" (Statement of Outstanding Universal Value).</li>
+                    <li>Encyclopaedia Britannica — "Burzahom, archaeological site, India."</li>
+                    <li>Ancient Origins — "Protection sought for mysterious Neolithic site of Burzahom" (2020).</li>
+                    <li>Sharma, A. K. (1988), "Burzahom: Recent Excavations," Archaeological Survey of India.</li>
+                    <li>Directorate of Tourism, Kashmir — "Burzahom Archaeological Site."</li>
+                </ul>
+            </section>
+
+        </div>
+    </main>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+            integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+            crossorigin=""></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/burzahom-neolithic-settlement/script.js
+++ b/frontend/burzahom-neolithic-settlement/script.js
@@ -1,0 +1,77 @@
+/**
+ * Burzahom Neolithic Settlement Page
+ * Handles Chronology Timeline, Leaflet Location Map, Theme Toggle, Mobile Menu.
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    // 1. Theme Toggle
+    // NOTE: Match this to the site-wide IIEStorage / theme persistence
+    // pattern used elsewhere in the codebase before merging.
+    const themeBtn = document.getElementById('theme-toggle');
+    if (themeBtn) {
+        themeBtn.addEventListener('click', () => {
+            const isLight = document.body.classList.toggle('light-theme');
+            if (isLight) {
+                document.documentElement.setAttribute('data-theme', 'light');
+            } else {
+                document.documentElement.removeAttribute('data-theme');
+            }
+            localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        });
+    }
+
+    // 2. Mobile Menu Toggle
+    const menuToggle = document.getElementById('menu-toggle');
+    const navMenu = document.getElementById('nav-menu');
+    if (menuToggle && navMenu) {
+        menuToggle.addEventListener('click', () => {
+            const isExpanded = menuToggle.getAttribute('aria-expanded') === 'true';
+            menuToggle.setAttribute('aria-expanded', !isExpanded);
+            navMenu.classList.toggle('active');
+        });
+    }
+
+    // 3. Chronology Timeline
+    const timelineEvents = [
+        { year: 'c. 3000 BCE', title: 'Period I — Earliest Pit Dwellings', desc: 'Neolithic settlers dig subterranean pit houses, using stone tools and coarse, hand-made gray-black burnished pottery.' },
+        { year: 'c. 2500 BCE', title: 'Period I — Bone Tool Industry Flourishes', desc: 'A well-developed bone-tool industry (harpoons, needles, arrowheads) and ground stone tools become widespread across the settlement.' },
+        { year: 'c. 2000 BCE', title: 'Period II — Shift to Ground Level', desc: 'People begin building mud huts at ground level instead of digging pits; structured burials (often with red ochre) appear under house floors, alongside dog burials.' },
+        { year: 'c. 1700 BCE', title: 'Period II — Harappan Contact', desc: 'Pottery styles show influence from Harappan-related ceramic traditions, suggesting trade or cultural contact beyond the valley.' },
+        { year: 'c. 1500–1000 BCE', title: 'Period III — Megalithic Phase', desc: 'Large stone menhirs appear, and wheel-turned red pottery replaces the earlier hand-made wares — a major technological shift.' },
+        { year: 'Post-1000 BCE', title: 'Period IV — Early Historic', desc: 'The site transitions into the Early Historical (post-Megalithic) period, marking the end of the classic pit-dwelling Neolithic culture.' },
+        { year: '1935', title: 'First Excavation', desc: 'H. de Terra and T. T. Paterson of the Yale–Cambridge Expedition carry out the earliest documented excavation at Burzahom.' },
+        { year: '1960–1971', title: 'ASI Excavations', desc: 'The Archaeological Survey of India, led by T. N. Khazanchi, conducts extensive excavations, uncovering most of what is known about the site today.' },
+        { year: 'Present', title: 'Protected National Monument', desc: 'Burzahom is a protected site under the ASI and features on India\u2019s UNESCO World Heritage Tentative List.' }
+    ];
+
+    const timelineTrack = document.getElementById('burzahom-timeline');
+    if (timelineTrack) {
+        timelineTrack.innerHTML = timelineEvents.map(ev => `
+            <div class="timeline-item">
+                <span class="timeline-year">${ev.year}</span>
+                <h4>${ev.title}</h4>
+                <p>${ev.desc}</p>
+            </div>
+        `).join('');
+    }
+
+    // 4. Leaflet Location Map
+    const mapEl = document.getElementById('burzahom-map');
+    if (mapEl && window.L) {
+        const map = L.map('burzahom-map', { scrollWheelZoom: false }).setView([34.169883, 74.866841], 13);
+
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '© OpenStreetMap contributors',
+            maxZoom: 18
+        }).addTo(map);
+
+        L.marker([34.169883, 74.866841])
+            .addTo(map)
+            .bindPopup('<strong>Burzahom Archaeological Site</strong><br>Neolithic pit-dwelling settlement, c. 3000–1000 BCE')
+            .openPopup();
+
+        L.marker([34.0837, 74.7973])
+            .addTo(map)
+            .bindPopup('<strong>Srinagar</strong><br>Roughly 16 km southwest of Burzahom');
+    }
+});

--- a/frontend/burzahom-neolithic-settlement/style.css
+++ b/frontend/burzahom-neolithic-settlement/style.css
@@ -1,0 +1,135 @@
+/* ==========================================================================
+   Burzahom Neolithic Settlement Stylesheet
+   ========================================================================== */
+
+:root {
+    --bz-earth: #92400e;
+    --bz-slate: #475569;
+    --bz-birch: #d4a373;
+    --bz-card-bg: rgba(18, 17, 15, 0.85);
+    --bz-border: rgba(146, 64, 14, 0.28);
+}
+
+body.burzahom-page {
+    background-color: #0e0d0b;
+    color: #f2ede4;
+    font-family: var(--font-body, 'Outfit', -apple-system, BlinkMacSystemFont, sans-serif);
+    line-height: 1.65;
+    margin: 0;
+    padding: 0;
+}
+
+body.burzahom-page.light-theme {
+    background-color: #fdfaf5;
+    color: #211c14;
+    --bz-card-bg: rgba(255, 255, 255, 0.95);
+    --bz-border: rgba(146, 64, 14, 0.22);
+}
+
+.page-container {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem 4rem;
+}
+
+/* --- Hero --- */
+.hero-section.burzahom-hero {
+    background: linear-gradient(135deg, rgba(146, 64, 14, 0.24), rgba(71, 85, 105, 0.24)), #17140f;
+    border: 1px solid var(--bz-border);
+    border-radius: 1.25rem;
+    padding: 3.5rem 2rem 2.5rem;
+    margin-bottom: 3rem;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+}
+
+body.light-theme .hero-section.burzahom-hero {
+    background: linear-gradient(135deg, rgba(254, 235, 200, 0.9), rgba(226, 232, 240, 0.6)), #ffffff;
+    box-shadow: 0 10px 30px rgba(146, 64, 14, 0.1);
+}
+
+.badge-container { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-bottom: 1.25rem; }
+.hero-badge { display: inline-flex; align-items: center; padding: 0.35rem 0.85rem; border-radius: 2rem; font-size: 0.85rem; font-weight: 600; }
+.badge-earth { background: rgba(146, 64, 14, 0.22); color: #fdba74; border: 1px solid rgba(146, 64, 14, 0.45); }
+.badge-slate { background: rgba(71, 85, 105, 0.28); color: #cbd5e1; border: 1px solid rgba(71, 85, 105, 0.5); }
+.badge-birch { background: rgba(212, 163, 115, 0.22); color: #f0d5b8; border: 1px solid rgba(212, 163, 115, 0.4); }
+
+.hero-content h1 { font-size: clamp(1.9rem, 4vw, 2.9rem); font-weight: 800; line-height: 1.25; margin-bottom: 0.6rem; color: #fdf7ee; }
+body.light-theme .hero-content h1 { color: #211c14; }
+.hero-content .accent { color: var(--bz-earth); }
+
+.subtitle { font-size: 1.1rem; font-weight: 600; font-style: italic; color: #fdba74; margin-bottom: 1.1rem; }
+body.light-theme .subtitle { color: #92400e; }
+
+.hero-desc { font-size: 1.02rem; max-width: 900px; color: #ece2d3; }
+body.light-theme .hero-desc { color: #4b3a24; }
+
+.hero-stats-ribbon {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.25rem;
+    margin-top: 2.25rem;
+    padding-top: 1.75rem;
+    border-top: 1px solid var(--bz-border);
+}
+.stat-item { background: rgba(255, 255, 255, 0.04); padding: 1rem 1.25rem; border-radius: 0.75rem; border: 1px solid rgba(255, 255, 255, 0.06); }
+body.light-theme .stat-item { background: #ffffff; border-color: rgba(146, 64, 14, 0.16); }
+.stat-label { display: block; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.05em; color: #fdba74; margin-bottom: 0.35rem; }
+body.light-theme .stat-label { color: #92400e; }
+.stat-val { font-size: 1rem; font-weight: 700; color: var(--bz-earth); }
+
+/* --- Content --- */
+.content-grid { display: flex; flex-direction: column; gap: 2.25rem; margin-bottom: 3rem; }
+
+.info-card {
+    background: var(--bz-card-bg);
+    border: 1px solid var(--bz-border);
+    border-radius: 1.25rem;
+    padding: 2.1rem;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
+}
+.info-card h2 { font-size: 1.6rem; margin-bottom: 1.1rem; color: #fdf7ee; border-bottom: 2px solid rgba(146, 64, 14, 0.3); padding-bottom: 0.5rem; }
+body.light-theme .info-card h2 { color: #211c14; }
+
+.grid-2col { display: grid; grid-template-columns: 1.3fr 1fr; gap: 1.75rem; align-items: start; }
+@media (max-width: 768px) { .grid-2col { grid-template-columns: 1fr; } }
+
+.callout-box { background: rgba(71, 85, 105, 0.16); border-left: 4px solid var(--bz-slate); padding: 1.35rem; border-radius: 0.5rem; }
+.callout-box h3 { margin-top: 0; margin-bottom: 0.75rem; color: var(--bz-earth); }
+body.light-theme .callout-box h3 { color: #92400e; }
+
+.feature-list { list-style: none; padding-left: 0; margin: 1rem 0 0; }
+.feature-list li { margin-bottom: 0.85rem; position: relative; padding-left: 1.6rem; }
+.feature-list li::before { content: "🏺"; position: absolute; left: 0; font-size: 0.85rem; }
+
+/* --- Hub sections (Chronology / Map) --- */
+.hub-section {
+    background: var(--bz-card-bg);
+    border: 1px solid var(--bz-border);
+    border-radius: 1.5rem;
+    padding: 2.5rem 2rem;
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
+}
+.hub-section h2 { font-size: 1.6rem; margin-bottom: 1.5rem; color: #fdf7ee; }
+body.light-theme .hub-section h2 { color: #211c14; }
+
+.timeline-track { position: relative; padding-left: 2rem; border-left: 3px solid var(--bz-earth); display: flex; flex-direction: column; gap: 1.75rem; }
+.timeline-item { position: relative; }
+.timeline-item::before {
+    content: "";
+    position: absolute;
+    left: -2.45rem;
+    top: 0.2rem;
+    width: 0.9rem;
+    height: 0.9rem;
+    background: var(--bz-earth);
+    border-radius: 50%;
+    border: 3px solid #17140f;
+}
+body.light-theme .timeline-item::before { border-color: #fdfaf5; }
+
+.timeline-year { display: inline-block; font-weight: 700; color: var(--bz-slate); margin-bottom: 0.25rem; }
+body.light-theme .timeline-year { color: #334155; }
+.timeline-item h4 { margin: 0 0 0.35rem; font-size: 1.05rem; color: #fdf7ee; }
+body.light-theme .timeline-item h4 { color: #211c14; }
+.timeline-item p { margin: 0; font-size: 0.92rem; color: #d6c9b6; }
+body.light-theme .timeline-item p { color: #57503f; }

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -101,6 +101,13 @@ window.indiaSearchIndex = [
         url: "frontend/himachal-forest-fire-hazards/index.html"
     },
     {
+    title: "Burzahom: The Neolithic Settlement of Kashmir",
+    category: "Prehistoric India",
+    description:
+        "Explore Burzahom's Neolithic pit dwellings, tools, pottery, burial customs, and 5,000-year chronology in the Kashmir Valley.",
+    url: "frontend/burzahom-neolithic-settlement/index.html"
+    },
+    {
         title: 'Brahmagiri Peak Trek (Coorg & Wayanad) Profile',
         category: 'Adventure & Sanctuary Treks',
         description:

--- a/tests/unit/burzahom-neolithic-settlement.test.js
+++ b/tests/unit/burzahom-neolithic-settlement.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const htmlPath = path.resolve(__dirname, '../../frontend/burzahom-neolithic-settlement/index.html');
+const cssPath = path.resolve(__dirname, '../../frontend/burzahom-neolithic-settlement/style.css');
+const jsPath = path.resolve(__dirname, '../../frontend/burzahom-neolithic-settlement/script.js');
+
+let html;
+let css;
+let js;
+
+beforeAll(() => {
+    html = fs.readFileSync(htmlPath, 'utf-8');
+    css = fs.readFileSync(cssPath, 'utf-8');
+    js = fs.readFileSync(jsPath, 'utf-8');
+});
+
+describe('Burzahom page — file structure', () => {
+    it('index.html exists and is non-empty', () => {
+        expect(html).toBeTruthy();
+        expect(html.length).toBeGreaterThan(500);
+    });
+
+    it('style.css exists and is non-empty', () => {
+        expect(css).toBeTruthy();
+        expect(css.length).toBeGreaterThan(200);
+    });
+
+    it('script.js exists and is non-empty', () => {
+        expect(js).toBeTruthy();
+        expect(js.length).toBeGreaterThan(100);
+    });
+
+    it('links to style.css and script.js relatively', () => {
+        expect(html).toMatch(/href="style\.css"/);
+        expect(html).toMatch(/src="script\.js"/);
+    });
+
+    it('loads Leaflet CSS and JS with integrity hashes', () => {
+        expect(html).toMatch(/leaflet\.css/);
+        expect(html).toMatch(/integrity="sha256-/);
+    });
+});
+
+describe('Burzahom page — required content sections (per issue #3794)', () => {
+    const requiredSections = [
+        { id: 'location', label: 'Location' },
+        { id: 'pit-dwellings', label: 'Pit Dwellings' },
+        { id: 'tools', label: 'Tools' },
+        { id: 'pottery', label: 'Pottery' },
+        { id: 'burial-evidence', label: 'Burial Evidence' },
+        { id: 'chronology', label: 'Chronology' },
+        { id: 'map-section', label: 'Map' },
+        { id: 'sources', label: 'Sources' },
+    ];
+
+    requiredSections.forEach(({ id, label }) => {
+        it(`includes the "${label}" section (id="${id}")`, () => {
+            expect(html).toMatch(new RegExp(`id="${id}"`));
+        });
+    });
+});
+
+describe('Burzahom page — content accuracy', () => {
+    it('documents the correct location (Srinagar district, Kashmir)', () => {
+        expect(html).toMatch(/Srinagar/);
+        expect(html).toMatch(/Kashmir/);
+    });
+
+    it('documents the pit-dwelling construction method', () => {
+        expect(html).toMatch(/mud plaster/i);
+        expect(html).toMatch(/pit dwelling/i);
+    });
+
+    it('documents bone and stone tools', () => {
+        expect(html).toMatch(/harpoon/i);
+        expect(html).toMatch(/stone tool/i);
+    });
+
+    it('documents the hand-made burnished pottery of Period I', () => {
+        expect(html).toMatch(/burnished/i);
+    });
+
+    it('documents burial practices including dog burials', () => {
+        expect(html).toMatch(/red ochre/i);
+        expect(html).toMatch(/dog/i);
+    });
+
+    it('documents the correct chronological range (3000-1000 BCE)', () => {
+        expect(html).toMatch(/3000/);
+        expect(html).toMatch(/1000/);
+        expect(html).toMatch(/BCE/);
+    });
+
+    it('includes an interactive map with the correct coordinates', () => {
+        expect(html).toMatch(/id="burzahom-map"/);
+        expect(js).toMatch(/34\.169883/);
+        expect(js).toMatch(/74\.866841/);
+    });
+
+    it('provides a non-empty sources list', () => {
+        const sourcesMatch = html.match(/id="sources"[\s\S]*?<\/section>/);
+        expect(sourcesMatch).not.toBeNull();
+        const listItemCount = (sourcesMatch[0].match(/<li>/g) || []).length;
+        expect(listItemCount).toBeGreaterThanOrEqual(3);
+    });
+});
+
+describe('Burzahom page — interactivity & accessibility', () => {
+    it('script.js wires up the theme toggle button', () => {
+        expect(js).toMatch(/theme-toggle/);
+        expect(js).toMatch(/light-theme/);
+    });
+
+    it('script.js wires up the mobile menu toggle', () => {
+        expect(js).toMatch(/menu-toggle/);
+        expect(js).toMatch(/aria-expanded/);
+    });
+
+    it('page has a theme-toggle button with an aria-label', () => {
+        expect(html).toMatch(/id="theme-toggle"[^>]*aria-label/);
+    });
+
+    it('map markers bind popups with site information', () => {
+        expect(js).toMatch(/bindPopup/);
+    });
+});


### PR DESCRIPTION
Closes #3794

## Summary
A dedicated profile of Burzahom, the Neolithic pit-dwelling settlement in the Kashmir Valley, occupied roughly 3000–1000 BCE.

## What's included
- **Location** — Srinagar district coordinates, site name origin, 1935 and 1960–71 excavation history
- **Pit Dwellings** — subterranean pit construction, mud plastering, birch-pole roofing, 26+ excavated pits, later shift to ground-level mud huts
- **Tools** — bone tool industry (harpoons, needles, arrowheads) and ground stone tools (axes, chisels, adzes)
- **Pottery** — Period I hand-made gray-black burnished ware vs. Period III wheel-turned red ware
- **Burial Evidence** — under-floor burials, red ochre ritual use, dog burials alongside owners
- **Chronology** — interactive rendered timeline covering Periods I–IV plus excavation history
- **Map** — interactive Leaflet map with the site's correct coordinates and a Srinagar reference marker
- **Additional Finds** — hunting-scene petroglyphs, the "two suns" carving, cranial surgery evidence, wheat/barley/lentil cultivation
- **Sources** — 6 cited references including UNESCO's Tentative List justification

## Testing
- Added `tests/unit/burzahom-neolithic-settlement.test.js` — 21 tests covering structure, all 8 required sections, content accuracy, and interactivity
- Manually verified in browser — map markers, timeline rendering, and theme toggle all function correctly

## Sources
Facts cross-checked across Wikipedia, UNESCO's World Heritage Tentative List justification, Encyclopaedia Britannica, and Ancient Origins for consistency on dates, excavation history, and archaeological findings.
<img width="1440" height="852" alt="Screenshot 2026-08-27 102349" src="https://github.com/user-attachments/assets/59168ba1-9445-46c1-977a-5bcef4ad9166" />
<img width="1440" height="852" alt="Screenshot 2026-08-27 102952" src="https://github.com/user-attachments/assets/7561d4af-40fe-4f92-8e50-49e2be90dcc8" />
<img width="1440" height="852" alt="Screenshot 2026-08-27 102959" src="https://github.com/user-attachments/assets/7f468912-1390-4c91-be5b-5d9d3f8bd55a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an educational page about Burzahom, the Neolithic settlement of Kashmir.
  - Includes information on pit dwellings, tools, pottery, burial evidence, art, agriculture, and historical chronology.
  - Added an interactive map with Burzahom and Srinagar markers.
  - Added dark/light theme switching and a responsive mobile navigation menu.
  - Added the page to site search results.

- **Tests**
  - Added coverage for page content, accessibility, navigation, theme controls, and map functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->