### PR TITLE
feat: add rivers of Northeast India explorer

### DIFF
--- a/frontend/northeast-rivers-explorer/index.html
+++ b/frontend/northeast-rivers-explorer/index.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script>
+        (function () {
+            const theme = localStorage.getItem("theme") || "dark";
+            if (theme === "light") {
+                document.documentElement.classList.add("light-theme");
+            }
+        })();
+    </script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Rivers of Northeast India | Incredible India Explorer</title>
+    <meta name="description" content="Explore Northeast India’s rivers: Brahmaputra, Barak, Subansiri, Lohit, Dibang, Manas and Dhansiri, with state-wise filtering, a map, and ecological importance.">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&family=Playfair+Display:ital,wght@0,600;0,700;1,500&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <a class="skip-link" href="#main">Skip to main content</a>
+
+    <header class="site-header">
+        <nav class="topnav" aria-label="Primary">
+            <a class="brand" href="../../index.html">Incredible India Explorer</a>
+            <div class="nav-links">
+                <a href="#rivers">Rivers</a>
+                <a href="#ecology">Ecology</a>
+                <a href="#map">Map</a>
+                <a href="#sources">Sources</a>
+            </div>
+            <button type="button" id="theme-toggle" class="theme-toggle" aria-label="Switch to light theme">☀️</button>
+        </nav>
+    </header>
+
+    <main id="main">
+        <header class="hero">
+            <p class="eyebrow">Brahmaputra &amp; Barak basins</p>
+            <h1>Rivers of Northeast India</h1>
+            <p class="hero-date">Assam · Arunachal Pradesh · Manipur · Nagaland</p>
+            <p class="lede">Seven rivers shape the Northeast: the Brahmaputra and its Himalayan tributaries, and the separate Barak system of the south. Filter by state, then place each river on the map.</p>
+        </header>
+
+        <section class="block" id="rivers" aria-labelledby="rivers-heading">
+            <div class="section-head">
+                <span class="tag">Rivers</span>
+                <h2 id="rivers-heading">The seven rivers</h2>
+            </div>
+            <p class="lede">State-wise filtering shows which of these courses run through Assam, Arunachal Pradesh, Manipur, or Nagaland. Several rivers cross more than one state.</p>
+            <div class="filter-bar" role="group" aria-label="Filter rivers by state">
+                <button type="button" class="filter-btn is-active" data-state="all" aria-pressed="true">All states</button>
+                <button type="button" class="filter-btn" data-state="assam" aria-pressed="false">Assam</button>
+                <button type="button" class="filter-btn" data-state="arunachal" aria-pressed="false">Arunachal Pradesh</button>
+                <button type="button" class="filter-btn" data-state="manipur" aria-pressed="false">Manipur</button>
+                <button type="button" class="filter-btn" data-state="nagaland" aria-pressed="false">Nagaland</button>
+            </div>
+            <p class="filter-status" id="filter-status" aria-live="polite">Showing all 7 rivers.</p>
+            <div class="river-grid" id="river-grid">
+                <article class="card river-card" data-place="brahmaputra" data-states="assam arunachal">
+                    <h3>Brahmaputra</h3>
+                    <p class="state-tags">Assam · Arunachal Pradesh</p>
+                    <p>Enters India as the Siang (Dihang) in Arunachal Pradesh. After the Lohit and Dibang join near Sadiya, the combined river is the Brahmaputra. It braids west across Assam, then turns south at Dhubri into Bangladesh as the Jamuna.</p>
+                </article>
+                <article class="card river-card" data-place="barak" data-states="assam manipur">
+                    <h3>Barak</h3>
+                    <p class="state-tags">Manipur · Assam</p>
+                    <p>Rises in the Manipur hills and flows through Assam’s Barak Valley (Cachar, Karimganj, Hailakandi). It is a separate basin from the Brahmaputra; in Bangladesh it becomes the Surma–Meghna system.</p>
+                </article>
+                <article class="card river-card" data-place="subansiri" data-states="assam arunachal">
+                    <h3>Subansiri</h3>
+                    <p class="state-tags">Arunachal Pradesh · Assam</p>
+                    <p>Largest north-bank tributary of the Brahmaputra. Snow- and monsoon-fed from Arunachal, it meets the main stem west of Majuli. The 1950 Assam earthquake changed its channel pattern.</p>
+                </article>
+                <article class="card river-card" data-place="lohit" data-states="assam arunachal">
+                    <h3>Lohit</h3>
+                    <p class="state-tags">Arunachal Pradesh · Assam</p>
+                    <p>Flows from the Mishmi Hills through Tezu. With the Dibang, it joins the Siang at the head of the Assam Valley; below that confluence the river is called Brahmaputra.</p>
+                </article>
+                <article class="card river-card" data-place="dibang" data-states="assam arunachal">
+                    <h3>Dibang</h3>
+                    <p class="state-tags">Arunachal Pradesh · Assam</p>
+                    <p>Drains the Dibang Valley around Anini and Roing. It is one of the three mountain streams that create the Brahmaputra name at the valley head near Sadiya.</p>
+                </article>
+                <article class="card river-card" data-place="manas" data-states="assam">
+                    <h3>Manas</h3>
+                    <p class="state-tags">Assam</p>
+                    <p>Enters India from Bhutan and crosses Manas National Park before joining the Brahmaputra from the north (right bank). It is a transboundary Himalayan tributary of the Assam floodplain.</p>
+                </article>
+                <article class="card river-card" data-place="dhansiri" data-states="assam nagaland">
+                    <h3>Dhansiri</h3>
+                    <p class="state-tags">Nagaland · Assam</p>
+                    <p>The south-bank Dhansiri rises in the Naga Hills, flows through Golaghat, and meets the Brahmaputra at Dhansirimukh. (A smaller north-bank river of the same name also exists.)</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="block" id="ecology" aria-labelledby="ecology-heading">
+            <div class="section-head">
+                <span class="tag">Ecology</span>
+                <h2 id="ecology-heading">Ecological importance</h2>
+            </div>
+            <p>Seasonal floods and heavy Himalayan sediment keep Assam’s grasslands and wetlands open. Kaziranga’s one-horned rhinoceros, wild buffalo, and swamp deer depend on Brahmaputra pulse flooding. Manas National Park (UNESCO) sits on the Manas–Beki floodplain: tiger, elephant, golden langur, and pygmy hog. Dibru-Saikhowa and the Lohit–Brahmaputra chars hold grassland and riverine forest. The Brahmaputra still supports the Ganges river dolphin. Rice, fish, and tea cultures of the valley follow the same flood pulse. The Barak wetlands of southern Assam are a second, independent freshwater system for fisheries and migratory birds.</p>
+        </section>
+
+        <section class="block" id="map" aria-labelledby="map-heading">
+            <div class="section-head">
+                <span class="tag">Geography</span>
+                <h2 id="map-heading">Interactive map</h2>
+            </div>
+            <p class="lede">Select a river to move the marker. Buttons follow the same state filter as the list above.</p>
+            <div class="map-layout">
+                <div class="map-frame-wrap">
+                    <iframe
+                        id="river-map"
+                        title="Map of rivers of Northeast India"
+                        src="https://www.openstreetmap.org/export/embed.html?bbox=91.2,25.9,92.3,26.5&amp;layer=mapnik&amp;marker=26.18,91.75"
+                        loading="lazy"
+                    ></iframe>
+                </div>
+                <div>
+                    <div class="map-buttons" id="map-buttons" role="group" aria-label="River locations">
+                        <button type="button" class="map-btn is-active" data-place="brahmaputra" data-states="assam arunachal" aria-pressed="true">Brahmaputra</button>
+                        <button type="button" class="map-btn" data-place="barak" data-states="assam manipur">Barak</button>
+                        <button type="button" class="map-btn" data-place="subansiri" data-states="assam arunachal">Subansiri</button>
+                        <button type="button" class="map-btn" data-place="lohit" data-states="assam arunachal">Lohit</button>
+                        <button type="button" class="map-btn" data-place="dibang" data-states="assam arunachal">Dibang</button>
+                        <button type="button" class="map-btn" data-place="manas" data-states="assam">Manas</button>
+                        <button type="button" class="map-btn" data-place="dhansiri" data-states="assam nagaland">Dhansiri</button>
+                    </div>
+                    <div class="card map-info" id="map-info" aria-live="polite">
+                        <h3 id="map-info-title">Brahmaputra</h3>
+                        <p id="map-info-desc">Marker at Guwahati, Assam, on the braided main stem. The Siang enters from Arunachal; Lohit and Dibang join near Sadiya.</p>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="block sources" id="sources" aria-labelledby="sources-heading">
+            <div class="section-head">
+                <span class="tag">References</span>
+                <h2 id="sources-heading">Sources</h2>
+            </div>
+            <ol>
+                <li><a href="https://en.wikipedia.org/wiki/Brahmaputra_River" target="_blank" rel="noopener noreferrer">Wikipedia — Brahmaputra River</a></li>
+                <li><a href="https://en.wikipedia.org/wiki/Barak_River" target="_blank" rel="noopener noreferrer">Wikipedia — Barak River</a></li>
+                <li><a href="https://en.wikipedia.org/wiki/Subansiri_River" target="_blank" rel="noopener noreferrer">Wikipedia — Subansiri River</a></li>
+                <li><a href="https://en.wikipedia.org/wiki/Lohit_River" target="_blank" rel="noopener noreferrer">Wikipedia — Lohit River</a></li>
+                <li><a href="https://en.wikipedia.org/wiki/Dibang_River" target="_blank" rel="noopener noreferrer">Wikipedia — Dibang River</a></li>
+                <li><a href="https://en.wikipedia.org/wiki/Manas_River" target="_blank" rel="noopener noreferrer">Wikipedia — Manas River</a></li>
+                <li><a href="https://en.wikipedia.org/wiki/Dhansiri" target="_blank" rel="noopener noreferrer">Wikipedia — Dhansiri</a></li>
+            </ol>
+        </section>
+    </main>
+
+    <footer class="page-footer">
+        <p>Incredible India Explorer · Rivers of Northeast India · <a href="../../index.html">Home</a></p>
+    </footer>
+
+    <script src="script.js" defer></script>
+</body>
+</html>

