### PR TITLE
feat: Add Kurnool Caves — Prehistoric Heritage explorer (#3786)

### DIFF
--- a/frontend/kurnool-caves-prehistoric/index.html
+++ b/frontend/kurnool-caves-prehistoric/index.html
@@ -1,0 +1,213 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kurnool Caves — Prehistoric Heritage | Incredible India Explorer</title>
+    <meta name="description" content="Explore the prehistoric archaeological heritage of the Kurnool Caves — Billa Surgam and its neighbours, Robert Bruce Foote's discoveries, Ice Age fossils, bone and stone tools, and the region's geology.">
+
+    <meta property="og:title" content="Kurnool Caves — Prehistoric Heritage">
+    <meta property="og:description" content="India's longest-studied cave system — 160+ years of fossils, bone tools, and Ice Age discoveries in the limestone caves of Kurnool.">
+    <meta property="og:type" content="article">
+
+    <link rel="stylesheet" href="../../styles.css">
+    <link rel="stylesheet" href="../pages-common.css">
+    <link rel="stylesheet" href="style.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+          integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+          crossorigin="" />
+
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "TouristAttraction",
+        "name": "Kurnool Caves (Billa Surgam)",
+        "description": "A group of limestone caves in Kurnool district, Andhra Pradesh, with one of India's longest continuous records of prehistoric archaeological investigation.",
+        "address": {
+            "@type": "PostalAddress",
+            "addressLocality": "Betamcherla",
+            "addressRegion": "Andhra Pradesh",
+            "addressCountry": "IN"
+        },
+        "geo": {
+            "@type": "GeoCoordinates",
+            "latitude": 15.4667,
+            "longitude": 78.2333
+        }
+    }
+    </script>
+</head>
+<body class="kurnool-page">
+
+    <header class="site-header" id="site-header">
+        <div class="header-inner">
+            <a href="../../index.html" class="logo">Incredible India Explorer</a>
+            <button id="menu-toggle" class="menu-toggle" aria-label="Toggle navigation menu" aria-expanded="false">☰</button>
+            <nav id="nav-menu" class="nav-menu">
+                <a href="../../index.html">Home</a>
+            </nav>
+            <button id="theme-toggle" class="theme-toggle" aria-label="Toggle dark/light theme">🌓</button>
+        </div>
+    </header>
+
+    <main class="page-container">
+
+        <!-- Hero -->
+        <section class="hero-section kurnool-hero">
+            <div class="badge-container">
+                <span class="hero-badge badge-ochre">Prehistoric India</span>
+                <span class="hero-badge badge-bone">Palaeolithic</span>
+                <span class="hero-badge badge-slate">Andhra Pradesh</span>
+            </div>
+            <div class="hero-content">
+                <h1>Kurnool Caves <span class="accent">— A Prehistoric Record 160 Years in the Making</span></h1>
+                <p class="subtitle">Billa Surgam and the limestone caves of the Kurnool basin</p>
+                <p class="hero-desc">
+                    Around the small town of Betamcherla in Andhra Pradesh, a cluster of limestone caves holds one of
+                    the longest continuous records of archaeological investigation anywhere in India — over 160 years
+                    of digging, since geologist Robert Bruce Foote first excavated the Billa Surgam caves in the
+                    1880s. Ice Age fossils, worked bone tools compared to France's famous Magdalenian industry, and
+                    layers of stone tools together tell the story of prehistoric humans living alongside a very
+                    different, now-vanished fauna.
+                </p>
+            </div>
+            <div class="hero-stats-ribbon">
+                <div class="stat-item"><span class="stat-label">Location</span><span class="stat-val">Betamcherla, Kurnool district</span></div>
+                <div class="stat-item"><span class="stat-label">First Excavated</span><span class="stat-val">1884–85, by R. B. Foote</span></div>
+                <div class="stat-item"><span class="stat-label">Palaeontological Specimens</span><span class="stat-val">~3,000</span></div>
+                <div class="stat-item"><span class="stat-label">Archaeological Specimens</span><span class="stat-val">~1,700</span></div>
+            </div>
+        </section>
+
+        <div class="content-grid">
+
+            <!-- Cave Locations -->
+            <section class="info-card" id="cave-locations">
+                <h2>📍 Cave Locations</h2>
+                <p>
+                    The best-known cave complex is <strong>Billa Surgam</strong>, located in a narrow valley on the
+                    western side of the Kurnool basin, roughly 4.5 km southeast of Betamcherla. It is not a single
+                    cave but a connected system that Foote subdivided into named chambers, including the
+                    <strong>Cathedral Cave</strong>, <strong>Charnel House Cave</strong>, and <strong>Purgatory
+                    Cave</strong>. Nearby, further caves were identified and excavated over the following century,
+                    including <strong>Muchchatla Chintamanu Gavi (MCG I)</strong>, and clusters around Betamcherla
+                    such as <strong>Gollagutta, Krishnamma Kona Gavi, and Sanyasula Gavi</strong>, as well as sites
+                    near Banaganapalli including <strong>Yaganti, Yerrazarigabbi, and Billam</strong>. Collectively,
+                    these caves — developed in the limestone country of the Nandyal basin — form what researchers
+                    refer to as the Kurnool cave region.
+                </p>
+            </section>
+
+            <!-- Archaeological Evidence -->
+            <section class="info-card" id="archaeological-evidence">
+                <h2>🔍 Archaeological Evidence</h2>
+                <div class="grid-2col">
+                    <div>
+                        <p>
+                            The Kurnool caves have the <strong>longest record of archaeological and
+                            palaeoenvironmental exploration of any cave system in India</strong>, stretching back to
+                            the first half of the 19th century. British surveyor <strong>Robert Bruce Foote</strong>,
+                            working with his son Henry, conducted landmark excavations at Billa Surgam in 1884 and
+                            1885, recovering roughly <strong>1,700 archaeological specimens and 3,000
+                            palaeontological specimens</strong>. Foote's work, alongside later excavations by
+                            M. L. K. Murthy (1974) and K. Thimma Reddy (1976, 1980) at neighbouring caves, revealed a
+                            complex <strong>Upper Palaeolithic</strong> culture whose people exploited local jungle
+                            resources with considerable skill.
+                        </p>
+                    </div>
+                    <div class="callout-box">
+                        <h3>India's First Prehistorian</h3>
+                        <p>
+                            Robert Bruce Foote is widely regarded as the founder of prehistoric archaeology in
+                            India. His Kurnool discoveries — alongside his earlier work near Madras — helped
+                            establish that stone-tool-using humans had lived in the subcontinent since deep
+                            prehistory, work he documented in papers to the Geological Survey of India through the
+                            1880s.
+                        </p>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Fossils -->
+            <section class="info-card" id="fossils">
+                <h2>🦴 Fossils</h2>
+                <p>
+                    The Kurnool cave deposits preserve a rich <strong>Late Pleistocene–Holocene fauna</strong>,
+                    including the remains of many living and extinct species. Foote's excavations recovered numerous
+                    animal bones, some bearing clear cut marks and signs of deliberate working — evidence that early
+                    humans processed these animals for food, hides, and raw material. Later study of these faunal
+                    remains, alongside additional excavation at sites like Muchchatla Chintamanu Gavi, has helped
+                    researchers reconstruct how the region's wildlife and vegetation shifted dramatically through the
+                    Late Pleistocene, including evidence of an arid phase that caused a sharp decline in vertebrate
+                    diversity.
+                </p>
+            </section>
+
+            <!-- Stone Tools -->
+            <section class="info-card" id="stone-tools">
+                <h2>🔨 Stone Tools</h2>
+                <p>
+                    Alongside the fossil record, the caves and their surrounding open-air sites have yielded an
+                    important lithic (stone tool) record. Foote himself observed <strong>scrapers and knives of
+                    brown, buff, or greyish chert</strong> at Billa Surgam. Beyond the caves, explorations of the
+                    wider Kurnool river valleys uncovered <strong>blade tool assemblages and microlithic
+                    assemblages</strong> — corresponding to industries later classified as "Series III" and "Series
+                    IV" by archaeologists L. A. Cammiade and M. C. Burkitt in 1930. Notably, some of Foote's own bone
+                    tools at Billa Surgam were found without clearly associated stone tools in the same deposits — a
+                    puzzle that has made precisely dating and contextualising the bone-tool finds more difficult for
+                    later researchers.
+                </p>
+            </section>
+
+            <!-- Geological Context -->
+            <section class="info-card" id="geological-context">
+                <h2>🪨 Geological Context</h2>
+                <p>
+                    The Kurnool caves are developed within the limestone formations of the <strong>Kurnool Group</strong>
+                    — part of the Cuddapah Basin — the same broad geological setting that also produced the nearby
+                    Belum Caves. Foote described the Billa Surgam caves as forming an <strong>"ossiferous" (bone-rich)
+                    cave complex</strong>: over time, sediments, animal remains, and cultural material accumulated in
+                    layers within the cave passages, later hardening into red clay-rich deposits that preserved bones
+                    and artefacts in remarkable detail. This same karst limestone landscape — soft rock steadily
+                    dissolved and hollowed out by underground water over geological time — is what created the cave
+                    systems in the first place, providing the natural "time capsules" that make the region so
+                    important for prehistoric research.
+                </p>
+            </section>
+
+            <!-- Chronology of Discovery -->
+            <section class="hub-section" id="chronology">
+                <h2>🕰️ Chronology of Discovery</h2>
+                <div class="timeline-track" id="kurnool-timeline">
+                    <!-- populated by script.js -->
+                </div>
+            </section>
+
+            <!-- Map -->
+            <section class="hub-section" id="map-section">
+                <h2>🗺️ Map</h2>
+                <div id="kurnool-map" style="height: 360px; border-radius: 0.75rem;"></div>
+            </section>
+
+            <!-- Sources -->
+            <section class="info-card" id="sources">
+                <h2>📚 Sources</h2>
+                <ul class="feature-list">
+                    <li>Live History India — "Robert Foote: Finding India's Stone Age" (2020).</li>
+                    <li>Murty, M. L. K. — "Ethnoarchaeology of the Kurnool Cave areas, South India."</li>
+                    <li>South Asian Studies — "In Foote's Steps: The History, Significance and Recent Archaeological Investigation of the Billa Surgam Caves in Southern India."</li>
+                    <li>ScienceDirect — "Additional vertebrate remains from one of the Late Pleistocene–Holocene Kurnool Caves (Muchchatla Chintamanu Gavi) of South India."</li>
+                    <li>Scholarspace, University of Hawaiʻi — "The Significance of Lithic Finds in the Cave Areas of Kurnool, India."</li>
+                    <li>Grotto Map — "Billa Surgam" excavation history archive.</li>
+                </ul>
+            </section>
+
+        </div>
+    </main>
+
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+            integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+            crossorigin=""></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/kurnool-caves-prehistoric/script.js
+++ b/frontend/kurnool-caves-prehistoric/script.js
@@ -1,0 +1,79 @@
+/**
+ * Kurnool Caves Prehistoric Heritage Page
+ * Handles Discovery Timeline, Leaflet Map, Theme Toggle, Mobile Menu.
+ */
+
+document.addEventListener('DOMContentLoaded', () => {
+    // 1. Theme Toggle
+    // NOTE: Match this to the site-wide IIEStorage / theme persistence
+    // pattern used elsewhere in the codebase before merging.
+    const themeBtn = document.getElementById('theme-toggle');
+    if (themeBtn) {
+        themeBtn.addEventListener('click', () => {
+            const isLight = document.body.classList.toggle('light-theme');
+            if (isLight) {
+                document.documentElement.setAttribute('data-theme', 'light');
+            } else {
+                document.documentElement.removeAttribute('data-theme');
+            }
+            localStorage.setItem('theme', isLight ? 'light' : 'dark');
+        });
+    }
+
+    // 2. Mobile Menu Toggle
+    const menuToggle = document.getElementById('menu-toggle');
+    const navMenu = document.getElementById('nav-menu');
+    if (menuToggle && navMenu) {
+        menuToggle.addEventListener('click', () => {
+            const isExpanded = menuToggle.getAttribute('aria-expanded') === 'true';
+            menuToggle.setAttribute('aria-expanded', !isExpanded);
+            navMenu.classList.toggle('active');
+        });
+    }
+
+    // 3. Chronology of Discovery Timeline
+    const timelineEvents = [
+        { year: '1844', title: 'First Reported by Newbold', desc: 'T. J. Newbold is the first to report fossiliferous caves at Billa Surgam, southeast of Betamcherla.' },
+        { year: '1884–85', title: "Foote's Landmark Excavations", desc: 'Robert Bruce Foote and his son Henry excavate the Cathedral, Charnel House, and Purgatory caves at Billa Surgam, recovering ~1,700 archaeological and ~3,000 palaeontological specimens.' },
+        { year: '1886', title: 'Faunal Remains Studied', desc: 'Palaeontologist Richard Lydekker examines the fossil fauna recovered from Foote\u2019s Billa Surgam excavations.' },
+        { year: '1927', title: 'Cammiade Expands the Picture', desc: 'L. A. Cammiade documents further caves near Betamcherla and Banaganapalli, and later classifies regional stone-tool industries with M. C. Burkitt.' },
+        { year: '1957', title: 'Allchins Revisit the Spoil Heaps', desc: 'F. R. and B. Allchin recover fragments of a Neolithic pot from Foote\u2019s old excavation spoil heaps, later reconstructed at the British Museum.' },
+        { year: '1974–1980', title: 'Murty and Thimma Reddy', desc: 'M. L. K. Murty and K. Thimma Reddy conduct fresh excavations at Muchchatla Chintamanu Gavi and other caves, confirming and extending Foote\u2019s findings.' },
+        { year: '2007 onward', title: 'Renewed Vertebrate Studies', desc: 'Later research re-examines Kurnool Cave faunal remains to reconstruct Late Pleistocene–Holocene climate and vegetation change.' },
+        { year: 'Recent', title: 'Ongoing Research & Preservation', desc: 'Archaeologists continue work at Billa Surgam, now also assessing the site\u2019s preservation against threats from local mining activity.' }
+    ];
+
+    const timelineTrack = document.getElementById('kurnool-timeline');
+    if (timelineTrack) {
+        timelineTrack.innerHTML = timelineEvents.map(ev => `
+            <div class="timeline-item">
+                <span class="timeline-year">${ev.year}</span>
+                <h4>${ev.title}</h4>
+                <p>${ev.desc}</p>
+            </div>
+        `).join('');
+    }
+
+    // 4. Leaflet Map — cave locations
+    const mapEl = document.getElementById('kurnool-map');
+    if (mapEl && window.L) {
+        const map = L.map('kurnool-map', { scrollWheelZoom: false }).setView([15.4667, 78.2333], 10);
+
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '© OpenStreetMap contributors',
+            maxZoom: 18
+        }).addTo(map);
+
+        const sites = [
+            { name: 'Billa Surgam Caves', coords: [15.4667, 78.2333], note: 'The main excavated cave complex; site of Foote\u2019s 1884-85 Cathedral, Charnel House, and Purgatory Cave excavations.' },
+            { name: 'Betamcherla', coords: [15.4894, 78.2075], note: 'Nearest town, on the Kurnool basin\u2019s western limestone plateau.' },
+            { name: 'Banaganapalli Cave Cluster', coords: [15.3167, 78.2167], note: 'Includes Yaganti, Yerrazarigabbi, and Billam caves, also explored by Foote.' }
+        ];
+
+        sites.forEach(s => {
+            L.marker(s.coords)
+                .addTo(map)
+                .bindPopup(`<strong>${s.name}</strong><br>${s.note}`);
+        });
+    }
+});

