### PR TITLE
Add Isampur prehistoric stone-tool site profile

### DIFF
--- a/frontend/isampur-stone-tools/index.html
+++ b/frontend/isampur-stone-tools/index.html
@@ -1,0 +1,359 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta
+        name="description"
+        content="Explore Isampur archaeological site in Karnataka, an important Acheulean quarry-cum-workshop revealing early stone-tool production in India."
+    >
+    <title>Isampur Stone Tools | Incredible India Explorer</title>
+
+    <link rel="stylesheet" href="../pages-common.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+    <header class="navbar" id="navbar">
+        <div class="nav-container">
+            <a href="../../index.html#home" class="nav-logo" id="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <button
+                class="menu-toggle"
+                id="menu-toggle"
+                aria-label="Toggle Menu"
+            >
+                <span class="bar"></span>
+                <span class="bar"></span>
+                <span class="bar"></span>
+            </button>
+
+            <nav class="nav-menu" id="nav-menu">
+                <a href="../../index.html#home" class="nav-link">Home</a>
+
+                <div class="nav-dropdown">
+                    <button
+                        class="nav-link dropdown-toggle"
+                        aria-haspopup="true"
+                        aria-expanded="false"
+                    >
+                        Destinations ▾
+                    </button>
+
+                    <div class="dropdown-menu">
+                        <a href="../../index.html#map" class="dropdown-item">
+                            Interactive Map
+                        </a>
+                        <a
+                            href="../travel/travel.html"
+                            class="dropdown-item"
+                        >
+                            Travel & Destinations
+                        </a>
+                        <a
+                            href="../heritage/heritage.html"
+                            class="dropdown-item"
+                        >
+                            Heritage Sites
+                        </a>
+                    </div>
+                </div>
+
+                <div class="nav-dropdown">
+                    <button
+                        class="nav-link dropdown-toggle active"
+                        aria-haspopup="true"
+                        aria-expanded="false"
+                    >
+                        Prehistory ▾
+                    </button>
+
+                    <div class="dropdown-menu">
+                        <a
+                            href="../prehistoric-india-explorer/index.html"
+                            class="dropdown-item"
+                        >
+                            Prehistoric India Hub
+                        </a>
+                        <a
+                            href="../didwana-stone-age-tools/index.html"
+                            class="dropdown-item"
+                        >
+                            Didwana Stone Age Tools
+                        </a>
+                        <a
+                            href="../paisra-prehistoric-site/index.html"
+                            class="dropdown-item"
+                        >
+                            Paisra Prehistoric Site
+                        </a>
+                        <a
+                            href="../acheulean-stone-technology/index.html"
+                            class="dropdown-item"
+                        >
+                            Acheulean Stone Technology
+                        </a>
+                        <a
+                            href="index.html"
+                            class="dropdown-item active"
+                        >
+                            Isampur Stone Tools
+                        </a>
+                    </div>
+                </div>
+
+                <button
+                    id="theme-toggle"
+                    class="btn-theme-toggle"
+                    aria-label="Toggle Dark/Light Mode"
+                >
+                    ☀️
+                </button>
+            </nav>
+        </div>
+    </header>
+
+    <main class="page-container">
+
+        <section class="hero-section">
+            <div class="hero-content">
+                <div class="site-badge">
+                    🪨 Lower Palaeolithic Archaeological Site
+                </div>
+
+                <h1>Prehistoric Tools of Isampur</h1>
+
+                <p class="subtitle">
+                    An Acheulean Quarry-Cum-Workshop in Karnataka
+                </p>
+
+                <p class="location">
+                    📍 Isampur, Hunsgi Valley, northern Karnataka, India
+                </p>
+
+                <p class="hero-desc">
+                    Isampur is one of India's most important Lower Palaeolithic
+                    archaeological sites. Its quarry and workshop context
+                    preserves stone blocks, cores, flakes, hammerstones and
+                    tools in different stages of manufacture, providing a rare
+                    view of how Acheulean hominins produced stone tools.
+                </p>
+            </div>
+        </section>
+
+        <div class="content-grid">
+
+            <section class="info-section">
+                <h2>Location</h2>
+
+                <div class="info-card">
+                    <p>
+                        Isampur lies in the
+                        <strong>Hunsgi Valley of northern Karnataka</strong>,
+                        within the wider Hunsgi-Baichbal prehistoric landscape.
+                    </p>
+
+                    <p>
+                        The site occupies a valley setting near an ancient
+                        drainage channel and limestone outcrops. The
+                        combination of water availability and accessible
+                        stone raw material made the location attractive to
+                        prehistoric toolmakers.
+                    </p>
+                </div>
+            </section>
+
+            <section class="info-section">
+                <h2>Archaeological Context</h2>
+
+                <div class="info-card">
+                    <p>
+                        Isampur is particularly important because it represents
+                        an
+                        <strong>in-situ Acheulean quarry-cum-workshop</strong>.
+                    </p>
+
+                    <p>
+                        Excavations revealed artefacts in different stages of
+                        production together with waste flakes and hammerstones,
+                        allowing researchers to reconstruct the process from
+                        raw-material selection to finished tool manufacture.
+                    </p>
+                </div>
+            </section>
+
+        </div>
+
+        <section class="discoveries-section">
+            <h2 class="section-title">Stone-Tool Evidence</h2>
+
+            <div class="discoveries-grid">
+
+                <article class="discovery-card">
+                    <span class="discovery-icon">🪨</span>
+                    <h3>Limestone Cores</h3>
+                    <p>
+                        Limestone blocks were selected and worked into cores
+                        before large flakes were detached.
+                    </p>
+                </article>
+
+                <article class="discovery-card">
+                    <span class="discovery-icon">⚒️</span>
+                    <h3>Hammerstones</h3>
+                    <p>
+                        Hammerstones made from materials including quartzite,
+                        basalt and chert provide evidence of active knapping.
+                    </p>
+                </article>
+
+                <article class="discovery-card">
+                    <span class="discovery-icon">🪓</span>
+                    <h3>Handaxes</h3>
+                    <p>
+                        Bifacial handaxes demonstrate the Acheulean tradition
+                        of shaping large stone tools.
+                    </p>
+                </article>
+
+                <article class="discovery-card">
+                    <span class="discovery-icon">🔨</span>
+                    <h3>Cleavers</h3>
+                    <p>
+                        Large cutting tools form another important part of the
+                        Acheulean assemblage.
+                    </p>
+                </article>
+
+                <article class="discovery-card">
+                    <span class="discovery-icon">🔪</span>
+                    <h3>Knives & Chopping Tools</h3>
+                    <p>
+                        Large flakes were further modified into cutting and
+                        chopping implements.
+                    </p>
+                </article>
+
+                <article class="discovery-card">
+                    <span class="discovery-icon">◈</span>
+                    <h3>Debitage</h3>
+                    <p>
+                        Numerous waste flakes preserve the different stages of
+                        stone reduction and tool manufacture.
+                    </p>
+                </article>
+
+            </div>
+        </section>
+
+        <section class="facts-section">
+            <h2 class="section-title">Dating Information</h2>
+
+            <div class="facts-grid">
+
+                <article class="fact-card">
+                    <span class="fact-icon">⏳</span>
+                    <strong>Lower Palaeolithic</strong>
+                    <p>
+                        Isampur belongs to the Acheulean tradition of the Lower
+                        Palaeolithic.
+                    </p>
+                </article>
+
+                <article class="fact-card">
+                    <span class="fact-icon">📅</span>
+                    <strong>~1.2 Million Years Ago</strong>
+                    <p>
+                        Government science-heritage material describes the
+                        excavated Acheulean cultural level at Isampur as about
+                        1.2 million years old.
+                    </p>
+                </article>
+
+                <article class="fact-card">
+                    <span class="fact-icon">🔬</span>
+                    <strong>Dating Evidence</strong>
+                    <p>
+                        Chronological interpretations have been developed
+                        through geological and absolute-dating research at the
+                        site and surrounding Hunsgi Valley.
+                    </p>
+                </article>
+
+            </div>
+        </section>
+
+        <section class="significance-section">
+            <h2 class="section-title">Why Isampur Matters</h2>
+
+            <div class="significance-grid">
+
+                <article class="significance-card">
+                    <h3>1. Quarry in Primary Context</h3>
+                    <p>
+                        Isampur preserves stone-tool production close to the
+                        original limestone source rather than only showing
+                        finished tools transported elsewhere.
+                    </p>
+                </article>
+
+                <article class="significance-card">
+                    <h3>2. Complete Manufacturing Sequence</h3>
+                    <p>
+                        Cores, flakes, waste material, hammerstones and finished
+                        tools allow researchers to reconstruct the stages of
+                        Acheulean manufacture.
+                    </p>
+                </article>
+
+                <article class="significance-card">
+                    <h3>3. Understanding Hominin Behaviour</h3>
+                    <p>
+                        The site provides evidence for how prehistoric
+                        toolmakers selected raw materials, organised working
+                        areas and used the surrounding landscape.
+                    </p>
+                </article>
+
+            </div>
+        </section>
+
+        <section class="map-section">
+            <h2 class="section-title">Isampur Location Map</h2>
+
+            <div class="map-wrapper">
+                <iframe
+                    title="Isampur Archaeological Site Map"
+                    src="https://www.google.com/maps?q=16.50,76.48&z=11&output=embed"
+                    width="100%"
+                    height="450"
+                    style="border:0;"
+                    allowfullscreen=""
+                    loading="lazy"
+                    referrerpolicy="no-referrer-when-downgrade"
+                ></iframe>
+            </div>
+
+            <p class="map-caption">
+                Approximate location of Isampur in the Hunsgi Valley of
+                northern Karnataka.
+            </p>
+        </section>
+
+    </main>
+
+    <footer class="footer">
+        <div class="footer-content">
+            <p>
+                &copy; 2026 Incredible India Explorer. Open Source Project.
+            </p>
+        </div>
+    </footer>
+
+    <script src="../app.js"></script>
+</body>
+</html>