--- a/frontend/northeast-rivers-explorer/script.js
+++ b/frontend/northeast-rivers-explorer/script.js
@@ -1,0 +1,199 @@
+(function () {
+    const places = {
+        brahmaputra: {
+            title: "Brahmaputra",
+            desc: "Marker at Guwahati, Assam, on the braided main stem. The Siang enters from Arunachal; Lohit and Dibang join near Sadiya.",
+            lat: 26.18,
+            lon: 91.75,
+            bbox: [91.2, 25.9, 92.3, 26.5]
+        },
+        barak: {
+            title: "Barak",
+            desc: "Marker at Silchar in Assam’s Barak Valley. The river rises in the Manipur hills and belongs to the Meghna system, not the Brahmaputra.",
+            lat: 24.8333,
+            lon: 92.7789,
+            bbox: [92.4, 24.5, 93.2, 25.1]
+        },
+        subansiri: {
+            title: "Subansiri",
+            desc: "North-bank Himalayan tributary. Marker near its meeting with the Brahmaputra west of Majuli, on the Arunachal–Assam course.",
+            lat: 26.859,
+            lon: 93.909,
+            bbox: [93.4, 26.5, 94.4, 27.3]
+        },
+        lohit: {
+            title: "Lohit",
+            desc: "Marker at Tezu, Arunachal Pradesh. The Lohit leaves the Mishmi Hills and joins the Siang and Dibang at the head of the Assam Valley.",
+            lat: 27.925,
+            lon: 96.162,
+            bbox: [95.7, 27.6, 96.6, 28.3]
+        },
+        dibang: {
+            title: "Dibang",
+            desc: "Marker at Roing, where the Dibang leaves the hills for the Assam plains before joining the Siang and Lohit.",
+            lat: 28.147,
+            lon: 95.843,
+            bbox: [95.4, 27.9, 96.3, 28.5]
+        },
+        manas: {
+            title: "Manas",
+            desc: "Marker at Manas National Park, Assam, on the river as it enters from Bhutan and crosses the protected floodplain.",
+            lat: 26.72,
+            lon: 90.95,
+            bbox: [90.5, 26.5, 91.3, 26.95]
+        },
+        dhansiri: {
+            title: "Dhansiri",
+            desc: "South-bank river from the Naga Hills. Marker at Golaghat, Assam; it meets the Brahmaputra at Dhansirimukh.",
+            lat: 26.516,
+            lon: 93.969,
+            bbox: [93.4, 26.2, 94.3, 26.85]
+        }
+    };
+
+    function mapSrc(place) {
+        const box = place.bbox.join(",");
+        return "https://www.openstreetmap.org/export/embed.html?bbox=" +
+            encodeURIComponent(box) +
+            "&layer=mapnik&marker=" +
+            encodeURIComponent(place.lat + "," + place.lon);
+    }
+
+    function hasState(el, state) {
+        if (state === "all") {
+            return true;
+        }
+        const states = (el.getAttribute("data-states") || "").split(/\s+/);
+        return states.indexOf(state) !== -1;
+    }
+
+    function initThemeToggle() {
+        const button = document.getElementById("theme-toggle");
+        const root = document.documentElement;
+
+        function applyTheme(theme) {
+            const isLight = theme === "light";
+            root.classList.toggle("light-theme", isLight);
+            document.body.classList.toggle("light-theme", isLight);
+            button.textContent = isLight ? "🌙" : "☀️";
+            button.setAttribute("aria-label", isLight ? "Switch to dark theme" : "Switch to light theme");
+        }
+
+        applyTheme(localStorage.getItem("theme") === "light" ? "light" : "dark");
+
+        button.addEventListener("click", function () {
+            const next = document.body.classList.contains("light-theme") ? "dark" : "light";
+            localStorage.setItem("theme", next);
+            applyTheme(next);
+        });
+    }
+
+    function initExplorer() {
+        const frame = document.getElementById("river-map");
+        const titleEl = document.getElementById("map-info-title");
+        const descEl = document.getElementById("map-info-desc");
+        const statusEl = document.getElementById("filter-status");
+        const filterButtons = document.querySelectorAll(".filter-btn");
+        const mapButtons = document.querySelectorAll(".map-btn");
+        const cards = document.querySelectorAll(".river-card");
+        let currentPlace = "brahmaputra";
+        let currentState = "all";
+
+        function showPlace(key) {
+            const place = places[key];
+            if (!place) {
+                return;
+            }
+            currentPlace = key;
+            frame.src = mapSrc(place);
+            titleEl.textContent = place.title;
+            descEl.textContent = place.desc;
+            mapButtons.forEach(function (btn) {
+                const active = btn.getAttribute("data-place") === key;
+                btn.classList.toggle("is-active", active);
+                btn.setAttribute("aria-pressed", active ? "true" : "false");
+            });
+        }
+
+        function applyFilter(state) {
+            currentState = state;
+            let visible = 0;
+            let firstVisible = null;
+
+            cards.forEach(function (card) {
+                const match = hasState(card, state);
+                card.classList.toggle("is-hidden", !match);
+                if (match) {
+                    visible += 1;
+                    if (!firstVisible) {
+                        firstVisible = card.getAttribute("data-place");
+                    }
+                }
+            });
+
+            mapButtons.forEach(function (btn) {
+                btn.classList.toggle("is-hidden", !hasState(btn, state));
+            });
+
+            filterButtons.forEach(function (btn) {
+                const active = btn.getAttribute("data-state") === state;
+                btn.classList.toggle("is-active", active);
+                btn.setAttribute("aria-pressed", active ? "true" : "false");
+            });
+
+            const label = state === "all" ? "all states" : btnLabel(state);
+            statusEl.textContent = "Showing " + visible + (visible === 1 ? " river" : " rivers") + " for " + label + ".";
+
+            const currentBtn = document.querySelector('.map-btn[data-place="' + currentPlace + '"]');
+            if (!currentBtn || currentBtn.classList.contains("is-hidden")) {
+                showPlace(firstVisible || "brahmaputra");
+            }
+        }
+
+        function btnLabel(state) {
+            const labels = {
+                assam: "Assam",
+                arunachal: "Arunachal Pradesh",
+                manipur: "Manipur",
+                nagaland: "Nagaland"
+            };
+            return labels[state] || state;
+        }
+
+        filterButtons.forEach(function (btn) {
+            btn.addEventListener("click", function () {
+                applyFilter(btn.getAttribute("data-state"));
+            });
+        });
+
+        mapButtons.forEach(function (btn) {
+            btn.addEventListener("click", function () {
+                showPlace(btn.getAttribute("data-place"));
+            });
+        });
+
+        cards.forEach(function (card) {
+            card.addEventListener("click", function () {
+                showPlace(card.getAttribute("data-place"));
+                const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+                document.getElementById("map").scrollIntoView({
+                    behavior: reduceMotion ? "auto" : "smooth",
+                    block: "start"
+                });
+            });
+            card.addEventListener("keydown", function (event) {
+                if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    card.click();
+                }
+            });
+            card.setAttribute("tabindex", "0");
+            card.setAttribute("role", "button");
+        });
+    }
+
+    document.addEventListener("DOMContentLoaded", function () {
+        initThemeToggle();
+        initExplorer();
+    });
+})();