--- a/frontend/kurnool-caves-prehistoric/style.css
+++ b/frontend/kurnool-caves-prehistoric/style.css
@@ -1,0 +1,135 @@
+/* ==========================================================================
+   Kurnool Caves Prehistoric Heritage Stylesheet
+   ========================================================================== */
+
+:root {
+    --kn-ochre: #b45309;
+    --kn-bone: #d6cfc0;
+    --kn-slate: #44403c;
+    --kn-card-bg: rgba(19, 17, 14, 0.85);
+    --kn-border: rgba(180, 83, 9, 0.28);
+}
+
+body.kurnool-page {
+    background-color: #0e0c0a;
+    color: #f1ece1;
+    font-family: var(--font-body, 'Outfit', -apple-system, BlinkMacSystemFont, sans-serif);
+    line-height: 1.65;
+    margin: 0;
+    padding: 0;
+}
+
+body.kurnool-page.light-theme {
+    background-color: #fbf8f2;
+    color: #211c14;
+    --kn-card-bg: rgba(255, 255, 255, 0.95);
+    --kn-border: rgba(180, 83, 9, 0.22);
+}
+
+.page-container {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 2rem 1.5rem 4rem;
+}
+
+/* --- Hero --- */
+.hero-section.kurnool-hero {
+    background: linear-gradient(135deg, rgba(180, 83, 9, 0.24), rgba(68, 64, 60, 0.28)), #161310;
+    border: 1px solid var(--kn-border);
+    border-radius: 1.25rem;
+    padding: 3.5rem 2rem 2.5rem;
+    margin-bottom: 3rem;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+}
+
+body.light-theme .hero-section.kurnool-hero {
+    background: linear-gradient(135deg, rgba(254, 235, 200, 0.85), rgba(231, 229, 228, 0.6)), #ffffff;
+    box-shadow: 0 10px 30px rgba(180, 83, 9, 0.1);
+}
+
+.badge-container { display: flex; flex-wrap: wrap; gap: 0.75rem; margin-bottom: 1.25rem; }
+.hero-badge { display: inline-flex; align-items: center; padding: 0.35rem 0.85rem; border-radius: 2rem; font-size: 0.85rem; font-weight: 600; }
+.badge-ochre { background: rgba(180, 83, 9, 0.22); color: #fdba74; border: 1px solid rgba(180, 83, 9, 0.45); }
+.badge-bone { background: rgba(214, 207, 192, 0.2); color: #e7e0d0; border: 1px solid rgba(214, 207, 192, 0.4); }
+.badge-slate { background: rgba(68, 64, 60, 0.32); color: #d6d3d1; border: 1px solid rgba(68, 64, 60, 0.55); }
+
+.hero-content h1 { font-size: clamp(1.9rem, 4vw, 2.9rem); font-weight: 800; line-height: 1.25; margin-bottom: 0.6rem; color: #fdf8ee; }
+body.light-theme .hero-content h1 { color: #211c14; }
+.hero-content .accent { color: var(--kn-ochre); }
+
+.subtitle { font-size: 1.1rem; font-weight: 600; font-style: italic; color: #fdba74; margin-bottom: 1.1rem; }
+body.light-theme .subtitle { color: #b45309; }
+
+.hero-desc { font-size: 1.02rem; max-width: 900px; color: #e9e0d0; }
+body.light-theme .hero-desc { color: #4b3a24; }
+
+.hero-stats-ribbon {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1.25rem;
+    margin-top: 2.25rem;
+    padding-top: 1.75rem;
+    border-top: 1px solid var(--kn-border);
+}
+.stat-item { background: rgba(255, 255, 255, 0.04); padding: 1rem 1.25rem; border-radius: 0.75rem; border: 1px solid rgba(255, 255, 255, 0.06); }
+body.light-theme .stat-item { background: #ffffff; border-color: rgba(180, 83, 9, 0.16); }
+.stat-label { display: block; font-size: 0.78rem; text-transform: uppercase; letter-spacing: 0.05em; color: #fdba74; margin-bottom: 0.35rem; }
+body.light-theme .stat-label { color: #b45309; }
+.stat-val { font-size: 1rem; font-weight: 700; color: var(--kn-ochre); }
+
+/* --- Content --- */
+.content-grid { display: flex; flex-direction: column; gap: 2.25rem; margin-bottom: 3rem; }
+
+.info-card {
+    background: var(--kn-card-bg);
+    border: 1px solid var(--kn-border);
+    border-radius: 1.25rem;
+    padding: 2.1rem;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.25);
+}
+.info-card h2 { font-size: 1.6rem; margin-bottom: 1.1rem; color: #fdf8ee; border-bottom: 2px solid rgba(180, 83, 9, 0.3); padding-bottom: 0.5rem; }
+body.light-theme .info-card h2 { color: #211c14; }
+
+.grid-2col { display: grid; grid-template-columns: 1.3fr 1fr; gap: 1.75rem; align-items: start; }
+@media (max-width: 768px) { .grid-2col { grid-template-columns: 1fr; } }
+
+.callout-box { background: rgba(68, 64, 60, 0.18); border-left: 4px solid var(--kn-slate); padding: 1.35rem; border-radius: 0.5rem; }
+.callout-box h3 { margin-top: 0; margin-bottom: 0.75rem; color: var(--kn-ochre); }
+body.light-theme .callout-box h3 { color: #b45309; }
+
+.feature-list { list-style: none; padding-left: 0; margin: 1rem 0 0; }
+.feature-list li { margin-bottom: 0.85rem; position: relative; padding-left: 1.6rem; }
+.feature-list li::before { content: "🦴"; position: absolute; left: 0; font-size: 0.85rem; }
+
+/* --- Hub sections (Chronology / Map) --- */
+.hub-section {
+    background: var(--kn-card-bg);
+    border: 1px solid var(--kn-border);
+    border-radius: 1.5rem;
+    padding: 2.5rem 2rem;
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
+}
+.hub-section h2 { font-size: 1.6rem; margin-bottom: 1.5rem; color: #fdf8ee; }
+body.light-theme .hub-section h2 { color: #211c14; }
+
+.timeline-track { position: relative; padding-left: 2rem; border-left: 3px solid var(--kn-ochre); display: flex; flex-direction: column; gap: 1.75rem; }
+.timeline-item { position: relative; }
+.timeline-item::before {
+    content: "";
+    position: absolute;
+    left: -2.45rem;
+    top: 0.2rem;
+    width: 0.9rem;
+    height: 0.9rem;
+    background: var(--kn-ochre);
+    border-radius: 50%;
+    border: 3px solid #161310;
+}
+body.light-theme .timeline-item::before { border-color: #fbf8f2; }
+
+.timeline-year { display: inline-block; font-weight: 700; color: var(--kn-slate); margin-bottom: 0.25rem; }
+body.light-theme .timeline-year { color: #44403c; }
+.timeline-item h4 { margin: 0 0 0.35rem; font-size: 1.05rem; color: #fdf8ee; }
+body.light-theme .timeline-item h4 { color: #211c14; }
+.timeline-item p { margin: 0; font-size: 0.92rem; color: #d6c9b6; }
+body.light-theme .timeline-item p { color: #57503f; }

--- a/tests/unit/kurnool-caves-prehistoric.test.js
+++ b/tests/unit/kurnool-caves-prehistoric.test.js
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+const htmlPath = path.resolve(__dirname, '../../frontend/kurnool-caves-prehistoric/index.html');
+const cssPath = path.resolve(__dirname, '../../frontend/kurnool-caves-prehistoric/style.css');
+const jsPath = path.resolve(__dirname, '../../frontend/kurnool-caves-prehistoric/script.js');
+
+let html;
+let css;
+let js;
+
+beforeAll(() => {
+    html = fs.readFileSync(htmlPath, 'utf-8');
+    css = fs.readFileSync(cssPath, 'utf-8');
+    js = fs.readFileSync(jsPath, 'utf-8');
+});
+
+describe('Kurnool Caves page — file structure', () => {
+    it('index.html exists and is non-empty', () => {
+        expect(html).toBeTruthy();
+        expect(html.length).toBeGreaterThan(500);
+    });
+
+    it('style.css exists and is non-empty', () => {
+        expect(css).toBeTruthy();
+        expect(css.length).toBeGreaterThan(200);
+    });
+
+    it('script.js exists and is non-empty', () => {
+        expect(js).toBeTruthy();
+        expect(js.length).toBeGreaterThan(100);
+    });
+
+    it('links to style.css and script.js relatively', () => {
+        expect(html).toMatch(/href="style\.css"/);
+        expect(html).toMatch(/src="script\.js"/);
+    });
+
+    it('loads Leaflet CSS and JS with integrity hashes', () => {
+        expect(html).toMatch(/leaflet\.css/);
+        expect(html).toMatch(/integrity="sha256-/);
+    });
+});
+
+describe('Kurnool Caves page — required content sections (per issue #3786)', () => {
+    const requiredSections = [
+        { id: 'cave-locations', label: 'Cave Locations' },
+        { id: 'archaeological-evidence', label: 'Archaeological Evidence' },
+        { id: 'fossils', label: 'Fossils' },
+        { id: 'stone-tools', label: 'Stone Tools' },
+        { id: 'geological-context', label: 'Geological Context' },
+        { id: 'map-section', label: 'Map' },
+        { id: 'sources', label: 'Sources' },
+    ];
+
+    requiredSections.forEach(({ id, label }) => {
+        it(`includes the "${label}" section (id="${id}")`, () => {
+            expect(html).toMatch(new RegExp(`id="${id}"`));
+        });
+    });
+});
+
+describe('Kurnool Caves page — content accuracy', () => {
+    it('names Billa Surgam and its excavated chambers', () => {
+        expect(html).toMatch(/Billa Surgam/);
+        expect(html).toMatch(/Cathedral Cave/);
+    });
+
+    it('credits Robert Bruce Foote and his 1884-85 excavations', () => {
+        expect(html).toMatch(/Robert Bruce Foote/);
+        expect(html).toMatch(/1884/);
+    });
+
+    it('documents fossil evidence including cut-marked bones', () => {
+        expect(html).toMatch(/cut marks/i);
+        expect(html).toMatch(/Pleistocene/);
+    });
+
+    it('documents stone tool evidence including microliths', () => {
+        expect(html).toMatch(/microlithic/i);
+        expect(html).toMatch(/chert/i);
+    });
+
+    it('documents the limestone/karst geological context', () => {
+        expect(html).toMatch(/limestone/i);
+        expect(html).toMatch(/Kurnool Group/);
+    });
+
+    it('includes an interactive map with multiple site markers', () => {
+        expect(html).toMatch(/id="kurnool-map"/);
+        expect(js).toMatch(/Billa Surgam Caves/);
+        expect(js).toMatch(/Banaganapalli/);
+    });
+
+    it('provides a non-empty sources list', () => {
+        const sourcesMatch = html.match(/id="sources"[\s\S]*?<\/section>/);
+        expect(sourcesMatch).not.toBeNull();
+        const listItemCount = (sourcesMatch[0].match(/<li>/g) || []).length;
+        expect(listItemCount).toBeGreaterThanOrEqual(3);
+    });
+});
+
+describe('Kurnool Caves page — interactivity & accessibility', () => {
+    it('script.js wires up the theme toggle button', () => {
+        expect(js).toMatch(/theme-toggle/);
+        expect(js).toMatch(/light-theme/);
+    });
+
+    it('script.js wires up the mobile menu toggle', () => {
+        expect(js).toMatch(/menu-toggle/);
+        expect(js).toMatch(/aria-expanded/);
+    });
+
+    it('page has a theme-toggle button with an aria-label', () => {
+        expect(html).toMatch(/id="theme-toggle"[^>]*aria-label/);
+    });
+
+    it('map markers bind popups with site information', () => {
+        expect(js).toMatch(/bindPopup/);
+    });
+
+    it('timeline is rendered dynamically from script.js data', () => {
+        expect(html).toMatch(/id="kurnool-timeline"/);
+        expect(js).toMatch(/timelineEvents/);
+    });
+});


### PR DESCRIPTION
Closes #3786

## Summary
A profile documenting the prehistoric archaeological heritage of the Kurnool cave region — one of India's longest-studied cave systems.

## What's included
- **Cave Locations** — Billa Surgam (Cathedral, Charnel House, Purgatory caves), Muchchatla Chintamanu Gavi, and clusters near Betamcherla and Banaganapalli
- **Archaeological Evidence** — Robert Bruce Foote's 1884–85 excavations (~1,700 archaeological + ~3,000 palaeontological specimens), later confirmed and extended by Murty and Thimma Reddy
- **Fossils** — Late Pleistocene–Holocene fauna, cut-marked bones showing human processing, climate/vegetation reconstruction studies
- **Stone Tools** — chert scrapers and knives, blade and microlithic assemblages classified as Series III/IV by Cammiade & Burkitt (1930)
- **Geological Context** — Kurnool Group limestone (Cuddapah Basin), ossiferous cave deposits
- **Chronology of Discovery** — interactive rendered timeline from 1844 to present
- **Map** — interactive Leaflet map with 3 site markers
- **Sources** — 6 cited references including peer-reviewed archaeological literature

## Testing
- Added `tests/unit/kurnool-caves-prehistoric.test.js` — 21 tests covering structure, all 7 required topics, content accuracy, and interactivity
- Manually verified in browser — map markers, timeline rendering, and theme toggle all function correctly

## Sources
Facts cross-checked across Live History India, a peer-reviewed South Asian Studies paper on Billa Surgam's excavation history, ScienceDirect, and University of Hawaiʻi archives for consistency on dates, excavators, and findings.
<img width="1440" height="852" alt="Screenshot 2026-08-27 104548" src="https://github.com/user-attachments/assets/f89242c3-e7da-4b74-839c-bc64b7b9c090" />
<img width="1440" height="852" alt="Screenshot 2026-08-27 104554" src="https://github.com/user-attachments/assets/a5a0c76a-0b33-449c-b2ff-ae3b0691a01b" />
<img width="1440" height="852" alt="Screenshot 2026-08-27 104559" src="https://github.com/user-attachments/assets/c32d7972-cebc-4f13-89d0-390c55073da4" />