--- a/frontend/isampur-stone-tools/style.css
+++ b/frontend/isampur-stone-tools/style.css
@@ -1,0 +1,268 @@
+:root {
+    --primary-color: #92400e;
+    --accent-color: #d97706;
+    --hero-bg: #fefce8;
+    --card-bg: #ffffff;
+    --text-color: #334155;
+    --heading-color: #1e293b;
+    --border-color: #e2e8f0;
+}
+
+body:not(.light-theme) {
+    --primary-color: #fbbf24;
+    --accent-color: #f59e0b;
+    --hero-bg: #292524;
+    --card-bg: #1e293b;
+    --text-color: #cbd5e1;
+    --heading-color: #f8fafc;
+    --border-color: #475569;
+}
+
+.page-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+}
+
+.hero-section {
+    background: var(--hero-bg);
+    border: 2px solid var(--accent-color);
+    border-radius: 16px;
+    padding: 4rem 2rem;
+    text-align: center;
+    margin-bottom: 4rem;
+}
+
+.site-badge {
+    display: inline-block;
+    background: var(--accent-color);
+    color: #111;
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    font-size: 0.9rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+.hero-content h1 {
+    margin: 0 0 1rem;
+    color: var(--primary-color);
+    font-size: 3.5rem;
+}
+
+.subtitle {
+    margin-bottom: 1rem;
+    color: var(--heading-color);
+    font-size: 1.4rem;
+    font-weight: 500;
+}
+
+.location {
+    margin-bottom: 1.5rem;
+    color: var(--text-color);
+    font-style: italic;
+}
+
+.hero-desc {
+    max-width: 800px;
+    margin: 0 auto;
+    color: var(--text-color);
+    font-size: 1.1rem;
+    line-height: 1.7;
+}
+
+.content-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 2.5rem;
+    margin-bottom: 4rem;
+}
+
+.info-section h2 {
+    margin-bottom: 1.5rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 2px solid var(--accent-color);
+    color: var(--primary-color);
+}
+
+.info-card {
+    height: 100%;
+    padding: 1.8rem;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    color: var(--text-color);
+    line-height: 1.7;
+}
+
+.section-title {
+    display: block;
+    width: fit-content;
+    margin: 0 auto 2rem;
+    padding-bottom: 0.5rem;
+    border-bottom: 2px solid var(--accent-color);
+    color: var(--primary-color);
+    text-align: center;
+    font-size: 2.2rem;
+}
+
+.discoveries-section,
+.facts-section,
+.significance-section,
+.map-section {
+    margin-bottom: 4rem;
+}
+
+.discoveries-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.5rem;
+}
+
+.discovery-card {
+    padding: 1.5rem;
+    background: var(--card-bg);
+    border-left: 4px solid var(--accent-color);
+    border-radius: 8px;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.06);
+}
+
+.discovery-icon {
+    display: block;
+    margin-bottom: 0.75rem;
+    font-size: 2rem;
+}
+
+.discovery-card h3 {
+    margin-bottom: 0.5rem;
+    color: var(--heading-color);
+}
+
+.discovery-card p {
+    margin: 0;
+    color: var(--text-color);
+    line-height: 1.6;
+}
+
+.facts-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.5rem;
+}
+
+.fact-card {
+    padding: 1.5rem;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    text-align: center;
+}
+
+.fact-icon {
+    display: block;
+    margin-bottom: 1rem;
+    font-size: 2.5rem;
+}
+
+.fact-card strong {
+    display: block;
+    margin-bottom: 0.5rem;
+    color: var(--heading-color);
+}
+
+.fact-card p {
+    margin: 0;
+    color: var(--text-color);
+    line-height: 1.6;
+}
+
+.significance-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.5rem;
+}
+
+.significance-card {
+    padding: 1.7rem;
+    background: var(--card-bg);
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+}
+
+.significance-card h3 {
+    margin-top: 0;
+    color: var(--heading-color);
+}
+
+.significance-card p {
+    margin-bottom: 0;
+    color: var(--text-color);
+    line-height: 1.65;
+}
+
+.map-wrapper {
+    overflow: hidden;
+    border: 1px solid var(--border-color);
+    border-radius: 12px;
+    background: var(--card-bg);
+}
+
+.map-caption {
+    margin-top: 0.75rem;
+    color: var(--text-color);
+    text-align: center;
+    font-size: 0.9rem;
+}
+
+.footer {
+    padding: 1.5rem 2rem;
+    color: var(--text-color);
+    text-align: center;
+}
+
+@media (max-width: 900px) {
+    .discoveries-grid,
+    .facts-grid,
+    .significance-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .hero-content h1 {
+        font-size: 2.8rem;
+    }
+}
+
+@media (max-width: 700px) {
+    .page-container {
+        padding: 1rem;
+    }
+
+    .content-grid,
+    .discoveries-grid,
+    .facts-grid,
+    .significance-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .hero-section {
+        padding: 3rem 1.25rem;
+    }
+
+    .hero-content h1 {
+        font-size: 2.3rem;
+    }
+
+    .subtitle {
+        font-size: 1.15rem;
+    }
+
+    .section-title {
+        font-size: 1.8rem;
+    }
+
+    .map-wrapper iframe {
+        height: 350px;
+    }
+}