--- a/frontend/northeast-rivers-explorer/style.css
+++ b/frontend/northeast-rivers-explorer/style.css
@@ -1,0 +1,339 @@
+:root {
+    --bg: #0c1614;
+    --bg-alt: #12201c;
+    --surface: #1a2c28;
+    --line: #2e4a42;
+    --text: #eef6f2;
+    --muted: #b8d0c6;
+    --dim: #7e9a90;
+    --accent: #5ec4a8;
+    --accent-2: #d4b06a;
+    --heading: "Playfair Display", Georgia, serif;
+    --body: "Outfit", system-ui, sans-serif;
+}
+
+body.light-theme,
+html.light-theme,
+html.light-theme body {
+    --bg: #eef6f2;
+    --bg-alt: #e2eee8;
+    --surface: #ffffff;
+    --line: #c0d4cc;
+    --text: #10241c;
+    --muted: #3a544c;
+    --dim: #5c7870;
+    --accent: #0e6e58;
+    --accent-2: #8a6410;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--body);
+    line-height: 1.65;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
+
+    * {
+        animation: none !important;
+        transition: none !important;
+    }
+}
+
+a {
+    color: var(--accent);
+}
+
+a:focus-visible,
+button:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+}
+
+.skip-link {
+    position: absolute;
+    left: -999px;
+    top: 0;
+    background: var(--accent);
+    color: #111;
+    padding: 0.5rem 1rem;
+    z-index: 1000;
+}
+
+.skip-link:focus {
+    left: 8px;
+    top: 8px;
+}
+
+.topnav {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.85rem 1.25rem;
+    background: var(--bg);
+    border-bottom: 1px solid var(--line);
+    overflow-x: auto;
+}
+
+.brand {
+    font-weight: 700;
+    text-decoration: none;
+    color: var(--text);
+    white-space: nowrap;
+}
+
+.nav-links {
+    display: flex;
+    gap: 0.9rem;
+    font-size: 0.85rem;
+}
+
+.nav-links a {
+    color: var(--muted);
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.nav-links a:hover {
+    color: var(--text);
+}
+
+.theme-toggle {
+    margin-left: auto;
+    border: 1px solid var(--line);
+    background: var(--surface);
+    color: var(--text);
+    border-radius: 999px;
+    width: 2.4rem;
+    height: 2.4rem;
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+.hero {
+    padding: 4.5rem 8vw 3.5rem;
+    background:
+        radial-gradient(900px 420px at 12% -20%, rgba(94, 196, 168, 0.18), transparent 55%),
+        var(--bg);
+    border-bottom: 1px solid var(--line);
+}
+
+.eyebrow {
+    font-size: 0.78rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--accent-2);
+    margin: 0 0 1rem;
+}
+
+h1 {
+    font-family: var(--heading);
+    font-size: clamp(2rem, 5vw, 3.4rem);
+    line-height: 1.1;
+    margin: 0 0 0.75rem;
+    max-width: 16ch;
+}
+
+.hero-date {
+    color: var(--accent);
+    font-weight: 600;
+    margin: 0 0 1.25rem;
+}
+
+.lede {
+    max-width: 68ch;
+    color: var(--muted);
+    font-size: 1.05rem;
+}
+
+.block {
+    padding: 4.5rem 8vw;
+    border-bottom: 1px solid var(--line);
+}
+
+.block:nth-child(even) {
+    background: var(--bg-alt);
+}
+
+.section-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.tag {
+    font-size: 0.72rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--accent);
+    border: 1px solid var(--line);
+    padding: 0.2rem 0.6rem;
+}
+
+h2 {
+    font-family: var(--heading);
+    font-size: clamp(1.5rem, 3vw, 2.1rem);
+    margin: 0;
+}
+
+.filter-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.filter-btn,
+.map-btn {
+    border: 1px solid var(--line);
+    background: var(--surface);
+    color: var(--text);
+    border-radius: 999px;
+    padding: 0.35rem 0.8rem;
+    cursor: pointer;
+    font-family: inherit;
+    font-size: 0.85rem;
+}
+
+.filter-btn.is-active,
+.filter-btn:hover,
+.map-btn.is-active,
+.map-btn:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+}
+
+.filter-status {
+    color: var(--dim);
+    font-size: 0.9rem;
+    margin: 0 0 1.25rem;
+}
+
+.river-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.25rem;
+}
+
+.card {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    padding: 1.35rem 1.4rem;
+}
+
+.card h3 {
+    margin: 0 0 0.35rem;
+    font-size: 1.05rem;
+}
+
+.card p {
+    color: var(--muted);
+    margin: 0;
+}
+
+.state-tags {
+    color: var(--accent) !important;
+    font-size: 0.82rem;
+    font-weight: 600;
+    margin-bottom: 0.55rem !important;
+}
+
+.river-card {
+    cursor: pointer;
+}
+
+.river-card.is-hidden,
+.map-btn.is-hidden {
+    display: none;
+}
+
+.map-layout {
+    display: grid;
+    grid-template-columns: 1.4fr 1fr;
+    gap: 1.25rem;
+    align-items: start;
+}
+
+.map-frame-wrap {
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    overflow: hidden;
+    min-height: 320px;
+    background: var(--surface);
+}
+
+.map-frame-wrap iframe {
+    display: block;
+    width: 100%;
+    height: 360px;
+    border: 0;
+}
+
+.map-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 0.9rem;
+}
+
+.sources ol {
+    max-width: 75ch;
+    padding-left: 1.2rem;
+}
+
+.sources li + li {
+    margin-top: 0.55rem;
+}
+
+.page-footer {
+    padding: 1.5rem 8vw;
+    color: var(--dim);
+    font-size: 0.9rem;
+}
+
+.page-footer a {
+    color: var(--muted);
+}
+
+@media (max-width: 768px) {
+    .river-grid,
+    .map-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .hero,
+    .block {
+        padding: 3rem 1.25rem;
+    }
+
+    .topnav {
+        flex-wrap: wrap;
+    }
+
+    .nav-links {
+        order: 3;
+        width: 100%;
+        padding-top: 0.35rem;
+    }
+}

--- a/frontend/search-index.js
+++ b/frontend/search-index.js
@@ -6671,5 +6671,14 @@ window.indiaSearchIndex = [
         description:
             "Explore the Deccan Traps: flood-basalt history, Western Ghats stratigraphy, a ~66 Ma timeline, intertrappean fossils, trap landscape, and an interactive site map.",
         url: "frontend/deccan-volcanic-landscape/index.html"
+    },
+
+    // --- Rivers of Northeast India (#3946) ---
+    {
+        title: "Rivers of Northeast India \u2014 Brahmaputra & Barak",
+        category: "Rivers",
+        description:
+            "Explore the Brahmaputra, Barak, Subansiri, Lohit, Dibang, Manas and Dhansiri, with state-wise filtering, an interactive map, and ecological importance.",
+        url: "frontend/northeast-rivers-explorer/index.html"
     }
 ];


### PR DESCRIPTION
## Description

Adds an educational page on the rivers of Northeast India: Brahmaputra, Barak, Subansiri, Lohit, Dibang, Manas, and Dhansiri, with state-wise filtering, an interactive map, and ecological importance.

Fixes #3946

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Accessibility improvement
- [ ] Performance improvement

## How Has This Been Tested?

- [x] Tested locally in browser
- [x] Tested in both dark and light themes
- [x] Tested at mobile viewport widths
- [x] Verified no console errors

## Checklist

- [x] My code follows the [coding standards](CONTRIBUTING.md#coding-standards) of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or errors
- [x] I have tested responsive layout (if UI change)
- [x] I have considered accessibility (aria labels, keyboard nav, focus)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive “Rivers of Northeast India” explorer covering seven major rivers.
  * Added state-based filtering, river details, interactive maps, and source information.
  * Added light and dark themes with saved preferences.
  * Added responsive layouts, keyboard navigation, and reduced-motion support.
  * Added the explorer to site search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->