--- a/frontend/narmada-valley-fossils/index.html
+++ b/frontend/narmada-valley-fossils/index.html
@@ -1,0 +1,348 @@
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function () {
+            const theme = localStorage.getItem("theme") || "dark";
+            if (theme === "light") {
+                document.documentElement.classList.add("light-theme");
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Fossil Discoveries of the Narmada Valley | Incredible India Explorer</title>
+    <meta name="description" content="Explore prehistoric fossil discoveries of the Narmada Valley, including Hathnora hominin remains, Pleistocene megafauna, dinosaur fossils, geological context, and important fossil localities.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&family=Playfair+Display:wght@600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header">
+        <nav class="topnav" aria-label="Primary navigation">
+            <a class="brand" href="../../index.html">Incredible India Explorer</a>
+
+            <div class="nav-links">
+                <a href="#geography">Geography</a>
+                <a href="#discoveries">Discoveries</a>
+                <a href="#geology">Geology</a>
+                <a href="#animals">Animals</a>
+                <a href="#significance">Significance</a>
+                <a href="#map">Map</a>
+            </div>
+
+            <button type="button" id="theme-toggle" class="theme-toggle"
+                    aria-label="Switch to light theme">☀️</button>
+        </nav>
+    </header>
+
+    <main id="main">
+        <header class="hero">
+            <p class="eyebrow">Palaeontology · Geoheritage · Prehistory</p>
+            <h1>Fossil Discoveries of the Narmada Valley</h1>
+            <p class="hero-date">A fossil record spanning the Late Cretaceous to the Pleistocene</p>
+            <p class="lede">
+                The Narmada Valley preserves an exceptional record of prehistoric life.
+                Dinosaur remains, large Ice Age mammals, crocodilians and the famous
+                Hathnora hominin discovery together reveal changing landscapes and
+                ecosystems across millions of years.
+            </p>
+
+            <dl class="hero-stats">
+                <div>
+                    <dt>Major hominin locality</dt>
+                    <dd>Hathnora</dd>
+                </div>
+                <div>
+                    <dt>River</dt>
+                    <dd>Narmada</dd>
+                </div>
+                <div>
+                    <dt>Key fossil record</dt>
+                    <dd>Dinosaurs → Megafauna</dd>
+                </div>
+                <div>
+                    <dt>Research value</dt>
+                    <dd>Human evolution</dd>
+                </div>
+            </dl>
+        </header>
+
+        <section class="block" id="geography" aria-labelledby="geography-heading">
+            <div class="section-head">
+                <span class="tag">Geography</span>
+                <h2 id="geography-heading">The Narmada fossil landscape</h2>
+            </div>
+
+            <div class="grid-2">
+                <article class="card">
+                    <h3>Central Indian river corridor</h3>
+                    <p>
+                        The Narmada flows east to west across central India through
+                        Madhya Pradesh and Gujarat before reaching the Arabian Sea.
+                        Its valley exposes sedimentary deposits that preserve fossils
+                        from very different geological periods.
+                    </p>
+                </article>
+
+                <article class="card">
+                    <h3>Important localities</h3>
+                    <p>
+                        Fossil-bearing areas include Hathnora and other Narmada
+                        basin localities around central Madhya Pradesh, while
+                        dinosaur-bearing Cretaceous rocks occur farther west in the
+                        broader Narmada basin.
+                    </p>
+                </article>
+            </div>
+        </section>
+
+        <section class="block" id="discoveries" aria-labelledby="discoveries-heading">
+            <div class="section-head">
+                <span class="tag">Discoveries</span>
+                <h2 id="discoveries-heading">Fossils that changed our understanding</h2>
+            </div>
+
+            <div class="timeline">
+                <article class="timeline-card">
+                    <div class="timeline-date">Late Cretaceous</div>
+                    <div>
+                        <h3>Dinosaur fossils of the Narmada basin</h3>
+                        <p>
+                            Dinosaur bones and eggshell material occur in the Lameta
+                            Formation of the Narmada region. The record includes
+                            titanosaur sauropods and abelisaurid theropods, including
+                            the species <em>Rajasaurus narmadensis</em>.
+                        </p>
+                    </div>
+                </article>
+
+                <article class="timeline-card">
+                    <div class="timeline-date">Pleistocene</div>
+                    <div>
+                        <h3>Hathnora hominin discovery</h3>
+                        <p>
+                            A partial hominin cranium discovered near Hathnora in
+                            the Narmada Valley became one of the most important
+                            prehistoric human fossils from the Indian subcontinent.
+                            Its precise taxonomic classification remains debated.
+                        </p>
+                    </div>
+                </article>
+
+                <article class="timeline-card">
+                    <div class="timeline-date">Pleistocene</div>
+                    <div>
+                        <h3>Large mammal fossils</h3>
+                        <p>
+                            Narmada sediments have yielded remains of large
+                            prehistoric mammals such as elephants, hippopotamuses,
+                            bovids and other fauna, providing evidence of ancient
+                            riverine and grassland environments.
+                        </p>
+                    </div>
+                </article>
+            </div>
+        </section>
+
+        <section class="block" id="geology" aria-labelledby="geology-heading">
+            <div class="section-head">
+                <span class="tag">Geological Context</span>
+                <h2 id="geology-heading">How the fossils were preserved</h2>
+            </div>
+
+            <div class="geology-grid">
+                <article class="layer-card">
+                    <span class="layer-period">Late Cretaceous</span>
+                    <h3>Lameta Formation</h3>
+                    <p>
+                        Fluvial and lacustrine sediments associated with the
+                        Lameta Formation preserve dinosaur bones, eggs and other
+                        vertebrate remains in parts of the Narmada basin.
+                    </p>
+                </article>
+
+                <article class="layer-card">
+                    <span class="layer-period">Pleistocene</span>
+                    <h3>River deposits</h3>
+                    <p>
+                        Younger gravel, sand and silt deposits along the Narmada
+                        record changing river environments and contain important
+                        mammalian and hominin remains.
+                    </p>
+                </article>
+
+                <article class="layer-card">
+                    <span class="layer-period">Modern landscape</span>
+                    <h3>Narmada terraces</h3>
+                    <p>
+                        River terraces and exposed sedimentary sections allow
+                        researchers to investigate how climate, rivers, vegetation
+                        and animal communities changed through time.
+                    </p>
+                </article>
+            </div>
+        </section>
+
+        <section class="block" id="animals" aria-labelledby="animals-heading">
+            <div class="section-head">
+                <span class="tag">Prehistoric Animals</span>
+                <h2 id="animals-heading">Life recorded in the valley</h2>
+            </div>
+
+            <div class="animal-grid">
+                <article class="animal-card featured">
+                    <span class="animal-type">Theropod</span>
+                    <h3><em>Rajasaurus narmadensis</em></h3>
+                    <p>
+                        A Late Cretaceous abelisaurid theropod from the Narmada
+                        basin, recognized by distinctive skull anatomy and a
+                        prominent nasal-frontal horn.
+                    </p>
+                </article>
+
+                <article class="animal-card">
+                    <span class="animal-type">Sauropod</span>
+                    <h3>Titanosaur dinosaurs</h3>
+                    <p>
+                        Long-necked herbivorous sauropods are represented by
+                        numerous skeletal remains from the Lameta Formation.
+                    </p>
+                </article>
+
+                <article class="animal-card">
+                    <span class="animal-type">Proboscidean</span>
+                    <h3>Prehistoric elephants</h3>
+                    <p>
+                        Fossil elephants and relatives document the rich
+                        Pleistocene megafauna that lived around ancient river
+                        environments.
+                    </p>
+                </article>
+
+                <article class="animal-card">
+                    <span class="animal-type">Hippopotamid</span>
+                    <h3>Hippopotamus relatives</h3>
+                    <p>
+                        Hippopotamid fossils indicate the presence of substantial
+                        water bodies and productive riverine habitats during parts
+                        of the Pleistocene.
+                    </p>
+                </article>
+
+                <article class="animal-card">
+                    <span class="animal-type">Reptile</span>
+                    <h3>Crocodilians</h3>
+                    <p>
+                        Crocodilian remains provide additional evidence for
+                        freshwater habitats associated with the prehistoric
+                        Narmada river system.
+                    </p>
+                </article>
+
+                <article class="animal-card">
+                    <span class="animal-type">Hominin</span>
+                    <h3>Hathnora hominin</h3>
+                    <p>
+                        The Hathnora cranium is a key South Asian hominin fossil
+                        and an important reference point in studies of human
+                        dispersal and evolution.
+                    </p>
+                </article>
+            </div>
+        </section>
+
+        <section class="block" id="significance" aria-labelledby="significance-heading">
+            <div class="section-head">
+                <span class="tag">Scientific Significance</span>
+                <h2 id="significance-heading">Why the Narmada Valley matters</h2>
+            </div>
+
+            <div class="grid-2">
+                <article class="card">
+                    <h3>Human evolution</h3>
+                    <p>
+                        The Hathnora discovery provides rare physical evidence for
+                        prehistoric hominins in South Asia and contributes to wider
+                        debates about early human dispersal across the region.
+                    </p>
+                </article>
+
+                <article class="card">
+                    <h3>Gondwana dinosaurs</h3>
+                    <p>
+                        Cretaceous dinosaur fossils connect India's prehistoric
+                        fauna with the wider Gondwanan world and help reconstruct
+                        ecosystems shortly before the end-Cretaceous extinction.
+                    </p>
+                </article>
+
+                <article class="card">
+                    <h3>Palaeoenvironment</h3>
+                    <p>
+                        Fossils from different periods allow scientists to compare
+                        ancient river systems, vegetation, climate and animal
+                        communities across deep geological time.
+                    </p>
+                </article>
+
+                <article class="card">
+                    <h3>Indian geoheritage</h3>
+                    <p>
+                        The valley demonstrates why geological landscapes are
+                        important archives of India's biological and environmental
+                        history.
+                    </p>
+                </article>
+            </div>
+        </section>
+
+        <section class="block" id="map" aria-labelledby="map-heading">
+            <div class="section-head">
+                <span class="tag">Map</span>
+                <h2 id="map-heading">Explore key fossil localities</h2>
+            </div>
+
+            <div class="map-layout">
+                <div class="map-frame-wrap">
+                    <iframe id="fossil-map"
+                            title="Map showing important Narmada Valley fossil localities"
+                            loading="lazy"
+                            src="https://www.openstreetmap.org/export/embed.html?bbox=72.8%2C20.4%2C82.5%2C24.8%26layer=mapnik%26marker=22.9%2C78.5">
+                    </iframe>
+                </div>
+
+                <div class="map-panel">
+                    <p>Select a locality to focus the map.</p>
+
+                    <div class="map-buttons">
+                        <button type="button" class="map-btn is-active" data-place="hathnora">Hathnora</button>
+                        <button type="button" class="map-btn" data-place="jabalpur">Jabalpur</button>
+                        <button type="button" class="map-btn" data-place="balasinor">Balasinor</button>
+                    </div>
+
+                    <article class="map-info">
+                        <h3 id="map-info-title">Hathnora</h3>
+                        <p id="map-info-desc">
+                            Near the Narmada River in Madhya Pradesh, Hathnora is
+                            associated with the famous Pleistocene hominin discovery
+                            and other fossil fauna.
+                        </p>
+                    </article>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="page-footer">
+        <p>Narmada Valley Fossil Explorer · Incredible India Explorer</p>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>
+```

--- a/frontend/narmada-valley-fossils/index.html
+++ b/frontend/narmada-valley-fossils/index.html
@@ -1,4 +1,4 @@
-```html
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -345,4 +345,3 @@
     <script src="script.js"></script>
 </body>
 </html>
-```

--- a/frontend/narmada-valley-fossils/script.js
+++ b/frontend/narmada-valley-fossils/script.js
@@ -1,0 +1,111 @@
+```javascript
+(function () {
+    const places = {
+        hathnora: {
+            title: "Hathnora",
+            desc: "Narmada Valley, Madhya Pradesh. Known for the important Pleistocene hominin cranium and associated fossil fauna.",
+            lat: 22.83,
+            lon: 78.53,
+            bbox: [77.9, 22.35, 79.15, 23.25]
+        },
+        jabalpur: {
+            title: "Jabalpur and Narmada basin",
+            desc: "Madhya Pradesh. The broader Narmada basin preserves Late Cretaceous Lameta Formation dinosaur fossils and younger Quaternary deposits.",
+            lat: 23.18,
+            lon: 79.95,
+            bbox: [79.35, 22.65, 80.55, 23.7]
+        },
+        balasinor: {
+            title: "Balasinor region",
+            desc: "Gujarat. The Narmada basin extends into Gujarat, where Late Cretaceous Lameta Formation dinosaur fossils include Rajasaurus and sauropod remains.",
+            lat: 22.95,
+            lon: 73.33,
+            bbox: [72.65, 22.35, 74.05, 23.55]
+        }
+    };
+
+    function mapSrc(place) {
+        return "https://www.openstreetmap.org/export/embed.html?bbox=" +
+            encodeURIComponent(place.bbox.join(",")) +
+            "&layer=mapnik&marker=" +
+            encodeURIComponent(place.lat + "," + place.lon);
+    }
+
+    function initThemeToggle() {
+        const button = document.getElementById("theme-toggle");
+        const root = document.documentElement;
+
+        if (!button) return;
+
+        function applyTheme(theme) {
+            const light = theme === "light";
+
+            root.classList.toggle("light-theme", light);
+            document.body.classList.toggle("light-theme", light);
+
+            button.textContent = light ? "🌙" : "☀️";
+            button.setAttribute(
+                "aria-label",
+                light ? "Switch to dark theme" : "Switch to light theme"
+            );
+        }
+
+        applyTheme(localStorage.getItem("theme") === "light" ? "light" : "dark");
+
+        button.addEventListener("click", function () {
+            const nextTheme = document.body.classList.contains("light-theme")
+                ? "dark"
+                : "light";
+
+            localStorage.setItem("theme", nextTheme);
+            applyTheme(nextTheme);
+        });
+    }
+
+    function initMap() {
+        const frame = document.getElementById("fossil-map");
+        const title = document.getElementById("map-info-title");
+        const description = document.getElementById("map-info-desc");
+        const buttons = document.querySelectorAll(".map-btn");
+
+        if (!frame || !title || !description || !buttons.length) return;
+
+        function showPlace(key) {
+            const place = places[key];
+
+            if (!place) return;
+
+            frame.src = mapSrc(place);
+            title.textContent = place.title;
+            description.textContent = place.desc;
+
+            buttons.forEach(function (button) {
+                const active = button.dataset.place === key;
+
+                button.classList.toggle("is-active", active);
+                button.setAttribute("aria-pressed", active ? "true" : "false");
+            });
+        }
+
+        buttons.forEach(function (button) {
+            button.setAttribute(
+                "aria-pressed",
+                button.classList.contains("is-active") ? "true" : "false"
+            );
+
+            button.addEventListener("click", function () {
+                showPlace(button.dataset.place);
+            });
+        });
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+        initThemeToggle();
+        initMap();
+    });
+
+    window.NarmadaFossilExplorer = {
+        places: places
+    };
+})();
+```

--- a/frontend/narmada-valley-fossils/script.js
+++ b/frontend/narmada-valley-fossils/script.js
@@ -1,4 +1,4 @@
-```javascript
+
 (function () {
     const places = {
         hathnora: {
@@ -108,4 +108,3 @@
         places: places
     };
 })();
-```

--- a/frontend/narmada-valley-fossils/style.css
+++ b/frontend/narmada-valley-fossils/style.css
@@ -1,4 +1,4 @@
-```css
+
 :root {
     --bg: #111713;
     --bg-alt: #192019;
@@ -419,4 +419,3 @@ h3 {
         transition: none !important;
     }
 }
-```

--- a/frontend/narmada-valley-fossils/style.css
+++ b/frontend/narmada-valley-fossils/style.css
@@ -1,0 +1,422 @@
+```css
+:root {
+    --bg: #111713;
+    --bg-alt: #192019;
+    --surface: #222b23;
+    --line: #3b493c;
+    --text: #edf3eb;
+    --muted: #b9c7b8;
+    --dim: #899889;
+    --accent: #c58b4e;
+    --accent-2: #7e9b68;
+    --heading: "Playfair Display", Georgia, serif;
+    --body: "Outfit", system-ui, sans-serif;
+}
+
+html.light-theme,
+html.light-theme body,
+body.light-theme {
+    --bg: #f4efe6;
+    --bg-alt: #e9e1d2;
+    --surface: #ffffff;
+    --line: #d1c4ae;
+    --text: #201c16;
+    --muted: #554c40;
+    --dim: #766b5c;
+    --accent: #8b541f;
+    --accent-2: #486536;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--body);
+    line-height: 1.65;
+}
+
+a {
+    color: var(--accent);
+}
+
+a:focus-visible,
+button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+}
+
+.skip-link {
+    position: absolute;
+    left: -999px;
+    top: 0;
+    background: var(--accent);
+    color: #111;
+    padding: 0.5rem 1rem;
+    z-index: 100;
+}
+
+.skip-link:focus {
+    left: 8px;
+    top: 8px;
+}
+
+.topnav {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.85rem 1.25rem;
+    background: var(--bg);
+    border-bottom: 1px solid var(--line);
+    overflow-x: auto;
+}
+
+.brand {
+    color: var(--text);
+    text-decoration: none;
+    font-weight: 700;
+    white-space: nowrap;
+}
+
+.nav-links {
+    display: flex;
+    gap: 0.9rem;
+    font-size: 0.85rem;
+}
+
+.nav-links a {
+    color: var(--muted);
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.nav-links a:hover {
+    color: var(--text);
+}
+
+.theme-toggle {
+    margin-left: auto;
+    flex-shrink: 0;
+    width: 2.4rem;
+    height: 2.4rem;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+}
+
+.hero {
+    padding: 4.5rem 8vw 3.5rem;
+    background:
+        radial-gradient(850px 400px at 10% -15%, rgba(126, 155, 104, 0.2), transparent 55%),
+        var(--bg);
+    border-bottom: 1px solid var(--line);
+}
+
+.eyebrow,
+.tag,
+.timeline-date,
+.layer-period,
+.animal-type {
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.eyebrow {
+    margin: 0 0 1rem;
+    color: var(--accent-2);
+    font-size: 0.78rem;
+}
+
+h1,
+h2,
+h3 {
+    font-family: var(--heading);
+}
+
+h1 {
+    max-width: 18ch;
+    margin: 0 0 0.75rem;
+    font-size: clamp(2rem, 5vw, 3.5rem);
+    line-height: 1.1;
+}
+
+h2 {
+    margin: 0;
+    font-size: clamp(1.5rem, 3vw, 2.2rem);
+}
+
+h3 {
+    margin-top: 0;
+}
+
+.hero-date {
+    margin: 0 0 1.25rem;
+    color: var(--accent);
+    font-weight: 600;
+}
+
+.lede {
+    max-width: 72ch;
+    color: var(--muted);
+    font-size: 1.05rem;
+}
+
+.hero-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2rem;
+    margin: 2.5rem 0 0;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--line);
+}
+
+.hero-stats dt {
+    color: var(--dim);
+    font-size: 0.72rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.hero-stats dd {
+    margin: 0.2rem 0 0;
+    font-family: var(--heading);
+    font-size: 1.35rem;
+    font-weight: 600;
+}
+
+.block {
+    padding: 4.5rem 8vw;
+    border-bottom: 1px solid var(--line);
+}
+
+.block:nth-child(even) {
+    background: var(--bg-alt);
+}
+
+.section-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.tag {
+    color: var(--accent);
+    border: 1px solid var(--line);
+    padding: 0.2rem 0.6rem;
+    font-size: 0.72rem;
+}
+
+.grid-2,
+.animal-grid,
+.geology-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1.5rem;
+}
+
+.card,
+.animal-card,
+.layer-card,
+.timeline-card,
+.map-info {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+    padding: 1.35rem 1.4rem;
+}
+
+.card h3,
+.animal-card h3,
+.layer-card h3,
+.timeline-card h3 {
+    margin-bottom: 0.6rem;
+}
+
+.card p,
+.animal-card p,
+.layer-card p,
+.timeline-card p,
+.map-info p {
+    margin: 0;
+    color: var(--muted);
+}
+
+.timeline {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.timeline-card {
+    display: grid;
+    grid-template-columns: 150px 1fr;
+    gap: 1.5rem;
+}
+
+.timeline-date {
+    color: var(--accent);
+    font-size: 0.75rem;
+    font-weight: 700;
+}
+
+.layer-card {
+    border-top: 4px solid var(--accent);
+}
+
+.layer-period {
+    display: block;
+    margin-bottom: 0.5rem;
+    color: var(--accent-2);
+    font-size: 0.72rem;
+    font-weight: 700;
+}
+
+.animal-grid {
+    grid-template-columns: repeat(3, 1fr);
+}
+
+.animal-card {
+    transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.animal-card:hover {
+    transform: translateY(-3px);
+    border-color: var(--accent);
+}
+
+.animal-card.featured {
+    border-color: var(--accent);
+    box-shadow: 0 0 20px rgba(197, 139, 78, 0.12);
+}
+
+.animal-type {
+    display: inline-block;
+    margin-bottom: 0.6rem;
+    color: var(--accent-2);
+    font-size: 0.7rem;
+    font-weight: 700;
+}
+
+.map-layout {
+    display: grid;
+    grid-template-columns: 1.5fr 1fr;
+    gap: 1.5rem;
+    align-items: start;
+}
+
+.map-frame-wrap {
+    overflow: hidden;
+    min-height: 320px;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 10px;
+}
+
+.map-frame-wrap iframe {
+    display: block;
+    width: 100%;
+    height: 380px;
+    border: 0;
+}
+
+.map-panel {
+    padding-top: 0.25rem;
+}
+
+.map-panel > p {
+    color: var(--muted);
+}
+
+.map-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin: 1rem 0;
+}
+
+.map-btn {
+    padding: 0.4rem 0.8rem;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    background: var(--surface);
+    color: var(--text);
+    cursor: pointer;
+    font-family: inherit;
+}
+
+.map-btn:hover,
+.map-btn.is-active {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.map-info h3 {
+    margin-bottom: 0.5rem;
+}
+
+.page-footer {
+    padding: 1.5rem 8vw;
+    color: var(--dim);
+    font-size: 0.9rem;
+}
+
+@media (max-width: 900px) {
+    .animal-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .map-layout {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 700px) {
+    .grid-2,
+    .geology-grid,
+    .animal-grid,
+    .timeline-card {
+        grid-template-columns: 1fr;
+    }
+
+    .hero,
+    .block {
+        padding: 3rem 1.25rem;
+    }
+
+    .topnav {
+        flex-wrap: wrap;
+    }
+
+    .nav-links {
+        order: 3;
+        width: 100%;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
+
+    * {
+        animation: none !important;
+        transition: none !important;
+    }
+}
+```

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -6550,15 +6550,22 @@ window.indiaSearchIndex = [
             "Explore the 2013 Uttarakhand flood disaster: extreme monsoon rainfall, Chorabari Tal glacial lake breach, Kedarnath devastation, Mandakini and Alaknanda valley impacts, Operation Surya Hope rescue, and disaster preparedness lessons.",
         url: "frontend/uttarakhand-floods-2013/index.html"
     },
-    // --- Stone Age Tool Discoveries of Didwana (#3790) ---
-    {
-        title: "Stone Age Tool Discoveries of Didwana \u2014 Prehistoric Rajasthan",
-        category: "Archaeological Excavations",
-        description:
-            "Explore the Stone Age tool discoveries of Didwana, Rajasthan: Lower, Middle and Upper Palaeolithic tool types, quartzite and sandstone raw materials, dune-section discovery context, and their scientific significance for dating early human occupation in the Thar Desert.",
-        url: "frontend/didwana-stone-age-tools/index.html"
-    },
-    // --- Prehistoric Paisra Site (#3789) ---
+// --- Prehistoric Tools of Isampur (#3782) ---
+{
+    title: "Prehistoric Tools of Isampur \u2014 Acheulean Quarry & Workshop",
+    category: "Archaeological Excavations",
+    description:
+        "Explore Isampur in Karnataka's Hunsgi Valley: its Lower Palaeolithic Acheulean quarry-cum-workshop context, limestone raw material, handaxes, cleavers, cores, flakes, hammerstones, dating evidence, archaeological significance, and location map.",
+    url: "frontend/isampur-stone-tools/index.html"
+},
+// --- Stone Age Tool Discoveries of Didwana (#3790) ---
+{
+    title: "Stone Age Tool Discoveries of Didwana \u2014 Prehistoric Rajasthan",
+    category: "Archaeological Excavations",
+    description:
+        "Explore the Stone Age tool discoveries of Didwana, Rajasthan: Lower, Middle and Upper Palaeolithic tool types, quartzite and sandstone raw materials, dune-section discovery context, and their scientific significance for dating early human occupation in the Thar Desert.",
+    url: "frontend/didwana-stone-age-tools/index.html"
+},    // --- Prehistoric Paisra Site (#3789) ---
     {
         title: "Prehistoric Paisra Site \u2014 Palaeolithic Bihar",
         category: "Archaeological Excavations",

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -6574,15 +6574,22 @@ window.indiaSearchIndex = [
             "Explore Acheulean stone tool technology across prehistoric India: handaxes, cleavers, major archaeological sites such as Attirampakkam, Hunsgi-Isampur, Bhimbetka, Chirki-Nevasa, Didwana and Paisra, a technology timeline, and an interactive map of key sites.",
         url: "frontend/acheulean-stone-technology/index.html"
     },
-    // --- Mesolithic Sites Across India (#3792) ---
-    {
-        title: "Mesolithic Sites Across India \u2014 Microliths & Rock Art",
-        category: "Archaeological Excavations",
-        description:
-            "Explore major Mesolithic sites across India including Bhimbetka, Bagor, Sarai Nahar Rai, Langhnaj, Adamgarh and Tilwara: microlithic stone tools, settlement and burial evidence, rock art, chronology, and an interactive map of key sites.",
-        url: "frontend/mesolithic-sites-india/index.html"
-    },
-    // --- feat/rama-setu-story ---
+// --- Stone Age of India (#3779) ---
+{
+    title: "Stone Age of India — Paleolithic, Mesolithic & Neolithic",
+    category: "Archaeological Excavations",
+    description:
+        "Explore India's Paleolithic, Mesolithic and Neolithic archaeological heritage through major periods, important sites, stone tools, early settlements, a prehistoric timeline and an interactive map.",
+    url: "frontend/stone-age-india/index.html"
+},
+// --- Mesolithic Sites Across India (#3792) ---
+{
+    title: "Mesolithic Sites Across India — Microliths & Rock Art",
+    category: "Archaeological Excavations",
+    description:
+        "Explore major Mesolithic sites across India including Bhimbetka, Bagor, Sarai Nahar Rai, Langhnaj, Adamgarh and Tilwara: microlithic stone tools, settlement and burial evidence, rock art, chronology, and an interactive map of key sites.",
+    url: "frontend/mesolithic-sites-india/index.html"
+},    // --- feat/rama-setu-story ---
     {
         title: "Add Rama Setu \u2014 The Legendary Journey to Lanka",
         category: "Culture & Literature",

--- a/frontend/stone-age-india/index.html
+++ b/frontend/stone-age-india/index.html
@@ -1,0 +1,469 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function () {
+            const theme = localStorage.getItem('theme') || 'dark';
+            document.documentElement.setAttribute('data-theme', theme);
+        })();
+    </script>
+
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta
+        name="description"
+        content="Explore India's Stone Age heritage through the Paleolithic, Mesolithic and Neolithic periods, important archaeological sites, stone tools, early settlements, timeline and interactive map."
+    >
+    <title>Stone Age of India | Incredible India Explorer</title>
+
+    <link rel="stylesheet" href="../pages-common.css">
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+    <header class="site-header">
+        <nav class="navbar" aria-label="Primary navigation">
+            <a href="../../index.html#home" class="nav-logo">
+                <span class="saffron">Incredible</span>
+                <span class="gold">India</span>
+                <span class="green">Explorer</span>
+            </a>
+
+            <div class="nav-links">
+                <a href="../../index.html#home">Home</a>
+                <a href="#periods">Periods</a>
+                <a href="#sites">Sites</a>
+                <a href="#tools">Tools</a>
+                <a href="#timeline">Timeline</a>
+                <a href="#map">Map</a>
+            </div>
+
+            <button
+                type="button"
+                id="theme-toggle"
+                class="theme-toggle"
+                aria-label="Toggle dark and light mode"
+            >
+                ☀️
+            </button>
+        </nav>
+    </header>
+
+    <main>
+        <section class="hero">
+            <div class="hero-content">
+                <span class="eyebrow">PREHISTORIC INDIA</span>
+                <h1>Explore the Stone Age of India</h1>
+                <p class="hero-subtitle">
+                    From early hunter-gatherers to the first farming communities.
+                </p>
+                <p class="hero-description">
+                    Travel through India's Paleolithic, Mesolithic and Neolithic
+                    archaeological heritage and discover how tools, settlements,
+                    food production and human lifestyles changed over thousands
+                    of years.
+                </p>
+
+                <div class="hero-stats">
+                    <div>
+                        <strong>3</strong>
+                        <span>Major periods</span>
+                    </div>
+                    <div>
+                        <strong>1M+</strong>
+                        <span>Years of prehistory</span>
+                    </div>
+                    <div>
+                        <strong>12+</strong>
+                        <span>Key sites</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="section" id="periods" aria-labelledby="periods-title">
+            <div class="section-heading">
+                <span class="eyebrow">MAJOR PERIODS</span>
+                <h2 id="periods-title">Three stages of Stone Age life</h2>
+            </div>
+
+            <div class="period-grid">
+                <article class="period-card paleolithic">
+                    <span class="period-number">01</span>
+                    <span class="period-label">Old Stone Age</span>
+                    <h3>Paleolithic</h3>
+                    <p class="period-date">
+                        c. 2 million BCE – 10,000 BCE
+                    </p>
+                    <p>
+                        Early communities depended mainly on hunting, gathering
+                        and wild resources. Large stone tools such as handaxes
+                        and cleavers became important technologies.
+                    </p>
+                    <ul>
+                        <li>Hunter-gatherer communities</li>
+                        <li>Handaxes and cleavers</li>
+                        <li>Rock shelters and open-air sites</li>
+                    </ul>
+                </article>
+
+                <article class="period-card mesolithic">
+                    <span class="period-number">02</span>
+                    <span class="period-label">Middle Stone Age</span>
+                    <h3>Mesolithic</h3>
+                    <p class="period-date">
+                        c. 10,000 – 6,000 BCE
+                    </p>
+                    <p>
+                        Smaller microlithic tools became widespread as people
+                        adapted to changing post-Ice Age environments. Hunting,
+                        fishing and gathering remained important.
+                    </p>
+                    <ul>
+                        <li>Microliths</li>
+                        <li>Rock art</li>
+                        <li>Burials and seasonal settlements</li>
+                    </ul>
+                </article>
+
+                <article class="period-card neolithic">
+                    <span class="period-number">03</span>
+                    <span class="period-label">New Stone Age</span>
+                    <h3>Neolithic</h3>
+                    <p class="period-date">
+                        c. 7,000 – 2,000 BCE
+                    </p>
+                    <p>
+                        Farming, animal domestication, pottery and more
+                        permanent settlements became increasingly important,
+                        although the transition occurred at different times
+                        across India.
+                    </p>
+                    <ul>
+                        <li>Ground and polished tools</li>
+                        <li>Agriculture and herding</li>
+                        <li>Settled village communities</li>
+                    </ul>
+                </article>
+            </div>
+        </section>
+
+        <section class="section alternate" id="sites" aria-labelledby="sites-title">
+            <div class="section-heading">
+                <span class="eyebrow">ARCHAEOLOGICAL HERITAGE</span>
+                <h2 id="sites-title">Important Stone Age sites</h2>
+            </div>
+
+            <div class="site-grid">
+                <article class="site-card">
+                    <span class="site-period">Paleolithic</span>
+                    <h3>Attirampakkam</h3>
+                    <p class="site-location">Tamil Nadu</p>
+                    <p>
+                        One of India's most important Paleolithic sites, known
+                        for a long sequence of Acheulean and later stone-tool
+                        technologies.
+                    </p>
+                </article>
+
+                <article class="site-card">
+                    <span class="site-period">Paleolithic</span>
+                    <h3>Hunsgi–Baichbal Valley</h3>
+                    <p class="site-location">Karnataka</p>
+                    <p>
+                        A major cluster of Paleolithic localities associated
+                        with stone-tool production and prehistoric occupation.
+                    </p>
+                </article>
+
+                <article class="site-card">
+                    <span class="site-period">Paleolithic</span>
+                    <h3>Bhimbetka</h3>
+                    <p class="site-location">Madhya Pradesh</p>
+                    <p>
+                        Rock shelters preserving evidence of prehistoric
+                        occupation and an extensive sequence of rock art.
+                    </p>
+                </article>
+
+                <article class="site-card">
+                    <span class="site-period">Mesolithic</span>
+                    <h3>Bagor</h3>
+                    <p class="site-location">Rajasthan</p>
+                    <p>
+                        A long-occupied site on the Kothari River with
+                        microlithic technology and evidence of changing
+                        subsistence practices.
+                    </p>
+                </article>
+
+                <article class="site-card">
+                    <span class="site-period">Mesolithic</span>
+                    <h3>Sarai Nahar Rai</h3>
+                    <p class="site-location">Uttar Pradesh</p>
+                    <p>
+                        An important Mesolithic burial site that provides
+                        evidence about the lives and mortuary practices of
+                        prehistoric communities.
+                    </p>
+                </article>
+
+                <article class="site-card">
+                    <span class="site-period">Mesolithic</span>
+                    <h3>Langhnaj</h3>
+                    <p class="site-location">Gujarat</p>
+                    <p>
+                        A key western Indian Mesolithic site associated with
+                        microliths, human remains and animal remains.
+                    </p>
+                </article>
+
+                <article class="site-card">
+                    <span class="site-period">Neolithic</span>
+                    <h3>Burzahom</h3>
+                    <p class="site-location">Kashmir</p>
+                    <p>
+                        Famous for pit dwellings, stone tools, pottery, animal
+                        remains and evidence of changing settlement patterns.
+                    </p>
+                </article>
+
+                <article class="site-card">
+                    <span class="site-period">Neolithic</span>
+                    <h3>Koldihwa</h3>
+                    <p class="site-location">Uttar Pradesh</p>
+                    <p>
+                        An important Belan Valley site associated with early
+                        farming and rice cultivation evidence.
+                    </p>
+                </article>
+
+                <article class="site-card">
+                    <span class="site-period">Neolithic</span>
+                    <h3>Chirand</h3>
+                    <p class="site-location">Bihar</p>
+                    <p>
+                        A major Neolithic settlement with pottery, bone tools,
+                        stone tools and evidence of food production.
+                    </p>
+                </article>
+
+                <article class="site-card">
+                    <span class="site-period">Neolithic</span>
+                    <h3>Daojali Hading</h3>
+                    <p class="site-location">Assam</p>
+                    <p>
+                        An important northeastern site associated with polished
+                        stone tools and early settled communities.
+                    </p>
+                </article>
+            </div>
+        </section>
+
+        <section class="section" id="tools" aria-labelledby="tools-title">
+            <div class="section-heading">
+                <span class="eyebrow">STONE TECHNOLOGY</span>
+                <h2 id="tools-title">Tools that shaped prehistoric life</h2>
+            </div>
+
+            <div class="tools-grid">
+                <article class="tool-card">
+                    <div class="tool-icon">🪓</div>
+                    <h3>Handaxes</h3>
+                    <p>
+                        Bifacially worked tools associated especially with
+                        Acheulean technology. They were useful for cutting,
+                        butchering and processing materials.
+                    </p>
+                </article>
+
+                <article class="tool-card">
+                    <div class="tool-icon">🔨</div>
+                    <h3>Cleavers</h3>
+                    <p>
+                        Large cutting tools with broad working edges that form
+                        part of the Acheulean toolkit found at several Indian
+                        Paleolithic sites.
+                    </p>
+                </article>
+
+                <article class="tool-card">
+                    <div class="tool-icon">🔹</div>
+                    <h3>Microliths</h3>
+                    <p>
+                        Small geometric and blade-like stone tools became
+                        characteristic of many Mesolithic assemblages and could
+                        be used as composite tool components.
+                    </p>
+                </article>
+
+                <article class="tool-card">
+                    <div class="tool-icon">⚒️</div>
+                    <h3>Ground Stone Tools</h3>
+                    <p>
+                        Polished axes and related tools became increasingly
+                        important during the Neolithic, particularly for
+                        woodworking and farming activities.
+                    </p>
+                </article>
+            </div>
+        </section>
+
+        <section class="section alternate" id="settlements" aria-labelledby="settlements-title">
+            <div class="section-heading">
+                <span class="eyebrow">EARLY SETTLEMENTS</span>
+                <h2 id="settlements-title">From shelters to villages</h2>
+            </div>
+
+            <div class="settlement-flow">
+                <article>
+                    <span>01</span>
+                    <h3>Mobile groups</h3>
+                    <p>
+                        Paleolithic communities moved through landscapes
+                        following water, animals and seasonal resources.
+                    </p>
+                </article>
+
+                <div class="flow-arrow">→</div>
+
+                <article>
+                    <span>02</span>
+                    <h3>Seasonal camps</h3>
+                    <p>
+                        Mesolithic groups used repeated camps, rock shelters
+                        and resource-rich locations while maintaining mobility.
+                    </p>
+                </article>
+
+                <div class="flow-arrow">→</div>
+
+                <article>
+                    <span>03</span>
+                    <h3>Village life</h3>
+                    <p>
+                        Neolithic communities increasingly invested in houses,
+                        storage, farming, herding and longer-term settlements.
+                    </p>
+                </article>
+            </div>
+        </section>
+
+        <section class="section" id="timeline" aria-labelledby="timeline-title">
+            <div class="section-heading">
+                <span class="eyebrow">TIMELINE</span>
+                <h2 id="timeline-title">A long prehistoric journey</h2>
+            </div>
+
+            <div class="timeline">
+                <article class="timeline-item">
+                    <span class="timeline-date">~2 million BCE</span>
+                    <div>
+                        <h3>Early Paleolithic traditions</h3>
+                        <p>
+                            Early stone-tool technologies appear in the Indian
+                            subcontinent.
+                        </p>
+                    </div>
+                </article>
+
+                <article class="timeline-item">
+                    <span class="timeline-date">~1.5 million BCE</span>
+                    <div>
+                        <h3>Acheulean expansion</h3>
+                        <p>
+                            Acheulean handaxes and cleavers become an important
+                            part of the archaeological record at sites such as
+                            Attirampakkam.
+                        </p>
+                    </div>
+                </article>
+
+                <article class="timeline-item">
+                    <span class="timeline-date">~10,000 BCE</span>
+                    <div>
+                        <h3>Mesolithic transition</h3>
+                        <p>
+                            Microlithic technologies become widespread as
+                            communities adapt to post-Ice Age environments.
+                        </p>
+                    </div>
+                </article>
+
+                <article class="timeline-item">
+                    <span class="timeline-date">~7,000 BCE</span>
+                    <div>
+                        <h3>Early Neolithic communities</h3>
+                        <p>
+                            Farming, animal management and more permanent
+                            settlements emerge in different parts of the
+                            subcontinent at different times.
+                        </p>
+                    </div>
+                </article>
+
+                <article class="timeline-item">
+                    <span class="timeline-date">~3,000–2,000 BCE</span>
+                    <div>
+                        <h3>Established village traditions</h3>
+                        <p>
+                            Neolithic lifeways become established across
+                            several regional traditions before later
+                            Chalcolithic developments.
+                        </p>
+                    </div>
+                </article>
+            </div>
+        </section>
+
+        <section class="section alternate" id="map" aria-labelledby="map-title">
+            <div class="section-heading">
+                <span class="eyebrow">INTERACTIVE MAP</span>
+                <h2 id="map-title">Explore Stone Age sites across India</h2>
+            </div>
+
+            <div class="map-layout">
+                <div
+                    id="stone-age-map"
+                    class="india-map"
+                    role="img"
+                    aria-label="Interactive map of selected Stone Age archaeological sites in India"
+                >
+                    <div class="map-outline" aria-hidden="true"></div>
+                </div>
+
+                <aside class="map-details" aria-live="polite">
+                    <p class="map-help">
+                        Select a site marker to view its period and archaeological
+                        significance.
+                    </p>
+
+                    <div id="map-detail">
+                        <span class="detail-period">SELECT A SITE</span>
+                        <h3 id="map-site-name">Stone Age India</h3>
+                        <p id="map-site-location">
+                            Choose a marker on the map.
+                        </p>
+                        <p id="map-site-description">
+                            Explore important Paleolithic, Mesolithic and
+                            Neolithic archaeological locations.
+                        </p>
+                    </div>
+
+                    <div class="map-legend">
+                        <span><i class="legend-dot paleolithic-dot"></i>Paleolithic</span>
+                        <span><i class="legend-dot mesolithic-dot"></i>Mesolithic</span>
+                        <span><i class="legend-dot neolithic-dot"></i>Neolithic</span>
+                    </div>
+                </aside>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <p>Incredible India Explorer · Exploring India's Stone Age heritage</p>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/stone-age-india/script.js
+++ b/frontend/stone-age-india/script.js
@@ -1,0 +1,210 @@
+const STONE_AGE_SITES = [
+    {
+        id: "attirampakkam",
+        name: "Attirampakkam",
+        location: "Tamil Nadu",
+        period: "Paleolithic",
+        color: "var(--stone-accent)",
+        top: "63%",
+        left: "57%",
+        description:
+            "A major Paleolithic site with a long archaeological sequence including Acheulean and later stone-tool technologies."
+    },
+    {
+        id: "hunsgi",
+        name: "Hunsgi–Baichbal Valley",
+        location: "Karnataka",
+        period: "Paleolithic",
+        color: "var(--stone-accent)",
+        top: "57%",
+        left: "47%",
+        description:
+            "A major cluster of Paleolithic localities associated with stone-tool manufacture and prehistoric occupation."
+    },
+    {
+        id: "bhimbetka",
+        name: "Bhimbetka",
+        location: "Madhya Pradesh",
+        period: "Paleolithic",
+        color: "var(--stone-accent)",
+        top: "39%",
+        left: "47%",
+        description:
+            "Rock shelters preserving prehistoric occupation and a long sequence of prehistoric rock art."
+    },
+    {
+        id: "bagor",
+        name: "Bagor",
+        location: "Rajasthan",
+        period: "Mesolithic",
+        color: "var(--stone-blue)",
+        top: "31%",
+        left: "32%",
+        description:
+            "A long-occupied riverside site with microlithic technology and evidence of changing subsistence practices."
+    },
+    {
+        id: "sarai-nahar-rai",
+        name: "Sarai Nahar Rai",
+        location: "Uttar Pradesh",
+        period: "Mesolithic",
+        color: "var(--stone-blue)",
+        top: "30%",
+        left: "56%",
+        description:
+            "An important Mesolithic burial site providing evidence about prehistoric communities and mortuary practices."
+    },
+    {
+        id: "langhnaj",
+        name: "Langhnaj",
+        location: "Gujarat",
+        period: "Mesolithic",
+        color: "var(--stone-blue)",
+        top: "47%",
+        left: "27%",
+        description:
+            "A western Indian Mesolithic site associated with microliths, human remains and animal remains."
+    },
+    {
+        id: "burzahom",
+        name: "Burzahom",
+        location: "Kashmir",
+        period: "Neolithic",
+        color: "var(--stone-green)",
+        top: "12%",
+        left: "42%",
+        description:
+            "Known for pit dwellings, stone tools, pottery and evidence of changing settlement and subsistence patterns."
+    },
+    {
+        id: "koldihwa",
+        name: "Koldihwa",
+        location: "Uttar Pradesh",
+        period: "Neolithic",
+        color: "var(--stone-green)",
+        top: "36%",
+        left: "55%",
+        description:
+            "A Belan Valley site associated with early farming and evidence relating to rice cultivation."
+    },
+    {
+        id: "chirand",
+        name: "Chirand",
+        location: "Bihar",
+        period: "Neolithic",
+        color: "var(--stone-green)",
+        top: "35%",
+        left: "65%",
+        description:
+            "A major Neolithic settlement with pottery, bone tools, stone tools and evidence of food production."
+    },
+    {
+        id: "daojali-hading",
+        name: "Daojali Hading",
+        location: "Assam",
+        period: "Neolithic",
+        color: "var(--stone-green)",
+        top: "23%",
+        left: "79%",
+        description:
+            "An important northeastern archaeological site associated with polished stone tools and early settled communities."
+    }
+];
+
+function updateMapDetails(site) {
+    const name = document.getElementById("map-site-name");
+    const location = document.getElementById("map-site-location");
+    const description = document.getElementById("map-site-description");
+    const period = document.querySelector(".detail-period");
+
+    if (!name || !location || !description || !period) {
+        return;
+    }
+
+    name.textContent = site.name;
+    location.textContent = site.location;
+    description.textContent = site.description;
+    period.textContent = site.period;
+}
+
+function renderStoneAgeMap() {
+    const map = document.getElementById("stone-age-map");
+
+    if (!map) {
+        return;
+    }
+
+    STONE_AGE_SITES.forEach((site) => {
+        const marker = document.createElement("button");
+
+        marker.type = "button";
+        marker.className = "map-marker";
+        marker.dataset.site = site.id;
+        marker.style.top = site.top;
+        marker.style.left = site.left;
+        marker.style.setProperty("--marker-color", site.color);
+        marker.setAttribute(
+            "aria-label",
+            `${site.name}, ${site.location}, ${site.period}`
+        );
+
+        marker.addEventListener("click", () => {
+            updateMapDetails(site);
+
+            document.querySelectorAll(".map-marker").forEach((item) => {
+                item.classList.remove("selected");
+            });
+
+            marker.classList.add("selected");
+        });
+
+        map.appendChild(marker);
+    });
+}
+
+function setupThemeToggle() {
+    const button = document.getElementById("theme-toggle");
+
+    if (!button) {
+        return;
+    }
+
+    const root = document.documentElement;
+
+    function updateButton() {
+        const isLight =
+            root.getAttribute("data-theme") === "light";
+
+        button.textContent = isLight ? "🌙" : "☀️";
+        button.setAttribute(
+            "aria-label",
+            isLight
+                ? "Switch to dark mode"
+                : "Switch to light mode"
+        );
+    }
+
+    updateButton();
+
+    button.addEventListener("click", () => {
+        const currentTheme =
+            root.getAttribute("data-theme") || "dark";
+
+        const nextTheme =
+            currentTheme === "light" ? "dark" : "light";
+
+        root.setAttribute("data-theme", nextTheme);
+        localStorage.setItem("theme", nextTheme);
+
+        updateButton();
+    });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    setupThemeToggle();
+    renderStoneAgeMap();
+});
+
+window.StoneAgeExplorer = {
+    sites: STONE_AGE_SITES
+};

--- a/frontend/stone-age-india/style.css
+++ b/frontend/stone-age-india/style.css
@@ -1,0 +1,594 @@
+:root {
+    --stone-bg: #111714;
+    --stone-bg-alt: #192019;
+    --stone-surface: #222b24;
+    --stone-border: #3d493f;
+    --stone-text: #eef2eb;
+    --stone-muted: #b8c2b8;
+    --stone-dim: #879187;
+    --stone-accent: #c58b4e;
+    --stone-green: #78976b;
+    --stone-blue: #6f9bb2;
+}
+
+html[data-theme="light"] {
+    --stone-bg: #f4efe7;
+    --stone-bg-alt: #e9e1d4;
+    --stone-surface: #ffffff;
+    --stone-border: #d2c5b2;
+    --stone-text: #211d18;
+    --stone-muted: #5c5348;
+    --stone-dim: #766c60;
+    --stone-accent: #89551f;
+    --stone-green: #4e6d40;
+    --stone-blue: #47738c;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    background: var(--stone-bg);
+    color: var(--stone-text);
+    font-family: "Outfit", system-ui, sans-serif;
+    line-height: 1.65;
+}
+
+a {
+    color: inherit;
+}
+
+.navbar {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+    padding: 0.85rem 6vw;
+    background: var(--stone-bg);
+    border-bottom: 1px solid var(--stone-border);
+}
+
+.nav-logo {
+    text-decoration: none;
+    font-weight: 700;
+    white-space: nowrap;
+}
+
+.nav-links {
+    display: flex;
+    gap: 1rem;
+    margin-left: auto;
+}
+
+.nav-links a {
+    color: var(--stone-muted);
+    font-size: 0.88rem;
+    text-decoration: none;
+}
+
+.nav-links a:hover {
+    color: var(--stone-text);
+}
+
+.theme-toggle {
+    border: 1px solid var(--stone-border);
+    border-radius: 50%;
+    width: 2.4rem;
+    height: 2.4rem;
+    background: var(--stone-surface);
+    color: var(--stone-text);
+    cursor: pointer;
+}
+
+.hero {
+    padding: 6rem 8vw 4.5rem;
+    background:
+        radial-gradient(circle at 15% 10%, rgba(120, 151, 107, 0.2), transparent 30%),
+        radial-gradient(circle at 85% 80%, rgba(197, 139, 78, 0.12), transparent 30%),
+        var(--stone-bg);
+    border-bottom: 1px solid var(--stone-border);
+}
+
+.hero-content {
+    max-width: 850px;
+}
+
+.eyebrow {
+    display: inline-block;
+    margin-bottom: 0.8rem;
+    color: var(--stone-accent);
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+}
+
+.hero h1,
+.section-heading h2,
+.period-card h3,
+.site-card h3,
+.tool-card h3,
+.settlement-flow h3,
+.timeline-item h3,
+.map-details h3 {
+    font-family: "Playfair Display", Georgia, serif;
+}
+
+.hero h1 {
+    max-width: 12ch;
+    margin: 0;
+    font-size: clamp(2.8rem, 7vw, 5.5rem);
+    line-height: 1.02;
+}
+
+.hero-subtitle {
+    margin: 1.25rem 0 0;
+    color: var(--stone-accent);
+    font-size: 1.35rem;
+    font-weight: 600;
+}
+
+.hero-description {
+    max-width: 68ch;
+    margin-top: 1rem;
+    color: var(--stone-muted);
+    font-size: 1.05rem;
+}
+
+.hero-stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2.5rem;
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--stone-border);
+}
+
+.hero-stats div {
+    display: flex;
+    flex-direction: column;
+}
+
+.hero-stats strong {
+    font-family: "Playfair Display", Georgia, serif;
+    font-size: 1.6rem;
+}
+
+.hero-stats span {
+    color: var(--stone-dim);
+    font-size: 0.8rem;
+}
+
+.section {
+    padding: 4.5rem 8vw;
+    border-bottom: 1px solid var(--stone-border);
+}
+
+.section.alternate {
+    background: var(--stone-bg-alt);
+}
+
+.section-heading {
+    margin-bottom: 2rem;
+}
+
+.section-heading h2 {
+    margin: 0;
+    font-size: clamp(2rem, 4vw, 3rem);
+    line-height: 1.15;
+}
+
+.period-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.25rem;
+}
+
+.period-card,
+.site-card,
+.tool-card {
+    background: var(--stone-surface);
+    border: 1px solid var(--stone-border);
+    border-radius: 12px;
+    padding: 1.5rem;
+}
+
+.period-card {
+    position: relative;
+    overflow: hidden;
+}
+
+.period-card::before {
+    content: "";
+    position: absolute;
+    inset: 0 auto auto 0;
+    width: 100%;
+    height: 4px;
+    background: var(--stone-accent);
+}
+
+.period-card.mesolithic::before {
+    background: var(--stone-blue);
+}
+
+.period-card.neolithic::before {
+    background: var(--stone-green);
+}
+
+.period-number {
+    display: block;
+    color: var(--stone-dim);
+    font-size: 0.75rem;
+    font-weight: 700;
+}
+
+.period-label,
+.site-period,
+.detail-period {
+    color: var(--stone-accent);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+}
+
+.period-card h3 {
+    margin: 0.25rem 0;
+    font-size: 2rem;
+}
+
+.period-date {
+    margin: 0 0 1rem;
+    color: var(--stone-dim);
+    font-size: 0.85rem;
+}
+
+.period-card p:not(.period-date),
+.site-card p,
+.tool-card p,
+.settlement-flow p,
+.timeline-item p,
+.map-details p {
+    color: var(--stone-muted);
+}
+
+.period-card ul {
+    margin-bottom: 0;
+    padding-left: 1.2rem;
+    color: var(--stone-muted);
+}
+
+.site-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+}
+
+.site-card {
+    transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.site-card:hover,
+.tool-card:hover {
+    transform: translateY(-3px);
+    border-color: var(--stone-accent);
+}
+
+.site-card h3 {
+    margin: 0.4rem 0 0;
+    font-size: 1.45rem;
+}
+
+.site-location {
+    margin: 0.15rem 0 0.8rem;
+    color: var(--stone-green) !important;
+    font-weight: 600;
+}
+
+.tools-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1rem;
+}
+
+.tool-icon {
+    font-size: 2rem;
+    margin-bottom: 0.5rem;
+}
+
+.tool-card h3 {
+    margin: 0;
+    font-size: 1.35rem;
+}
+
+.settlement-flow {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr auto 1fr;
+    align-items: center;
+    gap: 1rem;
+}
+
+.settlement-flow article {
+    padding: 1.5rem;
+    background: var(--stone-surface);
+    border: 1px solid var(--stone-border);
+    border-radius: 12px;
+}
+
+.settlement-flow article > span {
+    color: var(--stone-accent);
+    font-weight: 700;
+}
+
+.settlement-flow h3 {
+    margin: 0.3rem 0;
+}
+
+.flow-arrow {
+    color: var(--stone-accent);
+    font-size: 2rem;
+}
+
+.timeline {
+    position: relative;
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.timeline::before {
+    content: "";
+    position: absolute;
+    left: 115px;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+    background: var(--stone-border);
+}
+
+.timeline-item {
+    position: relative;
+    display: grid;
+    grid-template-columns: 100px 1fr;
+    gap: 2rem;
+    padding-bottom: 2rem;
+}
+
+.timeline-item::before {
+    content: "";
+    position: absolute;
+    left: 111px;
+    top: 0.4rem;
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    background: var(--stone-accent);
+}
+
+.timeline-date {
+    color: var(--stone-accent);
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-align: right;
+}
+
+.timeline-item h3 {
+    margin: 0;
+    font-size: 1.35rem;
+}
+
+.timeline-item p {
+    margin-top: 0.35rem;
+}
+
+.map-layout {
+    display: grid;
+    grid-template-columns: 1.6fr 0.9fr;
+    gap: 1.5rem;
+    align-items: stretch;
+}
+
+.india-map {
+    position: relative;
+    min-height: 520px;
+    overflow: hidden;
+    border: 1px solid var(--stone-border);
+    border-radius: 14px;
+    background:
+        radial-gradient(circle at 50% 45%, rgba(120, 151, 107, 0.08), transparent 45%),
+        var(--stone-surface);
+}
+
+.map-outline {
+    position: absolute;
+    inset: 10% 22%;
+    border: 2px solid var(--stone-green);
+    border-radius: 45% 35% 50% 55% / 35% 30% 60% 65%;
+    transform: rotate(8deg);
+    opacity: 0.5;
+}
+
+.map-outline::before {
+    content: "";
+    position: absolute;
+    inset: 18% 10%;
+    border: 1px dashed var(--stone-border);
+    border-radius: 50%;
+}
+
+.map-marker {
+    position: absolute;
+    z-index: 2;
+    width: 15px;
+    height: 15px;
+    padding: 0;
+    border: 3px solid var(--stone-surface);
+    border-radius: 50%;
+    background: var(--marker-color);
+    box-shadow: 0 0 0 2px var(--marker-color);
+    cursor: pointer;
+}
+
+.map-marker::after {
+    content: attr(aria-label);
+    position: absolute;
+    left: 15px;
+    top: -7px;
+    display: none;
+    white-space: nowrap;
+    padding: 0.25rem 0.45rem;
+    border: 1px solid var(--stone-border);
+    border-radius: 5px;
+    background: var(--stone-surface);
+    color: var(--stone-text);
+    font-size: 0.7rem;
+}
+
+.map-marker:hover::after,
+.map-marker:focus-visible::after {
+    display: block;
+}
+
+.map-details {
+    padding: 1.5rem;
+    border: 1px solid var(--stone-border);
+    border-radius: 14px;
+    background: var(--stone-surface);
+}
+
+.map-help {
+    margin-top: 0;
+}
+
+.map-details h3 {
+    margin: 0.4rem 0;
+    font-size: 2rem;
+}
+
+.map-legend {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+    margin-top: 2rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--stone-border);
+    color: var(--stone-muted);
+    font-size: 0.85rem;
+}
+
+.map-legend span {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.legend-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+}
+
+.paleolithic-dot {
+    background: var(--stone-accent);
+}
+
+.mesolithic-dot {
+    background: var(--stone-blue);
+}
+
+.neolithic-dot {
+    background: var(--stone-green);
+}
+
+.footer {
+    padding: 1.5rem 8vw;
+    color: var(--stone-dim);
+    font-size: 0.85rem;
+}
+
+@media (max-width: 1000px) {
+    .period-grid,
+    .site-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .tools-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+
+    .map-layout {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 750px) {
+    .navbar {
+        flex-wrap: wrap;
+        padding-inline: 1.25rem;
+    }
+
+    .nav-links {
+        order: 3;
+        width: 100%;
+        overflow-x: auto;
+        margin-left: 0;
+    }
+
+    .hero,
+    .section {
+        padding: 3.25rem 1.25rem;
+    }
+
+    .period-grid,
+    .site-grid,
+    .tools-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .settlement-flow {
+        grid-template-columns: 1fr;
+    }
+
+    .flow-arrow {
+        transform: rotate(90deg);
+        text-align: center;
+    }
+
+    .timeline::before {
+        left: 8px;
+    }
+
+    .timeline-item {
+        grid-template-columns: 1fr;
+        gap: 0.4rem;
+        padding-left: 2rem;
+    }
+
+    .timeline-item::before {
+        left: 4px;
+    }
+
+    .timeline-date {
+        text-align: left;
+    }
+
+    .india-map {
+        min-height: 420px;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
+
+    * {
+        transition: none !important;
+    }
+}

--- a/profiles/narmada_valley_fossils.md
+++ b/profiles/narmada_valley_fossils.md
@@ -1,0 +1,104 @@
+```markdown
+# 🦴 Fossil Discoveries of the Narmada Valley
+
+The Narmada Valley is one of India's most important regions for studying prehistoric life. Fossil-bearing deposits preserve evidence ranging from Late Cretaceous dinosaurs to Pleistocene mammals and hominins.
+
+---
+
+## 📍 Geography
+
+- **River:** Narmada
+- **Region:** Central India
+- **Major states:** Madhya Pradesh and Gujarat
+- **Important locality:** Hathnora, Madhya Pradesh
+- **Basin:** Narmada River Valley and associated sedimentary deposits
+
+The east-west Narmada corridor exposes sediments from different geological periods, making it valuable for reconstructing changing environments and prehistoric ecosystems.
+
+---
+
+## 🦖 Fossil Discoveries
+
+### Late Cretaceous dinosaurs
+
+The Lameta Formation of the Narmada basin contains important dinosaur remains, including:
+
+- *Rajasaurus narmadensis* — an abelisaurid theropod.
+- Titanosaur sauropods — large herbivorous dinosaurs.
+- Dinosaur eggs and eggshell fragments.
+- Other associated vertebrate remains.
+
+These fossils provide evidence of India's Gondwanan dinosaur fauna shortly before the end-Cretaceous extinction.
+
+### Hathnora hominin
+
+The Hathnora locality produced a partial hominin cranium during the 1980s. It is one of the most important prehistoric human fossils discovered in the Indian subcontinent.
+
+Its exact taxonomic classification has been debated, but the specimen is important for studying human evolution and prehistoric hominin dispersal in South Asia.
+
+### Pleistocene mammals
+
+The Narmada Valley also preserves remains of large prehistoric mammals, including:
+
+- Elephants and other proboscideans.
+- Hippopotamid remains.
+- Bovids.
+- Crocodilians.
+- Other Pleistocene vertebrates.
+
+---
+
+## 🪨 Geological Context
+
+### Lameta Formation
+
+Late Cretaceous dinosaur fossils in the Narmada basin occur in the Lameta Formation, which contains continental sediments deposited in environments including river channels, floodplains and shallow water bodies.
+
+### Quaternary river deposits
+
+Younger Narmada sediments and river terraces preserve Pleistocene fossils. These deposits help researchers understand changes in river systems, climate and prehistoric ecosystems.
+
+---
+
+## 🐘 Prehistoric Animals
+
+| Group | Examples | Importance |
+|---|---|---|
+| Theropods | *Rajasaurus narmadensis* | Carnivorous dinosaur diversity |
+| Sauropods | Titanosaurs | Large herbivore record |
+| Proboscideans | Fossil elephants | Pleistocene megafauna |
+| Hippopotamids | Hippopotamus relatives | Ancient freshwater environments |
+| Crocodilians | Fossil crocodilians | River and wetland habitats |
+| Hominins | Hathnora hominin | Human evolutionary history |
+
+---
+
+## 🔬 Scientific Significance
+
+The Narmada fossil record is significant because it connects several major areas of prehistoric research:
+
+1. **Dinosaur evolution** — Cretaceous fossils document India's distinctive Gondwanan dinosaur fauna.
+2. **Human evolution** — Hathnora provides rare hominin evidence from South Asia.
+3. **Palaeoenvironmental reconstruction** — fossils reveal changing river, floodplain and freshwater ecosystems.
+4. **Biogeography** — dinosaur fossils help compare India's fauna with other Gondwanan regions.
+5. **Geoheritage** — the valley demonstrates the scientific value of India's fossil-bearing landscapes.
+
+---
+
+## 🗺️ Key Localities
+
+### Hathnora
+Associated with the famous Pleistocene hominin discovery and other fossil fauna.
+
+### Jabalpur and surrounding Narmada basin
+Important for geological and palaeontological studies, including Cretaceous dinosaur-bearing formations and younger river deposits.
+
+### Narmada basin in Gujarat
+Late Cretaceous Lameta Formation exposures in the wider basin contain important dinosaur fossils, including abelisaurid and titanosaur remains.
+
+---
+
+## 📚 Research Value
+
+The Narmada Valley is particularly valuable because fossils from very different periods can be studied within the same broad river basin. Together they provide a long-term record of biological and environmental change in central India.
+```

--- a/tests/unit/narmada-valley-fossils.test.js
+++ b/tests/unit/narmada-valley-fossils.test.js
@@ -1,0 +1,89 @@
+```javascript
+import { describe, it, expect, beforeEach } from "vitest";
+import { JSDOM } from "jsdom";
+import fs from "fs";
+import path from "path";
+
+describe("Narmada Valley Fossil Explorer", () => {
+    let dom;
+    let document;
+    let window;
+
+    beforeEach(() => {
+        const htmlPath = path.resolve(
+            __dirname,
+            "../../frontend/narmada-valley-fossils/index.html"
+        );
+
+        const jsPath = path.resolve(
+            __dirname,
+            "../../frontend/narmada-valley-fossils/script.js"
+        );
+
+        const html = fs.readFileSync(htmlPath, "utf-8");
+        const js = fs.readFileSync(jsPath, "utf-8");
+
+        dom = new JSDOM(html, {
+            runScripts: "dangerously",
+            resources: "usable"
+        });
+
+        document = dom.window.document;
+        window = dom.window;
+
+        dom.window.eval(js);
+    });
+
+    it("renders the Narmada Valley page information", () => {
+        expect(document.title).toContain("Narmada Valley");
+
+        const heading = document.querySelector("h1");
+        expect(heading.textContent).toContain("Narmada Valley");
+    });
+
+    it("contains all required content sections", () => {
+        expect(document.getElementById("geography")).not.toBeNull();
+        expect(document.getElementById("discoveries")).not.toBeNull();
+        expect(document.getElementById("geology")).not.toBeNull();
+        expect(document.getElementById("animals")).not.toBeNull();
+        expect(document.getElementById("significance")).not.toBeNull();
+        expect(document.getElementById("map")).not.toBeNull();
+    });
+
+    it("contains important prehistoric discoveries", () => {
+        const content = document.body.textContent;
+
+        expect(content).toContain("Hathnora");
+        expect(content).toContain("Rajasaurus");
+        expect(content).toContain("Titanosaur");
+    });
+
+    it("supports interactive map locality selection", () => {
+        const buttons = document.querySelectorAll(".map-btn");
+
+        expect(buttons.length).toBe(3);
+
+        const jabalpur = document.querySelector(
+            '.map-btn[data-place="jabalpur"]'
+        );
+
+        jabalpur.click();
+
+        expect(jabalpur.classList.contains("is-active")).toBe(true);
+        expect(document.getElementById("map-info-title").textContent)
+            .toContain("Jabalpur");
+    });
+
+    it("supports theme switching", () => {
+        const button = document.getElementById("theme-toggle");
+
+        button.click();
+
+        expect(document.body.classList.contains("light-theme")).toBe(true);
+
+        button.click();
+
+        expect(document.body.classList.contains("light-theme")).toBe(false);
+    });
+});
+```

--- a/tests/unit/stone-age-india.test.js
+++ b/tests/unit/stone-age-india.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { JSDOM } from "jsdom";
+import fs from "fs";
+import path from "path";
+
+describe("Stone Age India Explorer", () => {
+    let dom;
+    let document;
+    let window;
+
+    beforeEach(() => {
+        const htmlPath = path.resolve(
+            __dirname,
+            "../../frontend/stone-age-india/index.html"
+        );
+
+        const jsPath = path.resolve(
+            __dirname,
+            "../../frontend/stone-age-india/script.js"
+        );
+
+        const html = fs.readFileSync(htmlPath, "utf-8");
+        const js = fs.readFileSync(jsPath, "utf-8");
+
+        dom = new JSDOM(html, {
+            runScripts: "dangerously",
+            resources: "usable"
+        });
+
+        document = dom.window.document;
+        window = dom.window;
+
+        dom.window.eval(js);
+    });
+
+    it("renders the Stone Age page", () => {
+        expect(document.title).toContain("Stone Age of India");
+
+        const heading = document.querySelector("h1");
+
+        expect(heading).not.toBeNull();
+        expect(heading.textContent).toContain("Stone Age of India");
+    });
+
+    it("contains all three major Stone Age periods", () => {
+        const content = document.body.textContent;
+
+        expect(content).toContain("Paleolithic");
+        expect(content).toContain("Mesolithic");
+        expect(content).toContain("Neolithic");
+    });
+
+    it("contains important archaeological sites", () => {
+        const content = document.body.textContent;
+
+        expect(content).toContain("Attirampakkam");
+        expect(content).toContain("Bhimbetka");
+        expect(content).toContain("Bagor");
+        expect(content).toContain("Burzahom");
+        expect(content).toContain("Chirand");
+    });
+
+    it("contains the tools section", () => {
+        const toolsSection = document.getElementById("tools");
+
+        expect(toolsSection).not.toBeNull();
+        expect(toolsSection.textContent).toContain("Handaxes");
+        expect(toolsSection.textContent).toContain("Microliths");
+    });
+
+    it("renders interactive map markers", () => {
+        const markers = document.querySelectorAll(".map-marker");
+
+        expect(markers.length).toBeGreaterThanOrEqual(8);
+    });
+
+    it("updates map details when a site is selected", () => {
+        const marker = document.querySelector(
+            '.map-marker[data-site="burzahom"]'
+        );
+
+        expect(marker).not.toBeNull();
+
+        marker.click();
+
+        expect(
+            document.getElementById("map-site-name").textContent
+        ).toBe("Burzahom");
+
+        expect(
+            document.getElementById("map-site-location").textContent
+        ).toBe("Kashmir");
+    });
+
+    it("contains a prehistoric timeline", () => {
+        const timeline = document.getElementById("timeline");
+
+        expect(timeline).not.toBeNull();
+
+        expect(
+            timeline.querySelectorAll(".timeline-item").length
+        ).toBeGreaterThanOrEqual(5);
+    });
+});


### PR DESCRIPTION
## Summary

- Added a dedicated Isampur archaeological site profile.
- Documented the site's location in the Hunsgi Valley of Karnataka.
- Added the Acheulean quarry-cum-workshop archaeological context.
- Covered limestone cores, flakes, hammerstones, handaxes and cleavers.
- Added dating information for the Lower Palaeolithic site.
- Added the site's scientific significance for understanding early stone-tool production.
- Added an interactive map showing the approximate Isampur location.
- Registered the new page in the project's search index.

Closes #3782

@Eshajha19 
I've resolved the issue. Kindly review it, and if everything looks good, please consider merging the corresponding PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive explorers for India’s Stone Age heritage and Narmada Valley fossil discoveries.
  * Added dedicated Isampur archaeological site documentation, including stone-tool evidence, historical context, and maps.
  * Added responsive layouts, dark/light theme switching, timelines, archaeological site details, and interactive map selections.
  * Added search entries for the new prehistoric heritage pages.

* **Documentation**
  * Added detailed Narmada Valley fossil research and discovery information.

* **Tests**
  * Added coverage for page content, theme switching, map interactions, site markers, and locality selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->